### PR TITLE
Add a stroke width option to the Line Tool

### DIFF
--- a/editor/src/tool/tool_options.rs
+++ b/editor/src/tool/tool_options.rs
@@ -6,6 +6,7 @@ pub enum ToolOptions {
 	Ellipse,
 	Shape { shape_type: ShapeType },
 	Line { stroke_width: u32 },
+	Pen { stroke_width: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/editor/src/tool/tool_options.rs
+++ b/editor/src/tool/tool_options.rs
@@ -5,8 +5,8 @@ pub enum ToolOptions {
 	Select { append_mode: SelectAppendMode },
 	Ellipse,
 	Shape { shape_type: ShapeType },
-	Line { stroke_width: u32 },
-	Pen { stroke_width: u32 },
+	Line { stroke_weight: u32 },
+	Pen { stroke_weight: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/editor/src/tool/tool_options.rs
+++ b/editor/src/tool/tool_options.rs
@@ -5,8 +5,8 @@ pub enum ToolOptions {
 	Select { append_mode: SelectAppendMode },
 	Ellipse,
 	Shape { shape_type: ShapeType },
-	Line { stroke_weight: u32 },
-	Pen { stroke_weight: u32 },
+	Line { weight: u32 },
+	Pen { weight: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/editor/src/tool/tool_options.rs
+++ b/editor/src/tool/tool_options.rs
@@ -5,6 +5,7 @@ pub enum ToolOptions {
 	Select { append_mode: SelectAppendMode },
 	Ellipse,
 	Shape { shape_type: ShapeType },
+	Line { stroke_width: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/editor/src/tool/tools/line.rs
+++ b/editor/src/tool/tools/line.rs
@@ -1,7 +1,7 @@
 use crate::consts::LINE_ROTATE_SNAP_ANGLE;
 use crate::input::keyboard::Key;
 use crate::input::{mouse::ViewportPosition, InputPreprocessor};
-use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
+use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData, ToolOptions, ToolType};
 use crate::{document::DocumentMessageHandler, message_prelude::*};
 use glam::{DAffine2, DVec2};
 use graphene::{layers::style, Operation};
@@ -50,6 +50,7 @@ struct LineToolData {
 	drag_start: ViewportPosition,
 	drag_current: ViewportPosition,
 	angle: f64,
+	stroke_width: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -75,12 +76,17 @@ impl Fsm for LineToolFsmState {
 					data.path = Some(vec![generate_uuid()]);
 					responses.push_back(DocumentMessage::DeselectAllLayers.into());
 
+					data.stroke_width = match tool_data.tool_options.get(&ToolType::Line) {
+						Some(&ToolOptions::Line { stroke_width }) => stroke_width,
+						_ => 5,
+					};
+
 					responses.push_back(
 						Operation::AddLine {
 							path: data.path.clone().unwrap(),
 							insert_index: -1,
 							transform: DAffine2::ZERO.to_cols_array(),
-							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, 5.)), None),
+							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_width as f32)), None),
 						}
 						.into(),
 					);

--- a/editor/src/tool/tools/line.rs
+++ b/editor/src/tool/tools/line.rs
@@ -50,7 +50,7 @@ struct LineToolData {
 	drag_start: ViewportPosition,
 	drag_current: ViewportPosition,
 	angle: f64,
-	stroke_width: u32,
+	stroke_weight: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -76,8 +76,8 @@ impl Fsm for LineToolFsmState {
 					data.path = Some(vec![generate_uuid()]);
 					responses.push_back(DocumentMessage::DeselectAllLayers.into());
 
-					data.stroke_width = match tool_data.tool_options.get(&ToolType::Line) {
-						Some(&ToolOptions::Line { stroke_width }) => stroke_width,
+					data.stroke_weight = match tool_data.tool_options.get(&ToolType::Line) {
+						Some(&ToolOptions::Line { stroke_weight }) => stroke_weight,
 						_ => 5,
 					};
 
@@ -86,7 +86,7 @@ impl Fsm for LineToolFsmState {
 							path: data.path.clone().unwrap(),
 							insert_index: -1,
 							transform: DAffine2::ZERO.to_cols_array(),
-							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_width as f32)), None),
+							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_weight as f32)), None),
 						}
 						.into(),
 					);

