### PR TITLE
Allow transforming layers

### DIFF
--- a/core/document/src/document.rs
+++ b/core/document/src/document.rs
@@ -140,6 +140,18 @@ impl Document {
 		Ok(root)
 	}
 
+	/// Returns a mutable reference to the layer or folder at the path. Does not return an error for root
+	pub fn document_layer_mut(&mut self, path: &[LayerId]) -> Result<&mut Layer, DocumentError> {
+		let mut root = &mut self.root;
+		for id in path {
+			if root.as_folder().is_err() {
+				return Ok(root);
+			}
+			root = root.as_folder_mut()?.layer_mut(*id).ok_or(DocumentError::LayerNotFound)?;
+		}
+		Ok(root)
+	}
+
 	/// Returns a reference to the layer struct at the specified `path`.
 	pub fn layer(&self, path: &[LayerId]) -> Result<&Layer, DocumentError> {
 		let (path, id) = split_path(path)?;
@@ -291,10 +303,11 @@ impl Document {
 				None
 			}
 			Operation::TransformLayer { path, transform } => {
-				let transform = self.root.transform * DAffine2::from_cols_array(&transform);
-				let layer = self.document_folder_mut(path).unwrap();
+				let layer = self.document_layer_mut(path).unwrap();
+				let transform = DAffine2::from_cols_array(&transform) * layer.transform;
 				layer.transform = transform;
 				layer.cache_dirty = true;
+				self.root.cache_dirty = true;
 				Some(vec![DocumentResponse::DocumentChanged])
 			}
 			Operation::DiscardWorkingFolder => {

--- a/core/document/src/document.rs
+++ b/core/document/src/document.rs
@@ -140,16 +140,22 @@ impl Document {
 		Ok(root)
 	}
 
+	/// Returns a reference to the layer or folder at the path. Does not return an error for root
+	pub fn document_layer(&mut self, path: &[LayerId]) -> Result<&Layer, DocumentError> {
+		if path.is_empty() {
+			return Ok(&self.root);
+		}
+		let (path, id) = split_path(path)?;
+		self.document_folder(path)?.as_folder()?.layer(id).ok_or(DocumentError::LayerNotFound)
+	}
+
 	/// Returns a mutable reference to the layer or folder at the path. Does not return an error for root
 	pub fn document_layer_mut(&mut self, path: &[LayerId]) -> Result<&mut Layer, DocumentError> {
-		let mut root = &mut self.root;
-		for id in path {
-			if root.as_folder().is_err() {
-				return Ok(root);
-			}
-			root = root.as_folder_mut()?.layer_mut(*id).ok_or(DocumentError::LayerNotFound)?;
+		if path.is_empty() {
+			return Ok(&mut self.root);
 		}
-		Ok(root)
+		let (path, id) = split_path(path)?;
+		self.document_folder_mut(path)?.as_folder_mut()?.layer_mut(id).ok_or(DocumentError::LayerNotFound)
 	}
 
 	/// Returns a reference to the layer struct at the specified `path`.


### PR DESCRIPTION
Closes #243 and unblocks #201 and #143.

I accidentally used the wrong function to get the layer. I can't find one that gets the root with an empty path and the layer / folder if that is where the path is pointing (unless I'm missing something @TrueDoctor) so I made a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/244)
<!-- Reviewable:end -->
