### PR TITLE
Remove vue-svg-loader dependency (saves 82 MB, fixes a security alert)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
 		"sass-loader": "^8.0.2",
 		"typescript": "^4.4.2",
 		"vue-loader": "^16.5.0",
-		"vue-svg-loader": "^0.17.0-beta.2",
 		"vue-template-compiler": "^2.6.14",
 		"wasm-pack": "^0.10.1"
 	}

--- a/frontend/src/utilities/files.ts
+++ b/frontend/src/utilities/files.ts
@@ -1,8 +1,5 @@
 export function download(filename: string, fileData: string) {
-	let type = "text/plain;charset=utf-8";
-	if (filename.endsWith(".svg")) {
-		type = "image/svg+xml;charset=utf-8";
-	}
+	const type = filename.endsWith(".svg") ? "image/svg+xml;charset=utf-8" : "text/plain;charset=utf-8";
 	const blob = new Blob([fileData], { type });
 	const url = URL.createObjectURL(blob);
 	const element = document.createElement("a");

--- a/frontend/vue-svg-loader.js
+++ b/frontend/vue-svg-loader.js
@@ -1,0 +1,4 @@
+module.exports = function VueSvgLoader(svg) {
+	this.cacheable();
+	return `<template>${svg}</template>`;
+};

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -78,20 +78,22 @@ module.exports = {
 					})
 			);
 
-		// Vue SVG Loader enables importing .svg files into .vue single-file components and using them directly in the HTML
-		// https://vue-svg-loader.js.org/
+		// Change the loaders used by the Vue compilation process
 		config.module
-			// Replace Vue's existing base loader by first clearing it (https://cli.vuejs.org/guide/webpack.html#replacing-loaders-of-a-rule)
+			// Replace Vue's existing base loader by first clearing it
+			// https://cli.vuejs.org/guide/webpack.html#replacing-loaders-of-a-rule
 			.rule("svg")
 			.uses.clear()
 			.end()
-			// Add vue-loader as a loader
+			// Add vue-loader as a loader for Vue single-file components
+			// https://www.npmjs.com/package/vue-loader
 			.use("vue-loader")
 			.loader("vue-loader")
 			.end()
-			// Add vue-svg-loader as a loader
-			.use("vue-svg-loader")
-			.loader("vue-svg-loader")
+			// Add vue-svg-loader as a loader for importing .svg files into Vue single-file components
+			// Located in ./vue-svg-loader.js
+			.use("./vue-svg-loader")
+			.loader("./vue-svg-loader")
 			.end();
 	},
 };


### PR DESCRIPTION
This fixes a security alert due to this badly maintained dependency using a transitive dependency with a security alert. This also reduces the `node_modules` folder from 274 MB to 192 MB which is a big victory!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/graphiteeditor/graphite/389)
<!-- Reviewable:end -->
