### PR TITLE
Change circle radius calculation

### DIFF
--- a/core/editor/src/tools/ellipse.rs
+++ b/core/editor/src/tools/ellipse.rs
@@ -138,7 +138,7 @@ fn make_operation(data: &EllipseToolData, tool_data: &DocumentToolData) -> Opera
 	let (cx, cy, r_scale) = if data.center_around_cursor { (x0, y0, 1.0) } else { ((x0 + x1) * 0.5, (y0 + y1) * 0.5, 0.5) };
 
 	if data.constrain_to_circle {
-		let r = f64::max((x1 - x0).abs(), (y1 - y0).abs()) * r_scale;
+		let r = ((x1 - x0).abs() + (y1 - y0).abs()) * 0.5 * r_scale;
 		Operation::AddCircle {
 			path: vec![],
 			insert_index: -1,


### PR DESCRIPTION
I "reverse engineered" (basically just looked at) how Affinity Photo handles this calculation and implemented it here.

IMO this feels really nice and we should at least make it an option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/103)
<!-- Reviewable:end -->
