### PR TITLE
Populate layer entry cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "log",
  "rand_chacha",
  "serde",
+ "serde_json",
  "spin",
  "thiserror",
 ]
@@ -113,7 +114,6 @@ dependencies = [
  "kurbo",
  "log",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -157,9 +157,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -274,9 +274,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scoped-tls"
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
  "itoa",
  "ryu",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 bitflags = "1.2.1"
 thiserror = "1.0.24"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 graphite-proc-macros = { path = "../proc-macros" }
 glam = { version="0.17", features = ["serde"] }
 rand_chacha = "0.3.1"

--- a/editor/src/document/document_file.rs
+++ b/editor/src/document/document_file.rs
@@ -252,6 +252,10 @@ impl DocumentMessageHandler {
 		self.layer_data.entry(path.to_vec()).or_insert_with(|| LayerData::new(true))
 	}
 
+	pub fn create_layerdata(&mut self, path: &[LayerId]) {
+		self.layer_data.insert(path.to_vec(), LayerData::new(true));
+	}
+
 	pub fn selected_layers(&self) -> impl Iterator<Item = &[LayerId]> {
 		self.layer_data.iter().filter_map(|(path, data)| data.selected.then(|| path.as_slice()))
 	}

--- a/editor/src/document/document_file.rs
+++ b/editor/src/document/document_file.rs
@@ -168,25 +168,15 @@ impl DocumentMessageHandler {
 		// We fully expect the serialization to succeed
 		val.unwrap()
 	}
+
 	pub fn deserialize_document(serialized_content: &str) -> Result<Self, DocumentError> {
 		log::info!("Deserialising: {:?}", serialized_content);
 		serde_json::from_str(serialized_content).map_err(|e| DocumentError::InvalidFile(e.to_string()))
 	}
+
 	pub fn with_name(name: String, ipp: &InputPreprocessor) -> Self {
-		let mut document = Self {
-			graphene_document: GrapheneDocument::default(),
-			document_undo_history: Vec::new(),
-			document_redo_history: Vec::new(),
-			saved_document_identifier: 0,
-			name,
-			layer_data: vec![(vec![], LayerData::new(true))].into_iter().collect(),
-			layer_range_selection_reference: Vec::new(),
-			movement_handler: MovementMessageHandler::default(),
-			transform_layer_handler: TransformLayerMessageHandler::default(),
-			snapping_enabled: true,
-			view_mode: ViewMode::default(),
-		};
-		document.graphene_document.root.transform = document.layerdata(&[]).calculate_offset_transform(ipp.viewport_bounds.size() / 2., 0.);
+		let mut document = Self { name, ..Self::default() };
+		document.graphene_document.root.transform = document.layer_data(&[]).calculate_offset_transform(ipp.viewport_bounds.size() / 2., 0.);
 		document
 	}
 
@@ -212,7 +202,7 @@ impl DocumentMessageHandler {
 		if self.graphene_document.layer(path).ok()?.overlay {
 			return None;
 		}
-		self.layer_data(path).selected = true;
+		self.layer_data_mut(path).selected = true;
 		let data = self.layer_panel_entry(path.to_vec()).ok()?;
 		(!path.is_empty()).then(|| FrontendMessage::UpdateLayer { data }.into())
 	}
@@ -257,15 +247,7 @@ impl DocumentMessageHandler {
 		shapes.collect::<Vec<VectorManipulatorShape>>()
 	}
 
-	pub fn layerdata(&self, path: &[LayerId]) -> &LayerData {
-		self.layer_data.get(path).expect("Layerdata does not exist")
-	}
-
-	pub fn layerdata_mut(&mut self, path: &[LayerId]) -> &mut LayerData {
-		self.layer_data.entry(path.to_vec()).or_insert_with(|| LayerData::new(true))
-	}
-
-	pub fn create_layerdata(&mut self, path: &[LayerId]) {
+	pub fn create_layer_data(&mut self, path: &[LayerId]) {
 		self.layer_data.insert(path.to_vec(), LayerData::new(true));
 	}
 
@@ -282,7 +264,7 @@ impl DocumentMessageHandler {
 				LayerDataType::Shape(_) => (),
 				LayerDataType::Folder(ref folder) => {
 					path.push(*id);
-					if self.layerdata(path).expanded {
+					if self.layer_data(path).expanded {
 						structure.push(space);
 						self.serialize_structure(folder, structure, data, path);
 						space = 0;
@@ -369,8 +351,18 @@ impl DocumentMessageHandler {
 		self.layers_sorted(Some(false))
 	}
 
-	pub fn layer_data(&mut self, path: &[LayerId]) -> &mut LayerData {
-		layer_data(&mut self.layer_data, path)
+	pub fn layer_data(&self, path: &[LayerId]) -> &LayerData {
+		self.layer_data.get(path).expect("Layerdata does not exist")
+	}
+
+	pub fn layer_data_mut(&mut self, path: &[LayerId]) -> &mut LayerData {
+		Self::layer_data_mut_no_borrow_self(&mut self.layer_data, path)
+	}
+
+	pub fn layer_data_mut_no_borrow_self<'a>(layer_data: &'a mut HashMap<Vec<LayerId>, LayerData>, path: &[LayerId]) -> &'a mut LayerData {
+		layer_data
+			.get_mut(path)
+			.unwrap_or_else(|| panic!("Layer data cannot be found because the path {:?} does not exist", path))
 	}
 
 	pub fn backup(&mut self, responses: &mut VecDeque<Message>) {
@@ -448,7 +440,7 @@ impl DocumentMessageHandler {
 	}
 
 	pub fn layer_panel_entry(&mut self, path: Vec<LayerId>) -> Result<LayerPanelEntry, EditorError> {
-		let data: LayerData = *layer_data(&mut self.layer_data, &path);
+		let data: LayerData = *self.layer_data_mut(&path);
 		let layer = self.graphene_document.layer(&path)?;
 		let entry = layer_panel_entry(&data, self.graphene_document.multiply_transforms(&path)?, layer, path);
 		Ok(entry)
@@ -459,26 +451,22 @@ impl DocumentMessageHandler {
 	pub fn layer_panel(&mut self, path: &[LayerId]) -> Result<Vec<LayerPanelEntry>, EditorError> {
 		let folder = self.graphene_document.folder(path)?;
 		let paths: Vec<Vec<LayerId>> = folder.layer_ids.iter().map(|id| [path, &[*id]].concat()).collect();
-		let data: Vec<LayerData> = paths.iter().map(|path| *layer_data(&mut self.layer_data, path)).collect();
-		let folder = self.graphene_document.folder(path)?;
-		let entries = folder
-			.layers()
-			.iter()
-			.zip(paths.iter().zip(data))
-			.rev()
-			.filter(|(layer, _)| !layer.overlay)
-			.map(|(layer, (path, data))| {
-				layer_panel_entry(
-					&data,
-					self.graphene_document
-						.generate_transform_across_scope(path, Some(self.graphene_document.root.transform.inverse()))
-						.unwrap(),
-					layer,
-					path.to_vec(),
-				)
-			})
-			.collect();
+		let entries = paths.iter().rev().filter_map(|path| self.layer_panel_entry_from_path(path)).collect();
 		Ok(entries)
+	}
+
+	pub fn layer_panel_entry_from_path(&self, path: &[LayerId]) -> Option<LayerPanelEntry> {
+		let layer_data = self.layer_data(path);
+		let transform = self
+			.graphene_document
+			.generate_transform_across_scope(path, Some(self.graphene_document.root.transform.inverse()))
+			.ok()?;
+		let layer = self.graphene_document.layer(path).ok()?;
+
+		match layer.overlay {
+			true => None,
+			false => Some(layer_panel_entry(layer_data, transform, layer, path.to_vec())),
+		}
 	}
 }
 
@@ -488,7 +476,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 		match message {
 			Movement(message) => self
 				.movement_handler
-				.process_action(message, (layer_data(&mut self.layer_data, &[]), &self.graphene_document, ipp), responses),
+				.process_action(message, (Self::layer_data_mut_no_borrow_self(&mut self.layer_data, &[]), &self.graphene_document, ipp), responses),
 			TransformLayers(message) => self
 				.transform_layer_handler
 				.process_action(message, (&mut self.layer_data, &mut self.graphene_document, ipp), responses),
@@ -547,7 +535,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 			CreateEmptyFolder(mut path) => {
 				let id = generate_uuid();
 				path.push(id);
-				self.layerdata_mut(&path).expanded = true;
+				self.layer_data_mut(&path).expanded = true;
 				responses.push_back(DocumentOperation::CreateFolder { path }.into())
 			}
 			GroupSelectedLayers => {
@@ -591,7 +579,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 				responses.push_back(DocumentOperation::ToggleLayerVisibility { path }.into());
 			}
 			ToggleLayerExpansion(path) => {
-				self.layer_data(&path).expanded ^= true;
+				self.layer_data_mut(&path).expanded ^= true;
 				responses.push_back(DocumentStructureChanged.into());
 				responses.push_back(LayerChanged(path).into())
 			}
@@ -638,7 +626,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 				} else {
 					if ctrl {
 						// Toggle selection when holding ctrl
-						let layer = self.layerdata_mut(&selected);
+						let layer = self.layer_data_mut(&selected);
 						layer.selected = !layer.selected;
 						responses.push_back(LayerChanged(selected.clone()).into());
 					} else {
@@ -751,7 +739,7 @@ impl MessageHandler<DocumentMessage, &InputPreprocessor> for DocumentMessageHand
 					}
 					.into(),
 				);
-				let root_layerdata = self.layerdata(&[]);
+				let root_layerdata = self.layer_data(&[]);
 
 				let scale = 0.5 + ASYMPTOTIC_EFFECT + root_layerdata.scale * SCALE_EFFECT;
 				let viewport_size = ipp.viewport_bounds.size();

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -1,4 +1,3 @@
-use crate::document::LayerData;
 use crate::frontend::frontend_message_handler::FrontendDocumentDetails;
 use crate::input::InputPreprocessor;
 use crate::message_prelude::*;
@@ -110,21 +109,6 @@ impl DocumentsMessageHandler {
 		} else {
 			self.document_ids.push(document_id);
 		}
-
-		fn generate_layerdata(path: &mut Vec<LayerId>, new_document: &mut DocumentMessageHandler) -> Result<(), graphene::DocumentError> {
-			new_document.create_layerdata(path);
-			let layer = new_document.graphene_document.layer(path)?;
-			if let graphene::layers::LayerDataType::Folder(f) = &layer.data {
-				for l in f.layer_ids.clone() {
-					path.push(l);
-					generate_layerdata(path, new_document)?;
-					path.pop();
-				}
-			}
-			Ok(())
-		}
-
-		generate_layerdata(&mut Vec::new(), &mut new_document).unwrap();
 
 		responses.extend(
 			new_document
@@ -297,7 +281,7 @@ impl MessageHandler<DocumentsMessage, &InputPreprocessor> for DocumentsMessageHa
 				document,
 				document_is_saved,
 			} => {
-				let document = DocumentMessageHandler::with_name_and_content(document_name, document, ipp);
+				let document = DocumentMessageHandler::with_name_and_content(document_name, document);
 				match document {
 					Ok(mut document) => {
 						document.set_save_state(document_is_saved);
@@ -331,7 +315,7 @@ impl MessageHandler<DocumentsMessage, &InputPreprocessor> for DocumentsMessageHa
 				let document = self.documents.get(&id).unwrap();
 				responses.push_back(
 					FrontendMessage::AutoSaveDocument {
-						document: document.graphene_document.serialize_document(),
+						document: document.serialize_document(),
 						details: FrontendDocumentDetails {
 							is_saved: document.is_saved(),
 							id,

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -112,11 +112,10 @@ impl DocumentsMessageHandler {
 
 		responses.extend(
 			new_document
-				.layer_panel(&[])
-				.unwrap()
-				.into_iter()
-				.map(|entry| FrontendMessage::UpdateLayer { data: entry })
-				.map(|msg| msg.into())
+				.layer_data
+				.keys()
+				.filter_map(|path| new_document.layer_panel_entry_from_path(path))
+				.map(|entry| FrontendMessage::UpdateLayer { data: entry }.into())
 				.collect::<Vec<_>>(),
 		);
 

--- a/editor/src/document/layer_panel.rs
+++ b/editor/src/document/layer_panel.rs
@@ -35,10 +35,6 @@ impl LayerData {
 	}
 }
 
-pub fn layer_data<'a>(layer_data: &'a mut HashMap<Vec<LayerId>, LayerData>, path: &[LayerId]) -> &'a mut LayerData {
-	layer_data.get_mut(path).expect(&format!("Layer data cannot be found because the path {:?} does not exist", path))
-}
-
 pub fn layer_panel_entry(layer_data: &LayerData, transform: DAffine2, layer: &Layer, path: Vec<LayerId>) -> LayerPanelEntry {
 	let layer_type: LayerType = (&layer.data).into();
 	let name = layer.name.clone().unwrap_or_else(|| format!("Unnamed {}", layer_type));

--- a/editor/src/document/mod.rs
+++ b/editor/src/document/mod.rs
@@ -3,6 +3,7 @@ mod document_message_handler;
 pub mod layer_panel;
 mod movement_handler;
 mod transform_layer_handler;
+mod vectorize_layerdata;
 
 #[doc(inline)]
 pub use document_file::LayerData;

--- a/editor/src/document/vectorize_layerdata.rs
+++ b/editor/src/document/vectorize_layerdata.rs
@@ -1,0 +1,25 @@
+/// Necessary because serde can't serialize hashmaps when the keys don't implement display.
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::iter::FromIterator;
+
+pub fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+	T: IntoIterator<Item = (&'a K, &'a V)>,
+	K: Serialize + 'a,
+	V: Serialize + 'a,
+{
+	let container: Vec<_> = target.into_iter().collect();
+	serde::Serialize::serialize(&container, ser)
+}
+
+pub fn deserialize<'de, T, K, V, D>(des: D) -> Result<T, D::Error>
+where
+	D: Deserializer<'de>,
+	T: FromIterator<(K, V)>,
+	K: Deserialize<'de>,
+	V: Deserialize<'de>,
+{
+	let container: Vec<_> = serde::Deserialize::deserialize(des)?;
+	Ok(T::from_iter(container.into_iter()))
+}

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -17,5 +17,4 @@ kurbo = { git = "https://github.com/GraphiteEditor/kurbo.git", features = [
 	"serde",
 ] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
 glam = { version = "0.17", features = ["serde"] }

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -34,10 +34,6 @@ impl Default for Document {
 }
 
 impl Document {
-	pub fn with_content(serialized_content: &str) -> Result<Self, DocumentError> {
-		serde_json::from_str(serialized_content).map_err(|e| DocumentError::InvalidFile(e.to_string()))
-	}
-
 	/// Wrapper around render, that returns the whole document as a Response.
 	pub fn render_root(&mut self, mode: ViewMode) -> String {
 		self.root.render(&mut vec![], mode);
@@ -46,12 +42,6 @@ impl Document {
 
 	pub fn current_state_identifier(&self) -> u64 {
 		self.state_identifier.finish()
-	}
-
-	pub fn serialize_document(&self) -> String {
-		let val = serde_json::to_string(self);
-		// We fully expect the serialization to succeed
-		val.unwrap()
 	}
 
 	/// Checks whether each layer under `path` intersects with the provided `quad` and adds all intersection layers as paths to `intersections`.


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #430 

The layer entry cache in the frontend was not populated when the document was opened because `UpdateLayer` was never called. This MR just creates the layerdata for all of the layers and then calls `UpdateLayer` on them.
