### PR TITLE
Bezier length implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,8 @@
 	// ESLint config
 	"eslint.format.enable": true,
 	"eslint.workingDirectories": [
-		"./frontend"
+		"./frontend",
+		"./bezier-rs/docs/interactive-docs",
 	],
 	"eslint.validate": [
 		"javascript",

--- a/bezier-rs/docs/interactive-docs/.eslintrc.js
+++ b/bezier-rs/docs/interactive-docs/.eslintrc.js
@@ -65,8 +65,7 @@ module.exports = {
 		"no-bitwise": "off",
 		"no-shadow": "off",
 		"no-use-before-define": "off",
-		// TODO: Vetur cannot properly recognize paths using @ which contradicts this rule
-		// "no-restricted-imports": ["error", { patterns: [".*", "!@/*"] }],
+		"no-restricted-imports": ["error", { patterns: [".*", "!@/*"] }],
 
 		// TypeScript plugin config
 		"@typescript-eslint/indent": "off",

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -12,17 +12,14 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import ExamplePane from "./components/ExamplePane.vue";
-import { drawText, getContextFromCanvas } from "./utils/drawing";
-import { WasmBezierInstance } from "./utils/types";
+import { drawText, getContextFromCanvas } from "@/utils/drawing";
+import { WasmBezierInstance } from "@/utils/types";
+
+import ExamplePane from "@/components/ExamplePane.vue";
 
 // eslint-disable-next-line
 const testBezierLib = async () => {
-	// TODO: Fix below
-	// eslint seems to think this pkg is the one in the frontend folder, not the one in interactive-docs (which is not what is actually imported)
-	// eslint-disable-next-line
-	import("../wasm/pkg").then((wasm) => {
-		// eslint-disable-next-line
+	import("@/../wasm/pkg").then((wasm) => {
 		const bezier = wasm.WasmBezier.new_quad([
 			[0, 0],
 			[50, 0],

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -23,7 +23,11 @@ const testBezierLib = async () => {
 	// eslint-disable-next-line
 	import("../wasm/pkg").then((wasm) => {
 		// eslint-disable-next-line
-		const bezier = wasm.WasmBezier.new_quad(0, 0, 50, 0, 100, 100);
+		const bezier = wasm.WasmBezier.new_quad([
+			[0, 0],
+			[50, 0],
+			[100, 100],
+		]);
 		const svgContainer = document.getElementById("svg-test");
 		if (svgContainer) {
 			svgContainer.innerHTML = bezier.to_svg();

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -2,13 +2,19 @@
 	<div class="App">
 		<h1>Bezier-rs Interactive Documentation</h1>
 		<p>This is the interactive documentation for the <b>bezier-rs</b> library. Click and drag on the endpoints of the example curves to visualize the various Bezier utilities and functions.</p>
-		<ExamplePane />
+		<div v-for="feature in features" :key="feature.id">
+			<ExamplePane :name="feature.name" :callback="feature.callback" />
+		</div>
 		<div id="svg-test" />
 	</div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
+
+import { drawText } from "./utils/drawing";
+
+import { WasmBezierInstance } from "./utils/types";
 
 import ExamplePane from "./components/ExamplePane.vue";
 
@@ -31,6 +37,24 @@ export default defineComponent({
 	name: "App",
 	components: {
 		ExamplePane,
+	},
+	data() {
+		return {
+			features: [
+				{
+					id: 0,
+					name: "Constructor",
+					callback: () => {},
+				},
+				{
+					id: 2,
+					name: "Length",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance) => {
+						drawText(canvas.getContext("2d"), `Length: ${bezier.length().toFixed(2)}`, 5, canvas.height - 7);
+					},
+				},
+			],
+		};
 	},
 });
 </script>

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -12,11 +12,9 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import { drawText } from "./utils/drawing";
-
-import { WasmBezierInstance } from "./utils/types";
-
 import ExamplePane from "./components/ExamplePane.vue";
+import { drawText, getContextFromCanvas } from "./utils/drawing";
+import { WasmBezierInstance } from "./utils/types";
 
 // eslint-disable-next-line
 const testBezierLib = async () => {
@@ -44,13 +42,14 @@ export default defineComponent({
 				{
 					id: 0,
 					name: "Constructor",
-					callback: () => {},
+					// eslint-disable-next-line
+					callback: (): void => {},
 				},
 				{
 					id: 2,
 					name: "Length",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance) => {
-						drawText(canvas.getContext("2d"), `Length: ${bezier.length().toFixed(2)}`, 5, canvas.height - 7);
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+						drawText(getContextFromCanvas(canvas), `Length: ${bezier.length().toFixed(2)}`, 5, canvas.height - 7);
 					},
 				},
 			],

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,4 +1,4 @@
-import { drawBezier } from "@/utils/drawing";
+import { drawBezier, getContextFromCanvas } from "@/utils/drawing";
 import { BezierCallback, Point, WasmBezierMutatorKey } from "@/utils/types";
 import { WasmBezierInstance } from "@/utils/wasm-comm";
 
@@ -40,11 +40,7 @@ class BezierDrawing {
 		this.canvas.width = 200;
 		this.canvas.height = 200;
 
-		const ctx = this.canvas.getContext("2d");
-		if (ctx == null) {
-			throw Error("Failed to create context");
-		}
-		this.ctx = ctx;
+		this.ctx = getContextFromCanvas(this.canvas);
 
 		this.dragIndex = null; // Index of the point being moved
 

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,5 +1,5 @@
 import { drawBezier } from "@/utils/drawing";
-import { Point, WasmBezierMutatorKey } from "@/utils/types";
+import { BezierCallback, Point, WasmBezierMutatorKey } from "@/utils/types";
 import { WasmBezierInstance } from "@/utils/wasm-comm";
 
 class BezierDrawing {
@@ -15,8 +15,11 @@ class BezierDrawing {
 
 	bezier: WasmBezierInstance;
 
-	constructor(bezier: WasmBezierInstance) {
+	callback: BezierCallback;
+
+	constructor(bezier: WasmBezierInstance, callback: BezierCallback) {
 		this.bezier = bezier;
+		this.callback = callback;
 		this.points = bezier
 			.get_points()
 			.map((p) => JSON.parse(p))
@@ -100,6 +103,7 @@ class BezierDrawing {
 
 	updateBezier(): void {
 		drawBezier(this.ctx, this.points);
+		this.callback(this.canvas, this.bezier);
 	}
 
 	getCanvas(): HTMLCanvasElement {

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -10,6 +10,8 @@ import { defineComponent, PropType } from "vue";
 
 import { WasmBezierInstance } from "../utils/wasm-comm";
 
+import { BezierCallback } from "../utils/types";
+
 import BezierDrawing from "./BezierDrawing";
 
 export default defineComponent({
@@ -20,9 +22,13 @@ export default defineComponent({
 			type: Object as PropType<WasmBezierInstance>,
 			required: true,
 		},
+		callback: {
+			type: Function as PropType<BezierCallback>,
+			required: true,
+		},
 	},
 	mounted() {
-		const bezierDrawing = new BezierDrawing(this.bezier);
+		const bezierDrawing = new BezierDrawing(this.bezier, this.callback);
 		const drawing = this.$refs.drawing as HTMLElement;
 		drawing.appendChild(bezierDrawing.getCanvas());
 		bezierDrawing.updateBezier();

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -8,9 +8,8 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 
-import { WasmBezierInstance } from "../utils/wasm-comm";
-
 import { BezierCallback } from "../utils/types";
+import { WasmBezierInstance } from "../utils/wasm-comm";
 
 import BezierDrawing from "./BezierDrawing";
 

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<h3>{{ title }}</h3>
-		<figure ref="drawing"></figure>
+		<h4 class="example_header">{{ title }}</h4>
+		<figure class="example_figure" ref="drawing"></figure>
 	</div>
 </template>
 
@@ -34,4 +34,11 @@ export default defineComponent({
 });
 </script>
 
-<style scoped></style>
+<style scoped>
+.example_header {
+	margin-bottom: 0;
+}
+.example_figure {
+	margin-top: 0.5em;
+}
+</style>

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -8,10 +8,9 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 
-import { BezierCallback } from "../utils/types";
-import { WasmBezierInstance } from "../utils/wasm-comm";
-
-import BezierDrawing from "./BezierDrawing";
+import BezierDrawing from "@/components/BezierDrawing";
+import { BezierCallback } from "@/utils/types";
+import { WasmBezierInstance } from "@/utils/wasm-comm";
 
 export default defineComponent({
 	name: "ExampleComponent",

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -44,12 +44,21 @@ export default defineComponent({
 				{
 					id: 0,
 					title: "Quadratic Bezier",
-					bezier: wasm.WasmBezier.new_quad(30, 30, 140, 20, 160, 170),
+					bezier: wasm.WasmBezier.new_quad([
+						[30, 30],
+						[140, 20],
+						[160, 170],
+					]),
 				},
 				{
 					id: 1,
 					title: "Cubic Bezier",
-					bezier: wasm.WasmBezier.new_cubic(30, 30, 60, 140, 150, 30, 160, 160),
+					bezier: wasm.WasmBezier.new_cubic([
+						[30, 30],
+						[60, 140],
+						[150, 30],
+						[160, 160],
+					]),
 				},
 			];
 		});

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -9,10 +9,10 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 
-import { BezierCallback } from "../utils/types";
-import { WasmBezierInstance } from "../utils/wasm-comm";
+import { BezierCallback } from "@/utils/types";
+import { WasmBezierInstance } from "@/utils/wasm-comm";
 
-import Example from "./Example.vue";
+import Example from "@/components/Example.vue";
 
 type ExampleData = {
 	id: number;
@@ -38,8 +38,7 @@ export default defineComponent({
 		};
 	},
 	mounted() {
-		// eslint-disable-next-line
-		import("../../wasm/pkg").then((wasm) => {
+		import("@/../wasm/pkg").then((wasm) => {
 			this.exampleData = [
 				{
 					id: 0,

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -1,13 +1,15 @@
 <template>
 	<div class="example_row">
 		<div v-for="example in exampleData" :key="example.id">
-			<Example :title="example.title" :bezier="example.bezier" />
+			<Example :title="example.title" :bezier="example.bezier" :callback="callback" />
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { BezierCallback } from "../utils/types";
+
+import { defineComponent, PropType } from "vue";
 
 import { WasmBezierInstance } from "../utils/wasm-comm";
 
@@ -24,6 +26,13 @@ export default defineComponent({
 	name: "ExamplePane",
 	components: {
 		Example,
+	},
+	props: {
+		name: String,
+		callback: {
+			type: Function as PropType<BezierCallback>,
+			required: true,
+		},
 	},
 	data() {
 		return {

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -7,14 +7,12 @@
 </template>
 
 <script lang="ts">
-import { BezierCallback } from "../utils/types";
-
 import { defineComponent, PropType } from "vue";
 
+import { BezierCallback } from "../utils/types";
 import { WasmBezierInstance } from "../utils/wasm-comm";
 
 import Example from "./Example.vue";
-// import wasm from "bezier-rs-wasm";
 
 type ExampleData = {
 	id: number;

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -1,7 +1,10 @@
 <template>
-	<div class="example_row">
-		<div v-for="example in exampleData" :key="example.id">
-			<Example :title="example.title" :bezier="example.bezier" :callback="callback" />
+	<div>
+		<h2 class="example_pane_header">{{ this.name }}</h2>
+		<div class="example_row">
+			<div v-for="example in exampleData" :key="example.id">
+				<Example :title="example.title" :bezier="example.bezier" :callback="callback" />
+			</div>
 		</div>
 	</div>
 </template>
@@ -42,7 +45,7 @@ export default defineComponent({
 			this.exampleData = [
 				{
 					id: 0,
-					title: "Quadratic Bezier",
+					title: "Quadratic",
 					bezier: wasm.WasmBezier.new_quad([
 						[30, 30],
 						[140, 20],
@@ -51,7 +54,7 @@ export default defineComponent({
 				},
 				{
 					id: 1,
-					title: "Cubic Bezier",
+					title: "Cubic",
 					bezier: wasm.WasmBezier.new_cubic([
 						[30, 30],
 						[60, 140],
@@ -70,5 +73,9 @@ export default defineComponent({
 	display: flex; /* or inline-flex */
 	flex-direction: row;
 	justify-content: center;
+}
+
+.example_pane_header {
+	margin-bottom: 0;
 }
 </style>

--- a/bezier-rs/docs/interactive-docs/src/main.ts
+++ b/bezier-rs/docs/interactive-docs/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from "vue";
 
-import App from "./App.vue";
+import App from "@/App.vue";
 
 createApp(App).mount("#app");

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -25,6 +25,12 @@ export const drawPoint = (ctx: CanvasRenderingContext2D, p: Point): void => {
 	ctx.fill();
 };
 
+export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number, y: number) => {
+	ctx.fillStyle = "black";
+	ctx.font = "16px Arial";
+	ctx.fillText(text, x, y);
+};
+
 export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[]): void => {
 	/* Until a bezier representation is finalized, treat the points as follows
 		points[0] = start point

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -1,5 +1,13 @@
 import { Point } from "@/utils/types";
 
+export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
+	const ctx = canvas.getContext("2d");
+	if (ctx === null) {
+		throw Error("Failed to fetch context");
+	}
+	return ctx;
+};
+
 export const drawLine = (ctx: CanvasRenderingContext2D, p1: Point, p2: Point): void => {
 	ctx.strokeStyle = "grey";
 	ctx.lineWidth = 1;
@@ -25,7 +33,7 @@ export const drawPoint = (ctx: CanvasRenderingContext2D, p: Point): void => {
 	ctx.fill();
 };
 
-export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number, y: number) => {
+export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number, y: number): void => {
 	ctx.fillStyle = "black";
 	ctx.font = "16px Arial";
 	ctx.fillText(text, x, y);

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -11,5 +11,5 @@ export type Point = {
 	y: number;
 	r: number;
 	mutator: WasmBezierMutatorKey;
-	selected?: boolean;
+	selected: boolean;
 };

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -4,6 +4,8 @@ export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 export type WasmBezierKey = keyof WasmBezierInstance;
 export type WasmBezierMutatorKey = "set_start" | "set_handle1" | "set_handle2" | "set_end";
 
+export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance) => void;
+
 export type Point = {
 	x: number;
 	y: number;

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -56,4 +56,8 @@ impl WasmBezier {
 	pub fn to_svg(&self) -> String {
 		self.internal.to_svg()
 	}
+	
+	pub fn length(self) -> f64 {
+		self.internal.length()
+	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -16,32 +16,36 @@ pub struct WasmBezier {
 
 #[wasm_bindgen]
 impl WasmBezier {
-	pub fn new_quad(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> WasmBezier {
+	/// Expect js_points to be a list of 3 pairs
+	pub fn new_quad(js_points: &JsValue) -> WasmBezier {
+		let points: [DVec2; 3] = js_points.into_serde().unwrap();
 		WasmBezier {
-			internal: Bezier::from_quadratic_coordinates(x1, y1, x2, y2, x3, y3),
+			internal: Bezier::from_quadratic_dvec2(points[0], points[1], points[2]),
 		}
 	}
 
-	pub fn new_cubic(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64, x4: f64, y4: f64) -> WasmBezier {
+	/// Expect js_points to be a list of 4 pairs
+	pub fn new_cubic(js_points: &JsValue) -> WasmBezier {
+		let points: [DVec2; 4] = js_points.into_serde().unwrap();
 		WasmBezier {
-			internal: Bezier::from_cubic_coordinates(x1, y1, x2, y2, x3, y3, x4, y4),
+			internal: Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]),
 		}
 	}
 
 	pub fn set_start(&mut self, x: f64, y: f64) {
-		self.internal.set_start( DVec2::from((x, y)) );
+		self.internal.set_start(DVec2::from((x, y)));
 	}
 
 	pub fn set_end(&mut self, x: f64, y: f64) {
-		self.internal.set_start( DVec2::from((x, y)) );
+		self.internal.set_start(DVec2::from((x, y)));
 	}
 
 	pub fn set_handle1(&mut self, x: f64, y: f64) {
-		self.internal.set_handle1( DVec2::from((x, y)) );
+		self.internal.set_handle1(DVec2::from((x, y)));
 	}
 
 	pub fn set_handle2(&mut self, x: f64, y: f64) {
-		self.internal.set_handle2( DVec2::from((x, y)) );
+		self.internal.set_handle2(DVec2::from((x, y)));
 	}
 
 	pub fn get_points(&self) -> Vec<JsValue> {
@@ -56,7 +60,7 @@ impl WasmBezier {
 	pub fn to_svg(&self) -> String {
 		self.internal.to_svg()
 	}
-	
+
 	pub fn length(&self) -> f64 {
 		self.internal.length()
 	}

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -37,7 +37,7 @@ impl WasmBezier {
 	}
 
 	pub fn set_end(&mut self, x: f64, y: f64) {
-		self.internal.set_start(DVec2::from((x, y)));
+		self.internal.set_end(DVec2::from((x, y)));
 	}
 
 	pub fn set_handle1(&mut self, x: f64, y: f64) {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -57,7 +57,7 @@ impl WasmBezier {
 		self.internal.to_svg()
 	}
 	
-	pub fn length(self) -> f64 {
+	pub fn length(&self) -> f64 {
 		self.internal.length()
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -157,16 +157,16 @@ impl Bezier {
 	///  Calculate the point on the curve based on the t-value provided
 	///  basis code based off of pseudocode found here: https://pomax.github.io/bezierinfo/#explanation
 	pub fn get_basis(&self, t: f64) -> DVec2 {
-		let t2 = t * t;
-		let mt = 1.0 - t;
-		let mt2 = mt * mt;
+		let t_squared = t * t;
+		let one_minus_t = 1.0 - t;
+		let squared_one_minus_t = one_minus_t * one_minus_t;
 
 		match self.handles {
-			BezierHandles::Quadratic { handle } => mt2 * self.start + 2.0 * mt * t * handle + t2 * self.end,
+			BezierHandles::Quadratic { handle } => squared_one_minus_t * self.start + 2.0 * one_minus_t * t * handle + t_squared * self.end,
 			BezierHandles::Cubic { handle1, handle2 } => {
-				let t3 = t2 * t;
-				let mt3 = mt2 * mt;
-				mt3 * self.start + 3.0 * mt2 * t * handle1 + 3.0 * mt * t2 * handle2 + t3 * self.end
+				let t_cubed = t_squared * t;
+				let cubed_one_minus_t = squared_one_minus_t * one_minus_t;
+				cubed_one_minus_t * self.start + 3.0 * squared_one_minus_t * t * handle1 + 3.0 * one_minus_t * t_squared * handle2 + t_cubed * self.end
 			}
 		}
 	}
@@ -180,17 +180,17 @@ impl Bezier {
 		const SUBDIVISIONS: i32 = 1000;
 		const RATIO: f64 = 1.0 / (SUBDIVISIONS as f64);
 
-		// o_point tracks the starting point of the subdivision
-		let mut o_point = self.get_basis(0.0);
+		// start_point tracks the starting point of the subdivision
+		let mut start_point = self.get_basis(0.0);
 		let mut length_subtotal = 0.0;
 		// calculate approximate distance between subdivision
-		for i in 1..SUBDIVISIONS + 1 {
+		for subdivision in 1..SUBDIVISIONS + 1 {
 			// get end point of the subdivision
-			let point = self.get_basis(f64::from(i) * RATIO);
+			let end_point = self.get_basis(f64::from(subdivision) * RATIO);
 			// calculate distance of subdivision
-			length_subtotal += (o_point - point).length();
-			// update o_point for next subdivision
-			o_point = point;
+			length_subtotal += (start_point - end_point).length();
+			// update start_point for next subdivision
+			start_point = end_point;
 		}
 
 		length_subtotal

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -1,19 +1,24 @@
 use glam::DVec2;
 
+/// Representation of the handle point(s) in a bezier segment
 pub enum BezierHandles {
 	Quadratic { handle: DVec2 },
 	Cubic { handle1: DVec2, handle2: DVec2 },
 }
 
-/// Representation of a bezier curve with 2D points
+/// Representation of a bezier segment with 2D points
 pub struct Bezier {
-	/// Segment representing the bezier curve
+	/// Start point of the bezier segment
 	start: DVec2,
+	/// Start point of the bezier segment
 	end: DVec2,
+	/// Handles of the bezier segment
 	handles: BezierHandles,
 }
 
 impl Bezier {
+	// TODO: Consider removing this function
+	/// Create a quadratic bezier using the provided coordinates as the start, handle, and end points
 	pub fn from_quadratic_coordinates(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> Self {
 		Bezier {
 			start: DVec2::from((x1, y1)),
@@ -22,6 +27,7 @@ impl Bezier {
 		}
 	}
 
+	/// Create a quadratc bezier using the provided DVec2s as the start, handle, and end points
 	pub fn from_quadratic_dvec2(p1: DVec2, p2: DVec2, p3: DVec2) -> Self {
 		Bezier {
 			start: p1,
@@ -30,6 +36,8 @@ impl Bezier {
 		}
 	}
 
+	// TODO: Consider removing this function
+	/// Create a cubic bezier using the provided coordinates as the start, handles, and end points
 	pub fn from_cubic_coordinates(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64, x4: f64, y4: f64) -> Self {
 		Bezier {
 			start: DVec2::from((x1, y1)),
@@ -41,6 +49,7 @@ impl Bezier {
 		}
 	}
 
+	/// Create a cubic bezier using the provided DVec2s as the start, handles, and end points
 	pub fn from_cubic_dvec2(p1: DVec2, p2: DVec2, p3: DVec2, p4: DVec2) -> Self {
 		Bezier {
 			start: p1,
@@ -82,25 +91,29 @@ impl Bezier {
 		)
 	}
 
+	/// Set the coordinates of the start point
 	pub fn set_start(&mut self, s: DVec2) {
 		self.start = s;
 	}
 
+	/// Set the coordinates of the end point
 	pub fn set_end(&mut self, e: DVec2) {
 		self.end = e;
 	}
 
+	/// Set the coordinates of the first handle point. This represents the only handle in a quadratic segment.
 	pub fn set_handle1(&mut self, h1: DVec2) {
 		match self.handles {
 			BezierHandles::Quadratic { ref mut handle } => {
 				*handle = h1;
 			}
-			BezierHandles::Cubic { ref mut handle1, handle2: _} => {
+			BezierHandles::Cubic { ref mut handle1, handle2: _ } => {
 				*handle1 = h1;
 			}
 		};
 	}
 
+	/// Set the coordinates of the second handle point. This will convert a quadratic segment into a cubic one.
 	pub fn set_handle2(&mut self, h2: DVec2) {
 		match self.handles {
 			BezierHandles::Quadratic { handle } => {
@@ -122,26 +135,17 @@ impl Bezier {
 
 	pub fn get_handle1(&self) -> DVec2 {
 		match self.handles {
-			BezierHandles::Quadratic { handle } => {
-				handle
-			}
-			BezierHandles::Cubic { handle1, handle2: _ } => {
-				handle1
-			}
+			BezierHandles::Quadratic { handle } => handle,
+			BezierHandles::Cubic { handle1, handle2: _ } => handle1,
 		}
 	}
 
 	pub fn get_handle2(&self) -> Option<DVec2> {
 		match self.handles {
-			BezierHandles::Quadratic { handle: _ } => {
-				None
-			}
-			BezierHandles::Cubic { handle1: _, handle2 } => {
-				Some(handle2)
-			}
+			BezierHandles::Quadratic { handle: _ } => None,
+			BezierHandles::Cubic { handle1: _, handle2 } => Some(handle2),
 		}
 	}
-
 
 	pub fn get_points(&self) -> [Option<DVec2>; 4] {
 		match self.handles {
@@ -158,14 +162,12 @@ impl Bezier {
 		let mt2 = mt * mt;
 
 		match self.handles {
-			BezierHandles::Quadratic { handle } => {
-				mt2 * self.start[0] + 2.0 * mt * t * handle[0] + t2 * self.end[0]
-			},
+			BezierHandles::Quadratic { handle } => mt2 * self.start[0] + 2.0 * mt * t * handle[0] + t2 * self.end[0],
 			BezierHandles::Cubic { handle1, handle2 } => {
 				let t3 = t2 * t;
 				let mt3 = mt2 * mt;
 				mt3 * self.start[0] + 3.0 * mt2 * t * handle1[0] + 3.0 * mt * t2 * handle2[0] + t3 * self.end[0]
-			},
+			}
 		}
 	}
 
@@ -177,14 +179,12 @@ impl Bezier {
 		let mt2 = mt * mt;
 
 		match self.handles {
-			BezierHandles::Quadratic { handle } => {
-				mt2 * self.start[1] + 2.0 * mt * t * handle[1] + t2 * self.end[1]
-			},
+			BezierHandles::Quadratic { handle } => mt2 * self.start[1] + 2.0 * mt * t * handle[1] + t2 * self.end[1],
 			BezierHandles::Cubic { handle1, handle2 } => {
 				let t3 = t2 * t;
 				let mt3 = mt2 * mt;
 				mt3 * self.start[1] + 3.0 * mt2 * t * handle1[1] + 3.0 * mt * t2 * handle2[1] + t3 * self.end[1]
-			},
+			}
 		}
 	}
 

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -204,7 +204,7 @@ impl Bezier {
 		for i in 1..subdivisions + 1 {
 			// get end point of the subdivision
 			let x = self.get_x_basis(f64::from(i) * ratio);
-			let y = self.get_x_basis(f64::from(i) * ratio);
+			let y = self.get_y_basis(f64::from(i) * ratio);
 			// calculate distance of subdivision
 			let dx = ox - x;
 			let dy = oy - y;

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -75,16 +75,16 @@ impl Bezier {
 	/// Convert to SVG
 	// TODO: Allow modifying the viewport, width and height
 	pub fn to_svg(&self) -> String {
-		let m_path = format!("M {} {}", self.start[0], self.start[1]);
+		let m_path = format!("M {} {}", self.start.x, self.start.y);
 		let handles_path = match self.handles {
 			BezierHandles::Quadratic { handle } => {
-				format!("Q {} {}", handle[0], handle[1])
+				format!("Q {} {}", handle.x, handle.y)
 			}
 			BezierHandles::Cubic { handle1, handle2 } => {
-				format!("C {} {}, {} {}", handle1[0], handle1[1], handle2[0], handle2[1])
+				format!("C {} {}, {} {}", handle1.x, handle1.y, handle2.x, handle2.y)
 			}
 		};
-		let curve_path = format!("{}, {} {}", handles_path, self.end[0], self.end[1]);
+		let curve_path = format!("{}, {} {}", handles_path, self.end.x, self.end.y);
 		format!(
 			r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{} {} {} {}" width="{}px" height="{}px"><path d="{} {} {}" stroke="black" fill="transparent"/></svg>"#,
 			0, 0, 100, 100, 100, 100, "\n", m_path, curve_path
@@ -107,7 +107,7 @@ impl Bezier {
 			BezierHandles::Quadratic { ref mut handle } => {
 				*handle = h1;
 			}
-			BezierHandles::Cubic { ref mut handle1, handle2: _ } => {
+			BezierHandles::Cubic { ref mut handle1, .. } => {
 				*handle1 = h1;
 			}
 		};
@@ -119,7 +119,7 @@ impl Bezier {
 			BezierHandles::Quadratic { handle } => {
 				self.handles = BezierHandles::Cubic { handle1: handle, handle2: h2 };
 			}
-			BezierHandles::Cubic { handle1: _, ref mut handle2 } => {
+			BezierHandles::Cubic { ref mut handle2, .. } => {
 				*handle2 = h2;
 			}
 		};

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -158,7 +158,7 @@ impl Bezier {
 		let mt = 1.0 - t;
 		let mt2 = mt * mt;
 
-		if self.points.len() == 3 {
+		if self.points[3].is_none() {
 			// quadratic
 			return mt2 * self.points[0].unwrap()[0] + 2.0 * mt * t * self.points[1].unwrap()[0] + t2 * self.points[2].unwrap()[0];
 		}
@@ -176,7 +176,7 @@ impl Bezier {
 		let mt = 1.0 - t;
 		let mt2 = mt * mt;
 
-		if self.points.len() == 3 {
+		if self.points[3].is_none() {
 			// quadratic
 			return mt2 * self.points[0].unwrap()[1] + 2.0 * mt * t * self.points[1].unwrap()[1] + t2 * self.points[2].unwrap()[1];
 		}


### PR DESCRIPTION
Core changes
- Implement the length function for a bezier segment
- Add section for length in the interactive documentation and display the length value

Other changes:
- Refactor `WasmBezier` to take lists of points
- Add back `eslint` rule that was causing problems

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
