### PR TITLE
Implement tool messaging and shape flipping

### DIFF
--- a/client/web/src/components/widgets/buttons/IconButton.vue
+++ b/client/web/src/components/widgets/buttons/IconButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<button class="icon-button" :class="`size-${String(size)}`">
+	<button class="icon-button" :class="`size-${String(size)}`" @click="onClick">
 		<IconLabel :icon="icon" />
 	</button>
 </template>
@@ -60,6 +60,7 @@ export default defineComponent({
 		icon: { type: String, required: true },
 		size: { type: Number, required: true },
 		gapAfter: { type: Boolean, default: false },
+		onClick: Function,
 	},
 	components: { IconLabel },
 });

--- a/client/web/src/components/widgets/options/ToolOptions.vue
+++ b/client/web/src/components/widgets/options/ToolOptions.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="tool-options">
 		<template v-for="(option, index) in optionsMap.get(activeTool) || []" :key="index">
-			<IconButton v-if="option.kind === 'icon_button'" :icon="option.icon" :size="24" :title="option.title" />
+			<IconButton v-if="option.kind === 'icon_button'" :icon="option.icon" :size="24" :title="option.title" :onClick="() => sendToolMessage(option.message)" />
 			<Separator v-if="option.kind === 'separator'" :type="option.type" />
 			<PopoverButton v-if="option.kind === 'popover_button'">
 				<h3>{{ option.title }}</h3>
@@ -38,6 +38,7 @@ interface IconButtonOption {
 	kind: "icon_button";
 	icon: string;
 	title: string;
+	message?: string;
 }
 
 interface SeparatorOption {
@@ -74,6 +75,12 @@ export default defineComponent({
 			// This is a placeholder call, using the Shape tool as an example
 			set_tool_options(this.$props.activeTool || "", { Shape: { shape_type: { Polygon: { vertices: newValue } } } });
 		},
+		async sendToolMessage(message?: string) {
+			if (message) {
+				const { send_tool_message } = await wasm;
+				send_tool_message(this.$props.activeTool || "", message);
+			}
+		},
 	},
 	data() {
 		const optionsMap: ToolOptionsMap = new Map([
@@ -96,8 +103,8 @@ export default defineComponent({
 
 					{ kind: "separator", type: SeparatorType.Section },
 
-					{ kind: "icon_button", icon: "FlipHorizontal", title: "Flip Horizontal" },
-					{ kind: "icon_button", icon: "FlipVertical", title: "Flip Vertical" },
+					{ kind: "icon_button", icon: "FlipHorizontal", title: "Flip Horizontal", message: "FlipHorizontal" },
+					{ kind: "icon_button", icon: "FlipVertical", title: "Flip Vertical", message: "FlipVertical" },
 
 					{ kind: "separator", type: SeparatorType.Related },
 


### PR DESCRIPTION
Closes #199

- Added a WASM-bound `send_tool_message` function that takes a `ToolType` and a `&JsValue`
    - It (safely) attempts to deserialize the `JsValue` into a `ToolMessage` associated with the given `ToolType`
- Added an optional `onClick` prop to `IconButton`
- Added an optional `message` field to `IconButtonOption`
    - It dispatches `send_tool_message` with the active tool
- Added a `FlipLayer(path, flip_horizontal, flip_vertical)` to `DocumentMessage `
- Added `FlipHorizontal` and `FlipVertical` messages to `SelectMessage`
    - Adding to a tool's message enum is the chosen approach for tool messages
    - Handling messages in the `transition` function allows for state-dependent message handling
- Fixed typos and wording for `set_tool_options`

## Caveats
The basic scale-matrix implementation of flipping means that flips are with respect to the shape's origin (generally the initial point it's drawn from). This is arguably desired behavior, but users may expect the operations to depend on the shape's "center of mass" or something similar.

Any suggestions to clean up the following? I tried to use an or-pattern, but the borrow checker prevents us from subsequently checking the variant within the block.
```rust
(_, FlipHorizontal) => {
	let selected_layers = document.layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone()));
	for path in selected_layers {
		responses.push_back(DocumentMessage::FlipLayer(path, true, false).into());
	}

	self
}
(_, FlipVertical) => {
	let selected_layers = document.layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.clone()));
	for path in selected_layers {
		responses.push_back(DocumentMessage::FlipLayer(path, false, true).into());
	}

	self
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/288)
<!-- Reviewable:end -->
