### PR TITLE
Fix viewport zoom/rotation while snapping to show snapped values

### DIFF
--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -611,7 +611,7 @@ impl DocumentMessageHandler {
 				})),
 				WidgetHolder::new(Widget::NumberInput(NumberInput {
 					unit: "°".into(),
-					value: Some(self.movement_handler.tilt / (std::f64::consts::PI / 180.)),
+					value: Some(self.movement_handler.snapped_angle() / (std::f64::consts::PI / 180.)),
 					increment_factor: 15.,
 					on_update: WidgetCallback::new(|number_input: &NumberInput| {
 						MovementMessage::SetCanvasRotation {
@@ -652,7 +652,7 @@ impl DocumentMessageHandler {
 				})),
 				WidgetHolder::new(Widget::NumberInput(NumberInput {
 					unit: "%".into(),
-					value: Some(self.movement_handler.zoom * 100.),
+					value: Some(self.movement_handler.snapped_scale() * 100.),
 					min: Some(0.000001),
 					max: Some(1000000.),
 					on_update: WidgetCallback::new(|number_input: &NumberInput| {


### PR DESCRIPTION
The zoom and tilt inputs on the top right corner of the viewport previously did not display the correct snapped when snap zooming or snap tilting and instead displayed the precise zoom and tilt values. I changed the appropriate widget value's to use ``snapped_scale()`` and ``snapped_angle()`` to fix this.

Closes #643
