### PR TITLE
Fix rotation input

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.vue
+++ b/frontend/src/components/widgets/inputs/NumberInput.vue
@@ -268,7 +268,11 @@ export default defineComponent({
 				return;
 			}
 
-			const sanitized = clamp(newValue, this.min, this.max);
+			// We cannot use the clamp function here as we need undifined values to lead to no clamp.
+
+			let sanitized = newValue;
+			if (typeof this.min === "number") sanitized = Math.max(sanitized, this.min);
+			if (typeof this.max === "number") sanitized = Math.min(sanitized, this.max);
 
 			this.setText(sanitized);
 		},


### PR DESCRIPTION
The rotation input field was clamped between 0 and 1 after `Better decimal rounding in the NumberInput widget` #457