### PR TITLE
Don't use eslint formatter for rust files in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,6 @@
 	],
 	"files.eol": "\n",
 	"html.format.wrapLineLength": 200,
-	"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 	"eslint.format.enable": true,
 	"eslint.workingDirectories": ["./client/web"],
 	"eslint.validate": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,29 +3,20 @@
 		"editor.formatOnSave": true,
 		"editor.formatOnPaste": true
 	},
-	"[vue]": {
-		"editor.codeActionsOnSave": { "source.fixAll.eslint": true },
+	"[typescript, javascript, json, vue]": {
+		"editor.codeActionsOnSave": {
+			"source.fixAll.eslint": true
+		},
 		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 	},
-	"[javascript]": {
-		"editor.codeActionsOnSave": { "source.fixAll.eslint": true },
-		"editor.formatOnSave": true,
-	},
-	"[json]": {
-		"editor.codeActionsOnSave": { "source.fixAll.eslint": true },
-		"editor.formatOnSave": true,
-	},
-	"[typescript, json]": {
-		"editor.codeActionsOnSave": { "source.fixAll.eslint": true },
-		"editor.formatOnSave": true,
-	},
-	"rust-analyzer.diagnostics.disabled": [
-		"missing-unsafe" // Remove when rust-analyzer bug fixes unsafe code on WASM JavaScript https://github.com/rust-analyzer/rust-analyzer/issues/5412
-	],
+	"rust-analyzer.experimental.procAttrMacros": true,
 	"files.eol": "\n",
 	"html.format.wrapLineLength": 200,
 	"eslint.format.enable": true,
-	"eslint.workingDirectories": ["./client/web"],
+	"eslint.workingDirectories": [
+		"./client/web"
+	],
 	"eslint.validate": [
 		"javascript",
 		"typescript",


### PR DESCRIPTION
Currently "dbaeumer.vscode-eslint" is globally set as the default formatter for the entire workspace. This does not work for rust files and therefore stops formatOnSave from working in VSCode. I propose removing this definition as this should be a user setting and not a workspace setting. Alternatively "dbaeumer.vscode-eslint" could be set as the default formatter for javascript/typescript/vue files only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/228)
<!-- Reviewable:end -->
