### PR TITLE
Stop click event from triggering from the Properties panel

### DIFF
--- a/frontend/src/lifetime/input.ts
+++ b/frontend/src/lifetime/input.ts
@@ -108,8 +108,10 @@ export function createInputManager(editor: EditorState, container: HTMLElement, 
 	const onPointerMove = (e: PointerEvent): void => {
 		if (!e.buttons) viewportPointerInteractionOngoing = false;
 
-		const modifiers = makeModifiersBitfield(e);
-		editor.instance.on_mouse_move(e.clientX, e.clientY, e.buttons, modifiers);
+		if (viewportPointerInteractionOngoing) {
+			const modifiers = makeModifiersBitfield(e);
+			editor.instance.on_mouse_move(e.clientX, e.clientY, e.buttons, modifiers);
+		}
 	};
 
 	const onPointerDown = (e: PointerEvent): void => {


### PR DESCRIPTION
Fixes a bug caused by #589. This MR made it so that click events where fired in the backend from change in the buttons from a mouse move in order to catch the case when another mouse button is pressed whilst dragging. However mouse move events used to be sent even when no viewport interaction was taking place causing incorrect behaviour. This MR resolves this.