### PR TITLE
Update intoiter syntax

### DIFF
--- a/editor/src/tool/mod.rs
+++ b/editor/src/tool/mod.rs
@@ -119,13 +119,14 @@ impl ToolFsmState {
 
 fn default_tool_options() -> HashMap<ToolType, ToolOptions> {
 	let tool_init = |tool: ToolType| (tool, tool.default_options());
-	std::array::IntoIter::new([
+	[
 		tool_init(ToolType::Select),
 		tool_init(ToolType::Pen),
 		tool_init(ToolType::Line),
 		tool_init(ToolType::Ellipse),
 		tool_init(ToolType::Shape), // TODO: Add more tool defaults
-	])
+	]
+	.into_iter()
 	.collect()
 }
 


### PR DESCRIPTION
Intoiter is now implemented for arrays by value: https://github.com/rust-lang/rust/pull/84147 The old syntax has been deprected (at least in nightly)