### PR TITLE
Restore the zoom to fit behaviour

### DIFF
--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -462,7 +462,7 @@ impl DocumentMessageHandler {
 
 	/// Calculates the bounding box of all layers in the document
 	pub fn all_layer_bounds(&self) -> Option<[DVec2; 2]> {
-			self.graphene_document.viewport_bounding_box(&[]).ok().flatten()
+		self.graphene_document.viewport_bounding_box(&[]).ok().flatten()
 	}
 
 	/// Calculates the document bounds used for scrolling and centring (the layer bounds or the artboard (if applicable))


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
#623 broke the zoom to fit all behavior with an empty document (creating a new finite document no longer centered the document in the user's view)
