### PR TITLE
Preserve layer stacking order on copy and paste

### DIFF
--- a/editor/src/document/portfolio_message_handler.rs
+++ b/editor/src/document/portfolio_message_handler.rs
@@ -414,7 +414,7 @@ impl MessageHandler<PortfolioMessage, &InputPreprocessorMessageHandler> for Port
 					responses.push_back(DeselectAllLayers.into());
 					responses.push_back(StartTransaction.into());
 
-					for entry in data {
+					for entry in data.iter().rev() {
 						let destination_path = [shallowest_common_folder.to_vec(), vec![generate_uuid()]].concat();
 
 						responses.push_front(


### PR DESCRIPTION
After looking into the issue, it only seems to happen when copying and pasting serialized data using `PortfolioMessage::PasteSerializedData`. To fix the issue, the copy buffer entry vector in [portfolio_message_handler.rs#L417](https://github.com/GraphiteEditor/Graphite/blob/59578c85c693414f86fdc448bb458a3233d8e14e/editor/src/document/portfolio_message_handler.rs#L417=) should be iterated in a reverse order.

Something similar can be seen when using `PortfolioMessage::PasteIntoFolder` in [portfolio_message_handler.rs#L397-L405](https://github.com/GraphiteEditor/Graphite/blob/59578c85c693414f86fdc448bb458a3233d8e14e/editor/src/document/portfolio_message_handler.rs#L397-L405=), where the iteration direction is changed based on the `insert_index`. In `PortfolioMessage::PasteSerializedData` the `insert_index` is known ahead of time which allows us to simply reverse the direciton.

This fix should result in `PortfolioMessage::PasteIntoFolder` and `PortfolioMessage::PasteSerializedData` producing matching results.

Closes #610 
