### PR TITLE
Bug Fix: duplication with Ctrl+D didn't properly duplicate

### DIFF
--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -525,9 +525,11 @@ impl Document {
 				let layer = self.layer(path)?.clone();
 				let (folder_path, _) = split_path(path.as_slice()).unwrap_or_else(|_| (&[], 0));
 				let folder = self.folder_mut(folder_path)?;
-				folder.add_layer(layer, None, -1).ok_or(DocumentError::IndexOutOfBounds)?;
-				self.mark_as_dirty(&path[..path.len() - 1])?;
-				Some(vec![DocumentChanged, FolderChanged { path: folder_path.to_vec() }])
+				if let Some(new_layer_id) = folder.add_layer(layer, None, -1){
+					self.mark_as_dirty(folder_path)?;
+					Some([vec![DocumentChanged, CreatedLayer { path: [folder_path, &[new_layer_id]].concat() }, FolderChanged { path: folder_path.to_vec() }], update_thumbnails_upstream(path.as_slice())].concat())
+				}
+				else {return Err(DocumentError::IndexOutOfBounds); }
 			}
 			Operation::RenameLayer { path, name } => {
 				self.layer_mut(path)?.name = Some(name.clone());

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -525,11 +525,24 @@ impl Document {
 				let layer = self.layer(path)?.clone();
 				let (folder_path, _) = split_path(path.as_slice()).unwrap_or_else(|_| (&[], 0));
 				let folder = self.folder_mut(folder_path)?;
-				if let Some(new_layer_id) = folder.add_layer(layer, None, -1){
+				if let Some(new_layer_id) = folder.add_layer(layer, None, -1) {
 					self.mark_as_dirty(folder_path)?;
-					Some([vec![DocumentChanged, CreatedLayer { path: [folder_path, &[new_layer_id]].concat() }, FolderChanged { path: folder_path.to_vec() }], update_thumbnails_upstream(path.as_slice())].concat())
+					Some(
+						[
+							vec![
+								DocumentChanged,
+								CreatedLayer {
+									path: [folder_path, &[new_layer_id]].concat(),
+								},
+								FolderChanged { path: folder_path.to_vec() },
+							],
+							update_thumbnails_upstream(path.as_slice()),
+						]
+						.concat(),
+					)
+				} else {
+					return Err(DocumentError::IndexOutOfBounds);
 				}
-				else {return Err(DocumentError::IndexOutOfBounds); }
 			}
 			Operation::RenameLayer { path, name } => {
 				self.layer_mut(path)?.name = Some(name.clone());

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -526,16 +526,11 @@ impl Document {
 				let (folder_path, _) = split_path(path.as_slice()).unwrap_or_else(|_| (&[], 0));
 				let folder = self.folder_mut(folder_path)?;
 				if let Some(new_layer_id) = folder.add_layer(layer, None, -1) {
+					let new_path = [folder_path, &[new_layer_id]].concat();
 					self.mark_as_dirty(folder_path)?;
 					Some(
 						[
-							vec![
-								DocumentChanged,
-								CreatedLayer {
-									path: [folder_path, &[new_layer_id]].concat(),
-								},
-								FolderChanged { path: folder_path.to_vec() },
-							],
+							vec![DocumentChanged, CreatedLayer { path: new_path }, FolderChanged { path: folder_path.to_vec() }],
 							update_thumbnails_upstream(path.as_slice()),
 						]
 						.concat(),


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
### Fixed Bug:
From the discord code-todo-list: "`Ctrl+D to duplicate a shape doesn't update the layer panel to show the new shape, then dragging it crashes the editor`"
