### PR TITLE
MVP eyedropper tool for fill colors

### DIFF
--- a/client/web/src/components/panels/Document.vue
+++ b/client/web/src/components/panels/Document.vue
@@ -65,7 +65,7 @@
 					<ShelfItemInput :icon="'LayoutSelectTool'" title="Select Tool (V)" :active="activeTool === 'Select'" @click="selectTool('Select')" />
 					<ShelfItemInput :icon="'LayoutCropTool'" title="Crop Tool" :active="activeTool === 'Crop'" @click="'tool not implemented' || selectTool('Crop')" />
 					<ShelfItemInput :icon="'LayoutNavigateTool'" title="Navigate Tool (Z)" :active="activeTool === 'Navigate'" @click="'tool not implemented' || selectTool('Navigate')" />
-					<ShelfItemInput :icon="'LayoutEyedropperTool'" title="Eyedropper Tool (I)" :active="activeTool === 'Eyedropper'" @click="'tool not implemented' || selectTool('Eyedropper')" />
+					<ShelfItemInput :icon="'LayoutEyedropperTool'" title="Eyedropper Tool (I)" :active="activeTool === 'Eyedropper'" @click="selectTool('Eyedropper')" />
 
 					<Separator :type="SeparatorType.Section" :direction="SeparatorDirection.Vertical" />
 

