### PR TITLE
Pass layer metadata to tools

### DIFF
--- a/core/editor/src/communication/dispatcher.rs
+++ b/core/editor/src/communication/dispatcher.rs
@@ -40,7 +40,7 @@ impl Dispatcher {
 			Global(message) => self.global_message_handler.process_action(message, (), &mut self.messages),
 			Tool(message) => self
 				.tool_message_handler
-				.process_action(message, (&self.document_message_handler.active_document().document, &self.input_preprocessor), &mut self.messages),
+				.process_action(message, (&self.document_message_handler.active_document(), &self.input_preprocessor), &mut self.messages),
 			Frontend(message) => self.frontend_message_handler.process_action(message, (), &mut self.messages),
 			InputPreprocessor(message) => self.input_preprocessor.process_action(message, (), &mut self.messages),
 			InputMapper(message) => {

--- a/core/editor/src/tool/mod.rs
+++ b/core/editor/src/tool/mod.rs
@@ -2,9 +2,9 @@ pub mod tool_message_handler;
 pub mod tool_settings;
 pub mod tools;
 
+use crate::document::Document;
 use crate::input::InputPreprocessor;
 use crate::message_prelude::*;
-use crate::SvgDocument;
 use crate::{
 	communication::{message::Message, MessageHandler},
 	Color,
@@ -25,12 +25,12 @@ pub mod tool_messages {
 	pub use super::tools::rectangle::{RectangleMessage, RectangleMessageDiscriminant};
 }
 
-pub type ToolActionHandlerData<'a> = (&'a SvgDocument, &'a DocumentToolData, &'a InputPreprocessor);
+pub type ToolActionHandlerData<'a> = (&'a Document, &'a DocumentToolData, &'a InputPreprocessor);
 
 pub trait Fsm {
 	type ToolData;
 
-	fn transition(self, message: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, messages: &mut VecDeque<Message>) -> Self;
+	fn transition(self, message: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, messages: &mut VecDeque<Message>) -> Self;
 }
 
 #[derive(Debug, Clone)]

--- a/core/editor/src/tool/tool_message_handler.rs
+++ b/core/editor/src/tool/tool_message_handler.rs
@@ -3,8 +3,8 @@ use document_core::color::Color;
 
 use crate::input::InputPreprocessor;
 use crate::{
+	document::Document,
 	tool::{ToolFsmState, ToolType},
-	SvgDocument,
 };
 use std::collections::VecDeque;
 
@@ -44,8 +44,8 @@ pub enum ToolMessage {
 pub struct ToolMessageHandler {
 	tool_state: ToolFsmState,
 }
-impl MessageHandler<ToolMessage, (&SvgDocument, &InputPreprocessor)> for ToolMessageHandler {
-	fn process_action(&mut self, message: ToolMessage, data: (&SvgDocument, &InputPreprocessor), responses: &mut VecDeque<Message>) {
+impl MessageHandler<ToolMessage, (&Document, &InputPreprocessor)> for ToolMessageHandler {
+	fn process_action(&mut self, message: ToolMessage, data: (&Document, &InputPreprocessor), responses: &mut VecDeque<Message>) {
 		let (document, input) = data;
 		use ToolMessage::*;
 		match message {

--- a/core/editor/src/tool/tools/ellipse.rs
+++ b/core/editor/src/tool/tools/ellipse.rs
@@ -1,6 +1,6 @@
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{message_prelude::*, SvgDocument};
+use crate::{document::Document, message_prelude::*};
 use document_core::{layers::style, Operation};
 use glam::{DAffine2, DVec2};
 
@@ -59,8 +59,8 @@ struct EllipseToolData {
 impl Fsm for EllipseToolFsmState {
 	type ToolData = EllipseToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		use EllipseMessage::*;
 		use EllipseToolFsmState::*;
 		if let ToolMessage::Ellipse(event) = event {

--- a/core/editor/src/tool/tools/fill.rs
+++ b/core/editor/src/tool/tools/fill.rs
@@ -29,7 +29,7 @@ impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Fill {
 			DVec2::new(point_1.x, point_2.y),
 		];
 
-		if let Some(path) = data.0.intersects_quad_root(quad).last() {
+		if let Some(path) = data.0.document.intersects_quad_root(quad).last() {
 			responses.push_back(
 				Operation::FillLayer {
 					path: path.to_vec(),

--- a/core/editor/src/tool/tools/line.rs
+++ b/core/editor/src/tool/tools/line.rs
@@ -1,6 +1,6 @@
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{message_prelude::*, SvgDocument};
+use crate::{document::Document, message_prelude::*};
 use document_core::{layers::style, Operation};
 use glam::{DAffine2, DVec2};
 
@@ -64,8 +64,8 @@ struct LineToolData {
 impl Fsm for LineToolFsmState {
 	type ToolData = LineToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		use LineMessage::*;
 		use LineToolFsmState::*;
 		if let ToolMessage::Line(event) = event {

--- a/core/editor/src/tool/tools/pen.rs
+++ b/core/editor/src/tool/tools/pen.rs
@@ -1,6 +1,6 @@
 use crate::input::InputPreprocessor;
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{message_prelude::*, SvgDocument};
+use crate::{document::Document, message_prelude::*};
 use document_core::{layers::style, Operation};
 use glam::DAffine2;
 
@@ -54,8 +54,8 @@ struct PenToolData {
 impl Fsm for PenToolFsmState {
 	type ToolData = PenToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		let pos = transform.inverse() * DAffine2::from_translation(input.mouse.position.to_dvec2());
 
 		use PenMessage::*;

--- a/core/editor/src/tool/tools/rectangle.rs
+++ b/core/editor/src/tool/tools/rectangle.rs
@@ -1,6 +1,6 @@
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{message_prelude::*, SvgDocument};
+use crate::{document::Document, message_prelude::*};
 use document_core::{layers::style, Operation};
 use glam::{DAffine2, DVec2};
 
@@ -58,8 +58,8 @@ struct RectangleToolData {
 impl Fsm for RectangleToolFsmState {
 	type ToolData = RectangleToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		use RectangleMessage::*;
 		use RectangleToolFsmState::*;
 		if let ToolMessage::Rectangle(event) = event {

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -7,7 +7,7 @@ use glam::{DAffine2, DVec2};
 
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{consts::SELECTION_TOLERANCE, message_prelude::*, SvgDocument};
+use crate::{consts::SELECTION_TOLERANCE, document::Document, message_prelude::*};
 
 #[derive(Default)]
 pub struct Select {
@@ -58,8 +58,8 @@ struct SelectToolData {
 impl Fsm for SelectToolFsmState {
 	type ToolData = SelectToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		use SelectMessage::*;
 		use SelectToolFsmState::*;
 		if let ToolMessage::Select(event) = event {
@@ -105,13 +105,13 @@ impl Fsm for SelectToolFsmState {
 
 					responses.push_back(Operation::DiscardWorkingFolder.into());
 					if data.drag_start == data.drag_current {
-						if let Some(intersection) = document.intersects_quad_root(quad).last() {
+						if let Some(intersection) = document.document.intersects_quad_root(quad).last() {
 							responses.push_back(DocumentMessage::SelectLayers(vec![intersection.clone()]).into());
 						} else {
 							responses.push_back(DocumentMessage::SelectLayers(vec![]).into());
 						}
 					} else {
-						responses.push_back(DocumentMessage::SelectLayers(document.intersects_quad_root(quad)).into());
+						responses.push_back(DocumentMessage::SelectLayers(document.document.intersects_quad_root(quad)).into());
 					}
 
 					Ready

--- a/core/editor/src/tool/tools/shape.rs
+++ b/core/editor/src/tool/tools/shape.rs
@@ -1,6 +1,6 @@
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{message_prelude::*, SvgDocument};
+use crate::{document::Document, message_prelude::*};
 use document_core::{layers::style, Operation};
 use glam::{DAffine2, DVec2};
 
@@ -60,8 +60,8 @@ struct ShapeToolData {
 impl Fsm for ShapeToolFsmState {
 	type ToolData = ShapeToolData;
 
-	fn transition(self, event: ToolMessage, document: &SvgDocument, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
-		let transform = document.root.transform;
+	fn transition(self, event: ToolMessage, document: &Document, tool_data: &DocumentToolData, data: &mut Self::ToolData, input: &InputPreprocessor, responses: &mut VecDeque<Message>) -> Self {
+		let transform = document.document.root.transform;
 		use ShapeMessage::*;
 		use ShapeToolFsmState::*;
 		if let ToolMessage::Shape(event) = event {


### PR DESCRIPTION
This passes the `active_document()` to the tools, as opposed to `active_document().document`. This gives tools access to the layer metadata, which will allow tool behavior to depend on state such as selections. This should greatly simplify #143.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/277)
<!-- Reviewable:end -->
