### PR TITLE
Add keyboard shortcut to duplicate layers

### DIFF
--- a/client/web/src/components/panels/Document.vue
+++ b/client/web/src/components/panels/Document.vue
@@ -202,10 +202,12 @@ export default defineComponent({
 			on_mouse_move(e.offsetX, e.offsetY);
 		},
 		async keyDown(e: KeyboardEvent) {
+			e.preventDefault();
 			const { on_key_down } = await wasm;
 			on_key_down(e.key);
 		},
 		async keyUp(e: KeyboardEvent) {
+			e.preventDefault();
 			const { on_key_up } = await wasm;
 			on_key_up(e.key);
 		},

--- a/core/document/src/document.rs
+++ b/core/document/src/document.rs
@@ -248,6 +248,13 @@ impl Document {
 				let (path, _) = split_path(path.as_slice()).unwrap_or_else(|_| (&[], 0));
 				Some(vec![DocumentResponse::DocumentChanged, DocumentResponse::FolderChanged { path: path.to_vec() }])
 			}
+			Operation::DuplicateLayer { path } => {
+				let layer = self.layer(&path)?.clone();
+				let (folder_path, _) = split_path(path.as_slice()).unwrap_or_else(|_| (&[], 0));
+				let folder = self.folder_mut(folder_path)?;
+				folder.add_layer(layer, -1).ok_or(DocumentError::IndexOutOfBounds)?;
+				Some(vec![DocumentResponse::DocumentChanged, DocumentResponse::FolderChanged { path: folder_path.to_vec() }])
+			}
 			Operation::AddFolder { path } => {
 				self.set_layer(&path, Layer::new(LayerDataTypes::Folder(Folder::default())))?;
 

--- a/core/document/src/operation.rs
+++ b/core/document/src/operation.rs
@@ -60,6 +60,9 @@ pub enum Operation {
 	DeleteLayer {
 		path: Vec<LayerId>,
 	},
+	DuplicateLayer {
+		path: Vec<LayerId>,
+	},
 	AddFolder {
 		path: Vec<LayerId>,
 	},

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -162,9 +162,7 @@ impl MessageHandler<DocumentMessage, ()> for DocumentMessageHandler {
 				}
 			}
 			DuplicateSelectedLayers => {
-				// TODO: Replace with drain_filter https://github.com/rust-lang/rust/issues/59618
-				let paths: Vec<Vec<LayerId>> = self.active_document().layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone())).collect();
-				for path in paths {
+				for path in self.active_document().layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone())) {
 					responses.push_back(DocumentOperation::DuplicateLayer { path }.into())
 				}
 			}

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -11,6 +11,7 @@ pub enum DocumentMessage {
 	SelectLayers(Vec<Vec<LayerId>>),
 	DeleteLayer(Vec<LayerId>),
 	DeleteSelectedLayers,
+	DuplicateSelectedLayers,
 	AddFolder(Vec<LayerId>),
 	RenameLayer(Vec<LayerId>, String),
 	ToggleLayerVisibility(Vec<LayerId>),
@@ -160,6 +161,13 @@ impl MessageHandler<DocumentMessage, ()> for DocumentMessageHandler {
 					responses.push_back(DocumentOperation::DeleteLayer { path }.into())
 				}
 			}
+			DuplicateSelectedLayers => {
+				// TODO: Replace with drain_filter https://github.com/rust-lang/rust/issues/59618
+				let paths: Vec<Vec<LayerId>> = self.active_document().layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone())).collect();
+				for path in paths {
+					responses.push_back(DocumentOperation::DuplicateLayer { path }.into())
+				}
+			}
 			SelectLayers(paths) => {
 				self.clear_selection();
 				for path in paths {
@@ -208,7 +216,7 @@ impl MessageHandler<DocumentMessage, ()> for DocumentMessageHandler {
 	}
 	fn actions(&self) -> ActionList {
 		if self.active_document().layer_data.values().any(|data| data.selected) {
-			actions!(DocumentMessageDiscriminant; Undo, DeleteSelectedLayers, RenderDocument, ExportDocument, NewDocument, NextDocument, PrevDocument)
+			actions!(DocumentMessageDiscriminant; Undo, DeleteSelectedLayers, DuplicateSelectedLayers, RenderDocument, ExportDocument, NewDocument, NextDocument, PrevDocument)
 		} else {
 			actions!(DocumentMessageDiscriminant; Undo, RenderDocument, ExportDocument, NewDocument, NextDocument, PrevDocument)
 		}

--- a/core/editor/src/input/input_mapper.rs
+++ b/core/editor/src/input/input_mapper.rs
@@ -167,6 +167,7 @@ impl Default for Mapping {
 			entry! {action=GlobalMessage::LogInfo, key_down=Key1},
 			entry! {action=GlobalMessage::LogDebug, key_down=Key2},
 			entry! {action=GlobalMessage::LogTrace, key_down=Key3},
+			entry! {action=DocumentMessage::DuplicateSelectedLayers, key_down=KeyD, modifiers=[KeyControl]},
 		];
 		Self { up, down, pointer_move }
 	}


### PR DESCRIPTION
Implements part of #189. @TrueDoctor is this roughly how you imagined the implementation? As you described I added `Operation::DuplicateLayer`. I then also added `DocumentMessage::DuplicateSelectedLayers` which mirrors how deleting the selected layers works. I added the `e.preventDefault();` calls in `Document.vue` because control-D (at least in Firefox) is the shortcut for adding a new bookmark. I'm not sure if this is the way you want to handle this or if we only want to preventDefault on some specific key presses.

Also about the 
```rust
// TODO: Replace with drain_filter https://github.com/rust-lang/rust/issues/59618
let paths: Vec<Vec<LayerId>> = self.active_document().layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone())).collect();
```

codeblock. It is now duplicated in the match arms of `DeleteSelectedLayers` and `DuplicateSelectedLayers`. Should that be extracted to a `selected_layers` function?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/214)
<!-- Reviewable:end -->
