### PR TITLE
Bezier split and trim implementation

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -66,18 +66,18 @@ export default defineComponent({
 				{
 					id: 3,
 					name: "Compute",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
-						const point = JSON.parse(bezier.compute(parseFloat(options)));
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
+						const point = JSON.parse(bezier.compute(options.t));
 						drawPoint(getContextFromCanvas(canvas), point, 4, "Red");
 					},
 					template: markRaw(SliderExample),
-					templateOptions: tSliderOptions,
+					templateOptions: { sliders: [{ ...tSliderOptions }] },
 				},
 				{
 					id: 4,
 					name: "Lookup Table",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
-						const lookupPoints = bezier.compute_lookup_table(Number(options));
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
+						const lookupPoints = bezier.compute_lookup_table(options.Steps);
 						lookupPoints.forEach((serialisedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
 								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, "Red");
@@ -86,22 +86,25 @@ export default defineComponent({
 					},
 					template: markRaw(SliderExample),
 					templateOptions: {
-						min: 2,
-						max: 15,
-						step: 1,
-						default: 5,
-						variable: "Steps",
+						sliders: [
+							{
+								min: 2,
+								max: 15,
+								step: 1,
+								default: 5,
+								variable: "Steps",
+							},
+						],
 					},
 				},
 				{
 					id: 5,
 					name: "Derivative",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
-						const t = parseFloat(options);
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 
-						const intersection = JSON.parse(bezier.compute(t));
-						const derivative = JSON.parse(bezier.derivative(t));
+						const intersection = JSON.parse(bezier.compute(options.t));
+						const derivative = JSON.parse(bezier.derivative(options.t));
 						const curveFactor = bezier.get_points().length - 1;
 
 						const tangentStart = {
@@ -119,17 +122,16 @@ export default defineComponent({
 						drawPoint(context, tangentEnd, 3, "Red");
 					},
 					template: markRaw(SliderExample),
-					templateOptions: tSliderOptions,
+					templateOptions: { sliders: [{ ...tSliderOptions }] },
 				},
 				{
 					id: 6,
 					name: "Normal",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
-						const t = parseFloat(options);
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 
-						const intersection = JSON.parse(bezier.compute(t));
-						const normal = JSON.parse(bezier.normal(t));
+						const intersection = JSON.parse(bezier.compute(options.t));
+						const normal = JSON.parse(bezier.normal(options.t));
 
 						const normalStart = {
 							x: intersection.x - normal.x * 20,
@@ -146,21 +148,48 @@ export default defineComponent({
 						drawPoint(context, normalEnd, 3, "Red");
 					},
 					template: markRaw(SliderExample),
-					templateOptions: tSliderOptions,
+					templateOptions: { sliders: [{ ...tSliderOptions }] },
 				},
 				{
 					id: 6,
 					name: "Split",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
-						const t = parseFloat(options);
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
-						const bezierPair = bezier.split(t);
+						const bezierPair = bezier.split(options.t);
 
-						drawBezierHelper(context, bezierPair.second, "orange");
-						drawBezierHelper(context, bezierPair.first, "Red");
+						drawBezierHelper(context, bezierPair.second, "orange", 3.5);
+						drawBezierHelper(context, bezierPair.first, "Red", 3.5);
 					},
 					template: markRaw(SliderExample),
-					templateOptions: tSliderOptions,
+					templateOptions: { sliders: [{ ...tSliderOptions }] },
+				},
+				{
+					id: 7,
+					name: "Trim",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
+						const context = getContextFromCanvas(canvas);
+						const trimmedBezier = bezier.trim(options.t1, options.t2);
+						drawBezierHelper(context, trimmedBezier, "Red", 3.5);
+					},
+					template: markRaw(SliderExample),
+					templateOptions: {
+						sliders: [
+							{
+								variable: "t1",
+								min: 0,
+								max: 1,
+								step: 0.01,
+								default: 0.25,
+							},
+							{
+								variable: "t2",
+								min: 0,
+								max: 1,
+								step: 0.01,
+								default: 0.75,
+							},
+						],
+					},
 				},
 			],
 		};

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { defineComponent, markRaw } from "vue";
 
-import { drawText, drawPoint, drawLine, getContextFromCanvas } from "@/utils/drawing";
+import { drawText, drawPoint, drawLine, getContextFromCanvas, drawBezierHelper } from "@/utils/drawing";
 import { WasmBezierInstance } from "@/utils/types";
 
 import ExamplePane from "@/components/ExamplePane.vue";
@@ -144,6 +144,20 @@ export default defineComponent({
 						drawPoint(context, normalStart, 3, "Red");
 						drawPoint(context, intersection, 3, "Red");
 						drawPoint(context, normalEnd, 3, "Red");
+					},
+					template: markRaw(SliderExample),
+					templateOptions: tSliderOptions,
+				},
+				{
+					id: 6,
+					name: "Split",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string): void => {
+						const t = parseFloat(options);
+						const context = getContextFromCanvas(canvas);
+						const bezierPair = bezier.split(t);
+
+						drawBezierHelper(context, bezierPair.second, "orange");
+						drawBezierHelper(context, bezierPair.first, "Red");
 					},
 					template: markRaw(SliderExample),
 					templateOptions: tSliderOptions,

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { defineComponent, markRaw } from "vue";
 
-import { drawText, drawPoint, drawLine, getContextFromCanvas, drawBezierHelper } from "@/utils/drawing";
+import { drawText, drawPoint, drawBezier, drawLine, getContextFromCanvas, drawBezierHelper } from "@/utils/drawing";
 import { WasmBezierInstance } from "@/utils/types";
 
 import ExamplePane from "@/components/ExamplePane.vue";
@@ -33,6 +33,9 @@ const testBezierLib = async () => {
 		}
 	});
 };