--- a/editor/src/tool/tools/line.rs
+++ b/editor/src/tool/tools/line.rs
@@ -50,7 +50,7 @@ struct LineToolData {
 	drag_start: ViewportPosition,
 	drag_current: ViewportPosition,
 	angle: f64,
-	stroke_weight: u32,
+	weight: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -76,8 +76,8 @@ impl Fsm for LineToolFsmState {
 					data.path = Some(vec![generate_uuid()]);
 					responses.push_back(DocumentMessage::DeselectAllLayers.into());
 
-					data.stroke_weight = match tool_data.tool_options.get(&ToolType::Line) {
-						Some(&ToolOptions::Line { stroke_weight }) => stroke_weight,
+					data.weight = match tool_data.tool_options.get(&ToolType::Line) {
+						Some(&ToolOptions::Line { weight }) => weight,
 						_ => 5,
 					};
 
@@ -86,7 +86,7 @@ impl Fsm for LineToolFsmState {
 							path: data.path.clone().unwrap(),
 							insert_index: -1,
 							transform: DAffine2::ZERO.to_cols_array(),
-							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_weight as f32)), None),
+							style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.weight as f32)), None),
 						}
 						.into(),
 					);

--- a/editor/src/tool/tools/pen.rs
+++ b/editor/src/tool/tools/pen.rs
@@ -49,7 +49,7 @@ impl Default for PenToolFsmState {
 struct PenToolData {
 	points: Vec<DAffine2>,
 	next_point: DAffine2,
-	stroke_width: u32,
+	stroke_weight: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -80,8 +80,8 @@ impl Fsm for PenToolFsmState {
 					data.points.push(pos);
 					data.next_point = pos;
 
-					data.stroke_width = match tool_data.tool_options.get(&ToolType::Pen) {
-						Some(&ToolOptions::Pen { stroke_width }) => stroke_width,
+					data.stroke_weight = match tool_data.tool_options.get(&ToolType::Pen) {
+						Some(&ToolOptions::Pen { stroke_weight }) => stroke_weight,
 						_ => 5,
 					};
 
@@ -146,7 +146,7 @@ fn make_operation(data: &PenToolData, tool_data: &DocumentToolData, show_preview
 			insert_index: -1,
 			transform: DAffine2::IDENTITY.to_cols_array(),
 			points,
-			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_width as f32)), Some(style::Fill::none())),
+			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_weight as f32)), Some(style::Fill::none())),
 		}
 		.into(),
 	]

--- a/editor/src/tool/tools/pen.rs
+++ b/editor/src/tool/tools/pen.rs
@@ -1,5 +1,5 @@
 use crate::input::InputPreprocessor;
-use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
+use crate::tool::{DocumentToolData, Fsm, ToolActionHandlerData, ToolOptions, ToolType};
 use crate::{document::DocumentMessageHandler, message_prelude::*};
 use glam::DAffine2;
 use graphene::{layers::style, Operation};
@@ -49,6 +49,7 @@ impl Default for PenToolFsmState {
 struct PenToolData {
 	points: Vec<DAffine2>,
 	next_point: DAffine2,
+	stroke_width: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -78,6 +79,11 @@ impl Fsm for PenToolFsmState {
 
 					data.points.push(pos);
 					data.next_point = pos;
+
+					data.stroke_width = match tool_data.tool_options.get(&ToolType::Pen) {
+						Some(&ToolOptions::Pen { stroke_width }) => stroke_width,
+						_ => 5,
+					};
 
 					Dragging
 				}
@@ -140,7 +146,7 @@ fn make_operation(data: &PenToolData, tool_data: &DocumentToolData, show_preview
 			insert_index: -1,
 			transform: DAffine2::IDENTITY.to_cols_array(),
 			points,
-			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, 5.)), Some(style::Fill::none())),
+			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_width as f32)), Some(style::Fill::none())),
 		}
 		.into(),
 	]

