### PR TITLE
Fix type error in Brave browser

### DIFF
--- a/frontend/src/state/fullscreen.ts
+++ b/frontend/src/state/fullscreen.ts
@@ -14,7 +14,7 @@ export function createFullscreenState() {
 
 	// Experimental Keyboard API: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/keyboard
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const keyboardLockApiSupported: Readonly<boolean> = "keyboard" in navigator && "lock" in (navigator as any).keyboard;
+	const keyboardLockApiSupported: Readonly<boolean> = "keyboard" in navigator && (navigator as any).keyboard && "lock" in (navigator as any).keyboard;
 
 	const enterFullscreen = async (): Promise<void> => {
 		await document.documentElement.requestFullscreen();


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

When using brave with the security shield turned on, the keyboard lock api is blocked which was causing a null type error.
The fix was tested to confirm it resolves the issue.