### PR TITLE
Fix ellipse tool behavior

### DIFF
--- a/core/editor/src/tools/ellipse.rs
+++ b/core/editor/src/tools/ellipse.rs
@@ -135,10 +135,14 @@ fn make_operation(data: &EllipseToolData, tool_data: &DocumentToolData) -> Opera
 	let x1 = data.drag_current.x as f64;
 	let y1 = data.drag_current.y as f64;
 
-	let (cx, cy, r_scale) = if data.center_around_cursor { (x0, y0, 1.0) } else { ((x0 + x1) * 0.5, (y0 + y1) * 0.5, 0.5) };
-
 	if data.constrain_to_circle {
-		let r = f64::max((x1 - x0).abs(), (y1 - y0).abs()) * r_scale;
+		let (cx, cy, r) = if data.center_around_cursor {
+			(x0, y0, f64::hypot(x1 - x0, y1 - y0))
+		} else {
+			let diameter = f64::max((x1 - x0).abs(), (y1 - y0).abs());
+			let (x2, y2) = (x0 + (x1 - x0).signum() * diameter, y0 + (y1 - y0).signum() * diameter);
+			((x0 + x2) * 0.5, (y0 + y2) * 0.5, diameter * 0.5)
+		};
 		Operation::AddCircle {
 			path: vec![],
 			insert_index: -1,
@@ -148,6 +152,7 @@ fn make_operation(data: &EllipseToolData, tool_data: &DocumentToolData) -> Opera
 			style: style::PathStyle::new(None, Some(style::Fill::new(tool_data.primary_color))),
 		}
 	} else {
+		let (cx, cy, r_scale) = if data.center_around_cursor { (x0, y0, 1.0) } else { ((x0 + x1) * 0.5, (y0 + y1) * 0.5, 0.5) };
 		let (rx, ry) = ((x1 - x0).abs() * r_scale, (y1 - y0).abs() * r_scale);
 		Operation::AddEllipse {
 			path: vec![],


### PR DESCRIPTION
Previously, the corner of the Circle's bounding box was not fixed to the starting location, when holding Shift. This PR changes this to the expected behavior. In addition the Circle now expands to the cursor location as expected when holding both Shift and Alt at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/105)
<!-- Reviewable:end -->