--- a/editor/src/tool/tools/pen.rs
+++ b/editor/src/tool/tools/pen.rs
@@ -49,7 +49,7 @@ impl Default for PenToolFsmState {
 struct PenToolData {
 	points: Vec<DAffine2>,
 	next_point: DAffine2,
-	stroke_weight: u32,
+	weight: u32,
 	path: Option<Vec<LayerId>>,
 }
 
@@ -80,8 +80,8 @@ impl Fsm for PenToolFsmState {
 					data.points.push(pos);
 					data.next_point = pos;
 
-					data.stroke_weight = match tool_data.tool_options.get(&ToolType::Pen) {
-						Some(&ToolOptions::Pen { stroke_weight }) => stroke_weight,
+					data.weight = match tool_data.tool_options.get(&ToolType::Pen) {
+						Some(&ToolOptions::Pen { weight }) => weight,
 						_ => 5,
 					};
 
@@ -146,7 +146,7 @@ fn make_operation(data: &PenToolData, tool_data: &DocumentToolData, show_preview
 			insert_index: -1,
 			transform: DAffine2::IDENTITY.to_cols_array(),
 			points,
-			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.stroke_weight as f32)), Some(style::Fill::none())),
+			style: style::PathStyle::new(Some(style::Stroke::new(tool_data.primary_color, data.weight as f32)), Some(style::Fill::none())),
 		}
 		.into(),
 	]

--- a/frontend/src/components/widgets/inputs/NumberInput.vue
+++ b/frontend/src/components/widgets/inputs/NumberInput.vue
@@ -19,7 +19,7 @@
 
 <style lang="scss">
 .number-input {
-	width: 80px;
+	min-width: 80px;
 	height: 24px;
 	position: relative;
 	border-radius: 2px;
@@ -38,7 +38,7 @@
 
 	input {
 		flex: 1 1 100%;
-		width: 100%;
+		width: 30px;
 		height: 18px;
 		line-height: 18px;
 		margin: 0 8px;

--- a/frontend/src/components/widgets/inputs/NumberInput.vue
+++ b/frontend/src/components/widgets/inputs/NumberInput.vue
@@ -38,7 +38,8 @@
 
 	input {
 		flex: 1 1 100%;
-		width: 30px;
+		width: 0;
+		min-width: 30px;
 		height: 18px;
 		line-height: 18px;
 		margin: 0 8px;

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -52,11 +52,11 @@ export default defineComponent({
 		},
 		async setLineOptions(newValue: number) {
 			// eslint-disable-next-line camelcase
-			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { stroke_weight: newValue } });
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { weight: newValue } });
 		},
 		async setPenOptions(newValue: number) {
 			// eslint-disable-next-line camelcase
-			(await wasm).set_tool_options(this.$props.activeTool || "", { Pen: { stroke_weight: newValue } });
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Pen: { weight: newValue } });
 		},
 		async sendToolMessage(message: string | object) {
 			(await wasm).send_tool_message(this.$props.activeTool || "", message);
@@ -135,8 +135,8 @@ export default defineComponent({
 				},
 			],
 			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
-			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Stroke Weight" } }],
-			Pen: [{ kind: "NumberInput", callback: this.setPenOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Stroke Weight" } }],
+			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Weight" } }],
+			Pen: [{ kind: "NumberInput", callback: this.setPenOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Weight" } }],
 		};
 
 		return {

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -52,11 +52,11 @@ export default defineComponent({
 		},
 		async setLineOptions(newValue: number) {
 			// eslint-disable-next-line camelcase
-			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { stroke_width: newValue } });
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { stroke_weight: newValue } });
 		},
 		async setPenOptions(newValue: number) {
 			// eslint-disable-next-line camelcase
-			(await wasm).set_tool_options(this.$props.activeTool || "", { Pen: { stroke_width: newValue } });
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Pen: { stroke_weight: newValue } });
 		},
 		async sendToolMessage(message: string | object) {
 			(await wasm).send_tool_message(this.$props.activeTool || "", message);
@@ -135,8 +135,8 @@ export default defineComponent({
 				},
 			],
 			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
-			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: "px", label: "Stroke Width" } }],
-			Pen: [{ kind: "NumberInput", callback: this.setPenOptions, props: { value: 5, min: 1, isInteger: true, unit: "px", label: "Stroke Width" } }],
+			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Stroke Weight" } }],
+			Pen: [{ kind: "NumberInput", callback: this.setPenOptions, props: { value: 5, min: 1, isInteger: true, unit: " px", label: "Stroke Weight" } }],
 		};
 
 		return {

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -54,6 +54,10 @@ export default defineComponent({
 			// eslint-disable-next-line camelcase
 			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { stroke_width: newValue } });
 		},
