### PR TITLE
Use `array::IntoIter` instead of copying

### DIFF
--- a/core/editor/src/tools/mod.rs
+++ b/core/editor/src/tools/mod.rs
@@ -98,14 +98,11 @@ impl ToolFsmState {
 
 fn default_tool_settings() -> HashMap<ToolType, ToolSettings> {
 	let tool_init = |tool: &ToolType| (*tool, tool.default_settings());
-	// TODO: when 1.51 is more common, change this to use array::IntoIter
-	[
+	std::array::IntoIter::new([
 		tool_init(&ToolType::Select),
 		tool_init(&ToolType::Ellipse),
 		tool_init(&ToolType::Shape), // TODO: Add more tool defaults
-	]
-	.iter()
-	.copied()
+	])
 	.collect()
 }
 


### PR DESCRIPTION
This resolves the TODO we left there earlier.

The CI seems to have upgraded to Rust 1.51 now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/80)
<!-- Reviewable:end -->
