### PR TITLE
Update Viewport bounds on scroll

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from "vue";
 
 import { fullscreenModeChanged } from "@/utilities/fullscreen";
-import { onKeyUp, onKeyDown, onMouseMove, onMouseDown, onMouseUp, onMouseScroll, onWindowResize } from "@/utilities/input";
+import { onKeyUp, onKeyDown, onMouseMove, onMouseDown, onMouseUp, onMouseScroll, onWindowResize, onScroll } from "@/utilities/input";
 import "@/utilities/errors";
 import App from "@/App.vue";
 import { panicProxy } from "@/utilities/panic-proxy";
@@ -32,4 +32,5 @@ const wasm = import("@/../wasm/pkg").then(panicProxy);
 	window.addEventListener("mouseup", onMouseUp);
 
 	window.addEventListener("wheel", onMouseScroll, { passive: false });
+	window.addEventListener("scroll", onScroll, true); // scroll event does not bubble for elements so we must capture it
 })();

--- a/frontend/src/utilities/input.ts
+++ b/frontend/src/utilities/input.ts
@@ -112,7 +112,7 @@ export async function onMouseScroll(e: WheelEvent) {
 	}
 }
 
-export async function onWindowResize() {
+async function updateViewportBounds() {
 	const viewports = Array.from(document.querySelectorAll(".canvas"));
 	const boundsOfViewports = viewports.map((canvas) => {
 		const bounds = canvas.getBoundingClientRect();
@@ -123,6 +123,17 @@ export async function onWindowResize() {
 	const data = Float64Array.from(flattened);
 
 	if (boundsOfViewports.length > 0) (await wasm).bounds_of_viewports(data);
+}
+
+export async function onWindowResize() {
+	await updateViewportBounds();
+}
+
+export async function onScroll(e: Event) {
+	const target = e.target && (e.target as HTMLElement);
+	if (target && target.classList.contains("main-window")) {
+		await updateViewportBounds();
+	}
 }
 
 export function makeModifiersBitfield(e: MouseEvent | KeyboardEvent): number {


### PR DESCRIPTION
The viewport bounds were not being updated when the page was scrolled.
This led to the canvas editing location not matching the mouse location.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #381

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/382)
<!-- Reviewable:end -->
