### PR TITLE
Pen tool fixes

### DIFF
--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -38,6 +38,9 @@ pub const BOUNDS_ROTATE_THRESHOLD: f64 = 20.;
 pub const VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE: f64 = 5.;
 pub const SELECTION_THRESHOLD: f64 = 10.;
 
+// Pen tool
+pub const CREATE_CURVE_THRESHOLD: f64 = 5.;
+
 // Line tool
 pub const LINE_ROTATE_SNAP_ANGLE: f64 = 15.;
 

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -204,7 +204,9 @@ impl Fsm for PenToolFsmState {
 					// Deselect everything (this means we are no longer dragging the handle)
 					data.shape_editor.deselect_all(responses);
 
+					// If the drag does not exceed the threshold, then replace the curve with a line
 					if data.drag_start_position.distance(input.mouse.position) < CREATE_CURVE_THRESHOLD {
+						// Modify the second to last element (as we have an unplaced element tracing to the cursor as the last element)
 						let replace_id = data.bez_path.len() - 2;
 						replace_path_element(data, transform, replace_id, convert_curve_to_line(data.bez_path[replace_id]), responses);
 					}

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -176,7 +176,7 @@ impl Fsm for PenToolFsmState {
 					let start_position = transform.inverse().transform_point2(snapped_position);
 					data.weight = tool_options.line_weight;
 
-					// Create the initial shape with a bez_path (only contains a moveto initially)
+					// Create the initial shape with a `bez_path` (only contains a moveto initially)
 					if let Some(layer_path) = &data.path {
 						data.bez_path = start_bez_path(start_position);
 						responses.push_back(
@@ -317,17 +317,17 @@ fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler,
 		// Clear previous overlays
 		data.shape_editor.remove_overlays(responses);
 
-		// Create a new shape from the updated bez_path
+		// Create a new `shape` from the updated `bez_path`
 		let bez_path = data.bez_path.clone().into_iter().collect();
 		data.curve_shape = VectorShape::new(layer_path.to_vec(), transform, &bez_path, false, responses);
 		data.shape_editor.set_shapes_to_modify(vec![data.curve_shape.clone()]);
 
-		// Select the second to last segment's handle
+		// Select the second to last `PathEl`'s handle
 		data.shape_editor.set_shape_selected(0);
 		let handle_element = data.shape_editor.select_nth_anchor(0, -2);
 		handle_element.select_point(ControlPointType::Handle2 as usize, true, responses);
 
-		// Select the last segment's anchor point
+		// Select the last `PathEl`'s anchor point
 		if let Some(last_anchor) = data.shape_editor.select_last_anchor() {
 			last_anchor.select_point(ControlPointType::Anchor as usize, true, responses);
 		}
@@ -335,7 +335,7 @@ fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler,
 	}
 }
 
-/// Replace a PathEl with another inside of bez_path by index
+/// Replace a `PathEl` with another inside of `bez_path` by index
 fn replace_path_element(data: &mut PenToolData, transform: DAffine2, replace_index: usize, replacement: PathEl, responses: &mut VecDeque<Message>) {
 	data.bez_path[replace_index] = replacement;
 	if let Some(layer_path) = &data.path {
@@ -343,14 +343,14 @@ fn replace_path_element(data: &mut PenToolData, transform: DAffine2, replace_ind
 	}
 }
 
-/// Remove a curve from the end of the bez_path
+/// Remove a curve from the end of the `bez_path`
 fn remove_from_curve(data: &mut PenToolData) {
 	// Refresh data's representation of the path
 	update_path_representation(data);
 	data.bez_path.pop();
 }
 
-/// Create the initial moveto for the bez_path
+/// Create the initial moveto for the `bez_path`
 fn start_bez_path(start_position: DVec2) -> Vec<PathEl> {
 	vec![PathEl::MoveTo(Point {
 		x: start_position.x,
@@ -358,7 +358,7 @@ fn start_bez_path(start_position: DVec2) -> Vec<PathEl> {
 	})]
 }
 
-/// Convert curve segment into a line segment
+/// Convert curve `PathEl` into a line `PathEl`
 fn convert_curve_to_line(curve: PathEl) -> PathEl {
 	match curve {
 		PathEl::CurveTo(_, _, p) => PathEl::LineTo(p),
@@ -366,7 +366,7 @@ fn convert_curve_to_line(curve: PathEl) -> PathEl {
 	}
 }
 
-/// Update data's version of bez_path to match ShapeEditor's version
+/// Update data's version of `bez_path` to match `ShapeEditor`'s version
 fn update_path_representation(data: &mut PenToolData) {
 	// TODO Update ShapeEditor to provide similar functionality
 	// We need to make sure we have the most up-to-date bez_path
@@ -376,7 +376,7 @@ fn update_path_representation(data: &mut PenToolData) {
 	}
 }
 
-/// Apply the bez_path to the shape in the viewport
+/// Apply the `bez_path` to the `shape` in the viewport
 fn apply_bez_path(layer_path: Vec<LayerId>, bez_path: Vec<PathEl>, transform: DAffine2) -> Message {
 	Operation::SetShapePathInViewport {
 		path: layer_path,

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -364,9 +364,9 @@ fn convert_curve_to_line(curve: PathEl) -> PathEl {
 	}
 }
 
-// Update data's version of the path data to match ShapeEditor's version
+// Update data's version of bez_path to match ShapeEditor's version
 fn update_path_representation(data: &mut PenToolData) {
-	// TODO Update ShapeEditor to provide simular functionality
+	// TODO Update ShapeEditor to provide similar functionality
 	// We need to make sure we have the most up-to-date bez_path
 	if !data.shape_editor.shapes_to_modify.is_empty() {
 		// Hacky way of saving the curve changes

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -215,14 +215,14 @@ impl Fsm for PenToolFsmState {
 					Drawing
 				}
 				(Drawing, Confirm) | (Drawing, Abort) => {
-					// Add a curve to the path
-					if let Some(layer_path) = &data.path {
-						remove_curve_from_end(&mut data.bez_path);
-						responses.push_back(apply_bez_path(layer_path.clone(), data.bez_path.clone(), transform));
-					}
-
 					// Cleanup, we are either canceling or finished drawing
 					if data.bez_path.len() >= 2 {
+						// Remove the last segment
+						if let Some(layer_path) = &data.path {
+							remove_curve_from_end(&mut data.bez_path);
+							responses.push_back(apply_bez_path(layer_path.clone(), data.bez_path.clone(), transform));
+						}
+
 						responses.push_back(DocumentMessage::DeselectAllLayers.into());
 						responses.push_back(DocumentMessage::CommitTransaction.into());
 					} else {

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -334,7 +334,7 @@ fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler,
 	}
 }
 
-/// Replace a PathEl by ID inside of the bez_path
+/// Replace a PathEl inside of bez_path by index
 fn replace_path_element(data: &mut PenToolData, transform: DAffine2, path_element_id: usize, replacement: PathEl, responses: &mut VecDeque<Message>) {
 	data.bez_path[path_element_id] = replacement;
 	if let Some(layer_path) = &data.path {

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -207,8 +207,9 @@ impl Fsm for PenToolFsmState {
 					// If the drag does not exceed the threshold, then replace the curve with a line
 					if data.drag_start_position.distance(input.mouse.position) < CREATE_CURVE_THRESHOLD {
 						// Modify the second to last element (as we have an unplaced element tracing to the cursor as the last element)
-						let replace_id = data.bez_path.len() - 2;
-						replace_path_element(data, transform, replace_id, convert_curve_to_line(data.bez_path[replace_id]), responses);
+						let replace_index = data.bez_path.len() - 2;
+						let line_from_curve = convert_curve_to_line(data.bez_path[replace_index]);
+						replace_path_element(data, transform, replace_index, line_from_curve, responses);
 					}
 
 					// Reselect the last point
@@ -334,9 +335,9 @@ fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler,
 	}
 }
 
-/// Replace a PathEl inside of bez_path by index
-fn replace_path_element(data: &mut PenToolData, transform: DAffine2, path_element_id: usize, replacement: PathEl, responses: &mut VecDeque<Message>) {
-	data.bez_path[path_element_id] = replacement;
+/// Replace a PathEl with another inside of bez_path by index
+fn replace_path_element(data: &mut PenToolData, transform: DAffine2, replace_index: usize, replacement: PathEl, responses: &mut VecDeque<Message>) {
+	data.bez_path[replace_index] = replacement;
 	if let Some(layer_path) = &data.path {
 		responses.push_back(apply_bez_path(layer_path.clone(), data.bez_path.clone(), transform));
 	}

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -334,7 +334,7 @@ fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler,
 	}
 }
 
-// Replace a path element by ID
+/// Replace a PathEl by ID inside of the bez_path
 fn replace_path_element(data: &mut PenToolData, transform: DAffine2, path_element_id: usize, replacement: PathEl, responses: &mut VecDeque<Message>) {
 	data.bez_path[path_element_id] = replacement;
 	if let Some(layer_path) = &data.path {
@@ -342,14 +342,14 @@ fn replace_path_element(data: &mut PenToolData, transform: DAffine2, path_elemen
 	}
 }
 
-// Remove a curve to the bez_path
+/// Remove a curve from the end of the bez_path
 fn remove_from_curve(data: &mut PenToolData) {
 	// Refresh data's representation of the path
 	update_path_representation(data);
 	data.bez_path.pop();
 }
 
-// Create the initial moveto for the bez_path
+/// Create the initial moveto for the bez_path
 fn start_bez_path(start_position: DVec2) -> Vec<PathEl> {
 	vec![PathEl::MoveTo(Point {
 		x: start_position.x,
@@ -357,6 +357,7 @@ fn start_bez_path(start_position: DVec2) -> Vec<PathEl> {
 	})]
 }
 
+/// Convert curve segment into a line segment
 fn convert_curve_to_line(curve: PathEl) -> PathEl {
 	match curve {
 		PathEl::CurveTo(_, _, p) => PathEl::LineTo(p),

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -296,7 +296,7 @@ impl Fsm for PenToolFsmState {
 	}
 }
 
-// Add to the curve and select the second anchor of the last point and the newly added anchor point
+/// Add to the curve and select the second anchor of the last point and the newly added anchor point
 fn add_to_curve(data: &mut PenToolData, input: &InputPreprocessorMessageHandler, transform: DAffine2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
 	// Refresh data's representation of the path
 	update_path_representation(data);
@@ -365,7 +365,7 @@ fn convert_curve_to_line(curve: PathEl) -> PathEl {
 	}
 }
 
-// Update data's version of bez_path to match ShapeEditor's version
+/// Update data's version of bez_path to match ShapeEditor's version
 fn update_path_representation(data: &mut PenToolData) {
 	// TODO Update ShapeEditor to provide similar functionality
 	// We need to make sure we have the most up-to-date bez_path
@@ -375,7 +375,7 @@ fn update_path_representation(data: &mut PenToolData) {
 	}
 }
 
-// Apply the bez_path to the shape in the viewport
+/// Apply the bez_path to the shape in the viewport
 fn apply_bez_path(layer_path: Vec<LayerId>, bez_path: Vec<PathEl>, transform: DAffine2) -> Message {
 	Operation::SetShapePathInViewport {
 		path: layer_path,


### PR DESCRIPTION
This PR resolves 3 known bugs with the pen tool.

1. Crash when aborting a line when you have less than 2 points. Thanks @caleb-ad 
2. Final segment of the pen tool having the handle data lost on abort (the last curve of a pen tool shape will jump incorrectly.)
3. All segments were curves, now line segments will be used instead if a drag threshold is not met.
