### PR TITLE
Fix panic dialogue when handling a message

### DIFF
--- a/frontend/src/lifetime/errors.ts
+++ b/frontend/src/lifetime/errors.ts
@@ -71,11 +71,12 @@ function githubUrl(panicDetails: string): string {
 		${browserVersion()}, ${operatingSystem()}
 
 		**Stack Trace**
-		Copied from the crash dialog in the Graphite Editor:`;
+		Copied from the crash dialog in the Graphite Editor:
+	`;
 
 	body += "\n\n```\n";
-	body += panicDetails;
-	body += "```";
+	body += panicDetails.trimEnd();
+	body += "\n```";
 
 	const fields = {
 		title: "[Crash Report] ",

--- a/frontend/src/lifetime/errors.ts
+++ b/frontend/src/lifetime/errors.ts
@@ -52,7 +52,7 @@ export function initErrorHandling(editor: EditorState, dialogState: DialogState)
 function githubUrl(panicDetails: string): string {
 	const url = new URL("https://github.com/GraphiteEditor/Graphite/issues/new");
 
-	const body = stripIndents`
+	let body = stripIndents`
 		**Describe the Crash**
 		Explain clearly what you were doing when the crash occurred.
 
@@ -71,12 +71,11 @@ function githubUrl(panicDetails: string): string {
 		${browserVersion()}, ${operatingSystem()}
 
 		**Stack Trace**
-		Copied from the crash dialog in the Graphite Editor:
+		Copied from the crash dialog in the Graphite Editor:`;
 
-		\`\`\`
-		${panicDetails}
-		\`\`\`
-		`;
+	body += "\n\n```\n";
+	body += panicDetails;
+	body += "```";
 
 	const fields = {
 		title: "[Crash Report] ",

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -4,7 +4,7 @@
 
 use crate::helpers::Error;
 use crate::type_translators::{translate_blend_mode, translate_key, translate_tool_type};
-use crate::{EDITOR_HAS_CRASHED, EDITOR_INSTANCES};
+use crate::{EDITOR_HAS_CRASHED, EDITOR_INSTANCES, JS_EDITOR_HANDLES};
 
 use editor::consts::{FILE_SAVE_SUFFIX, GRAPHITE_DOCUMENT_VERSION};
 use editor::input::input_preprocessor::ModifierKeys;
@@ -40,7 +40,8 @@ impl JsEditorHandle {
 		let editor_id = generate_uuid();
 		let editor = Editor::new();
 		let editor_handle = JsEditorHandle { editor_id, handle_response };
-		EDITOR_INSTANCES.with(|instances| instances.borrow_mut().insert(editor_id, (editor, editor_handle.clone())));
+		EDITOR_INSTANCES.with(|instances| instances.borrow_mut().insert(editor_id, editor));
+		JS_EDITOR_HANDLES.with(|instances| instances.borrow_mut().insert(editor_id, editor_handle.clone()));
 		editor_handle
 	}
 
@@ -56,7 +57,6 @@ impl JsEditorHandle {
 				.borrow_mut()
 				.get_mut(&self.editor_id)
 				.expect("EDITOR_INSTANCES does not contain the current editor_id")
-				.0
 				.handle_message(message.into())
 		});
 		for response in responses.into_iter() {

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -16,7 +16,8 @@ use wasm_bindgen::prelude::*;
 pub static EDITOR_HAS_CRASHED: AtomicBool = AtomicBool::new(false);
 pub static LOGGER: WasmLog = WasmLog;
 thread_local! {
-	pub static EDITOR_INSTANCES: RefCell<HashMap<u64, (editor::Editor, api::JsEditorHandle)>> = RefCell::new(HashMap::new());
+	pub static EDITOR_INSTANCES: RefCell<HashMap<u64, editor::Editor>> = RefCell::new(HashMap::new());
+	pub static JS_EDITOR_HANDLES: RefCell<HashMap<u64, api::JsEditorHandle>> = RefCell::new(HashMap::new());
 }
 
 // Initialize the backend
@@ -34,9 +35,9 @@ fn panic_hook(info: &panic::PanicInfo) {
 	let title = "The editor crashed — sorry about that".to_string();
 	let description = "An internal error occurred. Reload the editor to continue. Please report this by filing an issue on GitHub.".to_string();
 	log::error!("{}", info);
-	EDITOR_INSTANCES.with(|instances| {
+	JS_EDITOR_HANDLES.with(|instances| {
 		instances.borrow_mut().values_mut().for_each(|instance| {
-			instance.1.handle_response_rust_proxy(FrontendMessage::DisplayDialogPanic {
+			instance.handle_response_rust_proxy(FrontendMessage::DisplayDialogPanic {
 				panic_info: panic_info.clone(),
 				title: title.clone(),
 				description: description.clone(),


### PR DESCRIPTION
The crash dialogue is not triggered when a panic happens when handling a message because the `instances` refcell is borrowed and so cannot be borrowed again in order to get the `JsEditorHandle` and display the dialogue. This caused the panic handler to panic.

This MR splits `JsEditorHandle`s and rust `Editor`s into separate refcells to fix this (testable currently by pressing delete while drawing with pen tool).

Fixes #574