### PR TITLE
Ignore mouse events without any button state changes

### DIFF
--- a/editor/src/input/mouse.rs
+++ b/editor/src/input/mouse.rs
@@ -58,5 +58,6 @@ bitflags! {
 		const LEFT   = 0b0000_0001;
 		const RIGHT  = 0b0000_0010;
 		const MIDDLE = 0b0000_0100;
+		const NONE   = 0b0000_0000;
 	}
 }


### PR DESCRIPTION
Fixes #291

- `translate_mouse_event` returns an option, returning `None` when no mouse button state changes
- Only generate mouse press/released messages when `translate_mouse_event` returns `Some(...)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/343)
<!-- Reviewable:end -->
