### PR TITLE
Remove partialeq for layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,8 @@ dependencies = [
 [[package]]
 name = "kurbo"
 version = "0.8.1"
-source = "git+https://github.com/GraphiteEditor/kurbo.git?branch=bezpath-partial-eq#3f86bda9ba77d3b1279612bc5779e425f2d8714d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e30b1df631d23875f230ed3ddd1a88c231f269a04b2044eb6ca87e763b5f4c42"
 dependencies = [
  "arrayvec",
 ]

--- a/core/document/Cargo.toml
+++ b/core/document/Cargo.toml
@@ -10,8 +10,6 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4"
-# TODO: Swich to kurbo release when derive `PartialEq` is available for BezPath
-#kurbo = "0.8.0"
-kurbo = {git="https://github.com/GraphiteEditor/kurbo.git", branch="bezpath-partial-eq"}
+kurbo = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 glam = "0.16"

--- a/core/document/src/document.rs
+++ b/core/document/src/document.rs
@@ -5,7 +5,7 @@ use crate::{
 	DocumentError, DocumentResponse, LayerId, Operation,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Document {
 	pub root: Layer,
 	pub work: Layer,

--- a/core/document/src/layers/ellipse.rs
+++ b/core/document/src/layers/ellipse.rs
@@ -5,7 +5,7 @@ use super::LayerData;
 
 use std::fmt::Write;
 
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Ellipse {}
 
 impl Ellipse {

--- a/core/document/src/layers/folder.rs
+++ b/core/document/src/layers/folder.rs
@@ -4,7 +4,7 @@ use super::{style, Layer, LayerData, LayerDataTypes};
 
 use std::fmt::Write;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Folder {
 	next_assignment_id: LayerId,
 	pub layer_ids: Vec<LayerId>,

--- a/core/document/src/layers/line.rs
+++ b/core/document/src/layers/line.rs
@@ -6,7 +6,7 @@ use super::LayerData;
 
 use std::fmt::Write;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct Line {}
 
 impl Line {

--- a/core/document/src/layers/mod.rs
+++ b/core/document/src/layers/mod.rs
@@ -26,7 +26,7 @@ pub trait LayerData {
 	fn to_kurbo_path(&mut self, transform: glam::DAffine2, style: style::PathStyle) -> BezPath;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum LayerDataTypes {
 	Folder(Folder),
 	Ellipse(Ellipse),
@@ -77,7 +77,7 @@ impl LayerDataTypes {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Layer {
 	pub visible: bool,
 	pub name: Option<String>,

--- a/core/document/src/layers/polyline.rs
+++ b/core/document/src/layers/polyline.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use super::{style, LayerData};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct PolyLine {
 	points: Vec<glam::DVec2>,
 }

--- a/core/document/src/layers/rect.rs
+++ b/core/document/src/layers/rect.rs
@@ -6,7 +6,7 @@ use super::LayerData;
 
 use std::fmt::Write;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Rect {}
 
 impl Rect {

--- a/core/document/src/layers/shape.rs
+++ b/core/document/src/layers/shape.rs
@@ -6,7 +6,7 @@ use super::LayerData;
 
 use std::fmt::Write;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Shape {
 	equal_sides: bool,
 	sides: u8,


### PR DESCRIPTION
Layers should not need to be compared directly, but rather through their path / id, which is both quicker and more accurate and also is already done throughout the codebase. This PR just removes unnecessary `#[derive`s and also has the added benefit of removing our dependency on a forked version of kurbo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/230)
<!-- Reviewable:end -->
