### PR TITLE
Two improvements to the development workflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
 		"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 	},
 	"rust-analyzer.experimental.procAttrMacros": true,
+	"rust-analyzer.cargo.target": "wasm32-unknown-unknown",
 	"files.eol": "\n",
 	"html.format.wrapLineLength": 200,
 	"eslint.format.enable": true,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This is the primary means of running and developing the project. You may need to
 npm run serve
 ```
 
-The server automatically watches for changes to Vue files and rebuilds them. However core Rust and TypeScript file changes require a manual restart of the development server. (Please submit a PR to help it watch the `.ts` files!)
+The server automatically watches for changes to Vue files and rebuilds them. However TypeScript file changes require a manual restart of the development server. (Please submit a PR to help it watch the `.ts` files!)
 
 You can also use `npm run lint` and `npm run lint-no-fix` to solve web formatting and `cargo fmt` for Rust formatting. Also `npm run build` writes static files to `/client/web/dist` instead of serving them from memory.
 

--- a/client/web/vue.config.js
+++ b/client/web/vue.config.js
@@ -13,6 +13,7 @@ module.exports = {
 				(Plugin) =>
 					new Plugin({
 						crateDirectory: path.resolve(__dirname, "wasm"),
+						watchDirectories: [path.resolve(__dirname, "../../core")],
 					})
 			)
 			.end();


### PR DESCRIPTION
* Configure rust-analyzer to target wasm32-unknown-unknown
* Watch changes to core rust files

The readme also says that typescript files aren't watched, but the few files I tested it with are watched for me. Maybe you were hitting

```
Error from chokidar (/home/bjorn/Projects/Graphite/client/web/src/components/window/title-bar): Error: ENOSPC: System limit for number of file watchers reached, watch '/home/bjorn/Projects/Graphite/client/web/src/components/window/title-bar/WindowButtonsWindows.vue'
```

? (You need to scroll up to see it) This happened for me while the tsserver of vscode was running. When I forcefully killed it because it used too much cpu, this error got fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/270)
<!-- Reviewable:end -->