+		async setPenOptions(newValue: number) {
+			// eslint-disable-next-line camelcase
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Pen: { stroke_width: newValue } });
+		},
 		async sendToolMessage(message: string | object) {
 			(await wasm).send_tool_message(this.$props.activeTool || "", message);
 		},
@@ -132,6 +136,7 @@ export default defineComponent({
 			],
 			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
 			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: "px", label: "Stroke Width" } }],
+			Pen: [{ kind: "NumberInput", callback: this.setPenOptions, props: { value: 5, min: 1, isInteger: true, unit: "px", label: "Stroke Width" } }],
 		};
 
 		return {

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -41,7 +41,7 @@ export default defineComponent({
 	},
 	computed: {},
 	methods: {
-		async setToolOptions(newValue: number) {
+		async setShapeOptions(newValue: number) {
 			// TODO: Each value-input widget (i.e. not a button) should map to a field in an options struct,
 			// and updating a widget should send the whole updated struct to the backend.
 			// Later, it could send a single-field update to the backend.
@@ -49,6 +49,10 @@ export default defineComponent({
 			// This is a placeholder call, using the Shape tool as an example
 			// eslint-disable-next-line camelcase
 			(await wasm).set_tool_options(this.$props.activeTool || "", { Shape: { shape_type: { Polygon: { vertices: newValue } } } });
+		},
+		async setLineOptions(newValue: number) {
+			// eslint-disable-next-line camelcase
+			(await wasm).set_tool_options(this.$props.activeTool || "", { Line: { stroke_width: newValue } });
 		},
 		async sendToolMessage(message: string | object) {
 			(await wasm).send_tool_message(this.$props.activeTool || "", message);
@@ -126,7 +130,8 @@ export default defineComponent({
 					props: {},
 				},
 			],
-			Shape: [{ kind: "NumberInput", callback: this.setToolOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
+			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
+			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, label: "Stroke width" } }],
 		};
 
 		return {

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -131,7 +131,7 @@ export default defineComponent({
 				},
 			],
 			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
-			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, label: "Stroke Width" } }],
+			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, unit: "px", label: "Stroke Width" } }],
 		};
 
 		return {

--- a/frontend/src/components/widgets/options/ToolOptions.vue
+++ b/frontend/src/components/widgets/options/ToolOptions.vue
@@ -131,7 +131,7 @@ export default defineComponent({
 				},
 			],
 			Shape: [{ kind: "NumberInput", callback: this.setShapeOptions, props: { value: 6, min: 3, isInteger: true, label: "Sides" } }],
-			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, label: "Stroke width" } }],
+			Line: [{ kind: "NumberInput", callback: this.setLineOptions, props: { value: 5, min: 1, isInteger: true, label: "Stroke Width" } }],
 		};
 
 		return {


### PR DESCRIPTION
Closes #350

- Added a `Line` variant to the `ToolOptions` struct, with a `stroke_width` property
- Made the Line tool use the stroke width
- Allow the `NumberInput` widget to expand in width (we can tweak the default width and expansion behavior in this PR)
- Renamed the Vue `setToolOptions` method to `setShapeOptions` and added a new `setLineOptions` methods
    - This will be cleaned up when the unified layout system is implemented
- Added a new number input to the line tool, allowing line width to be specified

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/355)
<!-- Reviewable:end -->
