### PR TITLE
Dispatcher::handle_message does not need Result anymore

### DIFF
--- a/editor/src/communication/dispatcher.rs
+++ b/editor/src/communication/dispatcher.rs
@@ -1,4 +1,4 @@
-use crate::{message_prelude::*, EditorError};
+use crate::{message_prelude::*};
 
 pub use crate::document::DocumentsMessageHandler;
 pub use crate::input::{InputMapper, InputPreprocessor};
@@ -26,7 +26,7 @@ const GROUP_MESSAGES: &[MessageDiscriminant] = &[
 ];
 
 impl Dispatcher {
-	pub fn handle_message<T: Into<Message>>(&mut self, message: T) -> Result<(), EditorError> {
+	pub fn handle_message<T: Into<Message>>(&mut self, message: T) {
 		self.messages.push_back(message.into());
 
 		use Message::*;
@@ -50,7 +50,6 @@ impl Dispatcher {
 				}
 			}
 		}
-		Ok(())
 	}
 
 	pub fn collect_actions(&self) -> ActionList {
@@ -126,8 +125,8 @@ mod test {
 		let mut editor = create_editor_with_three_layers();
 
 		let document_before_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
-		editor.handle_message(DocumentsMessage::Copy).unwrap();
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
+		editor.handle_message(DocumentsMessage::Copy);
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
 		let document_after_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 
 		let layers_before_copy = document_before_copy.root.as_folder().unwrap().layers();
@@ -158,9 +157,9 @@ mod test {
 		let document_before_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 		let shape_id = document_before_copy.root.as_folder().unwrap().layer_ids[1];
 
-		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![shape_id]])).unwrap();
-		editor.handle_message(DocumentsMessage::Copy).unwrap();
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
+		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![shape_id]]));
+		editor.handle_message(DocumentsMessage::Copy);
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
 
 		let document_after_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 
@@ -192,7 +191,7 @@ mod test {
 		const LINE_INDEX: usize = 0;
 		const PEN_INDEX: usize = 1;
 
-		editor.handle_message(DocumentMessage::CreateFolder(vec![])).unwrap();
+		editor.handle_message(DocumentMessage::CreateFolder(vec![]));
 
 		let document_before_added_shapes = editor.dispatcher.documents_message_handler.active_document().document.clone();
 		let folder_id = document_before_added_shapes.root.as_folder().unwrap().layer_ids[FOLDER_INDEX];
@@ -205,8 +204,7 @@ mod test {
 				insert_index: 0,
 				transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
 				style: Default::default(),
-			})
-			.unwrap();
+			});
 
 		editor
 			.handle_message(Operation::AddPen {
@@ -215,17 +213,16 @@ mod test {
 				transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
 				style: Default::default(),
 				points: vec![(10.0, 20.0), (30.0, 40.0)],
-			})
-			.unwrap();
+			});
 
-		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![folder_id]])).unwrap();
+		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![folder_id]]));
 
 		let document_before_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 
-		editor.handle_message(DocumentsMessage::Copy).unwrap();
-		editor.handle_message(DocumentMessage::DeleteSelectedLayers).unwrap();
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
+		editor.handle_message(DocumentsMessage::Copy);
+		editor.handle_message(DocumentMessage::DeleteSelectedLayers);
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
 
 		let document_after_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 
@@ -282,12 +279,12 @@ mod test {
 		let rect_id = document_before_copy.root.as_folder().unwrap().layer_ids[RECT_INDEX];
 		let ellipse_id = document_before_copy.root.as_folder().unwrap().layer_ids[ELLIPSE_INDEX];
 
-		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![rect_id], vec![ellipse_id]])).unwrap();
-		editor.handle_message(DocumentsMessage::Copy).unwrap();
-		editor.handle_message(DocumentMessage::DeleteSelectedLayers).unwrap();
+		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![rect_id], vec![ellipse_id]]));
+		editor.handle_message(DocumentsMessage::Copy);
+		editor.handle_message(DocumentMessage::DeleteSelectedLayers);
 		editor.draw_rect(0., 800., 12., 200.);
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
-		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 }).unwrap();
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
+		editor.handle_message(DocumentsMessage::PasteIntoFolder { path: vec![], insert_index: -1 });
 
 		let document_after_copy = editor.dispatcher.documents_message_handler.active_document().document.clone();
 
