### PR TITLE
Implement the Crop Tool for artboard resizing

### DIFF
--- a/editor/src/communication/dispatcher.rs
+++ b/editor/src/communication/dispatcher.rs
@@ -117,7 +117,7 @@ impl Dispatcher {
 			&& !(matches!(
 				message,
 				InputPreprocessor(_) | Frontend(FrontendMessage::UpdateCanvasZoom { .. }) | Frontend(FrontendMessage::UpdateCanvasRotation { .. })
-			) || MessageDiscriminant::from(message).local_name().ends_with("MouseMove"))
+			) || MessageDiscriminant::from(message).local_name().ends_with("PointerMove"))
 		{
 			log::trace!("Message: {:?}", message);
 			// log::trace!("Hints: {:?}", self.input_mapper_message_handler.hints(self.collect_actions()));

--- a/editor/src/document/artboard_message.rs
+++ b/editor/src/document/artboard_message.rs
@@ -14,12 +14,15 @@ pub enum ArtboardMessage {
 
 	// Messages
 	AddArtboard {
-		top: f64,
-		left: f64,
-		height: f64,
-		width: f64,
+		position: (f64, f64),
+		size: (f64, f64),
 	},
 	RenderArtboards,
+	ResizeArtboard {
+		artboard: Vec<LayerId>,
+		position: (f64, f64),
+		size: (f64, f64),
+	},
 }
 
 impl From<DocumentOperation> for ArtboardMessage {

--- a/editor/src/document/artboard_message.rs
+++ b/editor/src/document/artboard_message.rs
@@ -14,6 +14,7 @@ pub enum ArtboardMessage {
 
 	// Messages
 	AddArtboard {
+		id: Option<LayerId>,
 		position: (f64, f64),
 		size: (f64, f64),
 	},

--- a/editor/src/document/artboard_message_handler.rs
+++ b/editor/src/document/artboard_message_handler.rs
@@ -75,13 +75,10 @@ impl MessageHandler<ArtboardMessage, ()> for ArtboardMessageHandler {
 			}
 			ResizeArtboard { artboard, position, size } => {
 				responses.push_back(
-					ArtboardMessage::DispatchOperation(
-						DocumentOperation::SetLayerTransform {
-							path: artboard,
-							transform: DAffine2::from_scale_angle_translation(size.into(), 0., position.into()).to_cols_array(),
-						}
-						.into(),
-					)
+					ArtboardMessage::DispatchOperation(Box::new(DocumentOperation::SetLayerTransform {
+						path: artboard,
+						transform: DAffine2::from_scale_angle_translation(size.into(), 0., position.into()).to_cols_array(),
+					}))
 					.into(),
 				);
 

--- a/editor/src/document/artboard_message_handler.rs
+++ b/editor/src/document/artboard_message_handler.rs
@@ -5,7 +5,7 @@ use graphene::document::Document as GrapheneDocument;
 use graphene::layers::style::{self, Fill, ViewMode};
 use graphene::Operation as DocumentOperation;
 
-use glam::{DAffine2, DVec2};
+use glam::DAffine2;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 

--- a/editor/src/document/artboard_message_handler.rs
+++ b/editor/src/document/artboard_message_handler.rs
@@ -36,7 +36,7 @@ impl MessageHandler<ArtboardMessage, ()> for ArtboardMessageHandler {
 			},
 
 			// Messages
-			AddArtboard { top, left, height, width } => {
+			AddArtboard { position, size } => {
 				let artboard_id = generate_uuid();
 				self.artboard_ids.push(artboard_id);
 
@@ -45,7 +45,7 @@ impl MessageHandler<ArtboardMessage, ()> for ArtboardMessageHandler {
 						DocumentOperation::AddRect {
 							path: vec![artboard_id],
 							insert_index: -1,
-							transform: DAffine2::from_scale_angle_translation(DVec2::new(height, width), 0., DVec2::new(top, left)).to_cols_array(),
+							transform: DAffine2::from_scale_angle_translation(size.into(), 0., position.into()).to_cols_array(),
 							style: style::PathStyle::new(None, Some(Fill::new(Color::WHITE))),
 						}
 						.into(),
@@ -72,6 +72,20 @@ impl MessageHandler<ArtboardMessage, ()> for ArtboardMessageHandler {
 						.into(),
 					);
 				}
+			}
+			ResizeArtboard { artboard, position, size } => {
+				responses.push_back(
+					ArtboardMessage::DispatchOperation(
+						DocumentOperation::SetLayerTransform {
+							path: artboard,
+							transform: DAffine2::from_scale_angle_translation(size.into(), 0., position.into()).to_cols_array(),
+						}
+						.into(),
+					)
+					.into(),
+				);
+
+				responses.push_back(DocumentMessage::RenderDocument.into());
 			}
 		}
 	}

--- a/editor/src/document/artboard_message_handler.rs
+++ b/editor/src/document/artboard_message_handler.rs
@@ -36,8 +36,8 @@ impl MessageHandler<ArtboardMessage, ()> for ArtboardMessageHandler {
 			},
 
 			// Messages
-			AddArtboard { position, size } => {
-				let artboard_id = generate_uuid();
+			AddArtboard { id, position, size } => {
+				let artboard_id = id.unwrap_or_else(generate_uuid);
 				self.artboard_ids.push(artboard_id);
 
 				responses.push_back(

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -230,6 +230,22 @@ impl DocumentMessageHandler {
 		})
 	}
 
+	pub fn bounding_boxes<'a>(&self, ignore_document: Option<&Vec<Vec<LayerId>>>, ignore_artboard: Option<LayerId>) -> Vec<[DVec2; 2]> {
+		[
+			self.visible_layers()
+				.filter(|path| ignore_document.map_or(true, |ignore_document| !ignore_document.iter().any(|ig| ig.as_slice() == *path)))
+				.filter_map(|path| self.graphene_document.viewport_bounding_box(path).ok()?)
+				.collect(),
+			self.artboard_message_handler
+				.artboard_ids
+				.iter()
+				.filter(|id| Some(**id) != ignore_artboard)
+				.filter_map(|path| self.artboard_message_handler.artboards_graphene_document.viewport_bounding_box(&[*path]).ok()?)
+				.collect::<Vec<[DVec2; 2]>>(),
+		]
+		.concat()
+	}
+
 	fn serialize_structure(&self, folder: &Folder, structure: &mut Vec<u64>, data: &mut Vec<LayerId>, path: &mut Vec<LayerId>) {
 		let mut space = 0;
 		for (id, layer) in folder.layer_ids.iter().zip(folder.layers()).rev() {

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -138,8 +138,8 @@ impl DocumentMessageHandler {
 		self.graphene_document.combined_viewport_bounding_box(paths)
 	}
 
-	pub fn artboard_bounding_box(&self, path: &[LayerId]) -> Option<[DVec2; 2]> {
-		self.artboard_message_handler.artboards_graphene_document.viewport_bounding_box(path).unwrap_or(None)
+	pub fn artboard_bounding_box_and_transform(&self, path: &[LayerId]) -> Option<([DVec2; 2], DAffine2)> {
+		self.artboard_message_handler.artboards_graphene_document.bounding_box_and_transform(path).unwrap_or(None)
 	}
 
 	// TODO: Consider moving this to some kind of overlays manager in the future

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -42,7 +42,7 @@ pub struct DocumentMessageHandler {
 	movement_handler: MovementMessageHandler,
 	#[serde(skip)]
 	overlays_message_handler: OverlaysMessageHandler,
-	artboard_message_handler: ArtboardMessageHandler,
+	pub artboard_message_handler: ArtboardMessageHandler,
 	#[serde(skip)]
 	transform_layer_handler: TransformLayerMessageHandler,
 	pub overlays_visible: bool,
@@ -136,6 +136,10 @@ impl DocumentMessageHandler {
 	pub fn selected_visible_layers_bounding_box(&self) -> Option<[DVec2; 2]> {
 		let paths = self.selected_visible_layers();
 		self.graphene_document.combined_viewport_bounding_box(paths)
+	}
+
+	pub fn artboard_bounding_box(&self, path: &[LayerId]) -> Option<[DVec2; 2]> {
+		self.artboard_message_handler.artboards_graphene_document.viewport_bounding_box(path).unwrap_or(None)
 	}
 
 	// TODO: Consider moving this to some kind of overlays manager in the future

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -208,19 +208,17 @@ impl DocumentMessageHandler {
 	}
 
 	/// Returns the bounding boxes for all visible layers and artboards, optionally excluding any paths.
-	pub fn bounding_boxes(&self, ignore_document: Option<&Vec<Vec<LayerId>>>, ignore_artboard: Option<LayerId>) -> impl Iterator<Item = [DVec2; 2]> {
+	pub fn bounding_boxes<'a>(&'a self, ignore_document: Option<&'a Vec<Vec<LayerId>>>, ignore_artboard: Option<LayerId>) -> impl Iterator<Item = [DVec2; 2]> + 'a {
 		self.visible_layers()
-			.filter(|path| ignore_document.clone().map_or(true, |ignore_document| !ignore_document.iter().any(|ig| ig.as_slice() == *path)))
+			.filter(move |path| ignore_document.map_or(true, |ignore_document| !ignore_document.iter().any(|ig| ig.as_slice() == *path)))
 			.filter_map(|path| self.graphene_document.viewport_bounding_box(path).ok()?)
 			.chain(
 				self.artboard_message_handler
 					.artboard_ids
 					.iter()
-					.filter(|&&id| Some(id) != ignore_artboard)
+					.filter(move |&&id| Some(id) != ignore_artboard)
 					.filter_map(|&path| self.artboard_message_handler.artboards_graphene_document.viewport_bounding_box(&[path]).ok()?),
 			)
-			.collect::<Vec<_>>()
-			.into_iter()
 	}
 
 	fn serialize_structure(&self, folder: &Folder, structure: &mut Vec<u64>, data: &mut Vec<LayerId>, path: &mut Vec<LayerId>) {

--- a/editor/src/document/movement_message.rs
+++ b/editor/src/document/movement_message.rs
@@ -19,7 +19,7 @@ pub enum MovementMessage {
 	IncreaseCanvasZoom {
 		center_on_mouse: bool,
 	},
-	MouseMove {
+	PointerMove {
 		snap_angle: Key,
 		wait_for_snap_angle_release: bool,
 		snap_zoom: Key,

--- a/editor/src/document/movement_message_handler.rs
+++ b/editor/src/document/movement_message_handler.rs
@@ -166,7 +166,7 @@ impl MessageHandler<MovementMessage, (&Document, &InputPreprocessorMessageHandle
 				}
 				responses.push_back(SetCanvasZoom { zoom_factor: new_scale }.into());
 			}
-			MouseMove {
+			PointerMove {
 				snap_angle,
 				wait_for_snap_angle_release,
 				snap_zoom,
@@ -344,7 +344,7 @@ impl MessageHandler<MovementMessage, (&Document, &InputPreprocessorMessageHandle
 
 		if self.panning || self.tilting || self.zooming {
 			let transforming = actions!(MovementMessageDiscriminant;
-				MouseMove,
+				PointerMove,
 				TransformCanvasEnd,
 			);
 			common.extend(transforming);

--- a/editor/src/document/transform_layer_message.rs
+++ b/editor/src/document/transform_layer_message.rs
@@ -14,7 +14,7 @@ pub enum TransformLayerMessage {
 	CancelTransformOperation,
 	ConstrainX,
 	ConstrainY,
-	MouseMove { slow_key: Key, snap_key: Key },
+	PointerMove { slow_key: Key, snap_key: Key },
 	TypeBackspace,
 	TypeDecimalPoint,
 	TypeDigit { digit: u8 },

--- a/editor/src/document/transform_layer_message_handler.rs
+++ b/editor/src/document/transform_layer_message_handler.rs
@@ -108,7 +108,7 @@ impl MessageHandler<TransformLayerMessage, (&mut HashMap<Vec<LayerId>, LayerMeta
 			}
 			ConstrainX => self.transform_operation.constrain_axis(Axis::X, &mut selected, self.snap),
 			ConstrainY => self.transform_operation.constrain_axis(Axis::Y, &mut selected, self.snap),
-			MouseMove { slow_key, snap_key } => {
+			PointerMove { slow_key, snap_key } => {
 				self.slow = ipp.keyboard.get(slow_key as usize);
 
 				let new_snap = ipp.keyboard.get(snap_key as usize);
@@ -173,7 +173,7 @@ impl MessageHandler<TransformLayerMessage, (&mut HashMap<Vec<LayerId>, LayerMeta
 
 		if self.transform_operation != TransformOperation::None {
 			let active = actions!(TransformLayerMessageDiscriminant;
-				MouseMove,
+				PointerMove,
 				CancelTransformOperation,
 				ApplyTransformOperation,
 				TypeDigit,

--- a/editor/src/input/input_mapper.rs
+++ b/editor/src/input/input_mapper.rs
@@ -43,7 +43,7 @@ impl Default for Mapping {
 			entry! {action=TransformLayerMessage::TypeDecimalPoint, key_down=KeyPeriod},
 			entry! {action=TransformLayerMessage::PointerMove { slow_key: KeyShift, snap_key: KeyControl }, triggers=[KeyShift, KeyControl]},
 			// Select
-			entry! {action=SelectMessage::PointerMove { axis_align: KeyShift, snap_angle: KeyControl, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
+			entry! {action=SelectMessage::PointerMove { axis_align: KeyShift, snap_angle: KeyControl, center: KeyAlt }, message=InputMapperMessage::PointerMove},
 			entry! {action=SelectMessage::DragStart { add_to_selection: KeyShift }, key_down=Lmb},
 			entry! {action=SelectMessage::DragStop, key_up=Lmb},
 			entry! {action=SelectMessage::EditLayer, message=InputMapperMessage::DoubleClick},
@@ -51,7 +51,7 @@ impl Default for Mapping {
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
 			// Crop
 			entry! {action=CropMessage::PointerDown, key_down=Lmb},
-			entry! {action=CropMessage::PointerMove { axis_align: KeyShift, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
+			entry! {action=CropMessage::PointerMove { constrain_axis_or_aspect: KeyShift, center: KeyAlt }, message=InputMapperMessage::PointerMove},
 			entry! {action=CropMessage::PointerUp, key_up=Lmb},
 			// Navigate
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: false }, key_up=Lmb, modifiers=[KeyShift]},

--- a/editor/src/input/input_mapper.rs
+++ b/editor/src/input/input_mapper.rs
@@ -29,7 +29,7 @@ impl Default for Mapping {
 		let mappings = mapping![
 			// Higher priority than entries in sections below
 			entry! {action=PortfolioMessage::Paste { clipboard: Clipboard::User }, key_down=KeyV, modifiers=[KeyControl]},
-			entry! {action=MovementMessage::MouseMove { snap_angle: KeyControl, wait_for_snap_angle_release: true, snap_zoom: KeyControl, zoom_from_viewport: None }, message=InputMapperMessage::PointerMove},
+			entry! {action=MovementMessage::PointerMove { snap_angle: KeyControl, wait_for_snap_angle_release: true, snap_zoom: KeyControl, zoom_from_viewport: None }, message=InputMapperMessage::PointerMove},
 			// Transform layers
 			entry! {action=TransformLayerMessage::ApplyTransformOperation, key_down=KeyEnter},
 			entry! {action=TransformLayerMessage::ApplyTransformOperation, key_down=Lmb},
@@ -41,22 +41,22 @@ impl Default for Mapping {
 			entry! {action=TransformLayerMessage::TypeNegate, key_down=KeyMinus},
 			entry! {action=TransformLayerMessage::TypeDecimalPoint, key_down=KeyComma},
 			entry! {action=TransformLayerMessage::TypeDecimalPoint, key_down=KeyPeriod},
-			entry! {action=TransformLayerMessage::MouseMove { slow_key: KeyShift, snap_key: KeyControl }, triggers=[KeyShift, KeyControl]},
+			entry! {action=TransformLayerMessage::PointerMove { slow_key: KeyShift, snap_key: KeyControl }, triggers=[KeyShift, KeyControl]},
 			// Select
-			entry! {action=SelectMessage::MouseMove { axis_align: KeyShift, snap_angle: KeyControl, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
+			entry! {action=SelectMessage::PointerMove { axis_align: KeyShift, snap_angle: KeyControl, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
 			entry! {action=SelectMessage::DragStart { add_to_selection: KeyShift }, key_down=Lmb},
 			entry! {action=SelectMessage::DragStop, key_up=Lmb},
 			entry! {action=SelectMessage::EditLayer, message=InputMapperMessage::DoubleClick},
 			entry! {action=SelectMessage::Abort, key_down=Rmb},
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
 			// Crop
-			entry! {action=CropMessage::MouseDown, key_down=Lmb},
-			entry! {action=CropMessage::MouseMove { axis_align: KeyShift, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
-			entry! {action=CropMessage::MouseUp, key_up=Lmb},
+			entry! {action=CropMessage::PointerDown, key_down=Lmb},
+			entry! {action=CropMessage::PointerMove { axis_align: KeyShift, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
+			entry! {action=CropMessage::PointerUp, key_up=Lmb},
 			// Navigate
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: false }, key_up=Lmb, modifiers=[KeyShift]},
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: true }, key_up=Lmb},
-			entry! {action=NavigateMessage::MouseMove { snap_angle: KeyControl, snap_zoom: KeyControl }, message=InputMapperMessage::PointerMove},
+			entry! {action=NavigateMessage::PointerMove { snap_angle: KeyControl, snap_zoom: KeyControl }, message=InputMapperMessage::PointerMove},
 			entry! {action=NavigateMessage::TranslateCanvasBegin, key_down=Mmb},
 			entry! {action=NavigateMessage::RotateCanvasBegin, key_down=Rmb},
 			entry! {action=NavigateMessage::ZoomCanvasBegin, key_down=Lmb},

--- a/editor/src/input/input_mapper.rs
+++ b/editor/src/input/input_mapper.rs
@@ -49,6 +49,10 @@ impl Default for Mapping {
 			entry! {action=SelectMessage::EditLayer, message=InputMapperMessage::DoubleClick},
 			entry! {action=SelectMessage::Abort, key_down=Rmb},
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
+			// Crop
+			entry! {action=CropMessage::MouseDown, key_down=Lmb},
+			entry! {action=CropMessage::MouseMove, message=InputMapperMessage::PointerMove},
+			entry! {action=CropMessage::MouseUp, key_up=Lmb},
 			// Navigate
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: false }, key_up=Lmb, modifiers=[KeyShift]},
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: true }, key_up=Lmb},

--- a/editor/src/input/input_mapper.rs
+++ b/editor/src/input/input_mapper.rs
@@ -43,7 +43,7 @@ impl Default for Mapping {
 			entry! {action=TransformLayerMessage::TypeDecimalPoint, key_down=KeyPeriod},
 			entry! {action=TransformLayerMessage::MouseMove { slow_key: KeyShift, snap_key: KeyControl }, triggers=[KeyShift, KeyControl]},
 			// Select
-			entry! {action=SelectMessage::MouseMove { axis_align: KeyShift, snap_angle: KeyControl }, message=InputMapperMessage::PointerMove},
+			entry! {action=SelectMessage::MouseMove { axis_align: KeyShift, snap_angle: KeyControl, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
 			entry! {action=SelectMessage::DragStart { add_to_selection: KeyShift }, key_down=Lmb},
 			entry! {action=SelectMessage::DragStop, key_up=Lmb},
 			entry! {action=SelectMessage::EditLayer, message=InputMapperMessage::DoubleClick},
@@ -51,7 +51,7 @@ impl Default for Mapping {
 			entry! {action=SelectMessage::Abort, key_down=KeyEscape},
 			// Crop
 			entry! {action=CropMessage::MouseDown, key_down=Lmb},
-			entry! {action=CropMessage::MouseMove, message=InputMapperMessage::PointerMove},
+			entry! {action=CropMessage::MouseMove { axis_align: KeyShift, centre: KeyAlt }, message=InputMapperMessage::PointerMove},
 			entry! {action=CropMessage::MouseUp, key_up=Lmb},
 			// Navigate
 			entry! {action=NavigateMessage::ClickZoom { zoom_in: false }, key_up=Lmb, modifiers=[KeyShift]},

--- a/editor/src/input/input_preprocessor.rs
+++ b/editor/src/input/input_preprocessor.rs
@@ -35,7 +35,7 @@ mod test {
 
 		let editor_mouse_state = EditorMouseState::from_editor_position(4., 809.);
 		let modifier_keys = ModifierKeys::ALT;
-		let message = InputPreprocessorMessage::MouseMove { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerMove { editor_mouse_state, modifier_keys };
 
 		let mut responses = VecDeque::new();
 
@@ -51,7 +51,7 @@ mod test {
 
 		let editor_mouse_state = EditorMouseState::new();
 		let modifier_keys = ModifierKeys::CONTROL;
-		let message = InputPreprocessorMessage::MouseDown { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerDown { editor_mouse_state, modifier_keys };
 
 		let mut responses = VecDeque::new();
 
@@ -67,7 +67,7 @@ mod test {
 
 		let editor_mouse_state = EditorMouseState::new();
 		let modifier_keys = ModifierKeys::SHIFT;
-		let message = InputPreprocessorMessage::MouseUp { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerUp { editor_mouse_state, modifier_keys };
 
 		let mut responses = VecDeque::new();
 

--- a/editor/src/input/input_preprocessor_message.rs
+++ b/editor/src/input/input_preprocessor_message.rs
@@ -16,8 +16,8 @@ pub enum InputPreprocessorMessage {
 	DoubleClick { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
 	KeyDown { key: Key, modifier_keys: ModifierKeys },
 	KeyUp { key: Key, modifier_keys: ModifierKeys },
-	MouseDown { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
-	MouseMove { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
 	MouseScroll { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
-	MouseUp { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
+	PointerDown { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
+	PointerMove { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
+	PointerUp { editor_mouse_state: EditorMouseState, modifier_keys: ModifierKeys },
 }

--- a/editor/src/input/input_preprocessor_message_handler.rs
+++ b/editor/src/input/input_preprocessor_message_handler.rs
@@ -67,24 +67,6 @@ impl MessageHandler<InputPreprocessorMessage, ()> for InputPreprocessorMessageHa
 				self.keyboard.unset(key as usize);
 				responses.push_back(InputMapperMessage::KeyUp(key).into());
 			}
-			InputPreprocessorMessage::MouseDown { editor_mouse_state, modifier_keys } => {
-				self.handle_modifier_keys(modifier_keys, responses);
-
-				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
-				self.mouse.position = mouse_state.position;
-
-				if let Some(message) = self.translate_mouse_event(mouse_state, KeyPosition::Pressed) {
-					responses.push_back(message);
-				}
-			}
-			InputPreprocessorMessage::MouseMove { editor_mouse_state, modifier_keys } => {
-				self.handle_modifier_keys(modifier_keys, responses);
-
-				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
-				self.mouse.position = mouse_state.position;
-
-				responses.push_back(InputMapperMessage::PointerMove.into());
-			}
 			InputPreprocessorMessage::MouseScroll { editor_mouse_state, modifier_keys } => {
 				self.handle_modifier_keys(modifier_keys, responses);
 
@@ -94,7 +76,25 @@ impl MessageHandler<InputPreprocessorMessage, ()> for InputPreprocessorMessageHa
 
 				responses.push_back(InputMapperMessage::MouseScroll.into());
 			}
-			InputPreprocessorMessage::MouseUp { editor_mouse_state, modifier_keys } => {
+			InputPreprocessorMessage::PointerDown { editor_mouse_state, modifier_keys } => {
+				self.handle_modifier_keys(modifier_keys, responses);
+
+				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
+				self.mouse.position = mouse_state.position;
+
+				if let Some(message) = self.translate_mouse_event(mouse_state, KeyPosition::Pressed) {
+					responses.push_back(message);
+				}
+			}
+			InputPreprocessorMessage::PointerMove { editor_mouse_state, modifier_keys } => {
+				self.handle_modifier_keys(modifier_keys, responses);
+
+				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
+				self.mouse.position = mouse_state.position;
+
+				responses.push_back(InputMapperMessage::PointerMove.into());
+			}
+			InputPreprocessorMessage::PointerUp { editor_mouse_state, modifier_keys } => {
 				self.handle_modifier_keys(modifier_keys, responses);
 
 				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);

--- a/editor/src/misc/test_utils.rs
+++ b/editor/src/misc/test_utils.rs
@@ -52,17 +52,17 @@ impl EditorTestUtils for Editor {
 		let mut editor_mouse_state = EditorMouseState::new();
 		editor_mouse_state.editor_position = ViewportPosition::new(x, y);
 		let modifier_keys = ModifierKeys::default();
-		self.input(InputPreprocessorMessage::MouseMove { editor_mouse_state, modifier_keys });
+		self.input(InputPreprocessorMessage::PointerMove { editor_mouse_state, modifier_keys });
 	}
 
 	fn mousedown(&mut self, editor_mouse_state: EditorMouseState) {
 		let modifier_keys = ModifierKeys::default();
-		self.input(InputPreprocessorMessage::MouseDown { editor_mouse_state, modifier_keys });
+		self.input(InputPreprocessorMessage::PointerDown { editor_mouse_state, modifier_keys });
 	}
 
 	fn mouseup(&mut self, editor_mouse_state: EditorMouseState) {
 		let modifier_keys = ModifierKeys::default();
-		self.handle_message(InputPreprocessorMessage::MouseUp { editor_mouse_state, modifier_keys });
+		self.handle_message(InputPreprocessorMessage::PointerUp { editor_mouse_state, modifier_keys });
 	}
 
 	fn lmb_mousedown(&mut self, x: f64, y: f64) {

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -114,19 +114,12 @@ impl SnapHandler {
 		&mut self,
 		responses: &mut VecDeque<Message>,
 		document_message_handler: &DocumentMessageHandler,
-		selected_layers: &[Vec<LayerId>],
+		(snap_x, snap_y): (Vec<f64>, Vec<f64>),
 		viewport_bounds: DVec2,
 		mouse_delta: DVec2,
 	) -> DVec2 {
 		if document_message_handler.snapping_enabled {
 			if let Some((targets_x, targets_y)) = &self.snap_targets {
-				let (snap_x, snap_y): (Vec<f64>, Vec<f64>) = selected_layers
-					.iter()
-					.filter_map(|path| document_message_handler.graphene_document.viewport_bounding_box(path).ok()?)
-					.flat_map(|[bound1, bound2]| [bound1, bound2, (bound1 + bound2) / 2.])
-					.map(|vec| vec.into())
-					.unzip();
-
 				let positions = targets_x.iter().flat_map(|&target| snap_x.iter().map(move |&snap| (target, target - mouse_delta.x - snap)));
 				let distances = targets_y.iter().flat_map(|&target| snap_y.iter().map(move |&snap| (target, target - mouse_delta.y - snap)));
 

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -95,13 +95,9 @@ impl SnapHandler {
 
 	/// Gets a list of snap targets for the X and Y axes (if specified) in Viewport coords for the target layers (usually all layers or all non-selected layers.)
 	/// This should be called at the start of a drag.
-	pub fn start_snap<'a>(&mut self, document_message_handler: &DocumentMessageHandler, bounding_boxes: Vec<[DVec2; 2]>, snap_x: bool, snap_y: bool) {
+	pub fn start_snap(&mut self, document_message_handler: &DocumentMessageHandler, bounding_boxes: impl Iterator<Item = [DVec2; 2]>, snap_x: bool, snap_y: bool) {
 		if document_message_handler.snapping_enabled {
-			let (x_targets, y_targets) = bounding_boxes
-				.into_iter()
-				.flat_map(|[bound1, bound2]| [bound1, bound2, ((bound1 + bound2) / 2.)])
-				.map(|vec| vec.into())
-				.unzip();
+			let (x_targets, y_targets) = bounding_boxes.flat_map(|[bound1, bound2]| [bound1, bound2, ((bound1 + bound2) / 2.)]).map(|vec| vec.into()).unzip();
 
 			// Could be made into sorted Vec or a HashSet for more performant lookups.
 			self.snap_targets = Some((if snap_x { x_targets } else { Vec::new() }, if snap_y { y_targets } else { Vec::new() }));

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -95,10 +95,10 @@ impl SnapHandler {
 
 	/// Gets a list of snap targets for the X and Y axes (if specified) in Viewport coords for the target layers (usually all layers or all non-selected layers.)
 	/// This should be called at the start of a drag.
-	pub fn start_snap<'a>(&mut self, document_message_handler: &DocumentMessageHandler, target_layers: impl Iterator<Item = &'a [LayerId]>, snap_x: bool, snap_y: bool) {
+	pub fn start_snap<'a>(&mut self, document_message_handler: &DocumentMessageHandler, bounding_boxes: Vec<[DVec2; 2]>, snap_x: bool, snap_y: bool) {
 		if document_message_handler.snapping_enabled {
-			let (x_targets, y_targets) = target_layers
-				.filter_map(|path| document_message_handler.graphene_document.viewport_bounding_box(path).ok()?)
+			let (x_targets, y_targets) = bounding_boxes
+				.into_iter()
 				.flat_map(|[bound1, bound2]| [bound1, bound2, ((bound1 + bound2) / 2.)])
 				.map(|vec| vec.into())
 				.unzip();

--- a/editor/src/viewport_tools/tool.rs
+++ b/editor/src/viewport_tools/tool.rs
@@ -186,7 +186,7 @@ pub fn standard_tool_message(tool: ToolType, message_type: StandardToolMessageTy
 	match message_type {
 		StandardToolMessageType::DocumentIsDirty => match tool {
 			ToolType::Select => Some(SelectMessage::DocumentIsDirty.into()),
-			ToolType::Crop => None,       // Some(CropMessage::DocumentIsDirty.into()),
+			ToolType::Crop => Some(CropMessage::DocumentIsDirty.into()),
 			ToolType::Navigate => None,   // Some(NavigateMessage::DocumentIsDirty.into()),
 			ToolType::Eyedropper => None, // Some(EyedropperMessage::DocumentIsDirty.into()),
 			ToolType::Text => Some(TextMessage::DocumentIsDirty.into()),
@@ -209,7 +209,7 @@ pub fn standard_tool_message(tool: ToolType, message_type: StandardToolMessageTy
 		},
 		StandardToolMessageType::Abort => match tool {
 			ToolType::Select => Some(SelectMessage::Abort.into()),
-			// ToolType::Crop => Some(CropMessage::Abort.into()),
+			ToolType::Crop => Some(CropMessage::Abort.into()),
 			ToolType::Navigate => Some(NavigateMessage::Abort.into()),
 			ToolType::Eyedropper => Some(EyedropperMessage::Abort.into()),
 			ToolType::Text => Some(TextMessage::Abort.into()),

--- a/editor/src/viewport_tools/tools/crop.rs
+++ b/editor/src/viewport_tools/tools/crop.rs
@@ -32,12 +32,12 @@ pub enum CropMessage {
 	DocumentIsDirty,
 
 	// Tool-specific messages
-	MouseDown,
-	MouseMove {
+	PointerDown,
+	PointerMove {
 		axis_align: Key,
 		centre: Key,
 	},
-	MouseUp,
+	PointerUp,
 }
 
 impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Crop {
@@ -60,7 +60,7 @@ impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Crop {
 		}
 	}
 
-	advertise_actions!(CropMessageDiscriminant; MouseDown, MouseUp, MouseMove, Abort);
+	advertise_actions!(CropMessageDiscriminant; PointerDown, PointerUp, PointerMove, Abort);
 }
 
 impl PropertyHolder for Crop {}
@@ -129,7 +129,7 @@ impl Fsm for CropToolFsmState {
 					buffer.into_iter().rev().for_each(|message| responses.push_front(message));
 					self
 				}
-				(CropToolFsmState::Ready, CropMessage::MouseDown) => {
+				(CropToolFsmState::Ready, CropMessage::PointerDown) => {
 					data.drag_start = input.mouse.position;
 					data.drag_current = input.mouse.position;
 
@@ -186,7 +186,7 @@ impl Fsm for CropToolFsmState {
 						}
 					}
 				}
-				(CropToolFsmState::ResizingBounds, CropMessage::MouseMove { axis_align, centre }) => {
+				(CropToolFsmState::ResizingBounds, CropMessage::PointerMove { axis_align, centre }) => {
 					if let Some(bounds) = &mut data.bounding_box_overlays {
 						if let Some(movement) = &mut bounds.selected_edges {
 							let (centre, axis_align) = (input.keyboard.get(centre as usize), input.keyboard.get(axis_align as usize));
@@ -211,7 +211,7 @@ impl Fsm for CropToolFsmState {
 					}
 					CropToolFsmState::ResizingBounds
 				}
-				(CropToolFsmState::Dragging, CropMessage::MouseMove { axis_align, .. }) => {
+				(CropToolFsmState::Dragging, CropMessage::PointerMove { axis_align, .. }) => {
 					if let Some(bounds) = &mut data.bounding_box_overlays {
 						let mouse_position = axis_align_drag(input.keyboard.get(axis_align as usize), input.mouse.position, data.drag_start);
 
@@ -240,7 +240,7 @@ impl Fsm for CropToolFsmState {
 					}
 					CropToolFsmState::Dragging
 				}
-				(CropToolFsmState::Drawing, CropMessage::MouseMove { axis_align, centre }) => {
+				(CropToolFsmState::Drawing, CropMessage::PointerMove { axis_align, centre }) => {
 					let mouse_position = input.mouse.position;
 					let snapped_mouse_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, mouse_position);
 
@@ -272,7 +272,7 @@ impl Fsm for CropToolFsmState {
 
 					CropToolFsmState::Drawing
 				}
-				(CropToolFsmState::Ready, CropMessage::MouseMove { .. }) => {
+				(CropToolFsmState::Ready, CropMessage::PointerMove { .. }) => {
 					let cursor = data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input, false));
 
 					if data.cursor != cursor {
@@ -282,7 +282,7 @@ impl Fsm for CropToolFsmState {
 
 					CropToolFsmState::Ready
 				}
-				(CropToolFsmState::ResizingBounds, CropMessage::MouseUp) => {
+				(CropToolFsmState::ResizingBounds, CropMessage::PointerUp) => {
 					data.snap_handler.cleanup(responses);
 
 					if let Some(bounds) = &mut data.bounding_box_overlays {
@@ -291,7 +291,7 @@ impl Fsm for CropToolFsmState {
 
 					CropToolFsmState::Ready
 				}
-				(CropToolFsmState::Drawing, CropMessage::MouseUp) => {
+				(CropToolFsmState::Drawing, CropMessage::PointerUp) => {
 					data.snap_handler.cleanup(responses);
 
 					if let Some(bounds) = &mut data.bounding_box_overlays {
@@ -302,7 +302,7 @@ impl Fsm for CropToolFsmState {
 
 					CropToolFsmState::Ready
 				}
-				(CropToolFsmState::Dragging, CropMessage::MouseUp) => {
+				(CropToolFsmState::Dragging, CropMessage::PointerUp) => {
 					data.snap_handler.cleanup(responses);
 
 					if let Some(bounds) = &mut data.bounding_box_overlays {

--- a/editor/src/viewport_tools/tools/crop.rs
+++ b/editor/src/viewport_tools/tools/crop.rs
@@ -1,3 +1,5 @@
+use crate::consts::SELECTION_TOLERANCE;
+use crate::document::transformation::Selected;
 use crate::document::DocumentMessageHandler;
 use crate::frontend::utility_types::MouseCursorIcon;
 use crate::input::InputPreprocessorMessageHandler;
@@ -59,7 +61,7 @@ impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Crop {
 		}
 	}
 
-	advertise_actions!(CropMessageDiscriminant; MouseMove, Abort);
+	advertise_actions!(CropMessageDiscriminant; MouseDown, MouseUp, MouseMove, Abort);
 }
 
 impl PropertyHolder for Crop {}
@@ -67,7 +69,8 @@ impl PropertyHolder for Crop {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CropToolFsmState {
 	Ready,
-	Resizing,
+	Dragging,
+	ResizingBounds,
 }
 
 impl Default for CropToolFsmState {
@@ -80,6 +83,8 @@ impl Default for CropToolFsmState {
 struct CropToolData {
 	bounding_box_overlays: Option<BoundingBoxOverlays>,
 	selected_board: Option<Vec<LayerId>>,
+	snap_handler: SnapHandler,
+	cursor: MouseCursorIcon,
 }
 
 impl Fsm for CropToolFsmState {
@@ -98,10 +103,139 @@ impl Fsm for CropToolFsmState {
 	) -> Self {
 		if let ToolMessage::Crop(event) = event {
 			match (self, event) {
+				(_, CropMessage::DocumentIsDirty) => {
+					let mut buffer = Vec::new();
+					match (
+						data.selected_board.as_ref().map(|path| document.artboard_bounding_box(&path)).unwrap_or(None),
+						data.bounding_box_overlays.take(),
+					) {
+						(None, Some(bounding_box_overlays)) => bounding_box_overlays.delete(&mut buffer),
+						(Some(bounds), paths) => {
+							let mut bounding_box_overlays = paths.unwrap_or_else(|| BoundingBoxOverlays::new(&mut buffer));
+
+							bounding_box_overlays.bounds = bounds;
+							bounding_box_overlays.transform(&mut buffer);
+
+							data.bounding_box_overlays = Some(bounding_box_overlays);
+
+							responses.push_back(OverlaysMessage::Rerender.into());
+						}
+						(_, _) => {}
+					};
+					buffer.into_iter().rev().for_each(|message| responses.push_front(message));
+					self
+				}
+				(CropToolFsmState::Ready, CropMessage::MouseDown) => {
+					let dragging_bounds = if let Some(bounding_box) = &mut data.bounding_box_overlays {
+						let edges = bounding_box.check_selected_edges(input.mouse.position);
+
+						bounding_box.selected_edges = edges.map(|(top, bottom, left, right)| {
+							let edges = SelectedEdges::new(top, bottom, left, right, bounding_box.bounds);
+							bounding_box.pivot = edges.calculate_pivot();
+							edges
+						});
+
+						edges
+					} else {
+						None
+					};
+
+					if let Some(selected_edges) = dragging_bounds {
+						let snap_x = selected_edges.2 || selected_edges.3;
+						let snap_y = selected_edges.0 || selected_edges.1;
+
+						data.snap_handler.start_snap(document, document.visible_layers(), snap_x, snap_y);
+
+						CropToolFsmState::ResizingBounds
+					} else {
+						let tolerance = DVec2::splat(SELECTION_TOLERANCE);
+						let quad = Quad::from_box([input.mouse.position - tolerance, input.mouse.position + tolerance]);
+						let intersection = document.artboard_message_handler.artboards_graphene_document.intersects_quad_root(quad);
+
+						responses.push_back(ToolMessage::DocumentIsDirty.into());
+						if let Some(intersection) = intersection.last() {
+							data.selected_board = Some(intersection.clone());
+
+							CropToolFsmState::Dragging
+						} else {
+							data.selected_board = None;
+
+							CropToolFsmState::Ready
+						}
+					}
+				}
+				(CropToolFsmState::ResizingBounds, CropMessage::MouseMove) => {
+					if let Some(bounds) = &mut data.bounding_box_overlays {
+						if let Some(movement) = &mut bounds.selected_edges {
+							let mouse_position = input.mouse.position;
+
+							let snapped_mouse_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, mouse_position);
+
+							let [bounds1, bounds2] = movement.new_size(snapped_mouse_position);
+							let root_transform = document.graphene_document.root.transform.inverse();
+							let [bounds1, bounds2] = [root_transform.transform_point2(bounds1), root_transform.transform_point2(bounds2)];
+							let size = bounds2 - bounds1;
+
+							responses.push_back(
+								ArtboardMessage::ResizeArtboard {
+									artboard: data.selected_board.clone().unwrap(),
+									position: bounds1.into(),
+									size: size.into(),
+								}
+								.into(),
+							);
+
+							responses.push_back(ToolMessage::DocumentIsDirty.into());
+						}
+					}
+					CropToolFsmState::ResizingBounds
+				}
+				(CropToolFsmState::Ready, CropMessage::MouseMove) => {
+					let cursor = data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input));
+
+					if data.cursor != cursor {
+						data.cursor = cursor;
+						responses.push_back(FrontendMessage::UpdateMouseCursor { cursor }.into());
+					}
+
+					CropToolFsmState::Ready
+				}
+				(CropToolFsmState::ResizingBounds, CropMessage::MouseUp) => {
+					data.snap_handler.cleanup(responses);
+
+					if let Some(bounds) = &mut data.bounding_box_overlays {
+						bounds.original_transforms.clear();
+					}
+
+					CropToolFsmState::Ready
+				}
+				(CropToolFsmState::Dragging, CropMessage::MouseUp) => {
+					data.snap_handler.cleanup(responses);
+
+					if let Some(bounds) = &mut data.bounding_box_overlays {
+						bounds.original_transforms.clear();
+					}
+
+					CropToolFsmState::Ready
+				}
+				(_, CropMessage::Abort) => {
+					if let Some(bounding_box_overlays) = data.bounding_box_overlays.take() {
+						bounding_box_overlays.delete(responses);
+					}
+
+					data.snap_handler.cleanup(responses);
+					CropToolFsmState::Ready
+				}
 				_ => self,
 			}
 		} else {
 			self
 		}
+	}
+
+	fn update_hints(&self, responses: &mut VecDeque<Message>) {}
+
+	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+		responses.push_back(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default }.into());
 	}
 }

--- a/editor/src/viewport_tools/tools/crop.rs
+++ b/editor/src/viewport_tools/tools/crop.rs
@@ -332,33 +332,27 @@ impl Fsm for CropToolFsmState {
 
 	fn update_hints(&self, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
-			CropToolFsmState::Ready => HintData(vec![HintGroup(vec![
-				HintInfo {
-					key_groups: vec![],
-					mouse: Some(MouseMotion::LmbDrag),
-					label: String::from("Move Artboard"),
-					plus: false,
-				},
-				HintInfo {
+			CropToolFsmState::Ready => HintData(vec![
+				HintGroup(vec![HintInfo {
 					key_groups: vec![],
 					mouse: Some(MouseMotion::LmbDrag),
 					label: String::from("Draw Artboard"),
 					plus: false,
-				},
-				HintInfo {
+				}]),
+				HintGroup(vec![HintInfo {
+					key_groups: vec![],
+					mouse: Some(MouseMotion::LmbDrag),
+					label: String::from("Move Artboard"),
+					plus: false,
+				}]),
+			]),
+			CropToolFsmState::Dragging => HintData(vec![HintGroup(vec![HintInfo {
 				key_groups: vec![KeysGroup(vec![Key::KeyShift])],
 				mouse: None,
-					label: String::from("Constrain Square"),
-					plus: true,
-				},
-				HintInfo {
-					key_groups: vec![KeysGroup(vec![Key::KeyAlt])],
-					mouse: None,
-					label: String::from("From Center"),
-					plus: true,
-				},
-			])]),
-			CropToolFsmState::Dragging | CropToolFsmState::Drawing | CropToolFsmState::ResizingBounds => HintData(vec![HintGroup(vec![
+				label: String::from("Constrain to Axis"),
+				plus: false,
+			}])]),
+			CropToolFsmState::Drawing | CropToolFsmState::ResizingBounds => HintData(vec![HintGroup(vec![
 				HintInfo {
 					key_groups: vec![KeysGroup(vec![Key::KeyShift])],
 					mouse: None,

--- a/editor/src/viewport_tools/tools/crop.rs
+++ b/editor/src/viewport_tools/tools/crop.rs
@@ -1,30 +1,107 @@
-use crate::layout::widgets::PropertyHolder;
+use crate::document::DocumentMessageHandler;
+use crate::frontend::utility_types::MouseCursorIcon;
+use crate::input::InputPreprocessorMessageHandler;
+use crate::layout::widgets::{IconButton, LayoutRow, PopoverButton, PropertyHolder, Separator, SeparatorDirection, SeparatorType, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
 use crate::message_prelude::*;
-use crate::viewport_tools::tool::ToolActionHandlerData;
+use crate::misc::{HintData, HintGroup, HintInfo, KeysGroup};
+use crate::viewport_tools::snapping::SnapHandler;
+use crate::viewport_tools::tool::{DocumentToolData, Fsm, ToolActionHandlerData, ToolType};
 
+use graphene::document::Document;
+use graphene::intersection::Quad;
+use graphene::layers::layer_info::LayerDataType;
+use graphene::Operation;
+
+use super::shared::transformation_cage::*;
+
+use glam::{DAffine2, DVec2};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
-pub struct Crop;
+pub struct Crop {
+	fsm_state: CropToolFsmState,
+	data: CropToolData,
+}
 
 #[remain::sorted]
 #[impl_message(Message, ToolMessage, Crop)]
 #[derive(PartialEq, Clone, Debug, Hash, Serialize, Deserialize)]
 pub enum CropMessage {
 	// Standard messages
-	// #[remain::unsorted]
-	// Abort,
+	#[remain::unsorted]
+	Abort,
+	#[remain::unsorted]
+	DocumentIsDirty,
 
 	// Tool-specific messages
+	MouseDown,
 	MouseMove,
+	MouseUp,
 }
 
 impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Crop {
 	fn process_action(&mut self, action: ToolMessage, data: ToolActionHandlerData<'a>, responses: &mut VecDeque<Message>) {
-		todo!("{}::handle_input {:?} {:?} {:?} ", module_path!(), action, data, responses);
+		if action == ToolMessage::UpdateHints {
+			self.fsm_state.update_hints(responses);
+			return;
+		}
+
+		if action == ToolMessage::UpdateCursor {
+			responses.push_back(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default }.into());
+			return;
+		}
+
+		let new_state = self.fsm_state.transition(action, data.0, data.1, &mut self.data, &(), data.2, responses);
+
+		if self.fsm_state != new_state {
+			self.fsm_state = new_state;
+			self.fsm_state.update_hints(responses);
+		}
 	}
 
-	advertise_actions!();
+	advertise_actions!(CropMessageDiscriminant; MouseMove, Abort);
 }
 
 impl PropertyHolder for Crop {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CropToolFsmState {
+	Ready,
+	Resizing,
+}
+
+impl Default for CropToolFsmState {
+	fn default() -> Self {
+		CropToolFsmState::Ready
+	}
+}
+
+#[derive(Clone, Debug, Default)]
+struct CropToolData {
+	bounding_box_overlays: Option<BoundingBoxOverlays>,
+	selected_board: Option<Vec<LayerId>>,
+}
+
+impl Fsm for CropToolFsmState {
+	type ToolData = CropToolData;
+	type ToolOptions = ();
+
+	fn transition(
+		self,
+		event: ToolMessage,
+		document: &DocumentMessageHandler,
+		tool_data: &DocumentToolData,
+		data: &mut Self::ToolData,
+		_tool_options: &Self::ToolOptions,
+		input: &InputPreprocessorMessageHandler,
+		responses: &mut VecDeque<Message>,
+	) -> Self {
+		if let ToolMessage::Crop(event) = event {
+			match (self, event) {
+				_ => self,
+			}
+		} else {
+			self
+		}
+	}
+}

--- a/editor/src/viewport_tools/tools/line.rs
+++ b/editor/src/viewport_tools/tools/line.rs
@@ -155,7 +155,7 @@ impl Fsm for LineToolFsmState {
 		if let ToolMessage::Line(event) = event {
 			match (self, event) {
 				(Ready, DragStart) => {
-					data.snap_handler.start_snap(document, document.visible_layers(), true, true);
+					data.snap_handler.start_snap(document, document.bounding_boxes(None, None), true, true);
 					data.drag_start = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, input.mouse.position);
 
 					responses.push_back(DocumentMessage::StartTransaction.into());

--- a/editor/src/viewport_tools/tools/navigate.rs
+++ b/editor/src/viewport_tools/tools/navigate.rs
@@ -28,7 +28,7 @@ pub enum NavigateMessage {
 	ClickZoom {
 		zoom_in: bool,
 	},
-	MouseMove {
+	PointerMove {
 		snap_angle: Key,
 		snap_zoom: Key,
 	},
@@ -66,7 +66,7 @@ impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for Navigate {
 
 		match self.fsm_state {
 			Ready => actions!(NavigateMessageDiscriminant; TranslateCanvasBegin, RotateCanvasBegin, ZoomCanvasBegin),
-			_ => actions!(NavigateMessageDiscriminant; ClickZoom, MouseMove, TransformCanvasEnd),
+			_ => actions!(NavigateMessageDiscriminant; ClickZoom, PointerMove, TransformCanvasEnd),
 		}
 	}
 }
@@ -111,7 +111,7 @@ impl Fsm for NavigateToolFsmState {
 				ClickZoom { zoom_in } => {
 					messages.push_front(MovementMessage::TransformCanvasEnd.into());
 
-					// Mouse has not moved from mousedown to mouseup
+					// Mouse has not moved from pointerdown to pointerup
 					if data.drag_start == input.mouse.position {
 						messages.push_front(if zoom_in {
 							MovementMessage::IncreaseCanvasZoom { center_on_mouse: true }.into()
@@ -122,9 +122,9 @@ impl Fsm for NavigateToolFsmState {
 
 					NavigateToolFsmState::Ready
 				}
-				MouseMove { snap_angle, snap_zoom } => {
+				PointerMove { snap_angle, snap_zoom } => {
 					messages.push_front(
-						MovementMessage::MouseMove {
+						MovementMessage::PointerMove {
 							snap_angle,
 							wait_for_snap_angle_release: false,
 							snap_zoom,

--- a/editor/src/viewport_tools/tools/path.rs
+++ b/editor/src/viewport_tools/tools/path.rs
@@ -626,7 +626,6 @@ fn add_shape_outline(responses: &mut VecDeque<Message>) -> Vec<LayerId> {
 		path: layer_path.clone(),
 		bez_path: BezPath::default(),
 		style: style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, 1.0)), None),
-		closed: false,
 	};
 	responses.push_back(DocumentMessage::Overlays(operation.into()).into());
 

--- a/editor/src/viewport_tools/tools/pen.rs
+++ b/editor/src/viewport_tools/tools/pen.rs
@@ -155,7 +155,7 @@ impl Fsm for PenToolFsmState {
 					responses.push_back(DocumentMessage::DeselectAllLayers.into());
 					data.path = Some(vec![generate_uuid()]);
 
-					data.snap_handler.start_snap(document, document.visible_layers(), true, true);
+					data.snap_handler.start_snap(document, document.bounding_boxes(None, None), true, true);
 					let snapped_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, input.mouse.position);
 
 					let pos = transform.inverse().transform_point2(snapped_position);

--- a/editor/src/viewport_tools/tools/select.rs
+++ b/editor/src/viewport_tools/tools/select.rs
@@ -527,7 +527,7 @@ impl Fsm for SelectToolFsmState {
 						DocumentMessage::Overlays(
 							Operation::SetLayerTransformInViewport {
 								path: data.drag_box_overlay_layer.clone().unwrap(),
-								transform: transform_from_box(data.drag_start, data.drag_current).to_cols_array(),
+								transform: transform_from_box(data.drag_start, data.drag_current, DAffine2::IDENTITY).to_cols_array(),
 							}
 							.into(),
 						)

--- a/editor/src/viewport_tools/tools/select.rs
+++ b/editor/src/viewport_tools/tools/select.rs
@@ -53,7 +53,7 @@ pub enum SelectMessage {
 	PointerMove {
 		axis_align: Key,
 		snap_angle: Key,
-		centre: Key,
+		center: Key,
 	},
 }
 
@@ -474,17 +474,17 @@ impl Fsm for SelectToolFsmState {
 					data.drag_current = mouse_position + closest_move;
 					Dragging
 				}
-				(ResizingBounds, PointerMove { axis_align, centre, .. }) => {
+				(ResizingBounds, PointerMove { axis_align, center, .. }) => {
 					if let Some(bounds) = &mut data.bounding_box_overlays {
 						if let Some(movement) = &mut bounds.selected_edges {
-							let (centre, axis_align) = (input.keyboard.get(centre as usize), input.keyboard.get(axis_align as usize));
+							let (center, axis_align) = (input.keyboard.get(center as usize), input.keyboard.get(axis_align as usize));
 
 							let mouse_position = input.mouse.position;
 
 							let snapped_mouse_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, mouse_position);
 
-							let [_position, size] = movement.new_size(snapped_mouse_position, bounds.transform, centre, axis_align);
-							let delta = movement.bounds_to_scale_transform(centre, size);
+							let [_position, size] = movement.new_size(snapped_mouse_position, bounds.transform, center, axis_align);
+							let delta = movement.bounds_to_scale_transform(center, size);
 
 							let selected = data.layers_dragging.iter().collect::<Vec<_>>();
 							let mut selected = Selected::new(&mut bounds.original_transforms, &mut bounds.pivot, &selected, responses, &document.graphene_document);

--- a/editor/src/viewport_tools/tools/select.rs
+++ b/editor/src/viewport_tools/tools/select.rs
@@ -332,6 +332,8 @@ impl Fsm for SelectToolFsmState {
 							let mut bounding_box_overlays = paths.unwrap_or_else(|| BoundingBoxOverlays::new(&mut buffer));
 
 							bounding_box_overlays.bounds = bounds;
+							bounding_box_overlays.transform = DAffine2::IDENTITY;
+
 							bounding_box_overlays.transform(&mut buffer);
 
 							data.bounding_box_overlays = Some(bounding_box_overlays);
@@ -486,7 +488,7 @@ impl Fsm for SelectToolFsmState {
 
 							let snapped_mouse_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, mouse_position);
 
-							let [min, size] = movement.new_size(snapped_mouse_position, centre, axis_align);
+							let [min, size] = movement.new_size(snapped_mouse_position, bounds.transform, centre, axis_align);
 							let delta = movement.bounds_to_scale_transform(centre, min, size);
 
 							let selected = data.layers_dragging.iter().collect::<Vec<_>>();
@@ -530,7 +532,7 @@ impl Fsm for SelectToolFsmState {
 						DocumentMessage::Overlays(
 							Operation::SetLayerTransformInViewport {
 								path: data.drag_box_overlay_layer.clone().unwrap(),
-								transform: transform_from_box(data.drag_start, data.drag_current),
+								transform: transform_from_box(data.drag_start, data.drag_current).to_cols_array(),
 							}
 							.into(),
 						)

--- a/editor/src/viewport_tools/tools/select.rs
+++ b/editor/src/viewport_tools/tools/select.rs
@@ -400,8 +400,7 @@ impl Fsm for SelectToolFsmState {
 						let snap_x = selected_edges.2 || selected_edges.3;
 						let snap_y = selected_edges.0 || selected_edges.1;
 
-						data.snap_handler
-							.start_snap(document, document.visible_layers().filter(|layer| !selected.iter().any(|path| path == layer)), snap_x, snap_y);
+						data.snap_handler.start_snap(document, document.bounding_boxes(Some(&selected), None), snap_x, snap_y);
 
 						data.layers_dragging = selected;
 
@@ -421,8 +420,7 @@ impl Fsm for SelectToolFsmState {
 						buffer.push(DocumentMessage::StartTransaction.into());
 						data.layers_dragging = selected;
 
-						data.snap_handler
-							.start_snap(document, document.visible_layers().filter(|layer| !data.layers_dragging.iter().any(|path| path == layer)), true, true);
+						data.snap_handler.start_snap(document, document.bounding_boxes(Some(&data.layers_dragging), None), true, true);
 
 						Dragging
 					} else {
@@ -436,8 +434,7 @@ impl Fsm for SelectToolFsmState {
 							buffer.push(DocumentMessage::AddSelectedLayers { additional_layers: selected.clone() }.into());
 							buffer.push(DocumentMessage::StartTransaction.into());
 							data.layers_dragging.append(&mut selected);
-							data.snap_handler
-								.start_snap(document, document.visible_layers().filter(|layer| !data.layers_dragging.iter().any(|path| path == layer)), true, true);
+							data.snap_handler.start_snap(document, document.bounding_boxes(Some(&data.layers_dragging), None), true, true);
 
 							Dragging
 						} else {
@@ -541,7 +538,7 @@ impl Fsm for SelectToolFsmState {
 					DrawingBox
 				}
 				(Ready, MouseMove { .. }) => {
-					let cursor = data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input));
+					let cursor = data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input, true));
 
 					if data.cursor != cursor {
 						data.cursor = cursor;

--- a/editor/src/viewport_tools/tools/select.rs
+++ b/editor/src/viewport_tools/tools/select.rs
@@ -489,7 +489,7 @@ impl Fsm for SelectToolFsmState {
 							let snapped_mouse_position = data.snap_handler.snap_position(responses, input.viewport_bounds.size(), document, mouse_position);
 
 							let [min, size] = movement.new_size(snapped_mouse_position, bounds.transform, centre, axis_align);
-							let delta = movement.bounds_to_scale_transform(centre, min, size);
+							let delta = movement.bounds_to_scale_transform(centre, size);
 
 							let selected = data.layers_dragging.iter().collect::<Vec<_>>();
 							let mut selected = Selected::new(&mut bounds.original_transforms, &mut bounds.pivot, &selected, responses, &document.graphene_document);

--- a/editor/src/viewport_tools/tools/shared/mod.rs
+++ b/editor/src/viewport_tools/tools/shared/mod.rs
@@ -1,1 +1,2 @@
 pub mod resize;
+pub mod transformation_cage;

--- a/editor/src/viewport_tools/tools/shared/resize.rs
+++ b/editor/src/viewport_tools/tools/shared/resize.rs
@@ -18,7 +18,7 @@ pub struct Resize {
 impl Resize {
 	/// Starts a resize, assigning the snap targets and snapping the starting position.
 	pub fn start(&mut self, responses: &mut VecDeque<Message>, viewport_bounds: DVec2, document: &DocumentMessageHandler, mouse_position: DVec2) {
-		self.snap_handler.start_snap(document, document.visible_layers(), true, true);
+		self.snap_handler.start_snap(document, document.bounding_boxes(None, None), true, true);
 		self.drag_start = self.snap_handler.snap_position(responses, viewport_bounds, document, mouse_position);
 	}
 

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -157,7 +157,13 @@ fn add_transform_handles(responses: &mut Vec<Message>) -> [Vec<LayerId>; 8] {
 
 /// Converts a bounding box to a rounded transform (with translation and scale)
 pub fn transform_from_box(pos1: DVec2, pos2: DVec2, transform: DAffine2) -> DAffine2 {
-	DAffine2::from_scale_angle_translation(transform.transform_vector2(pos2 - pos1).round(), 0., transform.transform_point2(pos1).round() - DVec2::splat(0.5))
+	let inverse = transform.inverse();
+	transform
+		* DAffine2::from_scale_angle_translation(
+			inverse.transform_vector2(transform.transform_vector2(pos2 - pos1).round()),
+			0.,
+			inverse.transform_point2(transform.transform_point2(pos1).round() - DVec2::splat(0.5)),
+		)
 }
 
 /// Aligns the mouse position to the closest axis

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -156,8 +156,8 @@ fn add_transform_handles(responses: &mut Vec<Message>) -> [Vec<LayerId>; 8] {
 }
 
 /// Converts a bounding box to a rounded transform (with translation and scale)
-pub fn transform_from_box(pos1: DVec2, pos2: DVec2) -> DAffine2 {
-	DAffine2::from_scale_angle_translation((pos2 - pos1).round(), 0., pos1.round() - DVec2::splat(0.5))
+pub fn transform_from_box(pos1: DVec2, pos2: DVec2, transform: DAffine2) -> DAffine2 {
+	DAffine2::from_scale_angle_translation(transform.transform_vector2(pos2 - pos1).round(), 0., transform.transform_point2(pos1).round() - DVec2::splat(0.5))
 }
 
 /// Aligns the mouse position to the closest axis
@@ -213,7 +213,7 @@ impl BoundingBoxOverlays {
 
 	/// Update the position of the bounding box and transform handles
 	pub fn transform(&mut self, buffer: &mut Vec<Message>) {
-		let transform = (self.transform * transform_from_box(self.bounds[0], self.bounds[1])).to_cols_array();
+		let transform = transform_from_box(self.bounds[0], self.bounds[1], self.transform).to_cols_array();
 		let path = self.bounding_box.clone();
 		buffer.push(DocumentMessage::Overlays(Operation::SetLayerTransformInViewport { path, transform }.into()).into());
 

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -266,7 +266,7 @@ impl BoundingBoxOverlays {
 		outside_bounds & inside_extended_bounds
 	}
 
-	pub fn get_cursor(&self, input: &InputPreprocessorMessageHandler) -> MouseCursorIcon {
+	pub fn get_cursor(&self, input: &InputPreprocessorMessageHandler, rotate: bool) -> MouseCursorIcon {
 		if let Some(directions) = self.check_selected_edges(input.mouse.position) {
 			match directions {
 				(true, false, false, false) | (false, true, false, false) => MouseCursorIcon::NSResize,
@@ -275,7 +275,7 @@ impl BoundingBoxOverlays {
 				(true, false, false, true) | (false, true, true, false) => MouseCursorIcon::NESWResize,
 				_ => MouseCursorIcon::Default,
 			}
-		} else if self.check_rotate(input.mouse.position) {
+		} else if rotate && self.check_rotate(input.mouse.position) {
 			MouseCursorIcon::Grabbing
 		} else {
 			MouseCursorIcon::Default

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -1,0 +1,224 @@
+use crate::consts::{BOUNDS_ROTATE_THRESHOLD, BOUNDS_SELECT_THRESHOLD, COLOR_ACCENT, VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE};
+use crate::document::transformation::OriginalTransforms;
+use crate::frontend::utility_types::MouseCursorIcon;
+use crate::input::InputPreprocessorMessageHandler;
+use crate::message_prelude::*;
+
+use graphene::color::Color;
+use graphene::layers::style::{self, Fill, Stroke};
+use graphene::Operation;
+
+use glam::{DAffine2, DVec2};
+
+#[derive(Clone, Debug, Default)]
+pub struct SelectedEdges {
+	bounds: [DVec2; 2],
+	top: bool,
+	bottom: bool,
+	left: bool,
+	right: bool,
+}
+
+impl SelectedEdges {
+	pub fn new(top: bool, bottom: bool, left: bool, right: bool, bounds: [DVec2; 2]) -> Self {
+		Self { top, bottom, left, right, bounds }
+	}
+
+	/// Calculate the pivot for the operation (the opposite point to the edge dragged)
+	pub fn calculate_pivot(&self) -> DVec2 {
+		let min = self.bounds[0];
+		let max = self.bounds[1];
+
+		let x = if self.left {
+			max.x
+		} else if self.right {
+			min.x
+		} else {
+			(min.x + max.x) / 2.
+		};
+
+		let y = if self.top {
+			max.y
+		} else if self.bottom {
+			min.y
+		} else {
+			(min.y + max.y) / 2.
+		};
+
+		DVec2::new(x, y)
+	}
+
+	/// Calculates the required scaling to resize the bounding box
+	pub fn pos_to_scale_transform(&self, mouse: DVec2) -> DAffine2 {
+		let mut min = self.bounds[0];
+		let mut max = self.bounds[1];
+		if self.top {
+			min.y = mouse.y;
+		} else if self.bottom {
+			max.y = mouse.y;
+		}
+		if self.left {
+			min.x = mouse.x
+		} else if self.right {
+			max.x = mouse.x;
+		}
+		DAffine2::from_scale((max - min) / (self.bounds[1] - self.bounds[0]))
+	}
+}
+
+pub fn add_bounding_box(responses: &mut Vec<Message>) -> Vec<LayerId> {
+	let path = vec![generate_uuid()];
+
+	let operation = Operation::AddOverlayRect {
+		path: path.clone(),
+		transform: DAffine2::ZERO.to_cols_array(),
+		style: style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, 1.0)), Some(Fill::none())),
+	};
+	responses.push(DocumentMessage::Overlays(operation.into()).into());
+
+	path
+}
+
+fn evaluate_transform_handle_positions((left, top): (f64, f64), (right, bottom): (f64, f64)) -> [DVec2; 8] {
+	[
+		DVec2::new(left, top),
+		DVec2::new(left, (top + bottom) / 2.),
+		DVec2::new(left, bottom),
+		DVec2::new((left + right) / 2., top),
+		DVec2::new((left + right) / 2., bottom),
+		DVec2::new(right, top),
+		DVec2::new(right, (top + bottom) / 2.),
+		DVec2::new(right, bottom),
+	]
+}
+
+fn add_transform_handles(responses: &mut Vec<Message>) -> [Vec<LayerId>; 8] {
+	const EMPTY_VEC: Vec<LayerId> = Vec::new();
+	let mut transform_handle_paths = [EMPTY_VEC; 8];
+
+	for item in &mut transform_handle_paths {
+		let current_path = vec![generate_uuid()];
+
+		let operation = Operation::AddOverlayRect {
+			path: current_path.clone(),
+			transform: DAffine2::ZERO.to_cols_array(),
+			style: style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, 2.0)), Some(Fill::new(Color::WHITE))),
+		};
+		responses.push(DocumentMessage::Overlays(operation.into()).into());
+
+		*item = current_path;
+	}
+
+	transform_handle_paths
+}
+
+pub fn transform_from_box(pos1: DVec2, pos2: DVec2) -> [f64; 6] {
+	DAffine2::from_scale_angle_translation((pos2 - pos1).round(), 0., pos1.round() - DVec2::splat(0.5)).to_cols_array()
+}
+
+/// Contains info on the overlays for the bounding box and transform handles
+#[derive(Clone, Debug, Default)]
+pub struct BoundingBoxOverlays {
+	pub bounding_box: Vec<LayerId>,
+	pub transform_handles: [Vec<LayerId>; 8],
+	pub bounds: [DVec2; 2],
+	pub selected_edges: Option<SelectedEdges>,
+	pub original_transforms: OriginalTransforms,
+	pub pivot: DVec2,
+}
+
+impl BoundingBoxOverlays {
+	#[must_use]
+	pub fn new(buffer: &mut Vec<Message>) -> Self {
+		Self {
+			bounding_box: add_bounding_box(buffer),
+			transform_handles: add_transform_handles(buffer),
+			..Default::default()
+		}
+	}
+
+	/// Update the position of the bounding box and transform handles
+	pub fn transform(&mut self, buffer: &mut Vec<Message>) {
+		let transform = transform_from_box(self.bounds[0], self.bounds[1]);
+		let path = self.bounding_box.clone();
+		buffer.push(DocumentMessage::Overlays(Operation::SetLayerTransformInViewport { path, transform }.into()).into());
+
+		// Helps push values that end in approximately half, plus or minus some floating point imprecision, towards the same side of the round() function
+		const BIAS: f64 = 0.0001;
+
+		for (position, path) in evaluate_transform_handle_positions(self.bounds[0].into(), self.bounds[1].into())
+			.into_iter()
+			.zip(&self.transform_handles)
+		{
+			let scale = DVec2::splat(VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE);
+			let translation = (position - (scale / 2.) - 0.5 + BIAS).round();
+			let transform = DAffine2::from_scale_angle_translation(scale, 0., translation).to_cols_array();
+			let path = path.clone();
+			buffer.push(DocumentMessage::Overlays(Operation::SetLayerTransformInViewport { path, transform }.into()).into());
+		}
+	}
+
+	/// Check if the user has selected the edge for dragging (returns which edge in order top, bottom, left, right)
+	pub fn check_selected_edges(&self, cursor: DVec2) -> Option<(bool, bool, bool, bool)> {
+		let min = self.bounds[0].min(self.bounds[1]);
+		let max = self.bounds[0].max(self.bounds[1]);
+		if min.x - cursor.x < BOUNDS_SELECT_THRESHOLD && min.y - cursor.y < BOUNDS_SELECT_THRESHOLD && cursor.x - max.x < BOUNDS_SELECT_THRESHOLD && cursor.y - max.y < BOUNDS_SELECT_THRESHOLD {
+			let mut top = (cursor.y - min.y).abs() < BOUNDS_SELECT_THRESHOLD;
+			let mut bottom = (max.y - cursor.y).abs() < BOUNDS_SELECT_THRESHOLD;
+			let mut left = (cursor.x - min.x).abs() < BOUNDS_SELECT_THRESHOLD;
+			let mut right = (max.x - cursor.x).abs() < BOUNDS_SELECT_THRESHOLD;
+			if cursor.y - min.y + max.y - cursor.y < BOUNDS_SELECT_THRESHOLD * 2. && (left || right) {
+				top = false;
+				bottom = false;
+			}
+			if cursor.x - min.x + max.x - cursor.x < BOUNDS_SELECT_THRESHOLD * 2. && (top || bottom) {
+				left = false;
+				right = false;
+			}
+
+			if top || bottom || left || right {
+				return Some((top, bottom, left, right));
+			}
+		}
+
+		None
+	}
+
+	/// Check if the user is rotating with the bounds
+	pub fn check_rotate(&self, cursor: DVec2) -> bool {
+		let min = self.bounds[0].min(self.bounds[1]);
+		let max = self.bounds[0].max(self.bounds[1]);
+
+		let outside_bounds = (min.x > cursor.x || cursor.x > max.x) || (min.y > cursor.y || cursor.y > max.y);
+		let inside_extended_bounds =
+			min.x - cursor.x < BOUNDS_ROTATE_THRESHOLD && min.y - cursor.y < BOUNDS_ROTATE_THRESHOLD && cursor.x - max.x < BOUNDS_ROTATE_THRESHOLD && cursor.y - max.y < BOUNDS_ROTATE_THRESHOLD;
+
+		outside_bounds & inside_extended_bounds
+	}
+
+	pub fn get_cursor(&self, input: &InputPreprocessorMessageHandler) -> MouseCursorIcon {
+		if let Some(directions) = self.check_selected_edges(input.mouse.position) {
+			match directions {
+				(true, false, false, false) | (false, true, false, false) => MouseCursorIcon::NSResize,
+				(false, false, true, false) | (false, false, false, true) => MouseCursorIcon::EWResize,
+				(true, false, true, false) | (false, true, false, true) => MouseCursorIcon::NWSEResize,
+				(true, false, false, true) | (false, true, true, false) => MouseCursorIcon::NESWResize,
+				_ => MouseCursorIcon::Default,
+			}
+		} else if self.check_rotate(input.mouse.position) {
+			MouseCursorIcon::Grabbing
+		} else {
+			MouseCursorIcon::Default
+		}
+	}
+
+	/// Removes the overlays
+	pub fn delete(self, buffer: &mut impl Extend<Message>) {
+		buffer.extend([DocumentMessage::Overlays(Operation::DeleteLayer { path: self.bounding_box }.into()).into()]);
+		buffer.extend(
+			self.transform_handles
+				.iter()
+				.map(|path| DocumentMessage::Overlays(Operation::DeleteLayer { path: path.clone() }.into()).into()),
+		);
+	}
+}

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -48,8 +48,7 @@ impl SelectedEdges {
 		DVec2::new(x, y)
 	}
 
-	/// Calculates the required scaling to resize the bounding box
-	pub fn pos_to_scale_transform(&self, mouse: DVec2) -> DAffine2 {
+	pub fn new_size(&self, mouse: DVec2) -> [DVec2; 2] {
 		let mut min = self.bounds[0];
 		let mut max = self.bounds[1];
 		if self.top {
@@ -62,6 +61,12 @@ impl SelectedEdges {
 		} else if self.right {
 			max.x = mouse.x;
 		}
+		[min, max]
+	}
+
+	/// Calculates the required scaling to resize the bounding box
+	pub fn pos_to_scale_transform(&self, mouse: DVec2) -> DAffine2 {
+		let [min, max] = self.new_size(mouse);
 		DAffine2::from_scale((max - min) / (self.bounds[1] - self.bounds[0]))
 	}
 }

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -50,7 +50,7 @@ impl SelectedEdges {
 	}
 
 	/// Computes the new bounds with the given mouse move and modifier keys
-	pub fn new_size(&self, mouse: DVec2, transform: DAffine2, centre: bool, constrain: bool) -> [DVec2; 2] {
+	pub fn new_size(&self, mouse: DVec2, transform: DAffine2, center: bool, constrain: bool) -> [DVec2; 2] {
 		let mouse = transform.inverse().transform_point2(mouse);
 
 		let mut min = self.bounds[0];
@@ -70,7 +70,7 @@ impl SelectedEdges {
 		if constrain && ((self.top || self.bottom) && (self.left || self.right)) {
 			size = size.abs().max(size.abs().yx()) * size.signum();
 		}
-		if centre {
+		if center {
 			if self.left || self.right {
 				size.x *= 2.;
 			}
@@ -83,31 +83,31 @@ impl SelectedEdges {
 		[min, size]
 	}
 
-	/// Offsets the transformation pivot in order to scale from the centre
-	fn offset_pivot(&self, centre: bool, size: DVec2) -> DVec2 {
+	/// Offsets the transformation pivot in order to scale from the center
+	fn offset_pivot(&self, center: bool, size: DVec2) -> DVec2 {
 		let mut offset = DVec2::ZERO;
 
-		if centre && self.right {
+		if center && self.right {
 			offset.x -= size.x / 2.;
 		}
-		if centre && self.left {
+		if center && self.left {
 			offset.x += size.x / 2.;
 		}
-		if centre && self.bottom {
+		if center && self.bottom {
 			offset.y -= size.y / 2.;
 		}
-		if centre && self.top {
+		if center && self.top {
 			offset.y += size.y / 2.;
 		}
 		offset
 	}
 
 	/// Moves the position to account for centring (only necessary with absolute transforms - e.g. with artboards)
-	pub fn centre_position(&self, mut position: DVec2, size: DVec2, centre: bool) -> DVec2 {
-		if centre && self.right {
+	pub fn center_position(&self, mut position: DVec2, size: DVec2, center: bool) -> DVec2 {
+		if center && self.right {
 			position.x -= size.x / 2.;
 		}
-		if centre && self.bottom {
+		if center && self.bottom {
 			position.y -= size.y / 2.;
 		}
 
@@ -115,8 +115,8 @@ impl SelectedEdges {
 	}
 
 	/// Calculates the required scaling to resize the bounding box
-	pub fn bounds_to_scale_transform(&self, centre: bool, size: DVec2) -> DAffine2 {
-		DAffine2::from_translation(self.offset_pivot(centre, size)) * DAffine2::from_scale(size / (self.bounds[1] - self.bounds[0]))
+	pub fn bounds_to_scale_transform(&self, center: bool, size: DVec2) -> DAffine2 {
+		DAffine2::from_translation(self.offset_pivot(center, size)) * DAffine2::from_scale(size / (self.bounds[1] - self.bounds[0]))
 	}
 }
 

--- a/editor/src/viewport_tools/tools/text.rs
+++ b/editor/src/viewport_tools/tools/text.rs
@@ -10,7 +10,7 @@ use crate::viewport_tools::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
 
 use glam::{DAffine2, DVec2};
 use graphene::intersection::Quad;
-use graphene::layers::style::{self, Fill, Stroke};
+use graphene::layers::style::{self, Stroke};
 use graphene::Operation;
 use kurbo::Shape;
 use serde::{Deserialize, Serialize};

--- a/editor/src/viewport_tools/tools/text.rs
+++ b/editor/src/viewport_tools/tools/text.rs
@@ -9,7 +9,6 @@ use crate::misc::{HintData, HintGroup, HintInfo, KeysGroup};
 use crate::viewport_tools::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
 
 use glam::{DAffine2, DVec2};
-use graphene::color::Color;
 use graphene::intersection::Quad;
 use graphene::layers::style::{self, Fill, Stroke};
 use graphene::Operation;

--- a/editor/src/viewport_tools/tools/text.rs
+++ b/editor/src/viewport_tools/tools/text.rs
@@ -11,7 +11,7 @@ use crate::viewport_tools::tool::{DocumentToolData, Fsm, ToolActionHandlerData};
 use glam::{DAffine2, DVec2};
 use graphene::color::Color;
 use graphene::intersection::Quad;
-use graphene::layers::style::{self, Stroke};
+use graphene::layers::style::{self, Fill, Stroke};
 use graphene::Operation;
 use kurbo::Shape;
 use serde::{Deserialize, Serialize};

--- a/frontend/src/components/panels/Document.vue
+++ b/frontend/src/components/panels/Document.vue
@@ -17,7 +17,7 @@
 			<LayoutCol class="shelf">
 				<LayoutCol class="tools" :scrollableY="true">
 					<ShelfItemInput icon="LayoutSelectTool" title="Select Tool (V)" :active="activeTool === 'Select'" :action="() => selectTool('Select')" />
-					<ShelfItemInput icon="LayoutCropTool" title="Crop Tool" :active="activeTool === 'Crop'" :action="() => (dialog.comingSoon(289), false) && selectTool('Crop')" />
+					<ShelfItemInput icon="LayoutCropTool" title="Crop Tool" :active="activeTool === 'Crop'" :action="() => selectTool('Crop')" />
 					<ShelfItemInput icon="LayoutNavigateTool" title="Navigate Tool (Z)" :active="activeTool === 'Navigate'" :action="() => selectTool('Navigate')" />
 					<ShelfItemInput icon="LayoutEyedropperTool" title="Eyedropper Tool (I)" :active="activeTool === 'Eyedropper'" :action="() => selectTool('Eyedropper')" />
 

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -250,7 +250,7 @@ impl JsEditorHandle {
 
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
-		let message = InputPreprocessorMessage::MouseMove { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerMove { editor_mouse_state, modifier_keys };
 		self.dispatch(message);
 	}
 
@@ -271,7 +271,7 @@ impl JsEditorHandle {
 
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
-		let message = InputPreprocessorMessage::MouseDown { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerDown { editor_mouse_state, modifier_keys };
 		self.dispatch(message);
 	}
 
@@ -281,7 +281,7 @@ impl JsEditorHandle {
 
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
-		let message = InputPreprocessorMessage::MouseUp { editor_mouse_state, modifier_keys };
+		let message = InputPreprocessorMessage::PointerUp { editor_mouse_state, modifier_keys };
 		self.dispatch(message);
 	}
 

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -517,6 +517,7 @@ impl JsEditorHandle {
 	/// Creates an artboard at a specified point with a width and height
 	pub fn create_artboard_and_fit_to_viewport(&self, pos_x: f64, pos_y: f64, width: f64, height: f64) {
 		let message = ArtboardMessage::AddArtboard {
+			id: None,
 			position: (pos_x, pos_y),
 			size: (width, height),
 		};

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -515,8 +515,11 @@ impl JsEditorHandle {
 	}
 
 	/// Creates an artboard at a specified point with a width and height
-	pub fn create_artboard_and_fit_to_viewport(&self, top: f64, left: f64, height: f64, width: f64) {
-		let message = ArtboardMessage::AddArtboard { top, left, height, width };
+	pub fn create_artboard_and_fit_to_viewport(&self, pos_x: f64, pos_y: f64, width: f64, height: f64) {
+		let message = ArtboardMessage::AddArtboard {
+			position: (pos_x, pos_y),
+			size: (width, height),
+		};
 		self.dispatch(message);
 		let message = DocumentMessage::ZoomCanvasToFitAll;
 		self.dispatch(message);

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -299,6 +299,12 @@ impl Document {
 		Ok(layer.data.bounding_box(transform))
 	}
 
+	pub fn bounding_box_and_transform(&self, path: &[LayerId]) -> Result<Option<([DVec2; 2], DAffine2)>, DocumentError> {
+		let layer = self.layer(path)?;
+		let transform = self.multiply_transforms(&path[..path.len() - 1])?;
+		Ok(layer.data.bounding_box(layer.transform).map(|bounds| (bounds, transform)))
+	}
+
 	pub fn visible_layers_bounding_box(&self) -> Option<[DVec2; 2]> {
 		let mut paths = vec![];
 		self.visible_layers(&mut vec![], &mut paths).ok()?;

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -499,8 +499,8 @@ impl Document {
 
 				Some([vec![DocumentChanged, CreatedLayer { path: path.clone() }], update_thumbnails_upstream(path)].concat())
 			}
-			Operation::AddOverlayShape { path, style, bez_path, closed } => {
-				let mut shape = Shape::from_bez_path(bez_path.clone(), *style, *closed);
+			Operation::AddOverlayShape { path, style, bez_path } => {
+				let mut shape = Shape::from_bez_path(bez_path.clone(), *style);
 				shape.render_index = -1;
 
 				let layer = Layer::new(LayerDataType::Shape(shape), DAffine2::IDENTITY.to_cols_array());
@@ -633,7 +633,7 @@ impl Document {
 
 				if let LayerDataType::Text(t) = &mut self.layer_mut(path)?.data {
 					let bezpath = t.to_bez_path();
-					self.layer_mut(path)?.data = layers::layer_info::LayerDataType::Shape(Shape::from_bez_path(bezpath, t.style, true));
+					self.layer_mut(path)?.data = layers::layer_info::LayerDataType::Shape(Shape::from_bez_path(bezpath, t.style));
 				}
 
 				if let LayerDataType::Shape(shape) = &mut self.layer_mut(path)?.data {

--- a/graphene/src/layers/simple_shape.rs
+++ b/graphene/src/layers/simple_shape.rs
@@ -69,7 +69,7 @@ impl Shape {
 		transforms.iter().skip(start).cloned().reduce(|a, b| a * b).unwrap_or(DAffine2::IDENTITY)
 	}
 
-	pub fn from_bez_path(bez_path: BezPath, style: PathStyle, closed: bool) -> Self {
+	pub fn from_bez_path(bez_path: BezPath, style: PathStyle) -> Self {
 		Self {
 			path: bez_path,
 			style,

--- a/graphene/src/operation.rs
+++ b/graphene/src/operation.rs
@@ -79,7 +79,6 @@ pub enum Operation {
 		path: Vec<LayerId>,
 		bez_path: kurbo::BezPath,
 		style: style::PathStyle,
-		closed: bool,
 	},
 	DeleteLayer {
 		path: Vec<LayerId>,

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -240,23 +240,23 @@ pub fn derive_hint(input_item: TokenStream) -> TokenStream {
 /// # Example
 /// ```ignore
 /// match (example_tool_state, event) {
-///     (ToolState::Ready, Event::MouseDown(mouse_state)) if *mouse_state == MouseState::Left => {
+///     (ToolState::Ready, Event::PointerDown(mouse_state)) if *mouse_state == MouseState::Left => {
 ///         #[edge("LMB Down")]
 ///         ToolState::Pending
 ///     }
-///     (SelectToolState::Pending, Event::MouseUp(mouse_state)) if *mouse_state == MouseState::Left => {
+///     (SelectToolState::Pending, Event::PointerUp(mouse_state)) if *mouse_state == MouseState::Left => {
 ///         #[edge("LMB Up: Select Object")]
 ///         SelectToolState::Ready
 ///     }
-///     (SelectToolState::Pending, Event::MouseMove(x,y)) => {
+///     (SelectToolState::Pending, Event::PointerMove(x,y)) => {
 ///         #[edge("Mouse Move")]
 ///         SelectToolState::TransformSelected
 ///     }
-///     (SelectToolState::TransformSelected, Event::MouseMove(x,y)) => {
+///     (SelectToolState::TransformSelected, Event::PointerMove(x,y)) => {
 ///         #[edge("Mouse Move")]
 ///         SelectToolState::TransformSelected
 ///     }
-///     (SelectToolState::TransformSelected, Event::MouseUp(mouse_state)) if *mouse_state == MouseState::Left => {
+///     (SelectToolState::TransformSelected, Event::PointerUp(mouse_state)) if *mouse_state == MouseState::Left => {
 ///         #[edge("LMB Up")]
 ///         SelectToolState::Ready
 ///     }


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #493

TODO:

- [x] Size to square with shift and centre with alt
- [x] Snap artboards & layers to other artboards
- [x] Fix resize behaviour with a rotated canvas - we want to calculate the bounding box with the shape transformed with just that layer's transform, and then transform the resulting box.
- [x] Allow artboards to be dragged and moved.