--- a/core/document/src/layers/style/mod.rs
+++ b/core/document/src/layers/style/mod.rs
@@ -19,6 +19,9 @@ impl Fill {
 	pub fn new(color: Color) -> Self {
 		Self { color: Some(color) }
 	}
+	pub fn color(&self) -> Option<Color> {
+		self.color
+	}
 	pub fn none() -> Self {
 		Self { color: None }
 	}
@@ -40,6 +43,12 @@ pub struct Stroke {
 impl Stroke {
 	pub fn new(color: Color, width: f32) -> Self {
 		Self { color, width }
+	}
+	pub fn color(&self) -> Color {
+		self.color
+	}
+	pub fn width(&self) -> f32 {
+		self.width
 	}
 	pub fn render(&self) -> String {
 		format!(r##" stroke="#{}"{} stroke-width="{}""##, self.color.rgb_hex(), format_opacity("stroke", self.color.a()), self.width)

--- a/core/editor/src/input/input_mapper.rs
+++ b/core/editor/src/input/input_mapper.rs
@@ -183,6 +183,7 @@ impl Default for Mapping {
 			entry! {action=ToolMessage::SelectTool(ToolType::Line), key_down=KeyL},
 			entry! {action=ToolMessage::SelectTool(ToolType::Pen), key_down=KeyP},
 			entry! {action=ToolMessage::SelectTool(ToolType::Shape), key_down=KeyY},
+			entry! {action=ToolMessage::SelectTool(ToolType::Eyedropper), key_down=KeyI},
 			entry! {action=ToolMessage::ResetColors, key_down=KeyX, modifiers=[KeyShift, KeyControl]},
 			entry! {action=ToolMessage::SwapColors, key_down=KeyX, modifiers=[KeyShift]},
 			// Document Actions

--- a/core/editor/src/input/input_mapper.rs
+++ b/core/editor/src/input/input_mapper.rs
@@ -122,6 +122,8 @@ impl Default for Mapping {
 			entry! {action=SelectMessage::DragStop, key_up=Lmb},
 			entry! {action=SelectMessage::Abort, key_down=Rmb},
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
+			// Eyedropper
+			entry! {action=EyedropperMessage::MouseDown, key_down=Lmb},
 			// Rectangle
 			entry! {action=RectangleMessage::Center, key_down=KeyAlt},
 			entry! {action=RectangleMessage::UnCenter, key_up=KeyAlt},

--- a/core/editor/src/input/input_mapper.rs
+++ b/core/editor/src/input/input_mapper.rs
@@ -123,7 +123,8 @@ impl Default for Mapping {
 			entry! {action=SelectMessage::Abort, key_down=Rmb},
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
 			// Eyedropper
-			entry! {action=EyedropperMessage::MouseDown, key_down=Lmb},
+			entry! {action=EyedropperMessage::LeftMouseDown, key_down=Lmb},
+			entry! {action=EyedropperMessage::RightMouseDown, key_down=Rmb},
 			// Rectangle
 			entry! {action=RectangleMessage::Center, key_down=KeyAlt},
 			entry! {action=RectangleMessage::UnCenter, key_up=KeyAlt},

--- a/core/editor/src/tool/tools/eyedropper.rs
+++ b/core/editor/src/tool/tools/eyedropper.rs
@@ -1,5 +1,8 @@
+use crate::consts::SELECTION_TOLERANCE;
+use crate::frontend::FrontendMessage;
 use crate::message_prelude::*;
-use crate::tool::ToolActionHandlerData;
+use crate::tool::{ToolActionHandlerData, ToolMessage};
+use glam::DVec2;
 
 #[derive(Default)]
 pub struct Eyedropper;
@@ -7,12 +10,40 @@ pub struct Eyedropper;
 #[impl_message(Message, ToolMessage, Eyedropper)]
 #[derive(PartialEq, Clone, Debug)]
 pub enum EyedropperMessage {
-	MouseMove,
+	MouseDown,
 }
 
 impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Eyedropper {
-	fn process_action(&mut self, action: ToolMessage, data: ToolActionHandlerData<'a>, responses: &mut VecDeque<Message>) {
-		todo!("{}::handle_input {:?} {:?} {:?} ", module_path!(), action, data, responses);
+	fn process_action(&mut self, _action: ToolMessage, data: ToolActionHandlerData<'a>, responses: &mut VecDeque<Message>) {
+		let mouse_pos = data.2.mouse.position;
+		let (x, y) = (mouse_pos.x as f64, mouse_pos.y as f64);
+		let (point_1, point_2) = (
+			DVec2::new(x - SELECTION_TOLERANCE, y - SELECTION_TOLERANCE),
+			DVec2::new(x + SELECTION_TOLERANCE, y + SELECTION_TOLERANCE),
+		);
+
+		let quad = [
+			DVec2::new(point_1.x, point_1.y),
+			DVec2::new(point_2.x, point_1.y),
+			DVec2::new(point_2.x, point_2.y),
+			DVec2::new(point_1.x, point_2.y),
+		];
+
+		if let Some(path) = data.0.document.intersects_quad_root(quad).last() {
+			if let Ok(layer) = data.0.document.layer(path) {
+				if let Some(fill) = layer.style.fill() {
+					if let Some(color) = fill.color() {
+						responses.push_back(
+							FrontendMessage::UpdateWorkingColors {
+								primary: color,
+								secondary: data.1.secondary_color,
+							}
+							.into(),
+						);
+					}
+				}
+			}
+		}
 	}
-	advertise_actions!();
+	advertise_actions!(EyedropperMessageDiscriminant; MouseDown);
 }


### PR DESCRIPTION
Closes #303.

This was marked for Sprint 7, but I realized this MVP would be a quick and useful addition.

- Enabled eyedropper tool on the tool shelf
- Added getters to `Fill` and `Stroke`
- Added `Lmb => MouseDown` input mapping for the eyedropper tool
- Implemented an MVP for the eyedropper tool
    - Just checks for the layer fill of the topmost layer intersecting the click
    - Updates the primary color

Caveat: The color update is implemented using `FrontendMessage::UpdateWorkingColors` as opposed to `SelectPrimaryColor`. That is because using the former doesn't update colors on the frontend. Adding `UpdateWorkingColors` to the handler for `SelectPrimaryColor` causes an unresponsive infinite-loop on the frontend. This is because `SwatchPairInput` registers a response handler for `ResponseType.UpdateWorkingColors` **but also** `watch`es `primaryColor` and `secondaryColor`, mapping changes to `SwatchPairInput.update{Primary | Secondary}Color`. Those two functions each the respective WASM functions, which in turn dispatch the color selection messages, causing an infinite loop.

In the future, I think this infinite loop should be avoided by removing the `watch`es and instead add callbacks to `ColorPicker`. We should only be dispatching the `Select...Color` messages when the frontend (i.e. the user) updates the colors. In fact, as it currently is, the response handler for `UpdateWorkingColors` always dispatches redundant calls to `SelectPrimaryColor` and `SelectSecondaryColor`.

I could implement that fix, but I think we should leave it for another PR to work out details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/300)
<!-- Reviewable:end -->