@@ -316,17 +313,17 @@ mod test {
 
 		let verify_order = |handler: &mut DocumentMessageHandler| (handler.all_layers_sorted(), handler.non_selected_layers_sorted(), handler.selected_layers_sorted());
 
-		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![0], vec![2]])).unwrap();
+		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![0], vec![2]]));
 
-		editor.handle_message(DocumentMessage::ReorderSelectedLayers(1)).unwrap();
+		editor.handle_message(DocumentMessage::ReorderSelectedLayers(1));
 		let (all, non_selected, selected) = verify_order(&mut editor.dispatcher.documents_message_handler.active_document_mut());
 		assert_eq!(all, non_selected.into_iter().chain(selected.into_iter()).collect::<Vec<_>>());
 
-		editor.handle_message(DocumentMessage::ReorderSelectedLayers(-1)).unwrap();
+		editor.handle_message(DocumentMessage::ReorderSelectedLayers(-1));
 		let (all, non_selected, selected) = verify_order(&mut editor.dispatcher.documents_message_handler.active_document_mut());
 		assert_eq!(all, selected.into_iter().chain(non_selected.into_iter()).collect::<Vec<_>>());
 
-		editor.handle_message(DocumentMessage::ReorderSelectedLayers(i32::MAX)).unwrap();
+		editor.handle_message(DocumentMessage::ReorderSelectedLayers(i32::MAX));
 		let (all, non_selected, selected) = verify_order(&mut editor.dispatcher.documents_message_handler.active_document_mut());
 		assert_eq!(all, non_selected.into_iter().chain(selected.into_iter()).collect::<Vec<_>>());
 	}

--- a/editor/src/communication/dispatcher.rs
+++ b/editor/src/communication/dispatcher.rs
@@ -1,4 +1,4 @@
-use crate::{message_prelude::*};
+use crate::message_prelude::*;
 
 pub use crate::document::DocumentsMessageHandler;
 pub use crate::input::{InputMapper, InputPreprocessor};
@@ -198,22 +198,20 @@ mod test {
 
 		// TODO: This adding of a Line and Pen should be rewritten using the corresponding functions in EditorTestUtils.
 		// This has not been done yet as the line and pen tool are not yet able to add layers to the currently selected folder
-		editor
-			.handle_message(Operation::AddLine {
-				path: vec![folder_id, LINE_INDEX as u64],
-				insert_index: 0,
-				transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-				style: Default::default(),
-			});
+		editor.handle_message(Operation::AddLine {
+			path: vec![folder_id, LINE_INDEX as u64],
+			insert_index: 0,
+			transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+			style: Default::default(),
+		});
 
-		editor
-			.handle_message(Operation::AddPen {
-				path: vec![folder_id, PEN_INDEX as u64],
-				insert_index: 0,
-				transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-				style: Default::default(),
-				points: vec![(10.0, 20.0), (30.0, 40.0)],
-			});
+		editor.handle_message(Operation::AddPen {
+			path: vec![folder_id, PEN_INDEX as u64],
+			insert_index: 0,
+			transform: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+			style: Default::default(),
+			points: vec![(10.0, 20.0), (30.0, 40.0)],
+		});
 
 		editor.handle_message(DocumentMessage::SetSelectedLayers(vec![vec![folder_id]]));
 

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -39,12 +39,11 @@ impl Editor {
 		Self { dispatcher: Dispatcher::new() }
 	}
 
-	pub fn handle_message<T: Into<Message>>(&mut self, message: T) -> Result<Vec<FrontendMessage>, EditorError> {
-		self.dispatcher.handle_message(message).map(|_| {
-			let mut responses = Vec::new();
-			std::mem::swap(&mut responses, &mut self.dispatcher.responses);
-			responses
-		})
+	pub fn handle_message<T: Into<Message>>(&mut self, message: T) -> Vec<FrontendMessage> {
+        self.dispatcher.handle_message(message);
+        let mut responses = Vec::new();
+        std::mem::swap(&mut responses, &mut self.dispatcher.responses);
+        responses
 	}
 }
 

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -40,10 +40,10 @@ impl Editor {
 	}
 
 	pub fn handle_message<T: Into<Message>>(&mut self, message: T) -> Vec<FrontendMessage> {
-        self.dispatcher.handle_message(message);
-        let mut responses = Vec::new();
-        std::mem::swap(&mut responses, &mut self.dispatcher.responses);
-        responses
+		self.dispatcher.handle_message(message);
+		let mut responses = Vec::new();
+		std::mem::swap(&mut responses, &mut self.dispatcher.responses);
+		responses
 	}
 }
 

