### PR TITLE
Implement function to find intersections between a Bezier and a linear line

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -274,18 +274,18 @@ export default defineComponent({
 					},
 				},
 				{
-					name: "Intersection Line",
+					name: "Line Intersection",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
 						const context = getContextFromCanvas(canvas);
 						const line = [
-							{ x: 120, y: 150 },
-							{ x: 90, y: 30 },
+							{ x: 150, y: 150 },
+							{ x: 30, y: 30 },
 						];
 						const mappedLine = line.map((p) => [p.x, p.y]);
 						drawLine(context, line[0], line[1], COLORS.NON_INTERACTIVE.STROKE_1);
-						const intersections: Point[] = bezier.intersection_line(mappedLine).map((p) => JSON.parse(p));
+						const intersections: Point[] = bezier.line_intersection(mappedLine).map((p) => JSON.parse(p));
 						intersections.forEach((p: Point) => {
-							drawPoint(context, p, 3, "magenta");
+							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
 						});
 					},
 				},

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -250,6 +250,45 @@ export default defineComponent({
 						});
 					},
 				},
+				{
+					name: "Rotate",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
+						const context = getContextFromCanvas(canvas);
+						const rotatedBezier = bezier
+							.rotate((options.angle * Math.PI) / 180)
+							.get_points()
+							.map((p) => JSON.parse(p));
+						drawBezier(context, rotatedBezier, null, { curveStrokeColor: COLORS.NON_INTERACTIVE.STROKE_1, radius: 3.5 });
+					},
+					template: markRaw(SliderExample),
+					templateOptions: {
+						sliders: [
+							{
+								variable: "angle",
+								min: -90,
+								max: 90,
+								step: 5,
+								default: 15,
+							},
+						],
+					},
+				},
+				{
+					name: "Intersection Line",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+						const context = getContextFromCanvas(canvas);
+						const line = [
+							{ x: 120, y: 150 },
+							{ x: 90, y: 30 },
+						];
+						const mappedLine = line.map((p) => [p.x, p.y]);
+						drawLine(context, line[0], line[1], COLORS.NON_INTERACTIVE.STROKE_1);
+						const intersections: Point[] = bezier.intersection_line(mappedLine).map((p) => JSON.parse(p));
+						intersections.forEach((p: Point) => {
+							drawPoint(context, p, 3, "magenta");
+						});
+					},
+				},
 			],
 		};
 	},

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use bezier_rs::Bezier;
-use glam::{DMat2, DVec2};
+use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -109,8 +109,7 @@ impl WasmBezier {
 	}
 
 	pub fn rotate(&self, angle: f64) -> WasmBezier {
-		let rotation_matrx = DMat2::from_angle(angle);
-		WasmBezier(self.0.rotate(rotation_matrx))
+		WasmBezier(self.0.rotate(angle))
 	}
 
 	pub fn line_intersection(&self, js_points: &JsValue) -> Vec<JsValue> {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use bezier_rs::Bezier;
-use glam::DVec2;
+use glam::{DMat2, DVec2};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -106,5 +106,15 @@ impl WasmBezier {
 	pub fn local_extrema(&self) -> JsValue {
 		let local_extrema = self.0.local_extrema();
 		JsValue::from_serde(&serde_json::to_string(&local_extrema).unwrap()).unwrap()
+	}
+
+	pub fn rotate(&self, angle: f64) -> WasmBezier {
+		let rotation_matrx = DMat2::from_angle(angle);
+		WasmBezier(self.0.rotate(rotation_matrx))
+	}
+
+	pub fn intersection_line(&self, js_points: &JsValue) -> Vec<JsValue> {
+		let line: [DVec2; 2] = js_points.into_serde().unwrap();
+		self.0.intersection_line(line).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -113,8 +113,8 @@ impl WasmBezier {
 		WasmBezier(self.0.rotate(rotation_matrx))
 	}
 
-	pub fn intersection_line(&self, js_points: &JsValue) -> Vec<JsValue> {
+	pub fn line_intersection(&self, js_points: &JsValue) -> Vec<JsValue> {
 		let line: [DVec2; 2] = js_points.into_serde().unwrap();
-		self.0.intersection_line(line).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
+		self.0.line_intersection(line).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -200,8 +200,8 @@ impl Bezier {
 	}
 
 	///  Calculate the point on the curve based on the `t`-value provided.
-	///  Basis code based off of pseudocode found here: <https://pomax.github.io/bezierinfo/#explanation>
-	fn _compute(&self, t: f64) -> DVec2 {
+	///  Basis code based off of pseudocode found here: <https://pomax.github.io/bezierinfo/#explanation>.
+	fn unrestricted_compute(&self, t: f64) -> DVec2 {
 		let t_squared = t * t;
 		let one_minus_t = 1.0 - t;
 		let squared_one_minus_t = one_minus_t * one_minus_t;
@@ -217,14 +217,14 @@ impl Bezier {
 	}
 
 	///  Calculate the point on the curve based on the `t`-value provided.
-	///  Expects `t` to be within the inclusive range `[0, 1]`
+	///  Expects `t` to be within the inclusive range `[0, 1]`.
 	pub fn compute(&self, t: f64) -> DVec2 {
 		assert!((0.0..=1.0).contains(&t));
-		self._compute(t)
+		self.unrestricted_compute(t)
 	}
 
-	/// Return a selection of equidistant points on the bezier curve
-	/// If no value is provided for `steps`, then the function will default `steps` to be 10
+	/// Return a selection of equidistant points on the bezier curve.
+	/// If no value is provided for `steps`, then the function will default `steps` to be 10.
 	pub fn compute_lookup_table(&self, steps: Option<i32>) -> Vec<DVec2> {
 		let steps_unwrapped = steps.unwrap_or(10);
 		let ratio: f64 = 1.0 / (steps_unwrapped as f64);
@@ -459,6 +459,7 @@ impl Bezier {
 			.unwrap()
 	}
 
+	/// Returns a Bezier curve that results from rotating the cruve by the given `DMat2`.
 	pub fn rotate(&self, rotation_matrix: DMat2) -> Bezier {
 		let rotated_start = rotation_matrix.mul_vec2(self.start);
 		let rotated_end = rotation_matrix.mul_vec2(self.end);
@@ -475,6 +476,7 @@ impl Bezier {
 		}
 	}
 
+	/// Returns a Bezier curve that results from translating the cruve by the given `DVec2`.
 	pub fn translate(&self, translation: DVec2) -> Bezier {
 		let translated_start = self.start + translation;
 		let translated_end = self.end + translation;
@@ -492,7 +494,7 @@ impl Bezier {
 	}
 
 	/// Returns a list of points where the provided `line` intersects with the Bezier curve.
-	/// - `line`: Expected to be received in the format of `[start_point, end_point]`
+	/// - `line`: Expected to be received in the format of `[start_point, end_point]`.
 	pub fn line_intersection(&self, line: [DVec2; 2]) -> Vec<DVec2> {
 		// Rotate the bezier and the line by the angle that the line makes with the x axis
 		let slope = line[1] - line[0];
@@ -531,7 +533,7 @@ impl Bezier {
 		list_intersection_t
 			.iter()
 			.filter(|&&t| utils::f64_approximately_in_range(t, 0., 1., max_abs_diff))
-			.map(|&t| self._compute(t))
+			.map(|&t| self.unrestricted_compute(t))
 			.filter(|&p| utils::dvec2_approximately_in_range(p, min, max, max_abs_diff).all())
 			.collect::<Vec<DVec2>>()
 	}

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -201,8 +201,8 @@ impl Bezier {
 		}
 	}
 
-	///  Calculate the point on the curve based on the `t`-value provided.
-	///  Basis code based off of pseudocode found here: <https://pomax.github.io/bezierinfo/#explanation>.
+	/// Calculate the point on the curve based on the `t`-value provided.
+	/// Basis code based off of pseudocode found here: <https://pomax.github.io/bezierinfo/#explanation>.
 	fn unrestricted_compute(&self, t: f64) -> DVec2 {
 		let t_squared = t * t;
 		let one_minus_t = 1.0 - t;
@@ -218,8 +218,8 @@ impl Bezier {
 		}
 	}
 
-	///  Calculate the point on the curve based on the `t`-value provided.
-	///  Expects `t` to be within the inclusive range `[0, 1]`.
+	/// Calculate the point on the curve based on the `t`-value provided.
+	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	pub fn compute(&self, t: f64) -> DVec2 {
 		assert!((0.0..=1.0).contains(&t));
 		self.unrestricted_compute(t)
@@ -478,7 +478,7 @@ impl Bezier {
 		}
 	}
 
-	/// Returns a Bezier curve that results from rotating the curve by the given angle (in radians).
+	/// Returns a Bezier curve that results from rotating the curve around the origin by the given angle (in radians).
 	pub fn rotate(&self, angle: f64) -> Bezier {
 		let rotation_matrix = DMat2::from_angle(angle);
 		self.apply_transformation(&|point| rotation_matrix.mul_vec2(point))
@@ -489,8 +489,8 @@ impl Bezier {
 		self.apply_transformation(&|point| point + translation)
 	}
 
-	/// Returns a list of points where the provided `line` intersects with the Bezier curve.
-	/// - `line` - Expected to be received in the format of `[start_point, end_point]`.
+	/// Returns a list of points where the provided line segment intersects with the Bezier curve.
+	/// - `line` - A line segment expected to be received in the format of `[start_point, end_point]`.
 	pub fn line_intersection(&self, line: [DVec2; 2]) -> Vec<DVec2> {
 		// Rotate the bezier and the line by the angle that the line makes with the x axis
 		let slope = line[1] - line[0];
@@ -509,8 +509,10 @@ impl Bezier {
 				let a = translated_bezier.start.y - 2. * handle.y + translated_bezier.end.y;
 				let b = 2. * (handle.y - translated_bezier.start.y);
 				let c = translated_bezier.start.y;
+
 				let discriminant = b * b - 4. * a * c;
 				let two_times_a = 2. * a;
+
 				utils::solve_quadratic(discriminant, two_times_a, b, c)
 			}
 			BezierHandles::Cubic { handle_start, handle_end } => {
@@ -519,6 +521,7 @@ impl Bezier {
 				let b = 3. * start_y - 6. * handle_start.y + 3. * handle_end.y;
 				let c = -3. * start_y + 3. * handle_start.y;
 				let d = start_y;
+
 				utils::solve_cubic(a, b, c, d)
 			}
 		};
@@ -530,7 +533,7 @@ impl Bezier {
 			.iter()
 			.filter(|&&t| utils::f64_approximately_in_range(t, 0., 1., max_abs_diff))
 			.map(|&t| self.unrestricted_compute(t))
-			.filter(|&p| utils::dvec2_approximately_in_range(p, min, max, max_abs_diff).all())
+			.filter(|&point| utils::dvec2_approximately_in_range(point, min, max, max_abs_diff).all())
 			.collect::<Vec<DVec2>>()
 	}
 }

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -35,7 +35,7 @@ pub fn compute_abc_for_cubic_through_points(start_point: DVec2, point_on_curve: 
 pub fn get_closest_point_in_lut(lut: &[DVec2], point: DVec2) -> (i32, f64) {
 	lut.iter()
 		.enumerate()
-		.map(|(i, p)| (i as i32, point.distance(*p)))
+		.map(|(i, p)| (i as i32, point.distance_squared(*p)))
 		.min_by(|x, y| (&(x.1)).partial_cmp(&(y.1)).unwrap())
 		.unwrap()
 }

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -1,4 +1,4 @@
-use glam::DVec2;
+use glam::{BVec2, DVec2};
 use std::f64::consts::PI;
 
 /// Helper to perform the computation of a and c, where b is the provided point on the curve.
@@ -66,57 +66,134 @@ pub fn solve_quadratic(discriminant: f64, two_times_a: f64, b: f64, c: f64) -> V
 	roots
 }
 
-/// Solve a cubic of the form t^3 + pt + q, derivation from: https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
-pub fn solve_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec<f64> {
+/// Compute the cube root of a number
+fn cube_root(f: f64) -> f64 {
+	if f < 0. {
+		-(-f).powf(1. / 3.)
+	} else {
+		f.powf(1. / 3.)
+	}
+}
+
+// Solve a cubic of the form x^3 + px + q, derivation from: https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+pub fn solve_reformatted_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
 	if p == 0. {
-		roots.push((-q).powf(1. / 3.));
+		roots.push(cube_root(-q));
 	} else if q == 0. {
 		if p < 0. {
 			roots.push((-p).powf(1. / 2.));
 		}
 	} else if discriminant == 0. {
 		let q_divided_by_2 = q / 2.;
+		let a_divided_by_3 = a / 3.;
 		// all roots are real, and 2 are repeated
-		roots.push(2. * (-q_divided_by_2).powf(1. / 3.) - a / 3.);
-		roots.push((q_divided_by_2).powf(1. / 3.) - a / 3.);
+		roots.push(2. * cube_root(-q_divided_by_2) - a_divided_by_3);
+		roots.push(cube_root(q_divided_by_2) - a_divided_by_3);
 	} else if discriminant > 0. {
 		// one real and two imaginary roots
 		let q_divided_by_2 = q / 2.;
-		roots.push((-q_divided_by_2 + discriminant).powf(1. / 3.) - (q_divided_by_2 + discriminant).powf(1. / 3.) - a / 3.);
+		let square_root_discriminant = discriminant.powf(1. / 2.);
+		roots.push(cube_root(-q_divided_by_2 + square_root_discriminant) - cube_root(q_divided_by_2 + square_root_discriminant) - a / 3.);
 	} else {
-		let q_divided_by_2 = q / 2.;
+		// three real roots
 		let p_divided_by_3 = p / 3.;
 		let a_divided_by_3 = a / 3.;
-		let r = (-p_divided_by_3).powf(1. / 2.);
-		let phi = (-q / (2. * (-p_divided_by_3).powf(1. / 3.))).acos();
+		let cube_root_r = (-p_divided_by_3).powf(1. / 2.);
+		let phi = (-q / (2. * cube_root_r.powi(3))).acos();
 
-		let two_times_r = 2. * r;
-
+		let two_times_cube_root_r = 2. * cube_root_r;
 		// three real roots
-		roots.push(two_times_r * (phi / 3.).cos() - a_divided_by_3);
-		roots.push(two_times_r * ((phi + 2. * PI) / 3.).cos() - a_divided_by_3);
-		roots.push(two_times_r * ((phi + 4. * PI) / 3.).cos() - a_divided_by_3);
+		roots.push(two_times_cube_root_r * (phi / 3.).cos() - a_divided_by_3);
+		roots.push(two_times_cube_root_r * ((phi + 2. * PI) / 3.).cos() - a_divided_by_3);
+		roots.push(two_times_cube_root_r * ((phi + 4. * PI) / 3.).cos() - a_divided_by_3);
 	}
 	roots
 }
 
+// Solve a cubic of the form ax^3 + bx^2 + ct + d
+pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
+	if a.abs() <= 1e-5 {
+		if b.abs() <= 1e-5 {
+			// if both a and b are approximately 0, treat as a linear problem
+			solve_linear(c, d)
+		} else {
+			// if a is approximately 0, treat as a quadratic problem
+			let discriminant = c * c - 4. * b * d;
+			solve_quadratic(discriminant, 2. * b, c, d)
+		}
+	} else {
+		let new_a = b / a;
+		let new_b = c / a;
+		let new_c = d / a;
+
+		// Refactor cubic to be of the form: a(t^3 + pt + q), derivation from: https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+		let p = (3. * new_b - new_a * new_a) / 3.;
+		let q = (2. * new_a.powi(3) - 9. * new_a * new_b + 27. * new_c) / 27.;
+		let discriminant = (p / 3.).powi(3) + (q / 2.).powi(2);
+		solve_reformatted_cubic(discriminant, new_a, p, q)
+	}
+}
+
+pub fn compare_f64(f1: f64, f2: f64, max_abs_diff: f64) -> bool {
+	(f1 - f2).abs() < max_abs_diff
+}
+
+pub fn f64_approximately_in_range(value: f64, min: f64, max: f64, max_abs_diff: f64) -> bool {
+	(min..=max).contains(&value) || compare_f64(value, min, max_abs_diff) || compare_f64(value, max, max_abs_diff)
+}
+
+pub fn compare_f64_dvec2(dv1: DVec2, dv2: DVec2, max_abs_diff: f64) -> BVec2 {
+	BVec2::new((dv1.x - dv2.x).abs() < max_abs_diff, (dv1.y - dv2.y).abs() < max_abs_diff)
+}
+
+pub fn dvec2_approximately_in_range(point: DVec2, min: DVec2, max: DVec2, max_abs_diff: f64) -> BVec2 {
+	(point.cmpge(min) & point.cmple(max)) | compare_f64_dvec2(point, min, max_abs_diff) | compare_f64_dvec2(point, max, max_abs_diff)
+}
+
 #[cfg(test)]
 mod tests {
-	use std::f32::consts::PI;
-
 	// use crate::Bezier;
-	use glam::DVec2;
+	use super::*;
 
 	#[test]
-	fn angle() {
-		let line: [DVec2; 2] = [DVec2::new(20., 20.), DVec2::new(10., 0.)];
-		let slope = line[1] - line[0];
-		println!("slope {}", slope);
-		let angle_between = DVec2::new(1., 0.).angle_between(slope) * 180. / (PI as f64);
-		let slope_angle = (slope.y / slope.x).atan().to_degrees();
-		let slope_angle_2 = (slope.y).atan2(slope.x).to_degrees();
-		println!("{} vs {} vs {}", angle_between, slope_angle, slope_angle_2);
-		// assert!(compare_f64(angle_between, slope_angle));
+	fn test_solve_cubic() {
+		// discriminant == 0
+		let roots1 = solve_cubic(1., 0., 0., 0.);
+		assert!(roots1.len() == 1);
+		assert!(roots1[0] == 0.);
+
+		let roots2 = solve_cubic(1., 3., 0., -4.);
+		assert!(roots2.len() == 2);
+		assert!(roots2[0] == 1.);
+		assert!(roots2[1] == -2.);
+
+		// p == 0
+		let roots3 = solve_cubic(1., 0., 0., -1.);
+		assert!(roots3.len() == 1);
+		assert!(roots3[0] == 1.);
+
+		// discriminant > 0
+		let roots4 = solve_cubic(1., 3., 0., 2.);
+		assert!(roots4.len() == 1);
+		assert!(compare_f64(roots4[0], -3.196, 1e-3));
+
+		// discriminant < 0
+		let roots5 = solve_cubic(1., 3., 0., -1.);
+		assert!(roots5.len() == 3);
+		assert!(compare_f64(roots5[0], 0.532, 1e-3));
+		assert!(compare_f64(roots5[1], -2.879, 1e-3));
+		assert!(compare_f64(roots5[2], -0.653, 1e-3));
+
+		// quadratic
+		let roots6 = solve_cubic(0., 3., 0., -3.);
+		assert!(roots6.len() == 2);
+		assert!(roots6[0] == 1.);
+		assert!(roots6[1] == -1.);
+
+		// linear
+		let roots7 = solve_cubic(0., 0., 1., -1.);
+		assert!(roots7.len() == 1);
+		assert!(roots7[0] == 1.);
 	}
 }

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -137,23 +137,23 @@ pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 }
 
 /// Compare two `f64` numbers with a provided max absolute value difference.
-pub fn compare_f64(f1: f64, f2: f64, max_abs_diff: f64) -> bool {
+pub fn f64_compare(f1: f64, f2: f64, max_abs_diff: f64) -> bool {
 	(f1 - f2).abs() < max_abs_diff
 }
 
 /// Determine if an `f64` number is within a given range by using a max absolute value difference comparison.
 pub fn f64_approximately_in_range(value: f64, min: f64, max: f64, max_abs_diff: f64) -> bool {
-	(min..=max).contains(&value) || compare_f64(value, min, max_abs_diff) || compare_f64(value, max, max_abs_diff)
+	(min..=max).contains(&value) || f64_compare(value, min, max_abs_diff) || f64_compare(value, max, max_abs_diff)
 }
 
 /// Compare the two values in a `DVec2` independently with a provided max absolute value difference.
-pub fn compare_f64_dvec2(dv1: DVec2, dv2: DVec2, max_abs_diff: f64) -> BVec2 {
+pub fn dvec2_compare(dv1: DVec2, dv2: DVec2, max_abs_diff: f64) -> BVec2 {
 	BVec2::new((dv1.x - dv2.x).abs() < max_abs_diff, (dv1.y - dv2.y).abs() < max_abs_diff)
 }
 
 /// Determine if the values in a `DVec2` are within a given range independently by using a max absolute value difference comparison.
 pub fn dvec2_approximately_in_range(point: DVec2, min: DVec2, max: DVec2, max_abs_diff: f64) -> BVec2 {
-	(point.cmpge(min) & point.cmple(max)) | compare_f64_dvec2(point, min, max_abs_diff) | compare_f64_dvec2(point, max, max_abs_diff)
+	(point.cmpge(min) & point.cmple(max)) | dvec2_compare(point, min, max_abs_diff) | dvec2_compare(point, max, max_abs_diff)
 }
 
 #[cfg(test)]
@@ -180,14 +180,14 @@ mod tests {
 		// discriminant > 0
 		let roots4 = solve_cubic(1., 3., 0., 2.);
 		assert!(roots4.len() == 1);
-		assert!(compare_f64(roots4[0], -3.196, 1e-3));
+		assert!(f64_compare(roots4[0], -3.196, 1e-3));
 
 		// discriminant < 0
 		let roots5 = solve_cubic(1., 3., 0., -1.);
 		assert!(roots5.len() == 3);
-		assert!(compare_f64(roots5[0], 0.532, 1e-3));
-		assert!(compare_f64(roots5[1], -2.879, 1e-3));
-		assert!(compare_f64(roots5[2], -0.653, 1e-3));
+		assert!(f64_compare(roots5[0], 0.532, 1e-3));
+		assert!(f64_compare(roots5[1], -2.879, 1e-3));
+		assert!(f64_compare(roots5[2], -0.653, 1e-3));
 
 		// quadratic
 		let roots6 = solve_cubic(0., 3., 0., -3.);

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -12,8 +12,8 @@ fn compute_abc_through_points(start_point: DVec2, point_on_curve: DVec2, end_poi
 	[a, point_on_curve, c]
 }
 
-/// Compute a, b, and c for a quadratic curve that fits the start, end and point on curve at `t`.
-/// The definition for the a, b, c points are defined in [the projection identity section](https://pomax.github.io/bezierinfo/#abc) of Pomax's bezier curve primer.
+/// Compute `a`, `b`, and `c` for a quadratic curve that fits the start, end and point on curve at `t`.
+/// The definition for the `a`, `b`, `c` points are defined in [the projection identity section](https://pomax.github.io/bezierinfo/#abc) of Pomax's bezier curve primer.
 pub fn compute_abc_for_quadratic_through_points(start_point: DVec2, point_on_curve: DVec2, end_point: DVec2, t: f64) -> [DVec2; 3] {
 	let t_squared = t * t;
 	let one_minus_t = 1. - t;
@@ -31,6 +31,7 @@ pub fn compute_abc_for_cubic_through_points(start_point: DVec2, point_on_curve: 
 	compute_abc_through_points(start_point, point_on_curve, end_point, t_cubed, cubed_one_minus_t)
 }
 
+/// Return the index and the value of the closest point in the LUT compared to the provided point.
 pub fn get_closest_point_in_lut(lut: &[DVec2], point: DVec2) -> (i32, f64) {
 	lut.iter()
 		.enumerate()
@@ -39,7 +40,7 @@ pub fn get_closest_point_in_lut(lut: &[DVec2], point: DVec2) -> (i32, f64) {
 		.unwrap()
 }
 
-/// Find the roots of the linear equation `ax + b`
+/// Find the roots of the linear equation `ax + b`.
 pub fn solve_linear(a: f64, b: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
 	if a != 0. {
@@ -48,8 +49,8 @@ pub fn solve_linear(a: f64, b: f64) -> Vec<f64> {
 	roots
 }
 
-/// Find the roots of the linear equation `ax^2 + bx + c`
-/// Precompute the `discriminant` (`b^2 - 4ac`) and `two_times_a` arguments prior to calling this function for efficiency purposes
+/// Find the roots of the linear equation `ax^2 + bx + c`.
+/// Precompute the `discriminant` (`b^2 - 4ac`) and `two_times_a` arguments prior to calling this function for efficiency purposes.
 pub fn solve_quadratic(discriminant: f64, two_times_a: f64, b: f64, c: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
 	if two_times_a != 0. {
@@ -66,7 +67,7 @@ pub fn solve_quadratic(discriminant: f64, two_times_a: f64, b: f64, c: f64) -> V
 	roots
 }
 
-/// Compute the cube root of a number
+/// Compute the cube root of a number.
 fn cube_root(f: f64) -> f64 {
 	if f < 0. {
 		-(-f).powf(1. / 3.)
@@ -75,7 +76,7 @@ fn cube_root(f: f64) -> f64 {
 	}
 }
 
-// Solve a cubic of the form x^3 + px + q, derivation from: https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+/// Solve a cubic of the form `x^3 + px + q`, derivation from: <https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm>.
 pub fn solve_reformatted_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
 	if p == 0. {
@@ -111,7 +112,7 @@ pub fn solve_reformatted_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec
 	roots
 }
 
-// Solve a cubic of the form ax^3 + bx^2 + ct + d
+/// Solve a cubic of the form `ax^3 + bx^2 + ct + d`.
 pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 	if a.abs() <= 1e-5 {
 		if b.abs() <= 1e-5 {
@@ -135,25 +136,28 @@ pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 	}
 }
 
+/// Compare two `f64` numbers with a provided max absolute value difference.
 pub fn compare_f64(f1: f64, f2: f64, max_abs_diff: f64) -> bool {
 	(f1 - f2).abs() < max_abs_diff
 }
 
+/// Determine if an `f64` number is within a given range by using a max absolute value difference comparison.
 pub fn f64_approximately_in_range(value: f64, min: f64, max: f64, max_abs_diff: f64) -> bool {
 	(min..=max).contains(&value) || compare_f64(value, min, max_abs_diff) || compare_f64(value, max, max_abs_diff)
 }
 
+/// Compare the two values in a `DVec2` independently with a provided max absolute value difference.
 pub fn compare_f64_dvec2(dv1: DVec2, dv2: DVec2, max_abs_diff: f64) -> BVec2 {
 	BVec2::new((dv1.x - dv2.x).abs() < max_abs_diff, (dv1.y - dv2.y).abs() < max_abs_diff)
 }
 
+/// Determine if the values in a `DVec2` are within a given range independently by using a max absolute value difference comparison.
 pub fn dvec2_approximately_in_range(point: DVec2, min: DVec2, max: DVec2, max_abs_diff: f64) -> BVec2 {
 	(point.cmpge(min) & point.cmple(max)) | compare_f64_dvec2(point, min, max_abs_diff) | compare_f64_dvec2(point, max, max_abs_diff)
 }
 
 #[cfg(test)]
 mod tests {
-	// use crate::Bezier;
 	use super::*;
 
 	#[test]

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -1,4 +1,5 @@
 use glam::DVec2;
+use std::f64::consts::PI;
 
 /// Helper to perform the computation of a and c, where b is the provided point on the curve.
 /// Given the correct power of `t` and `(1-t)`, the computation is the same for quadratic and cubic cases.
@@ -63,4 +64,59 @@ pub fn solve_quadratic(discriminant: f64, two_times_a: f64, b: f64, c: f64) -> V
 		roots = solve_linear(b, c);
 	}
 	roots
+}
+
+/// Solve a cubic of the form t^3 + pt + q, derivation from: https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
+pub fn solve_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec<f64> {
+	let mut roots = Vec::new();
+	if p == 0. {
+		roots.push((-q).powf(1. / 3.));
+	} else if q == 0. {
+		if p < 0. {
+			roots.push((-p).powf(1. / 2.));
+		}
+	} else if discriminant == 0. {
+		let q_divided_by_2 = q / 2.;
+		// all roots are real, and 2 are repeated
+		roots.push(2. * (-q_divided_by_2).powf(1. / 3.) - a / 3.);
+		roots.push((q_divided_by_2).powf(1. / 3.) - a / 3.);
+	} else if discriminant > 0. {
+		// one real and two imaginary roots
+		let q_divided_by_2 = q / 2.;
+		roots.push((-q_divided_by_2 + discriminant).powf(1. / 3.) - (q_divided_by_2 + discriminant).powf(1. / 3.) - a / 3.);
+	} else {
+		let q_divided_by_2 = q / 2.;
+		let p_divided_by_3 = p / 3.;
+		let a_divided_by_3 = a / 3.;
+		let r = (-p_divided_by_3).powf(1. / 2.);
+		let phi = (-q / (2. * (-p_divided_by_3).powf(1. / 3.))).acos();
+
+		let two_times_r = 2. * r;
+
+		// three real roots
+		roots.push(two_times_r * (phi / 3.).cos() - a_divided_by_3);
+		roots.push(two_times_r * ((phi + 2. * PI) / 3.).cos() - a_divided_by_3);
+		roots.push(two_times_r * ((phi + 4. * PI) / 3.).cos() - a_divided_by_3);
+	}
+	roots
+}
+
+#[cfg(test)]
+mod tests {
+	use std::f32::consts::PI;
+
+	// use crate::Bezier;
+	use glam::DVec2;
+
+	#[test]
+	fn angle() {
+		let line: [DVec2; 2] = [DVec2::new(20., 20.), DVec2::new(10., 0.)];
+		let slope = line[1] - line[0];
+		println!("slope {}", slope);
+		let angle_between = DVec2::new(1., 0.).angle_between(slope) * 180. / (PI as f64);
+		let slope_angle = (slope.y / slope.x).atan().to_degrees();
+		let slope_angle_2 = (slope.y).atan2(slope.x).to_degrees();
+		println!("{} vs {} vs {}", angle_between, slope_angle, slope_angle_2);
+		// assert!(compare_f64(angle_between, slope_angle));
+	}
 }


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
This function is implemented on top of https://github.com/GraphiteEditor/Graphite/pull/693 because it can re-use the root finding helper functions.

Functions implemented:
- `rotate` and `translate`
  -  Needed for the `line_intersection` function
- `line_intersection`
  - Rotates and translates the Bezier and line such that the line is on top of the x-axis, then perform root finding to get intersection points
  - Root finding is done with the `y` coordinates as the variable, since we want to find when `x = 0`
- Add tests for cubic root finding

UI changes
- Add sections for `rotate` and `line_intersection`