+
+const NON_INTERACTIVE_STROKE_1 = "red";
+const NON_INTERACTIVE_STROKE_2 = "orange";
 
 const tSliderOptions = {
 	min: 0,
@@ -68,7 +71,7 @@ export default defineComponent({
 					name: "Compute",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const point = JSON.parse(bezier.compute(options.t));
-						drawPoint(getContextFromCanvas(canvas), point, 4, "Red");
+						drawPoint(getContextFromCanvas(canvas), point, 4, NON_INTERACTIVE_STROKE_1);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: { sliders: [{ ...tSliderOptions }] },
@@ -77,10 +80,10 @@ export default defineComponent({
 					id: 4,
 					name: "Lookup Table",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
-						const lookupPoints = bezier.compute_lookup_table(options.Steps);
+						const lookupPoints = bezier.compute_lookup_table(options.steps);
 						lookupPoints.forEach((serialisedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
-								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, "Red");
+								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, NON_INTERACTIVE_STROKE_1);
 							}
 						});
 					},
@@ -92,7 +95,7 @@ export default defineComponent({
 								max: 15,
 								step: 1,
 								default: 5,
-								variable: "Steps",
+								variable: "steps",
 							},
 						],
 					},
@@ -116,10 +119,10 @@ export default defineComponent({
 							y: intersection.y + derivative.y / curveFactor,
 						};
 
-						drawLine(context, tangentStart, tangentEnd, "Red");
-						drawPoint(context, tangentStart, 3, "Red");
-						drawPoint(context, intersection, 3, "Red");
-						drawPoint(context, tangentEnd, 3, "Red");
+						drawLine(context, tangentStart, tangentEnd, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, tangentStart, 3, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, intersection, 3, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, tangentEnd, 3, NON_INTERACTIVE_STROKE_1);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: { sliders: [{ ...tSliderOptions }] },
@@ -142,10 +145,10 @@ export default defineComponent({
 							y: intersection.y + normal.y * 20,
 						};
 
-						drawLine(context, normalStart, normalEnd, "Red");
-						drawPoint(context, normalStart, 3, "Red");
-						drawPoint(context, intersection, 3, "Red");
-						drawPoint(context, normalEnd, 3, "Red");
+						drawLine(context, normalStart, normalEnd, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, normalStart, 3, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, intersection, 3, NON_INTERACTIVE_STROKE_1);
+						drawPoint(context, normalEnd, 3, NON_INTERACTIVE_STROKE_1);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: { sliders: [{ ...tSliderOptions }] },
@@ -155,10 +158,10 @@ export default defineComponent({
 					name: "Split",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
-						const bezierPair = bezier.split(options.t);
+						const bezierPairPoints = JSON.parse(bezier.split(options.t));
 
-						drawBezierHelper(context, bezierPair.second, "orange", 3.5);
-						drawBezierHelper(context, bezierPair.first, "Red", 3.5);
+						drawBezier(context, bezierPairPoints[0], NON_INTERACTIVE_STROKE_2, 3.5);
+						drawBezier(context, bezierPairPoints[1], NON_INTERACTIVE_STROKE_1, 3.5);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: { sliders: [{ ...tSliderOptions }] },
@@ -169,7 +172,7 @@ export default defineComponent({
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 						const trimmedBezier = bezier.trim(options.t1, options.t2);
-						drawBezierHelper(context, trimmedBezier, "Red", 3.5);
+						drawBezierHelper(context, trimmedBezier, NON_INTERACTIVE_STROKE_1, 3.5);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: {

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -2,7 +2,7 @@
 	<div class="App">
 		<h1>Bezier-rs Interactive Documentation</h1>
 		<p>This is the interactive documentation for the <b>bezier-rs</b> library. Click and drag on the endpoints of the example curves to visualize the various Bezier utilities and functions.</p>
-		<div v-for="feature in features" :key="feature.id">
+		<div v-for="(feature, index) in features" :key="index">
 			<ExamplePane :template="feature.template" :templateOptions="feature.templateOptions" :name="feature.name" :callback="feature.callback" />
 		</div>
 		<br />
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { defineComponent, markRaw } from "vue";
 
-import { drawText, drawPoint, drawBezier, drawLine, getContextFromCanvas, drawBezierHelper } from "@/utils/drawing";
+import { drawText, drawPoint, drawBezier, drawLine, getContextFromCanvas, drawBezierHelper, COLORS } from "@/utils/drawing";
 import { WasmBezierInstance } from "@/utils/types";
 
 import ExamplePane from "@/components/ExamplePane.vue";
@@ -34,9 +34,6 @@ const testBezierLib = async () => {
 	});
 };
 
-const NON_INTERACTIVE_STROKE_1 = "red";
-const NON_INTERACTIVE_STROKE_2 = "orange";
-
 const tSliderOptions = {
 	min: 0,
 	max: 1,
@@ -54,36 +51,32 @@ export default defineComponent({
 		return {
 			features: [
 				{
-					id: 0,
 					name: "Constructor",
 					// eslint-disable-next-line
 					callback: (): void => {},
 				},
 				{
-					id: 2,
 					name: "Length",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
 						drawText(getContextFromCanvas(canvas), `Length: ${bezier.length().toFixed(2)}`, 5, canvas.height - 7);
 					},
 				},
 				{
-					id: 3,
 					name: "Compute",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const point = JSON.parse(bezier.compute(options.t));
-						drawPoint(getContextFromCanvas(canvas), point, 4, NON_INTERACTIVE_STROKE_1);
+						drawPoint(getContextFromCanvas(canvas), point, 4, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 					template: markRaw(SliderExample),
-					templateOptions: { sliders: [{ ...tSliderOptions }] },
+					templateOptions: { sliders: [tSliderOptions] },
 				},
 				{
-					id: 4,
 					name: "Lookup Table",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const lookupPoints = bezier.compute_lookup_table(options.steps);
 						lookupPoints.forEach((serialisedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
-								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, NON_INTERACTIVE_STROKE_1);
+								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, COLORS.NON_INTERACTIVE.STROKE_1);
 							}
 						});
 					},
@@ -101,7 +94,6 @@ export default defineComponent({
 					},
 				},
 				{
-					id: 5,
 					name: "Derivative",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
@@ -119,16 +111,15 @@ export default defineComponent({
 							y: intersection.y + derivative.y / curveFactor,
 						};
 
-						drawLine(context, tangentStart, tangentEnd, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, tangentStart, 3, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, intersection, 3, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, tangentEnd, 3, NON_INTERACTIVE_STROKE_1);
+						drawLine(context, tangentStart, tangentEnd, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, tangentStart, 3, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, intersection, 3, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, tangentEnd, 3, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 					template: markRaw(SliderExample),
-					templateOptions: { sliders: [{ ...tSliderOptions }] },
+					templateOptions: { sliders: [tSliderOptions] },
 				},
 				{
-					id: 6,
 					name: "Normal",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
@@ -145,34 +136,32 @@ export default defineComponent({
 							y: intersection.y + normal.y * 20,
 						};
 
-						drawLine(context, normalStart, normalEnd, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, normalStart, 3, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, intersection, 3, NON_INTERACTIVE_STROKE_1);
-						drawPoint(context, normalEnd, 3, NON_INTERACTIVE_STROKE_1);
+						drawLine(context, normalStart, normalEnd, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, normalStart, 3, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, intersection, 3, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawPoint(context, normalEnd, 3, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 					template: markRaw(SliderExample),
-					templateOptions: { sliders: [{ ...tSliderOptions }] },
+					templateOptions: { sliders: [tSliderOptions] },
 				},
 				{
-					id: 6,
 					name: "Split",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 						const bezierPairPoints = JSON.parse(bezier.split(options.t));
 
-						drawBezier(context, bezierPairPoints[0], NON_INTERACTIVE_STROKE_2, 3.5);
-						drawBezier(context, bezierPairPoints[1], NON_INTERACTIVE_STROKE_1, 3.5);
+						drawBezier(context, bezierPairPoints[0], null, COLORS.NON_INTERACTIVE.STROKE_2, 3.5);
+						drawBezier(context, bezierPairPoints[1], null, COLORS.NON_INTERACTIVE.STROKE_1, 3.5);
 					},
 					template: markRaw(SliderExample),
-					templateOptions: { sliders: [{ ...tSliderOptions }] },
+					templateOptions: { sliders: [tSliderOptions] },
 				},
 				{
-					id: 7,
 					name: "Trim",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 						const trimmedBezier = bezier.trim(options.t1, options.t2);
-						drawBezierHelper(context, trimmedBezier, NON_INTERACTIVE_STROKE_1, 3.5);
+						drawBezierHelper(context, trimmedBezier, COLORS.NON_INTERACTIVE.STROKE_1, 3.5);
 					},
 					template: markRaw(SliderExample),
 					templateOptions: {

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,4 +1,4 @@
-import { drawBezier, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
+import { drawBezier, getContextFromCanvas, getPointSizeByIndex, DEFAULT_ENDPOINT_RADIUS } from "@/utils/drawing";
 import { BezierCallback, BezierPoint, WasmBezierMutatorKey } from "@/utils/types";
 import { WasmBezierInstance } from "@/utils/wasm-comm";
 
@@ -105,7 +105,7 @@ class BezierDrawing {
 			this.options = options;
 		}
 		this.clearFigure();
-		drawBezier(this.ctx, this.points, "black", this.dragIndex);
+		drawBezier(this.ctx, this.points, "black", DEFAULT_ENDPOINT_RADIUS, this.dragIndex);
 		this.callback(this.canvas, this.bezier, this.options);
 	}
 

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,4 +1,4 @@
-import { drawBezier, getContextFromCanvas, getPointSizeByIndex, DEFAULT_ENDPOINT_RADIUS } from "@/utils/drawing";
+import { drawBezier, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
 import { BezierCallback, BezierPoint, WasmBezierMutatorKey } from "@/utils/types";
 import { WasmBezierInstance } from "@/utils/wasm-comm";
 
@@ -105,7 +105,7 @@ class BezierDrawing {
 			this.options = options;
 		}
 		this.clearFigure();
-		drawBezier(this.ctx, this.points, "black", DEFAULT_ENDPOINT_RADIUS, this.dragIndex);
+		drawBezier(this.ctx, this.points, this.dragIndex);
 		this.callback(this.canvas, this.bezier, this.options);
 	}
 

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -20,9 +20,9 @@ class BezierDrawing {
 
 	callback: BezierCallback;
 
-	options: string;
+	options: Record<string, number>;
 
-	constructor(bezier: WasmBezierInstance, callback: BezierCallback, options: string) {
+	constructor(bezier: WasmBezierInstance, callback: BezierCallback, options: Record<string, number>) {
 		this.bezier = bezier;
 		this.callback = callback;
 		this.options = options;
@@ -100,8 +100,8 @@ class BezierDrawing {
 		}
 	}
 
-	updateBezier(options = ""): void {
-		if (options !== "") {
+	updateBezier(options: Record<string, number> = {}): void {
+		if (Object.values(options).length !== 0) {
 			this.options = options;
 		}
 		this.clearFigure();

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -105,7 +105,7 @@ class BezierDrawing {
 			this.options = options;
 		}
 		this.clearFigure();
-		drawBezier(this.ctx, this.points, this.dragIndex);
+		drawBezier(this.ctx, this.points, "black", this.dragIndex);
 		this.callback(this.canvas, this.bezier, this.options);
 	}
 

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -30,8 +30,8 @@ export default defineComponent({
 			required: true,
 		},
 		options: {
-			type: String,
-			default: "",
+			type: Object as PropType<Record<string, number>>,
+			default: () => ({}),
 		},
 	},
 	mounted() {
@@ -40,8 +40,11 @@ export default defineComponent({
 		this.bezierDrawing.updateBezier();
 	},
 	watch: {
-		options() {
-			this.bezierDrawing.updateBezier(this.options);
+		options: {
+			deep: true,
+			handler() {
+				this.bezierDrawing.updateBezier(this.options);
+			},
 		},
 	},
 });

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -3,7 +3,7 @@
 		<h2 class="example_pane_header">{{ name }}</h2>
 		<div class="example_row">
 			<div v-for="example in exampleData" :key="example.id">
-				<component :is="template" :templateOptions="templateOptions" :title="example.title" :bezier="example.bezier" :callback="callback" />
+				<component :is="template" :templateOptions="{ ...templateOptions }" :title="example.title" :bezier="example.bezier" :callback="callback" />
 			</div>
 		</div>
 	</div>

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -3,7 +3,7 @@
 		<h2 class="example_pane_header">{{ name }}</h2>
 		<div class="example_row">
 			<div v-for="example in exampleData" :key="example.id">
-				<component :is="template" :templateOptions="{ ...templateOptions }" :title="example.title" :bezier="example.bezier" :callback="callback" />
+				<component :is="template" :templateOptions="templateOptions" :title="example.title" :bezier="example.bezier" :callback="callback" />
 			</div>
 		</div>
 	</div>

--- a/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
@@ -1,15 +1,17 @@
 <template>
 	<div>
-		<Example :title="title" :bezier="bezier" :callback="callback" :options="value.toString()" />
-		<div class="slider_label">{{ templateOptions.variable }} = {{ value }}</div>
-		<input class="slider" v-model="value" type="range" :step="templateOptions.step" :min="templateOptions.min" :max="templateOptions.max" />
+		<Example :title="title" :bezier="bezier" :callback="callback" :options="$data" />
+		<div v-for="(slider, index) in templateOptions.sliders" :key="index">
+			<div class="slider_label">{{ slider.variable }} = {{ $data[slider.variable] }}</div>
+			<input class="slider" v-model.number="$data[slider.variable]" type="range" :step="slider.step" :min="slider.min" :max="slider.max" />
+		</div>
 	</div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 
-import { BezierCallback } from "@/utils/types";
+import { BezierCallback, SliderOption } from "@/utils/types";
 import { WasmBezierInstance } from "@/utils/wasm-comm";
 
 import Example from "@/components/Example.vue";
@@ -35,9 +37,8 @@ export default defineComponent({
 		},
 	},
 	data() {
-		return {
-			value: this.templateOptions.default,
-		};
+		const sliders: SliderOption[] = this.templateOptions.sliders;
+		return Object.assign({}, ...sliders.map((s) => ({ [s.variable]: s.default })));
 	},
 });
 </script>

--- a/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
@@ -1,9 +1,9 @@
 <template>
 	<div>
-		<Example :title="title" :bezier="bezier" :callback="callback" :options="$data" />
+		<Example :title="title" :bezier="bezier" :callback="callback" :options="sliderData" />
 		<div v-for="(slider, index) in templateOptions.sliders" :key="index">
-			<div class="slider_label">{{ slider.variable }} = {{ $data[slider.variable] }}</div>
-			<input class="slider" v-model.number="$data[slider.variable]" type="range" :step="slider.step" :min="slider.min" :max="slider.max" />
+			<div class="slider_label">{{ slider.variable }} = {{ sliderData[slider.variable] }}</div>
+			<input class="slider" v-model.number="sliderData[slider.variable]" type="range" :step="slider.step" :min="slider.min" :max="slider.max" />
 		</div>
 	</div>
 </template>
@@ -38,7 +38,9 @@ export default defineComponent({
 	},
 	data() {
 		const sliders: SliderOption[] = this.templateOptions.sliders;
-		return Object.assign({}, ...sliders.map((s) => ({ [s.variable]: s.default })));
+		return {
+			sliderData: Object.assign({}, ...sliders.map((s) => ({ [s.variable]: s.default }))),
+		};
 	},
 });
 </script>

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -1,11 +1,6 @@
 import { Point, WasmBezierInstance } from "@/utils/types";
 
-const RADIUS_SIZE = {
-	large: 5,
-	small: 3,
-};
-
-export const getPointSizeByIndex = (index: number, numPoints: number): number => RADIUS_SIZE[index === 0 || index === numPoints - 1 ? "large" : "small"];
+export const getPointSizeByIndex = (index: number, numPoints: number, radius = 5): number => (index === 0 || index === numPoints - 1 ? radius : (radius * 2) / 3);
 
 export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
 	const ctx = canvas.getContext("2d");
@@ -46,15 +41,17 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
-export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black"): void => {
+export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black", radius = 5): void => {
 	drawBezier(
 		ctx,
 		bezier.get_points().map((p) => JSON.parse(p)),
-		stroke
+		stroke,
+		null,
+		radius
 	);
 };
 
-export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", dragIndex: number | null = null): void => {
+export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", dragIndex: number | null = null, radius = 5): void => {
 	/* Until a bezier representation is finalized, treat the points as follows
 		points[0] = start point
 		points[1] = handle start
@@ -91,6 +88,6 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], strok
 	drawLine(ctx, end, handleEnd, stroke);
 
 	points.forEach((point, index) => {
-		drawPoint(ctx, point, getPointSizeByIndex(index, points.length), index === dragIndex ? "Blue" : stroke);
+		drawPoint(ctx, point, getPointSizeByIndex(index, points.length, radius), index === dragIndex ? "Blue" : stroke);
 	});
 };

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -1,10 +1,21 @@
 import { Point, WasmBezierInstance } from "@/utils/types";
 
 const HANDLE_RADIUS_FACTOR = 2 / 3;
+const DEFAULT_ENDPOINT_RADIUS = 5;
 
-export const DEFAULT_ENDPOINT_RADIUS = 5;
+export const COLORS = {
+	INTERACTIVE: {
+		STROKE_1: "black",
+		STROKE_2: "grey",
+		SELECTED: "blue",
+	},
+	NON_INTERACTIVE: {
+		STROKE_1: "red",
+		STROKE_2: "orange",
+	},
+};
 
-export const getPointSizeByIndex = (index: number, numPoints: number, radius = DEFAULT_ENDPOINT_RADIUS): number => (index === 0 || index === numPoints - 1 ? radius : (radius * 2) / 3);
+export const getPointSizeByIndex = (index: number, numPoints: number, radius = DEFAULT_ENDPOINT_RADIUS): number => (index === 0 || index === numPoints - 1 ? radius : radius * HANDLE_RADIUS_FACTOR);
 
 export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
 	const ctx = canvas.getContext("2d");
@@ -14,7 +25,7 @@ export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRendering
 	return ctx;
 };
 
-export const drawLine = (ctx: CanvasRenderingContext2D, point1: Point, point2: Point, strokeColor = "gray"): void => {
+export const drawLine = (ctx: CanvasRenderingContext2D, point1: Point, point2: Point, strokeColor = COLORS.INTERACTIVE.STROKE_2): void => {
 	ctx.strokeStyle = strokeColor;
 	ctx.lineWidth = 1;
 
@@ -24,7 +35,7 @@ export const drawLine = (ctx: CanvasRenderingContext2D, point1: Point, point2: P
 	ctx.stroke();
 };
 
-export const drawPoint = (ctx: CanvasRenderingContext2D, point: Point, radius: number, strokeColor = "black"): void => {
+export const drawPoint = (ctx: CanvasRenderingContext2D, point: Point, radius: number, strokeColor = COLORS.INTERACTIVE.STROKE_1): void => {
 	// Outline the point
 	ctx.strokeStyle = strokeColor;
 	ctx.lineWidth = radius / 3;
@@ -45,17 +56,12 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
-export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black", radius = DEFAULT_ENDPOINT_RADIUS): void => {
-	drawBezier(
-		ctx,
-		bezier.get_points().map((p: string) => JSON.parse(p)),
-		stroke,
-		radius,
-		null
-	);
+export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, strokeColor = COLORS.INTERACTIVE.STROKE_1, radius = DEFAULT_ENDPOINT_RADIUS): void => {
+	const points = bezier.get_points().map((p: string) => JSON.parse(p));
+	drawBezier(ctx, points, null, strokeColor, radius);
 };
 
-export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", radius = DEFAULT_ENDPOINT_RADIUS, dragIndex: number | null = null): void => {
+export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragIndex: number | null = null, strokeColor = COLORS.INTERACTIVE.STROKE_1, radius = DEFAULT_ENDPOINT_RADIUS): void => {
 	// Points passed to drawBezier are interpreted as follows
 	//	points[0] = start point
 	//	points[1] = handle start
@@ -75,7 +81,7 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], strok
 		end = points[2];
 	}
 
-	ctx.strokeStyle = stroke;
+	ctx.strokeStyle = strokeColor;
 	ctx.lineWidth = 2;
 
 	ctx.beginPath();
@@ -87,10 +93,10 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], strok
 	}
 	ctx.stroke();
 
-	drawLine(ctx, start, handleStart, stroke);
-	drawLine(ctx, end, handleEnd, stroke);
+	drawLine(ctx, start, handleStart, strokeColor);
+	drawLine(ctx, end, handleEnd, strokeColor);
 
 	points.forEach((point, index) => {
-		drawPoint(ctx, point, getPointSizeByIndex(index, points.length, radius), index === dragIndex ? "Blue" : stroke);
+		drawPoint(ctx, point, getPointSizeByIndex(index, points.length, radius), index === dragIndex ? COLORS.INTERACTIVE.SELECTED : strokeColor);
 	});
 };

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -4,6 +4,7 @@ const HANDLE_RADIUS_FACTOR = 2 / 3;
 const DEFAULT_ENDPOINT_RADIUS = 5;
 
 export const COLORS = {
+	CANVAS: "white",
 	INTERACTIVE: {
 		STROKE_1: "black",
 		STROKE_2: "grey",
@@ -44,14 +45,14 @@ export const drawPoint = (ctx: CanvasRenderingContext2D, point: Point, radius: n
 	ctx.stroke();
 
 	// Fill the point (hiding any overlapping lines)
-	ctx.fillStyle = "white";
+	ctx.fillStyle = COLORS.CANVAS;
 	ctx.beginPath();
 	ctx.arc(point.x, point.y, radius * HANDLE_RADIUS_FACTOR, 0, 2 * Math.PI, false);
 	ctx.fill();
 };
 
-export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number, y: number): void => {
-	ctx.fillStyle = "black";
+export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number, y: number, textColor = COLORS.INTERACTIVE.STROKE_1): void => {
+	ctx.fillStyle = textColor;
 	ctx.font = "16px Arial";
 	ctx.fillText(text, x, y);
 };

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -1,6 +1,10 @@
 import { Point, WasmBezierInstance } from "@/utils/types";
 
-export const getPointSizeByIndex = (index: number, numPoints: number, radius = 5): number => (index === 0 || index === numPoints - 1 ? radius : (radius * 2) / 3);
+const HANDLE_RADIUS_FACTOR = 2 / 3;
+
+export const DEFAULT_ENDPOINT_RADIUS = 5;
+
+export const getPointSizeByIndex = (index: number, numPoints: number, radius = DEFAULT_ENDPOINT_RADIUS): number => (index === 0 || index === numPoints - 1 ? radius : (radius * 2) / 3);
 
 export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRenderingContext2D => {
 	const ctx = canvas.getContext("2d");
@@ -31,7 +35,7 @@ export const drawPoint = (ctx: CanvasRenderingContext2D, point: Point, radius: n
 	// Fill the point (hiding any overlapping lines)
 	ctx.fillStyle = "white";
 	ctx.beginPath();
-	ctx.arc(point.x, point.y, radius * (2 / 3), 0, 2 * Math.PI, false);
+	ctx.arc(point.x, point.y, radius * HANDLE_RADIUS_FACTOR, 0, 2 * Math.PI, false);
 	ctx.fill();
 };
 
@@ -41,23 +45,22 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
-export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black", radius = 5): void => {
+export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black", radius = DEFAULT_ENDPOINT_RADIUS): void => {
 	drawBezier(
 		ctx,
-		bezier.get_points().map((p) => JSON.parse(p)),
+		bezier.get_points().map((p: string) => JSON.parse(p)),
 		stroke,
-		null,
-		radius
+		radius,
+		null
 	);
 };
 
-export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", dragIndex: number | null = null, radius = 5): void => {
-	/* Until a bezier representation is finalized, treat the points as follows
-		points[0] = start point
-		points[1] = handle start
-		points[2] = (optional) handle end
-		points[3] = end point
-	*/
+export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", radius = DEFAULT_ENDPOINT_RADIUS, dragIndex: number | null = null): void => {
+	// Points passed to drawBezier are interpreted as follows
+	//	points[0] = start point
+	//	points[1] = handle start
+	//	points[2] = (optional) handle end
+	//	points[3] = end point
 	const start = points[0];
 	let end = null;
 	let handleStart = null;

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -1,4 +1,4 @@
-import { Point } from "@/utils/types";
+import { Point, WasmBezierInstance } from "@/utils/types";
 
 const RADIUS_SIZE = {
 	large: 5,
@@ -46,7 +46,15 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
-export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragIndex: number | null = null): void => {
+export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, stroke = "black"): void => {
+	drawBezier(
+		ctx,
+		bezier.get_points().map((p) => JSON.parse(p)),
+		stroke
+	);
+};
+
+export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], stroke = "black", dragIndex: number | null = null): void => {
 	/* Until a bezier representation is finalized, treat the points as follows
 		points[0] = start point
 		points[1] = handle start
@@ -67,7 +75,7 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragI
 		end = points[2];
 	}
 
-	ctx.strokeStyle = "black";
+	ctx.strokeStyle = stroke;
 	ctx.lineWidth = 2;
 
 	ctx.beginPath();
@@ -79,10 +87,10 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragI
 	}
 	ctx.stroke();
 
-	drawLine(ctx, start, handleStart);
-	drawLine(ctx, end, handleEnd);
+	drawLine(ctx, start, handleStart, stroke);
+	drawLine(ctx, end, handleEnd, stroke);
 
 	points.forEach((point, index) => {
-		drawPoint(ctx, point, getPointSizeByIndex(index, points.length), index === dragIndex ? "Blue" : "Black");
+		drawPoint(ctx, point, getPointSizeByIndex(index, points.length), index === dragIndex ? "Blue" : stroke);
 	});
 };

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -4,7 +4,15 @@ export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 export type WasmBezierKey = keyof WasmBezierInstance;
 export type WasmBezierMutatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
 
-export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: string) => void;
+export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>) => void;
+
+export type SliderOption = {
+	min: number;
+	max: number;
+	step: number;
+	default: number;
+	variable: string;
+};
 
 export type Point = {
 	x: number;

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -34,19 +34,19 @@ impl WasmBezier {
 	}
 
 	pub fn set_start(&mut self, x: f64, y: f64) {
-		self.0.set_start(DVec2::from((x, y)));
+		self.0.set_start(DVec2::new(x, y));
 	}
 
 	pub fn set_end(&mut self, x: f64, y: f64) {
-		self.0.set_end(DVec2::from((x, y)));
+		self.0.set_end(DVec2::new(x, y));
 	}
 
 	pub fn set_handle_start(&mut self, x: f64, y: f64) {
-		self.0.set_handle_start(DVec2::from((x, y)));
+		self.0.set_handle_start(DVec2::new(x, y));
 	}
 
 	pub fn set_handle_end(&mut self, x: f64, y: f64) {
-		self.0.set_handle_end(DVec2::from((x, y)));
+		self.0.set_handle_end(DVec2::new(x, y));
 	}
 
 	pub fn get_points(&self) -> Vec<JsValue> {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -9,14 +9,16 @@ struct Point {
 	y: f64,
 }
 
-/// Wrapper of the `Bezier` struct to be used in JS
+/// Wrapper of the `Bezier` struct to be used in JS.
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct WasmBezier {
 	internal: Bezier,
 }
 
-/// Wrapper of the `Bezier` struct to be used in JS
+/// Struct for returning a pair of `Bezier` structs.
+/// This is a workaround because wasm_bindgen does not support lists of template type T where T is a wasm_bindgen struct.
+/// This applies to the split function.
 #[wasm_bindgen(getter_with_clone)]
 pub struct WasmBezierPair {
 	pub first: WasmBezier,

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -9,16 +9,15 @@ struct Point {
 	y: f64,
 }
 
-#[wasm_bindgen]
-#[derive(Copy, Clone)]
 /// Wrapper of the `Bezier` struct to be used in JS
+#[wasm_bindgen]
+#[derive(Clone)]
 pub struct WasmBezier {
 	internal: Bezier,
 }
 
-#[wasm_bindgen]
-#[derive(Copy, Clone)]
 /// Wrapper of the `Bezier` struct to be used in JS
+#[wasm_bindgen(getter_with_clone)]
 pub struct WasmBezierPair {
 	pub first: WasmBezier,
 	pub second: WasmBezier,

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -12,18 +12,7 @@ struct Point {
 /// Wrapper of the `Bezier` struct to be used in JS.
 #[wasm_bindgen]
 #[derive(Clone)]
-pub struct WasmBezier {
-	internal: Bezier,
-}
-
-/// Struct for returning a pair of `Bezier` structs.
-/// This is a workaround because wasm_bindgen does not support lists of template type T where T is a wasm_bindgen struct.
-/// This applies to the split function.
-#[wasm_bindgen(getter_with_clone)]
-pub struct WasmBezierPair {
-	pub first: WasmBezier,
-	pub second: WasmBezier,
-}
+pub struct WasmBezier(Bezier);
 
 /// Convert a `DVec2` into a `JsValue`
 pub fn vec_to_point(p: &DVec2) -> JsValue {
@@ -35,72 +24,68 @@ impl WasmBezier {
 	/// Expect js_points to be a list of 3 pairs
 	pub fn new_quad(js_points: &JsValue) -> WasmBezier {
 		let points: [DVec2; 3] = js_points.into_serde().unwrap();
-		WasmBezier {
-			internal: Bezier::from_quadratic_dvec2(points[0], points[1], points[2]),
-		}
+		WasmBezier(Bezier::from_quadratic_dvec2(points[0], points[1], points[2]))
 	}
 
 	/// Expect js_points to be a list of 4 pairs
 	pub fn new_cubic(js_points: &JsValue) -> WasmBezier {
 		let points: [DVec2; 4] = js_points.into_serde().unwrap();
-		WasmBezier {
-			internal: Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]),
-		}
+		WasmBezier(Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]))
 	}
 
 	pub fn set_start(&mut self, x: f64, y: f64) {
-		self.internal.set_start(DVec2::from((x, y)));
+		self.0.set_start(DVec2::from((x, y)));
 	}
 
 	pub fn set_end(&mut self, x: f64, y: f64) {
-		self.internal.set_end(DVec2::from((x, y)));
+		self.0.set_end(DVec2::from((x, y)));
 	}
 
 	pub fn set_handle_start(&mut self, x: f64, y: f64) {
-		self.internal.set_handle_start(DVec2::from((x, y)));
+		self.0.set_handle_start(DVec2::from((x, y)));
 	}
 
 	pub fn set_handle_end(&mut self, x: f64, y: f64) {
-		self.internal.set_handle_end(DVec2::from((x, y)));
+		self.0.set_handle_end(DVec2::from((x, y)));
 	}
 
 	pub fn get_points(&self) -> Vec<JsValue> {
-		self.internal.get_points().iter().flatten().map(vec_to_point).collect()
+		self.0.get_points().iter().flatten().map(vec_to_point).collect()
 	}
 
 	pub fn to_svg(&self) -> String {
-		self.internal.to_svg()
+		self.0.to_svg()
 	}
 
 	pub fn length(&self) -> f64 {
-		self.internal.length()
+		self.0.length()
 	}
 
 	pub fn compute(&self, t: f64) -> JsValue {
-		vec_to_point(&self.internal.compute(t))
+		vec_to_point(&self.0.compute(t))
 	}
 
 	pub fn compute_lookup_table(&self, steps: i32) -> Vec<JsValue> {
-		self.internal.compute_lookup_table(Some(steps)).iter().map(vec_to_point).collect()
+		self.0.compute_lookup_table(Some(steps)).iter().map(vec_to_point).collect()
 	}
 
 	pub fn derivative(&self, t: f64) -> JsValue {
-		vec_to_point(&self.internal.derivative(t))
+		vec_to_point(&self.0.derivative(t))
 	}
 
 	pub fn normal(&self, t: f64) -> JsValue {
-		vec_to_point(&self.internal.normal(t))
+		vec_to_point(&self.0.normal(t))
 	}
 
-	pub fn split(&self, t: f64) -> WasmBezierPair {
-		let beziers = self.internal.split(t);
-		WasmBezierPair {
-			first: WasmBezier { internal: beziers[0] },
-			second: WasmBezier { internal: beziers[1] },
-		}
+	pub fn split(&self, t: f64) -> JsValue {
+		let bezier_points: [Vec<Point>; 2] = self
+			.0
+			.split(t)
+			.map(|bezier| bezier.get_points().iter().flatten().map(|point| Point { x: point.x, y: point.y }).collect());
+		JsValue::from_serde(&serde_json::to_string(&bezier_points).unwrap()).unwrap()
 	}
 
 	pub fn trim(&self, t1: f64, t2: f64) -> WasmBezier {
-		WasmBezier { internal: self.internal.trim(t1, t2) }
+		WasmBezier(self.0.trim(t1, t2))
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -10,9 +10,18 @@ struct Point {
 }
 
 #[wasm_bindgen]
+#[derive(Copy, Clone)]
 /// Wrapper of the `Bezier` struct to be used in JS
 pub struct WasmBezier {
 	internal: Bezier,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone)]
+/// Wrapper of the `Bezier` struct to be used in JS
+pub struct WasmBezierPair {
+	pub first: WasmBezier,
+	pub second: WasmBezier,
 }
 
 /// Convert a `DVec2` into a `JsValue`
@@ -80,5 +89,13 @@ impl WasmBezier {
 
 	pub fn normal(&self, t: f64) -> JsValue {
 		vec_to_point(&self.internal.normal(t))
+	}
+
+	pub fn split(&self, t: f64) -> WasmBezierPair {
+		let beziers = self.internal.split(t);
+		WasmBezierPair {
+			first: WasmBezier { internal: beziers[0] },
+			second: WasmBezier { internal: beziers[1] },
+		}
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -97,4 +97,8 @@ impl WasmBezier {
 			second: WasmBezier { internal: beziers[1] },
 		}
 	}
+
+	pub fn trim(&self, t1: f64, t2: f64) -> WasmBezier {
+		WasmBezier { internal: self.internal.trim(t1, t2) }
+	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -257,6 +257,7 @@ impl Bezier {
 		derivative.normalize().perp()
 	}
 
+	/// Returns the pair of Bezier curves that result from splitting the original curve at the point corresponding to `t`
 	pub fn split(&self, t: f64) -> [Bezier; 2] {
 		let split_point = self.compute(t);
 
@@ -287,11 +288,21 @@ impl Bezier {
 		}
 	}
 
+	/// Returns the Bezier curve representing the sub-curve starting at the point corresponding to `t1` and ending add the point corresponding to `t2`
 	pub fn trim(&self, t1: f64, t2: f64) -> Bezier {
-		let t1_split_side = if t1 < t2 { 1 } else { 0 };
-		let t2_split_side = if t1 < t2 { 0 } else { 1 };
+		// Depending on the order of t1 and t2, determine which half of the split we need to keep
+		let t1_split_side = if t1 <= t2 { 1 } else { 0 };
+		let t2_split_side = if t1 <= t2 { 0 } else { 1 };
 		let bezier_starting_at_t1 = self.split(t1)[t1_split_side];
-		let adjusted_t2 = if t1 < t2 { (t2 - t1) / (1. - t1) } else { t2 / t1 };
+		// Ajust the ratio t2 to its corresponding value on the new curve that was split on t1
+		let adjusted_t2 = if t1 < t2 || (t1 == t2 && t1 == 0.) {
+			// Case where we took the split from t1 to the end
+			// Also cover the t1 == t2 case where there would otherwise be a divide by 0
+			(t2 - t1) / (1. - t1)
+		} else {
+			// Case where we took the split from the beginning to t1
+			t2 / t1
+		};
 		bezier_starting_at_t1.split(adjusted_t2)[t2_split_side]
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -270,25 +270,20 @@ impl Bezier {
 				Bezier::from_quadratic_dvec2(self.start, t * handle - t_minus_one * self.start, split_point),
 				Bezier::from_quadratic_dvec2(split_point, t * self.end - t_minus_one * handle, self.end),
 			],
-			BezierHandles::Cubic { handle1, handle2 } => {
-				let t_cubed = t_squared * t;
-				let cubed_t_minus_one = squared_t_minus_one * t_minus_one;
-
-				[
-					Bezier::from_cubic_dvec2(
-						self.start,
-						t * handle1 - t_minus_one * self.start,
-						t_squared * handle2 - 2. * t * t_minus_one * handle1 + squared_t_minus_one * self.start,
-						split_point,
-					),
-					Bezier::from_cubic_dvec2(
-						split_point,
-						t_squared * self.end - 2. * t * t_minus_one * handle2 + squared_t_minus_one * handle1,
-						t * self.end - t_minus_one * handle2,
-						self.end,
-					),
-				]
-			}
+			BezierHandles::Cubic { handle_start, handle_end } => [
+				Bezier::from_cubic_dvec2(
+					self.start,
+					t * handle_start - t_minus_one * self.start,
+					t_squared * handle_end - 2. * t * t_minus_one * handle_start + squared_t_minus_one * self.start,
+					split_point,
+				),
+				Bezier::from_cubic_dvec2(
+					split_point,
+					t_squared * self.end - 2. * t * t_minus_one * handle_end + squared_t_minus_one * handle_start,
+					t * self.end - t_minus_one * handle_end,
+					self.end,
+				),
+			],
 		}
 	}
 
@@ -298,7 +293,7 @@ impl Bezier {
 		match self.handles {
 			// TODO: Actually calculate the correct handle locations
 			BezierHandles::Quadratic { handle } => Bezier::from_quadratic_dvec2(start, handle, end),
-			BezierHandles::Cubic { handle1, handle2 } => Bezier::from_cubic_dvec2(start, handle1, handle2, end),
+			BezierHandles::Cubic { handle_start, handle_end } => Bezier::from_cubic_dvec2(start, handle_start, handle_end, end),
 		}
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -287,13 +287,11 @@ impl Bezier {
 		}
 	}
 
-	pub fn subsplit(&self, t1: f64, t2: f64) -> Bezier {
-		let start = self.compute(t1);
-		let end = self.compute(t2);
-		match self.handles {
-			// TODO: Actually calculate the correct handle locations
-			BezierHandles::Quadratic { handle } => Bezier::from_quadratic_dvec2(start, handle, end),
-			BezierHandles::Cubic { handle_start, handle_end } => Bezier::from_cubic_dvec2(start, handle_start, handle_end, end),
-		}
+	pub fn trim(&self, t1: f64, t2: f64) -> Bezier {
+		let t1_split_side = if t1 < t2 { 1 } else { 0 };
+		let t2_split_side = if t1 < t2 { 0 } else { 1 };
+		let bezier_starting_at_t1 = self.split(t1)[t1_split_side];
+		let adjusted_t2 = if t1 < t2 { (t2 - t1) / (1. - t1) } else { t2 / t1 };
+		bezier_starting_at_t1.split(adjusted_t2)[t2_split_side]
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -33,9 +33,9 @@ impl Bezier {
 	/// Create a quadratic bezier using the provided coordinates as the start, handle, and end points
 	pub fn from_quadratic_coordinates(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> Self {
 		Bezier {
-			start: DVec2::from((x1, y1)),
-			handles: BezierHandles::Quadratic { handle: DVec2::from((x2, y2)) },
-			end: DVec2::from((x3, y3)),
+			start: DVec2::new(x1, y1),
+			handles: BezierHandles::Quadratic { handle: DVec2::new(x2, y2) },
+			end: DVec2::new(x3, y3),
 		}
 	}
 
@@ -52,12 +52,12 @@ impl Bezier {
 	/// Create a cubic bezier using the provided coordinates as the start, handles, and end points
 	pub fn from_cubic_coordinates(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64, x4: f64, y4: f64) -> Self {
 		Bezier {
-			start: DVec2::from((x1, y1)),
+			start: DVec2::new(x1, y1),
 			handles: BezierHandles::Cubic {
-				handle_start: DVec2::from((x2, y2)),
-				handle_end: DVec2::from((x3, y3)),
+				handle_start: DVec2::new(x2, y2),
+				handle_end: DVec2::new(x3, y3),
 			},
-			end: DVec2::from((x4, y4)),
+			end: DVec2::new(x4, y4),
 		}
 	}
 

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -288,19 +288,19 @@ impl Bezier {
 		}
 	}
 
-	/// Returns the Bezier curve representing the sub-curve starting at the point corresponding to `t1` and ending add the point corresponding to `t2`
+	/// Returns the Bezier curve representing the sub-curve starting at the point corresponding to `t1` and ending at the point corresponding to `t2`
 	pub fn trim(&self, t1: f64, t2: f64) -> Bezier {
-		// Depending on the order of t1 and t2, determine which half of the split we need to keep
+		// Depending on the order of `t1` and `t2`, determine which half of the split we need to keep
 		let t1_split_side = if t1 <= t2 { 1 } else { 0 };
 		let t2_split_side = if t1 <= t2 { 0 } else { 1 };
 		let bezier_starting_at_t1 = self.split(t1)[t1_split_side];
-		// Ajust the ratio t2 to its corresponding value on the new curve that was split on t1
+		// Adjust the ratio `t2` to its corresponding value on the new curve that was split on `t1`
 		let adjusted_t2 = if t1 < t2 || (t1 == t2 && t1 == 0.) {
 			// Case where we took the split from t1 to the end
-			// Also cover the t1 == t2 case where there would otherwise be a divide by 0
+			// Also cover the `t1` == t2 case where there would otherwise be a divide by 0
 			(t2 - t1) / (1. - t1)
 		} else {
-			// Case where we took the split from the beginning to t1
+			// Case where we took the split from the beginning to `t1`
 			t2 / t1
 		};
 		bezier_starting_at_t1.split(adjusted_t2)[t2_split_side]


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Implement the split and trim functions for a Bezier curve
- `split` returns the two Bezier curves that result from splitting the original at the point corresponding to `t`
- `trim` returns the single Bezier curve that results from taking the segment from `t1` to `t2` of the original curve
  - If `t1` > `t2`, the returned curve will travel in the opposite direction from the original
- Refactored the frontend to allow for variable amounts of sliders per example
- Add helper for drawing additional curves on the UI canvas