--- a/editor/src/misc/test_utils.rs
+++ b/editor/src/misc/test_utils.rs
@@ -62,7 +62,7 @@ impl EditorTestUtils for Editor {
 	}
 
 	fn mouseup(&mut self, state: EditorMouseState) {
-		self.handle_message(InputPreprocessorMessage::MouseUp(state, ModifierKeys::default())).unwrap();
+		self.handle_message(InputPreprocessorMessage::MouseUp(state, ModifierKeys::default()));
 	}
 
 	fn lmb_mousedown(&mut self, x: f64, y: f64) {
@@ -74,14 +74,14 @@ impl EditorTestUtils for Editor {
 	}
 
 	fn input(&mut self, message: InputPreprocessorMessage) {
-		self.handle_message(Message::InputPreprocessor(message)).unwrap();
+		self.handle_message(Message::InputPreprocessor(message));
 	}
 
 	fn select_tool(&mut self, typ: ToolType) {
-		self.handle_message(Message::Tool(ToolMessage::ActivateTool(typ))).unwrap();
+		self.handle_message(Message::Tool(ToolMessage::ActivateTool(typ)));
 	}
 
 	fn select_primary_color(&mut self, color: Color) {
-		self.handle_message(Message::Tool(ToolMessage::SelectPrimaryColor(color))).unwrap();
+		self.handle_message(Message::Tool(ToolMessage::SelectPrimaryColor(color)));
 	}
 }

--- a/frontend/wasm/src/document.rs
+++ b/frontend/wasm/src/document.rs
@@ -14,11 +14,9 @@ fn convert_error(err: editor::EditorError) -> JsValue {
 }
 
 fn dispatch<T: Into<Message>>(message: T) -> Result<(), JsValue> {
-	let result = crate::EDITOR_STATE.with(|state| state.borrow_mut().handle_message(message.into()));
-	if let Ok(messages) = result {
-		crate::handle_responses(messages);
-	}
-	Ok(())
+	let messages = crate::EDITOR_STATE.with(|state| state.borrow_mut().handle_message(message.into()));
+    crate::handle_responses(messages);
+	Ok(()) // TODO
 }
 
 /// Modify the currently selected tool in the document state store

