### PR TITLE
Add alignment of selected layers

### DIFF
--- a/client/web/src/components/widgets/options/ToolOptions.vue
+++ b/client/web/src/components/widgets/options/ToolOptions.vue
@@ -87,15 +87,15 @@ export default defineComponent({
 			[
 				"Select",
 				[
-					{ kind: "IconButton", icon: "AlignLeft", title: "Align Left" },
-					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center" },
-					{ kind: "IconButton", icon: "AlignRight", title: "Align Right" },
+					{ kind: "IconButton", icon: "AlignLeft", title: "Align Left", message: "AlignLeft" },
+					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center", message: "AlignHorizontalCenter" },
+					{ kind: "IconButton", icon: "AlignRight", title: "Align Right", message: "AlignRight" },
 
 					{ kind: "Separator", type: SeparatorType.Unrelated },
 
-					{ kind: "IconButton", icon: "AlignTop", title: "Align Top" },
-					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center" },
-					{ kind: "IconButton", icon: "AlignBottom", title: "Align Bottom" },
+					{ kind: "IconButton", icon: "AlignTop", title: "Align Top", message: "AlignTop" },
+					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center", message: "AlignVerticalCenter" },
+					{ kind: "IconButton", icon: "AlignBottom", title: "Align Bottom", message: "AlignBottom" },
 
 					{ kind: "Separator", type: SeparatorType.Related },
 

--- a/client/web/src/components/widgets/options/ToolOptions.vue
+++ b/client/web/src/components/widgets/options/ToolOptions.vue
@@ -38,7 +38,7 @@ interface IconButtonOption {
 	kind: "IconButton";
 	icon: string;
 	title: string;
-	message?: string;
+	message?: string | object;
 }
 
 interface SeparatorOption {
@@ -87,15 +87,15 @@ export default defineComponent({
 			[
 				"Select",
 				[
-					{ kind: "IconButton", icon: "AlignLeft", title: "Align Left", message: "AlignLeft" },
-					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center", message: "AlignHorizontalCenter" },
-					{ kind: "IconButton", icon: "AlignRight", title: "Align Right", message: "AlignRight" },
+					{ kind: "IconButton", icon: "AlignLeft", title: "Align Left", message: { Align: ["X", "Min"] } },
+					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center", message: { Align: ["X", "Average"] } },
+					{ kind: "IconButton", icon: "AlignRight", title: "Align Right", message: { Align: ["X", "Max"] } },
 
 					{ kind: "Separator", type: SeparatorType.Unrelated },
 
-					{ kind: "IconButton", icon: "AlignTop", title: "Align Top", message: "AlignTop" },
-					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center", message: "AlignVerticalCenter" },
-					{ kind: "IconButton", icon: "AlignBottom", title: "Align Bottom", message: "AlignBottom" },
+					{ kind: "IconButton", icon: "AlignTop", title: "Align Top", message: { Align: ["Y", "Min"] } },
+					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center", message: { Align: ["Y", "Average"] } },
+					{ kind: "IconButton", icon: "AlignBottom", title: "Align Bottom", message: { Align: ["Y", "Max"] } },
 
 					{ kind: "Separator", type: SeparatorType.Related },
 

--- a/client/web/src/components/widgets/options/ToolOptions.vue
+++ b/client/web/src/components/widgets/options/ToolOptions.vue
@@ -88,13 +88,13 @@ export default defineComponent({
 				"Select",
 				[
 					{ kind: "IconButton", icon: "AlignLeft", title: "Align Left", message: { Align: ["X", "Min"] } },
-					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center", message: { Align: ["X", "Average"] } },
+					{ kind: "IconButton", icon: "AlignHorizontalCenter", title: "Align Horizontal Center", message: { Align: ["X", "Center"] } },
 					{ kind: "IconButton", icon: "AlignRight", title: "Align Right", message: { Align: ["X", "Max"] } },
 
 					{ kind: "Separator", type: SeparatorType.Unrelated },
 
 					{ kind: "IconButton", icon: "AlignTop", title: "Align Top", message: { Align: ["Y", "Min"] } },
-					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center", message: { Align: ["Y", "Average"] } },
+					{ kind: "IconButton", icon: "AlignVerticalCenter", title: "Align Vertical Center", message: { Align: ["Y", "Center"] } },
 					{ kind: "IconButton", icon: "AlignBottom", title: "Align Bottom", message: { Align: ["Y", "Max"] } },
 
 					{ kind: "Separator", type: SeparatorType.Related },

--- a/core/document/src/document.rs
+++ b/core/document/src/document.rs
@@ -416,7 +416,7 @@ impl Document {
 
 				let path = path.as_slice()[..path.len() - 1].to_vec();
 
-				Some(vec![DocumentResponse::DocumentChanged, DocumentResponse::FolderChanged { path: path.clone() }])
+				Some(vec![DocumentResponse::DocumentChanged, DocumentResponse::FolderChanged { path }])
 			}
 			Operation::FillLayer { path, color } => {
 				let layer = self.layer_mut(path).unwrap();

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -2,13 +2,13 @@ use crate::message_prelude::*;
 use crate::{
 	consts::{MOUSE_ZOOM_RATE, VIEWPORT_SCROLL_RATE, VIEWPORT_ZOOM_SCALE_MAX, VIEWPORT_ZOOM_SCALE_MIN, WHEEL_ZOOM_RATE},
 	input::{mouse::ViewportPosition, InputPreprocessor},
-	tool::tools::select::{AlignAggregate, AlignAxis},
 };
 use document_core::layers::BlendMode;
 use document_core::layers::Layer;
 use document_core::{DocumentResponse, LayerId, Operation as DocumentOperation};
 use glam::{DAffine2, DVec2};
 use log::warn;
+use serde::{Deserialize, Serialize};
 
 use crate::document::Document;
 use std::collections::VecDeque;
@@ -63,6 +63,20 @@ pub enum DocumentMessage {
 	MoveSelectedLayersTo { path: Vec<LayerId>, insert_index: isize },
 	ReorderSelectedLayers(i32), // relatve_position,
 	SetLayerTranslation(Vec<LayerId>, Option<f64>, Option<f64>),
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum AlignAxis {
+	X,
+	Y,
+}
+
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum AlignAggregate {
+	Min,
+	Max,
+	Center,
+	Average,
 }
 
 impl From<DocumentOperation> for DocumentMessage {

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -60,6 +60,7 @@ pub enum DocumentMessage {
 	DragLayer(Vec<LayerId>, DVec2),
 	MoveSelectedLayersTo { path: Vec<LayerId>, insert_index: isize },
 	ReorderSelectedLayers(i32), // relatve_position,
+	SetLayerCoordinates(Vec<LayerId>, Option<f64>, Option<f64>),
 }
 
 impl From<DocumentOperation> for DocumentMessage {
@@ -660,6 +661,24 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 						transform.to_cols_array()
 					};
 					responses.push_back(DocumentOperation::SetLayerTransform { path, transform }.into());
+				}
+			}
+			SetLayerCoordinates(path, x_option, y_option) => {
+				if let Ok(layer) = self.active_document_mut().document.layer_mut(&path) {
+					let mut transform = layer.transform;
+					if let Some(x) = x_option {
+						transform.translation.x = x;
+					}
+					if let Some(y) = y_option {
+						transform.translation.y = y;
+					}
+					responses.push_back(
+						DocumentOperation::SetLayerTransform {
+							path,
+							transform: transform.to_cols_array(),
+						}
+						.into(),
+					);
 				}
 			}
 			message => todo!("document_action_handler does not implement: {}", message.to_discriminant().global_name()),

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -642,6 +642,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 				}
 			}
 			AlignSelectedLayers(axis, aggregate) => {
+				// TODO: Handle folder nested transforms with the transforms API
 				let selected_paths = self.selected_layers_sorted();
 				if selected_paths.len() == 0 {
 					return;

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -671,6 +671,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 					AlignAggregate::Min => bounding_box_coords.reduce(|a, b| a.min(b)).unwrap(),
 					AlignAggregate::Max => bounding_box_coords.reduce(|a, b| a.max(b)).unwrap(),
 					AlignAggregate::Center => {
+						// TODO: Refactor with `reduce` and `merge_bounding_boxes` once the latter is added
 						let bounding_boxes = selected_paths.iter().map(|path| {
 							let layer = self.active_document().document.layer(path).unwrap();
 							layer.bounding_box(layer.transform, layer.style).unwrap()

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -658,14 +658,14 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 			AlignSelectedLayers(axis, aggregate) => {
 				// TODO: Handle folder nested transforms with the transforms API
 				let selected_paths = self.selected_layers_sorted();
-				if selected_paths.len() == 0 {
+				if selected_paths.is_empty() {
 					return;
 				}
 
 				let selected_layers = selected_paths.iter().map(|path| {
 					let layer = self.active_document().document.layer(path).unwrap();
 					let point = {
-						let bounding_box = layer.bounding_box(layer.transform, layer.style).unwrap();
+						let bounding_box = layer.bounding_box(layer.transform, layer.style).unwrap_or_default();
 						match aggregate {
 							AlignAggregate::Min => bounding_box[0],
 							AlignAggregate::Max => bounding_box[1],
@@ -735,12 +735,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 			SetLayerTranslation(path, x_option, y_option) => {
 				if let Ok(layer) = self.active_document_mut().document.layer_mut(&path) {
 					let mut transform = layer.transform;
-					if let Some(x) = x_option {
-						transform.translation.x = x;
-					}
-					if let Some(y) = y_option {
-						transform.translation.y = y;
-					}
+					transform.translation = DVec2::new(x_option.unwrap_or(transform.translation.x), y_option.unwrap_or(transform.translation.y));
 					responses.push_back(
 						DocumentOperation::SetLayerTransform {
 							path,

--- a/core/editor/src/document/document_message_handler.rs
+++ b/core/editor/src/document/document_message_handler.rs
@@ -662,10 +662,10 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 					return;
 				}
 
-				let selected_layers = selected_paths.iter().map(|path| {
+				let selected_layers = selected_paths.iter().filter_map(|path| {
 					let layer = self.active_document().document.layer(path).unwrap();
 					let point = {
-						let bounding_box = layer.bounding_box(layer.transform, layer.style).unwrap_or_default();
+						let bounding_box = layer.bounding_box(layer.transform, layer.style)?;
 						match aggregate {
 							AlignAggregate::Min => bounding_box[0],
 							AlignAggregate::Max => bounding_box[1],
@@ -677,7 +677,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 						AlignAxis::X => (point.x, layer.transform.translation.x),
 						AlignAxis::Y => (point.y, layer.transform.translation.y),
 					};
-					(path.clone(), bounding_box_coord, translation_coord)
+					Some((path.clone(), bounding_box_coord, translation_coord))
 				});
 
 				let bounding_box_coords = selected_layers.clone().map(|(_, bounding_box_coord, _)| bounding_box_coord);
@@ -686,9 +686,9 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 					AlignAggregate::Max => bounding_box_coords.reduce(|a, b| a.max(b)).unwrap(),
 					AlignAggregate::Center => {
 						// TODO: Refactor with `reduce` and `merge_bounding_boxes` once the latter is added
-						let bounding_boxes = selected_paths.iter().map(|path| {
+						let bounding_boxes = selected_paths.iter().filter_map(|path| {
 							let layer = self.active_document().document.layer(path).unwrap();
-							layer.bounding_box(layer.transform, layer.style).unwrap()
+							layer.bounding_box(layer.transform, layer.style)
 						});
 						let min = bounding_boxes
 							.clone()

--- a/core/editor/src/document/mod.rs
+++ b/core/editor/src/document/mod.rs
@@ -5,4 +5,4 @@ mod document_message_handler;
 pub use document_file::{Document, LayerData};
 
 #[doc(inline)]
-pub use document_message_handler::{DocumentMessage, DocumentMessageDiscriminant, DocumentMessageHandler};
+pub use document_message_handler::{AlignAggregate, AlignAxis, DocumentMessage, DocumentMessageDiscriminant, DocumentMessageHandler};

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -39,6 +39,7 @@ pub enum AlignAxis {
 pub enum AlignAggregate {
 	Min,
 	Max,
+	Center,
 	Average,
 }
 

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -24,12 +24,7 @@ pub enum SelectMessage {
 	MouseMove,
 	Abort,
 
-	AlignLeft,
-	AlignHorizontalCenter,
-	AlignRight,
-	AlignTop,
-	AlignVerticalCenter,
-	AlignBottom,
+	Align(AlignDimension, AlignAggregate),
 	FlipHorizontal,
 	FlipVertical,
 }
@@ -181,33 +176,8 @@ impl Fsm for SelectToolFsmState {
 
 					Ready
 				}
-				(_, AlignLeft) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::X, AlignAggregate::Min).into());
-
-					self
-				}
-				(_, AlignHorizontalCenter) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::X, AlignAggregate::Average).into());
-
-					self
-				}
-				(_, AlignRight) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::X, AlignAggregate::Max).into());
-
-					self
-				}
-				(_, AlignTop) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::Y, AlignAggregate::Min).into());
-
-					self
-				}
-				(_, AlignVerticalCenter) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::Y, AlignAggregate::Average).into());
-
-					self
-				}
-				(_, AlignBottom) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(AlignDimension::Y, AlignAggregate::Max).into());
+				(_, Align(dimension, aggregate)) => {
+					responses.push_back(DocumentMessage::AlignSelectedLayers(dimension, aggregate).into());
 
 					self
 				}

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -8,7 +8,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
 use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
-use crate::{consts::SELECTION_TOLERANCE, document::Document, message_prelude::*};
+use crate::{
+	consts::SELECTION_TOLERANCE,
+	document::{AlignAggregate, AlignAxis, Document},
+	message_prelude::*,
+};
 
 #[derive(Default)]
 pub struct Select {
@@ -27,20 +31,6 @@ pub enum SelectMessage {
 	Align(AlignAxis, AlignAggregate),
 	FlipHorizontal,
 	FlipVertical,
-}
-
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum AlignAxis {
-	X,
-	Y,
-}
-
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum AlignAggregate {
-	Min,
-	Max,
-	Center,
-	Average,
 }
 
 impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Select {

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -125,7 +125,7 @@ impl Fsm for SelectToolFsmState {
 						responses.push_back(make_operation(data, tool_data, transform));
 					} else {
 						for (path, offset) in &data.layers_dragging {
-							responses.push_back(DocumentMessage::DragLayer(path.clone(), offset.clone()).into());
+							responses.push_back(DocumentMessage::DragLayer(path.clone(), *offset).into());
 						}
 					}
 

--- a/core/editor/src/tool/tools/select.rs
+++ b/core/editor/src/tool/tools/select.rs
@@ -24,13 +24,13 @@ pub enum SelectMessage {
 	MouseMove,
 	Abort,
 
-	Align(AlignDimension, AlignAggregate),
+	Align(AlignAxis, AlignAggregate),
 	FlipHorizontal,
 	FlipVertical,
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum AlignDimension {
+pub enum AlignAxis {
 	X,
 	Y,
 }
@@ -176,8 +176,8 @@ impl Fsm for SelectToolFsmState {
 
 					Ready
 				}
-				(_, Align(dimension, aggregate)) => {
-					responses.push_back(DocumentMessage::AlignSelectedLayers(dimension, aggregate).into());
+				(_, Align(axis, aggregate)) => {
+					responses.push_back(DocumentMessage::AlignSelectedLayers(axis, aggregate).into());
 
 					self
 				}


### PR DESCRIPTION
Closes #198

- Added messages to alignment icon buttons within select tool
- Added a document message `SetLayerCoordinates` that takes a path and two `Option<f64>`
    - It translates the path by a given x (if `Some`) and y (if `Some`) offset
- Added and handled alignment messages to `SelectMessage`
- Added `align_selected` helper to `select.rs`
    - Accepts two new enums, `AlignDimension` and `AlignAggregate`
    - Aggregates a particular coordinate of the selected layers with min, max, or average
    - Uses `SetLayerCoordinates` to update all the selected layers, offsetting them to account for when bounding box point != origin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/296)
<!-- Reviewable:end -->
