### PR TITLE
De duplicate Overlay render messages

### DIFF
--- a/editor/src/communication/dispatcher.rs
+++ b/editor/src/communication/dispatcher.rs
@@ -30,6 +30,7 @@ struct DispatcherMessageHandlers {
 // In addition, these messages do not change any state in the backend (aside from caches).
 const SIDE_EFFECT_FREE_MESSAGES: &[MessageDiscriminant] = &[
 	MessageDiscriminant::Portfolio(PortfolioMessageDiscriminant::Document(DocumentMessageDiscriminant::RenderDocument)),
+	MessageDiscriminant::Portfolio(PortfolioMessageDiscriminant::Document(DocumentMessageDiscriminant::Overlays(OverlaysMessageDiscriminant::Rerender))),
 	MessageDiscriminant::Portfolio(PortfolioMessageDiscriminant::Document(DocumentMessageDiscriminant::FolderChanged)),
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::UpdateDocumentLayer),
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::DisplayDocumentLayerTreeStructure),

--- a/editor/src/document/overlays_message_handler.rs
+++ b/editor/src/document/overlays_message_handler.rs
@@ -18,26 +18,27 @@ impl MessageHandler<OverlaysMessage, bool> for OverlaysMessageHandler {
 			// Sub-messages
 			#[remain::unsorted]
 			DispatchOperation(operation) => match self.overlays_graphene_document.handle_operation(&operation) {
-				Ok(_) => (),
+				Ok(_) => responses.push_back(OverlaysMessage::Rerender.into()),
 				Err(e) => log::error!("OverlaysError: {:?}", e),
 			},
 
 			// Messages
 			ClearAllOverlays => todo!(),
-			Rerender => (),
-		}
-
-		// Render overlays
-		responses.push_back(
-			FrontendMessage::UpdateDocumentOverlays {
-				svg: if overlays_visible {
-					self.overlays_graphene_document.render_root(ViewMode::Normal)
-				} else {
-					String::from("")
-				},
+			Rerender =>
+			// Render overlays
+			{
+				responses.push_back(
+					FrontendMessage::UpdateDocumentOverlays {
+						svg: if overlays_visible {
+							self.overlays_graphene_document.render_root(ViewMode::Normal)
+						} else {
+							String::from("")
+						},
+					}
+					.into(),
+				)
 			}
-			.into(),
-		);
+		}
 	}
 
 	fn actions(&self) -> ActionList {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Drastically improve overlay performance by properly utilizing the message de duplication system

![image](https://user-images.githubusercontent.com/21245806/152805393-3e075ba7-91d4-47db-8bb7-222eb70b6d83.png)
Performance comparison for a 100 gon
(Also note the number of dropped frames indicated in red at the top)