--- a/frontend/wasm/src/document.rs
+++ b/frontend/wasm/src/document.rs
@@ -15,7 +15,7 @@ fn convert_error(err: editor::EditorError) -> JsValue {
 
 fn dispatch<T: Into<Message>>(message: T) {
 	let messages = crate::EDITOR_STATE.with(|state| state.borrow_mut().handle_message(message.into()));
-    crate::handle_responses(messages);
+	crate::handle_responses(messages);
 }
 
 /// Modify the currently selected tool in the document state store

--- a/frontend/wasm/src/document.rs
+++ b/frontend/wasm/src/document.rs
@@ -13,17 +13,16 @@ fn convert_error(err: editor::EditorError) -> JsValue {
 	Error::new(&err.to_string()).into()
 }
 
-fn dispatch<T: Into<Message>>(message: T) -> Result<(), JsValue> {
+fn dispatch<T: Into<Message>>(message: T) {
 	let messages = crate::EDITOR_STATE.with(|state| state.borrow_mut().handle_message(message.into()));
     crate::handle_responses(messages);
-	Ok(()) // TODO
 }
 
 /// Modify the currently selected tool in the document state store
 #[wasm_bindgen]
 pub fn select_tool(tool: String) -> Result<(), JsValue> {
 	match translate_tool(&tool) {
-		Some(tool) => dispatch(ToolMessage::ActivateTool(tool)),
+		Some(tool) => Ok(dispatch(ToolMessage::ActivateTool(tool))),
 		None => Err(Error::new(&format!("Couldn't select {} because it was not recognized as a valid tool", tool)).into()),
 	}
 }
@@ -33,7 +32,7 @@ pub fn select_tool(tool: String) -> Result<(), JsValue> {
 pub fn set_tool_options(tool: String, options: &JsValue) -> Result<(), JsValue> {
 	match options.into_serde::<ToolOptions>() {
 		Ok(options) => match translate_tool(&tool) {
-			Some(tool) => dispatch(ToolMessage::SetToolOptions(tool, options)),
+			Some(tool) => Ok(dispatch(ToolMessage::SetToolOptions(tool, options))),
 			None => Err(Error::new(&format!("Couldn't set options for {} because it was not recognized as a valid tool", tool)).into()),
 		},
 		Err(err) => Err(Error::new(&format!("Invalid JSON for ToolOptions: {}", err)).into()),
@@ -54,65 +53,65 @@ pub fn send_tool_message(tool: String, message: &JsValue) -> Result<(), JsValue>
 		None => Err(Error::new(&format!("Couldn't send message for {} because it was not recognized as a valid tool", tool)).into()),
 	};
 	match tool_message {
-		Ok(tool_message) => dispatch(tool_message),
+		Ok(tool_message) => Ok(dispatch(tool_message)),
 		Err(err) => Err(err),
 	}
 }
 
 #[wasm_bindgen]
-pub fn select_document(document: usize) -> Result<(), JsValue> {
+pub fn select_document(document: usize) {
 	dispatch(DocumentsMessage::SelectDocument(document))
 }
 
 #[wasm_bindgen]
-pub fn get_open_documents_list() -> Result<(), JsValue> {
+pub fn get_open_documents_list() {
 	dispatch(DocumentsMessage::GetOpenDocumentsList)
 }
 
 #[wasm_bindgen]
-pub fn new_document() -> Result<(), JsValue> {
+pub fn new_document() {
 	dispatch(DocumentsMessage::NewDocument)
 }
 
 #[wasm_bindgen]
-pub fn open_document() -> Result<(), JsValue> {
+pub fn open_document() {
 	dispatch(DocumentsMessage::OpenDocument)
 }
 
 #[wasm_bindgen]
-pub fn open_document_file(name: String, content: String) -> Result<(), JsValue> {
+pub fn open_document_file(name: String, content: String) {
 	dispatch(DocumentsMessage::OpenDocumentFile(name, content))
 }
 
 #[wasm_bindgen]
-pub fn save_document() -> Result<(), JsValue> {
+pub fn save_document() {
 	dispatch(DocumentMessage::SaveDocument)
 }
 
 #[wasm_bindgen]
-pub fn close_document(document: usize) -> Result<(), JsValue> {
+pub fn close_document(document: usize) {
 	dispatch(DocumentsMessage::CloseDocument(document))
 }
 
 #[wasm_bindgen]
-pub fn close_all_documents() -> Result<(), JsValue> {
+pub fn close_all_documents() {
 	dispatch(DocumentsMessage::CloseAllDocuments)
 }
 
 #[wasm_bindgen]
-pub fn close_active_document_with_confirmation() -> Result<(), JsValue> {
+pub fn close_active_document_with_confirmation() {
 	dispatch(DocumentsMessage::CloseActiveDocumentWithConfirmation)
 }
 
 #[wasm_bindgen]
-pub fn close_all_documents_with_confirmation() -> Result<(), JsValue> {
+pub fn close_all_documents_with_confirmation() {
 	dispatch(DocumentsMessage::CloseAllDocumentsWithConfirmation)
 }
 
 /// Send new bounds when document panel viewports get resized or moved within the editor
 /// [left, top, right, bottom]...
 #[wasm_bindgen]
-pub fn bounds_of_viewports(bounds_of_viewports: &[f64]) -> Result<(), JsValue> {
+pub fn bounds_of_viewports(bounds_of_viewports: &[f64]) {
 	let chunked: Vec<_> = bounds_of_viewports.chunks(4).map(ViewportBounds::from_slice).collect();
 	let ev = InputPreprocessorMessage::BoundsOfViewports(chunked);
 	dispatch(ev)
@@ -120,7 +119,7 @@ pub fn bounds_of_viewports(bounds_of_viewports: &[f64]) -> Result<(), JsValue> {
 
 /// Mouse movement within the screenspace bounds of the viewport
 #[wasm_bindgen]
-pub fn on_mouse_move(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_mouse_move(x: f64, y: f64, mouse_keys: u8, modifiers: u8) {
 	let editor_mouse_state = EditorMouseState::from_keys_and_editor_position(mouse_keys, (x, y).into());
 
 	let modifier_keys = ModifierKeys::from_bits(modifiers).expect("invalid modifier keys");
@@ -131,7 +130,7 @@ pub fn on_mouse_move(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<()
 
 /// Mouse scrolling within the screenspace bounds of the viewport
 #[wasm_bindgen]
-pub fn on_mouse_scroll(x: f64, y: f64, mouse_keys: u8, wheel_delta_x: i32, wheel_delta_y: i32, wheel_delta_z: i32, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_mouse_scroll(x: f64, y: f64, mouse_keys: u8, wheel_delta_x: i32, wheel_delta_y: i32, wheel_delta_z: i32, modifiers: u8) {
 	let mut editor_mouse_state = EditorMouseState::from_keys_and_editor_position(mouse_keys, (x, y).into());
 	editor_mouse_state.scroll_delta = ScrollDelta::new(wheel_delta_x, wheel_delta_y, wheel_delta_z);
 
@@ -143,7 +142,7 @@ pub fn on_mouse_scroll(x: f64, y: f64, mouse_keys: u8, wheel_delta_x: i32, wheel
 
 /// A mouse button depressed within screenspace the bounds of the viewport
 #[wasm_bindgen]
-pub fn on_mouse_down(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_mouse_down(x: f64, y: f64, mouse_keys: u8, modifiers: u8) {
 	let editor_mouse_state = EditorMouseState::from_keys_and_editor_position(mouse_keys, (x, y).into());
 
 	let modifier_keys = ModifierKeys::from_bits(modifiers).expect("invalid modifier keys");
@@ -154,7 +153,7 @@ pub fn on_mouse_down(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<()
 
 /// A mouse button released
 #[wasm_bindgen]
-pub fn on_mouse_up(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_mouse_up(x: f64, y: f64, mouse_keys: u8, modifiers: u8) {
 	let editor_mouse_state = EditorMouseState::from_keys_and_editor_position(mouse_keys, (x, y).into());
 
 	let modifier_keys = ModifierKeys::from_bits(modifiers).expect("invalid modifier keys");
@@ -165,7 +164,7 @@ pub fn on_mouse_up(x: f64, y: f64, mouse_keys: u8, modifiers: u8) -> Result<(), 
 
 /// A keyboard button depressed within screenspace the bounds of the viewport
 #[wasm_bindgen]
-pub fn on_key_down(name: String, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_key_down(name: String, modifiers: u8) {
 	let key = translate_key(&name);
 	let mods = ModifierKeys::from_bits(modifiers).expect("invalid modifier keys");
 	log::trace!("Key down {:?}, name: {}, modifiers: {:?}", key, name, mods);
@@ -175,7 +174,7 @@ pub fn on_key_down(name: String, modifiers: u8) -> Result<(), JsValue> {
 
 /// A keyboard button released
 #[wasm_bindgen]
-pub fn on_key_up(name: String, modifiers: u8) -> Result<(), JsValue> {
+pub fn on_key_up(name: String, modifiers: u8) {
 	let key = translate_key(&name);
 	let mods = ModifierKeys::from_bits(modifiers).expect("invalid modifier keys");
 	log::trace!("Key up {:?}, name: {}, modifiers: {:?}", key, name, mods);
@@ -185,55 +184,55 @@ pub fn on_key_up(name: String, modifiers: u8) -> Result<(), JsValue> {
 
 /// Update primary color
 #[wasm_bindgen]
-pub fn update_primary_color(primary_color: Color) -> Result<(), JsValue> {
+pub fn update_primary_color(primary_color: Color) {
 	dispatch(ToolMessage::SelectPrimaryColor(primary_color.inner()))
 }
 
 /// Update secondary color
 #[wasm_bindgen]
-pub fn update_secondary_color(secondary_color: Color) -> Result<(), JsValue> {
+pub fn update_secondary_color(secondary_color: Color) {
 	dispatch(ToolMessage::SelectSecondaryColor(secondary_color.inner()))
 }
 
 /// Swap primary and secondary color
 #[wasm_bindgen]
-pub fn swap_colors() -> Result<(), JsValue> {
+pub fn swap_colors() {
 	dispatch(ToolMessage::SwapColors)
 }
 
 /// Reset primary and secondary colors to their defaults
 #[wasm_bindgen]
-pub fn reset_colors() -> Result<(), JsValue> {
+pub fn reset_colors() {
 	dispatch(ToolMessage::ResetColors)
 }
 
 /// Undo history one step
 #[wasm_bindgen]
-pub fn undo() -> Result<(), JsValue> {
+pub fn undo() {
 	dispatch(DocumentMessage::Undo)
 }
 
 /// Redo history one step
 #[wasm_bindgen]
-pub fn redo() -> Result<(), JsValue> {
+pub fn redo() {
 	dispatch(DocumentMessage::Redo)
 }
 
 /// Select all layers
 #[wasm_bindgen]
-pub fn select_all_layers() -> Result<(), JsValue> {
+pub fn select_all_layers() {
 	dispatch(DocumentMessage::SelectAllLayers)
 }
 
 /// Deselect all layers
 #[wasm_bindgen]
-pub fn deselect_all_layers() -> Result<(), JsValue> {
+pub fn deselect_all_layers() {
 	dispatch(DocumentMessage::DeselectAllLayers)
 }
 
 /// Reorder selected layer
 #[wasm_bindgen]
-pub fn reorder_selected_layers(delta: i32) -> Result<(), JsValue> {
+pub fn reorder_selected_layers(delta: i32) {
 	dispatch(DocumentMessage::ReorderSelectedLayers(delta))
 }
 
@@ -260,96 +259,96 @@ pub fn set_blend_mode_for_selected_layers(blend_mode_svg_style_name: String) -> 
 		_ => return Err(convert_error(EditorError::Misc("UnknownBlendMode".to_string()))),
 	};
 
-	dispatch(DocumentMessage::SetBlendModeForSelectedLayers(blend_mode))
+	Ok(dispatch(DocumentMessage::SetBlendModeForSelectedLayers(blend_mode)))
 }
 
 /// Set the opacity for the selected layers
 #[wasm_bindgen]
-pub fn set_opacity_for_selected_layers(opacity_percent: f64) -> Result<(), JsValue> {
+pub fn set_opacity_for_selected_layers(opacity_percent: f64) {
 	dispatch(DocumentMessage::SetOpacityForSelectedLayers(opacity_percent / 100.))
 }
 
 /// Export the document
 #[wasm_bindgen]
-pub fn export_document() -> Result<(), JsValue> {
+pub fn export_document() {
 	dispatch(DocumentMessage::ExportDocument)
 }
 
 /// Sets the zoom to the value
 #[wasm_bindgen]
-pub fn set_canvas_zoom(new_zoom: f64) -> Result<(), JsValue> {
+pub fn set_canvas_zoom(new_zoom: f64) {
 	let ev = MovementMessage::SetCanvasZoom(new_zoom);
 	dispatch(ev)
 }
 
 /// Zoom in to the next step
 #[wasm_bindgen]
-pub fn increase_canvas_zoom() -> Result<(), JsValue> {
+pub fn increase_canvas_zoom() {
 	let ev = MovementMessage::IncreaseCanvasZoom;
 	dispatch(ev)
 }
 
 /// Zoom out to the next step
 #[wasm_bindgen]
-pub fn decrease_canvas_zoom() -> Result<(), JsValue> {
+pub fn decrease_canvas_zoom() {
 	let ev = MovementMessage::DecreaseCanvasZoom;
 	dispatch(ev)
 }
 
 /// Sets the rotation to the new value (in radians)
 #[wasm_bindgen]
-pub fn set_rotation(new_radians: f64) -> Result<(), JsValue> {
+pub fn set_rotation(new_radians: f64) {
 	let ev = MovementMessage::SetCanvasRotation(new_radians);
 	dispatch(ev)
 }
 
 /// Translates document (in viewport coords)
 #[wasm_bindgen]
-pub fn translate_canvas(delta_x: f64, delta_y: f64) -> Result<(), JsValue> {
+pub fn translate_canvas(delta_x: f64, delta_y: f64) {
 	let ev = MovementMessage::TranslateCanvas((delta_x, delta_y).into());
 	dispatch(ev)
 }
 
 /// Translates document (in viewport coords)
 #[wasm_bindgen]
-pub fn translate_canvas_by_fraction(delta_x: f64, delta_y: f64) -> Result<(), JsValue> {
+pub fn translate_canvas_by_fraction(delta_x: f64, delta_y: f64) {
 	let ev = MovementMessage::TranslateCanvasByViewportFraction((delta_x, delta_y).into());
 	dispatch(ev)
 }
 
 /// Update the list of selected layers. The layer paths have to be stored in one array and are separated by LayerId::MAX
 #[wasm_bindgen]
-pub fn select_layers(paths: Vec<LayerId>) -> Result<(), JsValue> {
+pub fn select_layers(paths: Vec<LayerId>) {
 	let paths = paths.split(|id| *id == LayerId::MAX).map(|path| path.to_vec()).collect();
 	dispatch(DocumentMessage::SetSelectedLayers(paths))
 }
 
 /// Toggle visibility of a layer from the layer list
 #[wasm_bindgen]
-pub fn toggle_layer_visibility(path: Vec<LayerId>) -> Result<(), JsValue> {
+pub fn toggle_layer_visibility(path: Vec<LayerId>) {
 	dispatch(DocumentMessage::ToggleLayerVisibility(path))
 }
 
 /// Toggle expansions state of a layer from the layer list
 #[wasm_bindgen]
-pub fn toggle_layer_expansion(path: Vec<LayerId>) -> Result<(), JsValue> {
+pub fn toggle_layer_expansion(path: Vec<LayerId>) {
 	dispatch(DocumentMessage::ToggleLayerExpansion(path))
 }
 
 /// Renames a layer from the layer list
 #[wasm_bindgen]
-pub fn rename_layer(path: Vec<LayerId>, new_name: String) -> Result<(), JsValue> {
+pub fn rename_layer(path: Vec<LayerId>, new_name: String) {
 	dispatch(DocumentMessage::RenameLayer(path, new_name))
 }
 
 /// Deletes a layer from the layer list
 #[wasm_bindgen]
-pub fn delete_layer(path: Vec<LayerId>) -> Result<(), JsValue> {
+pub fn delete_layer(path: Vec<LayerId>) {
 	dispatch(DocumentMessage::DeleteLayer(path))
 }
 
 /// Requests the backend to add a layer to the layer list
 #[wasm_bindgen]
-pub fn add_folder(path: Vec<LayerId>) -> Result<(), JsValue> {
+pub fn add_folder(path: Vec<LayerId>) {
 	dispatch(DocumentMessage::CreateFolder(path))
 }


### PR DESCRIPTION
I skimmed the code and saw that `Dispatcher::handle_message` does not need `Result` anymore. It used to, but the relevant code passage referring to `Err` has been removed.

Eliminating this simplifies some places quite a bit.

In case this simplification is unwanted, feel free to discard it, of course.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/365)
<!-- Reviewable:end -->
