### PR TITLE
Support Linear line segments, add linear section to interactive docs

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -9,6 +9,7 @@
 				:name="feature.name"
 				:callback="feature.callback"
 				:curveDegrees="feature.curveDegrees"
+				:customPoints="feature.customPoints"
 				:createThroughPoints="feature.createThroughPoints"
 				:cubicOptions="feature.cubicOptions"
 			/>
@@ -20,7 +21,7 @@
 import { defineComponent, markRaw } from "vue";
 
 import { drawText, drawPoint, drawBezier, drawLine, getContextFromCanvas, drawBezierHelper, COLORS } from "@/utils/drawing";
-import { Point, WasmBezierInstance } from "@/utils/types";
+import { BezierCurveType, Point, WasmBezierInstance } from "@/utils/types";
 
 import ExamplePane from "@/components/ExamplePane.vue";
 import SliderExample from "@/components/SliderExample.vue";
@@ -52,7 +53,7 @@ export default defineComponent({
 					name: "Bezier Through Points",
 					// eslint-disable-next-line
 					callback: (): void => {},
-					curveDegrees: new Set([2, 3]),
+					curveDegrees: new Set([BezierCurveType.Quadratic, BezierCurveType.Cubic]),
 					createThroughPoints: true,
 					template: markRaw(SliderExample),
 					templateOptions: {
@@ -78,10 +79,17 @@ export default defineComponent({
 							{
 								min: 0,
 								max: 100,
-								step: 5,
-								default: 10,
+								step: 2,
+								default: 30,
 								variable: "midpoint separation",
 							},
+						],
+					},
+					customPoints: {
+						[BezierCurveType.Quadratic]: [
+							[30, 50],
+							[120, 70],
+							[160, 170],
 						],
 					},
 				},
@@ -138,7 +146,20 @@ export default defineComponent({
 							}
 						}
 					},
-					curveDegrees: new Set([2, 3]),
+					curveDegrees: new Set([BezierCurveType.Quadratic, BezierCurveType.Cubic]),
+					customPoints: {
+						[BezierCurveType.Quadratic]: [
+							[30, 40],
+							[110, 50],
+							[120, 130],
+						],
+						[BezierCurveType.Cubic]: [
+							[50, 50],
+							[60, 100],
+							[100, 140],
+							[140, 150],
+						],
+					},
 				},
 				{
 					name: "Tangent",
@@ -262,8 +283,8 @@ export default defineComponent({
 								variable: "angle",
 								min: 0,
 								max: 2,
-								step: 1 / 16,
-								default: 1 / 8,
+								step: 1 / 50,
+								default: 0.12,
 								unit: "π",
 							},
 						],

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -8,6 +8,7 @@
 				:templateOptions="feature.templateOptions"
 				:name="feature.name"
 				:callback="feature.callback"
+				:curveDegrees="feature.curveDegrees"
 				:createThroughPoints="feature.createThroughPoints"
 				:cubicOptions="feature.cubicOptions"
 			/>
@@ -51,6 +52,7 @@ export default defineComponent({
 					name: "Bezier Through Points",
 					// eslint-disable-next-line
 					callback: (): void => {},
+					curveDegrees: new Set([2, 3]),
 					createThroughPoints: true,
 					template: markRaw(SliderExample),
 					templateOptions: {
@@ -120,6 +122,23 @@ export default defineComponent({
 							},
 						],
 					},
+				},
+				{
+					name: "Derivative",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+						const context = getContextFromCanvas(canvas);
+
+						const derivativeBezier = bezier.derivative();
+						if (derivativeBezier) {
+							const points: Point[] = derivativeBezier.get_points().map((p) => JSON.parse(p));
+							if (points.length === 2) {
+								drawLine(context, points[0], points[1], COLORS.NON_INTERACTIVE.STROKE_1);
+							} else {
+								drawBezier(context, points, null, { curveStrokeColor: COLORS.NON_INTERACTIVE.STROKE_1, radius: 3.5 });
+							}
+						}
+					},
+					curveDegrees: new Set([2, 3]),
 				},
 				{
 					name: "Tangent",

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -102,9 +102,9 @@ export default defineComponent({
 					},
 				},
 				{
-					name: "Compute",
+					name: "Evaluate",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
-						const point = JSON.parse(bezier.compute(options.t));
+						const point = JSON.parse(bezier.evaluate(options.t));
 						drawPoint(getContextFromCanvas(canvas), point, 4, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 					template: markRaw(SliderExample),
@@ -168,7 +168,7 @@ export default defineComponent({
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 
-						const intersection = JSON.parse(bezier.compute(options.t));
+						const intersection = JSON.parse(bezier.evaluate(options.t));
 						const tangent = JSON.parse(bezier.tangent(options.t));
 
 						const tangentEnd = {
@@ -188,7 +188,7 @@ export default defineComponent({
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 
-						const intersection = JSON.parse(bezier.compute(options.t));
+						const intersection = JSON.parse(bezier.evaluate(options.t));
 						const normal = JSON.parse(bezier.normal(options.t));
 
 						const normalEnd = {
@@ -260,7 +260,7 @@ export default defineComponent({
 						const extrema: number[][] = JSON.parse(bezier.local_extrema());
 						extrema.forEach((tValues, index) => {
 							tValues.forEach((t) => {
-								const point: Point = JSON.parse(bezier.compute(t));
+								const point: Point = JSON.parse(bezier.evaluate(t));
 								drawPoint(context, point, 4, dimensionColors[index]);
 							});
 						});

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -8,10 +8,10 @@
 				:templateOptions="feature.templateOptions"
 				:name="feature.name"
 				:callback="feature.callback"
+				:createThroughPoints="feature.createThroughPoints"
 				:curveDegrees="feature.curveDegrees"
 				:customPoints="feature.customPoints"
-				:createThroughPoints="feature.createThroughPoints"
-				:cubicOptions="feature.cubicOptions"
+				:customOptions="feature.customOptions"
 			/>
 		</div>
 	</div>
@@ -67,23 +67,25 @@ export default defineComponent({
 							},
 						],
 					},
-					cubicOptions: {
-						sliders: [
-							{
-								min: 0.01,
-								max: 0.99,
-								step: 0.01,
-								default: 0.5,
-								variable: "t",
-							},
-							{
-								min: 0,
-								max: 100,
-								step: 2,
-								default: 30,
-								variable: "midpoint separation",
-							},
-						],
+					customOptions: {
+						[BezierCurveType.Cubic]: {
+							sliders: [
+								{
+									min: 0.01,
+									max: 0.99,
+									step: 0.01,
+									default: 0.5,
+									variable: "t",
+								},
+								{
+									min: 0,
+									max: 100,
+									step: 2,
+									default: 30,
+									variable: "midpoint separation",
+								},
+							],
+						},
 					},
 					customPoints: {
 						[BezierCurveType.Quadratic]: [
@@ -264,6 +266,19 @@ export default defineComponent({
 						});
 						drawText(getContextFromCanvas(canvas), "X extrema", 5, canvas.height - 20, dimensionColors[0]);
 						drawText(getContextFromCanvas(canvas), "Y extrema", 5, canvas.height - 5, dimensionColors[1]);
+					},
+					customPoints: {
+						[BezierCurveType.Quadratic]: [
+							[40, 40],
+							[160, 30],
+							[110, 150],
+						],
+						[BezierCurveType.Cubic]: [
+							[160, 180],
+							[170, 10],
+							[30, 90],
+							[180, 160],
+						],
 					},
 				},
 				{

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -6,15 +6,14 @@ import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierMutato
 // Offset to increase selectable range, used to make points easier to grab
 const FUDGE_FACTOR = 3;
 
-const MAP_LENGTH_TO_MUTATOR_INDEX: { [k: number]: number[] } = {
-	2: [0, 3],
-	3: [0, 1, 3],
-	4: [0, 1, 2, 3],
+// Given the number of points in the curve, map the index of a point to the correct mutator key
+const MAP_POINTS_TO_MUTATOR_BY_NUMBER_POINTS: { [k: number]: WasmBezierMutatorKey[] } = {
+	2: ["set_start", "set_end"],
+	3: ["set_start", "set_handle_start", "set_end"],
+	4: ["set_start", "set_handle_start", "set_handle_end", "set_end"],
 };
 
 class BezierDrawing {
-	static indexToMutator: WasmBezierMutatorKey[] = ["set_start", "set_handle_start", "set_handle_end", "set_end"];
-
 	points: BezierPoint[];
 
 	canvas: HTMLCanvasElement;
@@ -44,7 +43,7 @@ class BezierDrawing {
 				y: p.y,
 				r: getPointSizeByIndex(i, points.length),
 				selected: false,
-				mutator: BezierDrawing.indexToMutator[MAP_LENGTH_TO_MUTATOR_INDEX[points.length][i]],
+				mutator: MAP_POINTS_TO_MUTATOR_BY_NUMBER_POINTS[points.length][i],
 			}));
 
 		if (this.createThroughPoints && this.points.length === 4) {

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,13 +1,12 @@
 import { WasmBezier } from "@/../wasm/pkg";
+
 import { COLORS, drawBezier, drawPoint, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
 import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierMutatorKey, WasmBezierInstance } from "@/utils/types";
 
 // Offset to increase selectable range, used to make points easier to grab
 const FUDGE_FACTOR = 3;
 
-const MAP_LENGTH_TO_MUTATOR_INDEX: {
-	[k: number]: number[];
-} = {
+const MAP_LENGTH_TO_MUTATOR_INDEX: { [k: number]: number[] } = {
 	2: [0, 3],
 	3: [0, 1, 3],
 	4: [0, 1, 2, 3],
@@ -78,11 +77,11 @@ class BezierDrawing {
 	}
 
 	mouseMoveHandler(evt: MouseEvent): void {
+		if (evt.buttons === 0) this.deselectPointHandler();
+
 		const mx = evt.offsetX;
 		const my = evt.offsetY;
-		if (evt.buttons === 0) {
-			this.deselectPointHandler();
-		}
+
 		if (this.dragIndex !== null) {
 			const selectableRange = getPointSizeByIndex(this.dragIndex, this.points.length);
 			if (mx - selectableRange > 0 && my - selectableRange > 0 && mx + selectableRange < this.canvas.width && my + selectableRange < this.canvas.height) {

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -1,13 +1,13 @@
 import { WasmBezier } from "@/../wasm/pkg";
 
 import { COLORS, drawBezier, drawPoint, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
-import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierMutatorKey, WasmBezierInstance } from "@/utils/types";
+import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierManipulatorKey, WasmBezierInstance } from "@/utils/types";
 
 // Offset to increase selectable range, used to make points easier to grab
 const FUDGE_FACTOR = 3;
 
-// Given the number of points in the curve, map the index of a point to the correct mutator key
-const MAP_POINTS_TO_MUTATOR_BY_NUMBER_POINTS: { [k: number]: WasmBezierMutatorKey[] } = {
+// Given the number of points in the curve, map the index of a point to the correct manipulator key
+const MANIPULATOR_KEYS_FROM_BEZIER_TYPE: { [k: number]: WasmBezierManipulatorKey[] } = {
 	2: ["set_start", "set_end"],
 	3: ["set_start", "set_handle_start", "set_end"],
 	4: ["set_start", "set_handle_start", "set_handle_end", "set_end"],
@@ -43,7 +43,7 @@ class BezierDrawing {
 				y: p.y,
 				r: getPointSizeByIndex(i, points.length),
 				selected: false,
-				mutator: MAP_POINTS_TO_MUTATOR_BY_NUMBER_POINTS[points.length][i],
+				manipulator: MANIPULATOR_KEYS_FROM_BEZIER_TYPE[points.length][i],
 			}));
 
 		if (this.createThroughPoints && this.points.length === 4) {
@@ -87,7 +87,7 @@ class BezierDrawing {
 				const selectedPoint = this.points[this.dragIndex];
 				selectedPoint.x = mx;
 				selectedPoint.y = my;
-				this.bezier[selectedPoint.mutator](selectedPoint.x, selectedPoint.y);
+				this.bezier[selectedPoint.manipulator](selectedPoint.x, selectedPoint.y);
 			}
 		}
 		this.updateBezier({ x: mx, y: my });

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -78,14 +78,11 @@ class BezierDrawing {
 	}
 
 	mouseMoveHandler(evt: MouseEvent): void {
-		if (evt.buttons === 0) {
-			this.deselectPointHandler();
-			return;
-		}
-
 		const mx = evt.offsetX;
 		const my = evt.offsetY;
-
+		if (evt.buttons === 0) {
+			this.deselectPointHandler();
+		}
 		if (this.dragIndex !== null) {
 			const selectableRange = getPointSizeByIndex(this.dragIndex, this.points.length);
 			if (mx - selectableRange > 0 && my - selectableRange > 0 && mx + selectableRange < this.canvas.width && my + selectableRange < this.canvas.height) {

--- a/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/components/BezierDrawing.ts
@@ -5,6 +5,14 @@ import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierMutato
 // Offset to increase selectable range, used to make points easier to grab
 const FUDGE_FACTOR = 3;
 
+const MAP_LENGTH_TO_MUTATOR_INDEX: {
+	[k: number]: number[];
+} = {
+	2: [0, 3],
+	3: [0, 1, 3],
+	4: [0, 1, 2, 3],
+};
+
 class BezierDrawing {
 	static indexToMutator: WasmBezierMutatorKey[] = ["set_start", "set_handle_start", "set_handle_end", "set_end"];
 
@@ -37,7 +45,7 @@ class BezierDrawing {
 				y: p.y,
 				r: getPointSizeByIndex(i, points.length),
 				selected: false,
-				mutator: BezierDrawing.indexToMutator[points.length === 3 && i > 1 ? i + 1 : i],
+				mutator: BezierDrawing.indexToMutator[MAP_LENGTH_TO_MUTATOR_INDEX[points.length][i]],
 			}));
 
 		if (this.createThroughPoints && this.points.length === 4) {

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -56,6 +56,7 @@ export default defineComponent({
 <style scoped>
 .example_header {
 	margin-bottom: 0;
+	text-transform: capitalize;
 }
 .example_figure {
 	margin-top: 0.5em;

--- a/bezier-rs/docs/interactive-docs/src/components/Example.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/Example.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<h4 class="example_header">{{ title }}</h4>
-		<figure class="example_figure" ref="drawing"></figure>
+		<h4 class="example-header">{{ title }}</h4>
+		<figure class="example-figure" ref="drawing"></figure>
 	</div>
 </template>
 
@@ -54,11 +54,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.example_header {
+.example-header {
 	margin-bottom: 0;
-	text-transform: capitalize;
 }
-.example_figure {
+
+.example-figure {
 	margin-top: 0.5em;
 }
 </style>

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -46,6 +46,10 @@ export default defineComponent({
 			type: Boolean as PropType<boolean>,
 			default: false,
 		},
+		curveDegrees: {
+			type: Set as PropType<Set<number>>,
+			default: () => new Set([1, 2, 3]),
+		},
 	},
 	data() {
 		return {
@@ -54,6 +58,10 @@ export default defineComponent({
 	},
 	mounted() {
 		import("@/../wasm/pkg").then((wasm: WasmRawInstance) => {
+			const linearPoints = [
+				[30, 60],
+				[140, 120],
+			];
 			const quadraticPoints = [
 				[30, 50],
 				[140, 30],
@@ -65,18 +73,28 @@ export default defineComponent({
 				[150, 30],
 				[160, 160],
 			];
-			this.exampleData = [
-				{
+			this.exampleData = [];
+			if (this.curveDegrees.has(1)) {
+				this.exampleData.push({
+					title: "Linear",
+					bezier: wasm.WasmBezier.new_linear(linearPoints),
+					templateOptions: this.templateOptions as TemplateOption,
+				});
+			}
+			if (this.curveDegrees.has(2)) {
+				this.exampleData.push({
 					title: "Quadratic",
 					bezier: wasm.WasmBezier.new_quadratic(quadraticPoints),
 					templateOptions: this.templateOptions as TemplateOption,
-				},
-				{
+				});
+			}
+			if (this.curveDegrees.has(3)) {
+				this.exampleData.push({
 					title: "Cubic",
 					bezier: wasm.WasmBezier.new_cubic(cubicPoints),
 					templateOptions: (this.cubicOptions || this.templateOptions) as TemplateOption,
-				},
-			];
+				});
+			}
 		});
 	},
 });

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<h2 class="example_pane_header">{{ name }}</h2>
-		<div class="example_row">
+		<h2 class="example-pane-header">{{ name }}</h2>
+		<div class="example-row">
 			<div v-for="(example, index) in exampleData" :key="index">
 				<component :is="template" :templateOptions="example.templateOptions" :title="example.title" :bezier="example.bezier" :callback="callback" :createThroughPoints="createThroughPoints" />
 			</div>
@@ -63,7 +63,10 @@ export default defineComponent({
 		Example,
 	},
 	props: {
-		name: String,
+		name: {
+			type: String as PropType<string>,
+			required: true,
+		},
 		callback: {
 			type: Function as PropType<BezierCallback>,
 			required: true,
@@ -72,7 +75,10 @@ export default defineComponent({
 			type: Object as PropType<Component>,
 			default: Example,
 		},
-		templateOptions: Object as PropType<TemplateOption>,
+		templateOptions: {
+			type: Object as PropType<TemplateOption>,
+			required: false,
+		},
 		customOptions: {
 			type: Object as PropType<CustomTemplateOptions>,
 			default: () => ({}),
@@ -116,13 +122,13 @@ export default defineComponent({
 </script>
 
 <style>
-.example_row {
+.example-row {
 	display: flex; /* or inline-flex */
 	flex-direction: row;
 	justify-content: center;
 }
 
-.example_pane_header {
+.example-pane-header {
 	margin-bottom: 0;
 }
 </style>

--- a/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/ExamplePane.vue
@@ -12,7 +12,7 @@
 <script lang="ts">
 import { defineComponent, PropType, Component } from "vue";
 
-import { BezierCallback, TemplateOption, WasmBezierInstance, WasmRawInstance } from "@/utils/types";
+import { BezierCallback, BezierCurveType, TemplateOption, WasmBezierInstance, WasmRawInstance } from "@/utils/types";
 
 import Example from "@/components/Example.vue";
 
@@ -20,6 +20,10 @@ type ExampleData = {
 	title: string;
 	bezier: WasmBezierInstance;
 	templateOptions: TemplateOption;
+};
+
+type CustomPoints = {
+	[key in BezierCurveType]: number[][];
 };
 
 export default defineComponent({
@@ -47,8 +51,12 @@ export default defineComponent({
 			default: false,
 		},
 		curveDegrees: {
-			type: Set as PropType<Set<number>>,
-			default: () => new Set([1, 2, 3]),
+			type: Set as PropType<Set<BezierCurveType>>,
+			default: () => new Set(Object.values(BezierCurveType)),
+		},
+		customPoints: {
+			type: Object as PropType<CustomPoints>,
+			default: () => ({}),
 		},
 	},
 	data() {
@@ -74,24 +82,24 @@ export default defineComponent({
 				[160, 160],
 			];
 			this.exampleData = [];
-			if (this.curveDegrees.has(1)) {
+			if (this.curveDegrees.has(BezierCurveType.Linear)) {
 				this.exampleData.push({
 					title: "Linear",
-					bezier: wasm.WasmBezier.new_linear(linearPoints),
+					bezier: wasm.WasmBezier.new_linear(this.customPoints[BezierCurveType.Linear] || linearPoints),
 					templateOptions: this.templateOptions as TemplateOption,
 				});
 			}
-			if (this.curveDegrees.has(2)) {
+			if (this.curveDegrees.has(BezierCurveType.Quadratic)) {
 				this.exampleData.push({
 					title: "Quadratic",
-					bezier: wasm.WasmBezier.new_quadratic(quadraticPoints),
+					bezier: wasm.WasmBezier.new_quadratic(this.customPoints[BezierCurveType.Quadratic] || quadraticPoints),
 					templateOptions: this.templateOptions as TemplateOption,
 				});
 			}
-			if (this.curveDegrees.has(3)) {
+			if (this.curveDegrees.has(BezierCurveType.Cubic)) {
 				this.exampleData.push({
 					title: "Cubic",
-					bezier: wasm.WasmBezier.new_cubic(cubicPoints),
+					bezier: wasm.WasmBezier.new_cubic(this.customPoints[BezierCurveType.Cubic] || cubicPoints),
 					templateOptions: (this.cubicOptions || this.templateOptions) as TemplateOption,
 				});
 			}

--- a/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
+++ b/bezier-rs/docs/interactive-docs/src/components/SliderExample.vue
@@ -2,7 +2,7 @@
 	<div>
 		<Example :title="title" :bezier="bezier" :callback="callback" :options="sliderData" :createThroughPoints="createThroughPoints" />
 		<div v-for="(slider, index) in templateOptions.sliders" :key="index">
-			<div class="slider_label">{{ slider.variable }} = {{ sliderData[slider.variable] }}{{ sliderUnits[slider.variable] }}</div>
+			<div class="slider-label">{{ slider.variable }} = {{ sliderData[slider.variable] }}{{ sliderUnits[slider.variable] }}</div>
 			<input class="slider" v-model.number="sliderData[slider.variable]" type="range" :step="slider.step" :min="slider.min" :max="slider.max" />
 		</div>
 	</div>

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -59,6 +59,20 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
+export const drawCurve = (ctx: CanvasRenderingContext2D, points: Point[], strokeColor = COLORS.INTERACTIVE.STROKE_1): void => {
+	ctx.strokeStyle = strokeColor;
+	ctx.lineWidth = 2;
+
+	ctx.beginPath();
+	ctx.moveTo(points[0].x, points[0].y);
+	if (points.length === 3) {
+		ctx.quadraticCurveTo(points[1].x, points[1].y, points[2].x, points[2].y);
+	} else {
+		ctx.bezierCurveTo(points[1].x, points[1].y, points[2].x, points[2].y, points[3].x, points[3].y);
+	}
+	ctx.stroke();
+};
+
 export const drawBezierHelper = (ctx: CanvasRenderingContext2D, bezier: WasmBezierInstance, bezierStyleConfig: Partial<BezierStyleConfig> = {}): void => {
 	const points = bezier.get_points().map((p: string) => JSON.parse(p));
 	drawBezier(ctx, points, null, bezierStyleConfig);
@@ -95,27 +109,24 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragI
 		handleStart = points[1];
 		handleEnd = points[2];
 		end = points[3];
-	} else {
+	} else if (points.length === 3) {
 		handleStart = points[1];
 		handleEnd = handleStart;
 		end = points[2];
-	}
-
-	ctx.strokeStyle = styleConfig.curveStrokeColor;
-	ctx.lineWidth = 2;
-
-	ctx.beginPath();
-	ctx.moveTo(points[0].x, points[0].y);
-	if (points.length === 3) {
-		ctx.quadraticCurveTo(handleStart.x, handleStart.y, end.x, end.y);
 	} else {
-		ctx.bezierCurveTo(handleStart.x, handleStart.y, handleEnd.x, handleEnd.y, end.x, end.y);
+		handleStart = start;
+		handleEnd = points[1];
+		end = handleEnd;
 	}
-	ctx.stroke();
 
-	if (styleConfig.drawHandles) {
-		drawLine(ctx, start, handleStart, styleConfig.handleLineStrokeColor);
-		drawLine(ctx, end, handleEnd, styleConfig.handleLineStrokeColor);
+	if (points.length === 2) {
+		drawLine(ctx, start, end, styleConfig.curveStrokeColor);
+	} else {
+		drawCurve(ctx, points, styleConfig.curveStrokeColor);
+		if (styleConfig.drawHandles) {
+			drawLine(ctx, start, handleStart, styleConfig.handleLineStrokeColor);
+			drawLine(ctx, end, handleEnd, styleConfig.handleLineStrokeColor);
+		}
 	}
 
 	points.forEach((point, index) => {

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -28,9 +28,9 @@ export const getContextFromCanvas = (canvas: HTMLCanvasElement): CanvasRendering
 	return ctx;
 };
 
-export const drawLine = (ctx: CanvasRenderingContext2D, point1: Point, point2: Point, strokeColor = COLORS.INTERACTIVE.STROKE_2): void => {
+export const drawLine = (ctx: CanvasRenderingContext2D, point1: Point, point2: Point, strokeColor = COLORS.INTERACTIVE.STROKE_2, lineWidth = 1): void => {
 	ctx.strokeStyle = strokeColor;
-	ctx.lineWidth = 1;
+	ctx.lineWidth = lineWidth;
 
 	ctx.beginPath();
 	ctx.moveTo(point1.x, point1.y);
@@ -120,7 +120,7 @@ export const drawBezier = (ctx: CanvasRenderingContext2D, points: Point[], dragI
 	}
 
 	if (points.length === 2) {
-		drawLine(ctx, start, end, styleConfig.curveStrokeColor);
+		drawLine(ctx, start, end, styleConfig.curveStrokeColor, 2);
 	} else {
 		drawCurve(ctx, points, styleConfig.curveStrokeColor);
 		if (styleConfig.drawHandles) {

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -2,6 +2,7 @@ export type WasmRawInstance = typeof import("../../wasm/pkg");
 export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 
 export type WasmBezierKey = keyof WasmBezierInstance;
+export type WasmBezierConstructorKey = "new_linear" | "new_quadratic" | "new_cubic";
 export type WasmBezierMutatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
 
 export enum BezierCurveType {

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -3,7 +3,7 @@ export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 
 export type WasmBezierKey = keyof WasmBezierInstance;
 export type WasmBezierConstructorKey = "new_linear" | "new_quadratic" | "new_cubic";
-export type WasmBezierMutatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
+export type WasmBezierManipulatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
 
 export enum BezierCurveType {
 	Linear = "Linear",
@@ -32,7 +32,7 @@ export type Point = {
 };
 
 export type BezierPoint = Point & {
-	mutator: WasmBezierMutatorKey;
+	manipulator: WasmBezierManipulatorKey;
 };
 
 export type BezierStyleConfig = {

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -6,9 +6,9 @@ export type WasmBezierConstructorKey = "new_linear" | "new_quadratic" | "new_cub
 export type WasmBezierMutatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
 
 export enum BezierCurveType {
-	Linear = "linear",
-	Quadratic = "quadratic",
-	Cubic = "cubic",
+	Linear = "Linear",
+	Quadratic = "Quadratic",
+	Cubic = "Cubic",
 }
 
 export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point) => void;

--- a/bezier-rs/docs/interactive-docs/src/utils/types.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/types.ts
@@ -4,6 +4,12 @@ export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 export type WasmBezierKey = keyof WasmBezierInstance;
 export type WasmBezierMutatorKey = "set_start" | "set_handle_start" | "set_handle_end" | "set_end";
 
+export enum BezierCurveType {
+	Linear = "linear",
+	Quadratic = "quadratic",
+	Cubic = "cubic",
+}
+
 export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point) => void;
 
 export type SliderOption = {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -21,7 +21,7 @@ fn vec_to_point(p: &DVec2) -> JsValue {
 
 /// Convert a bezier to a list of points.
 fn bezier_to_points(bezier: Bezier) -> Vec<Point> {
-	bezier.get_points().iter().map(|point| Point { x: point.x, y: point.y }).collect()
+	bezier.get_points().map(|point| Point { x: point.x, y: point.y }).collect()
 }
 
 /// Serialize some data and then convert it to a JsValue.
@@ -76,7 +76,7 @@ impl WasmBezier {
 	}
 
 	pub fn get_points(&self) -> Vec<JsValue> {
-		self.0.get_points().iter().map(vec_to_point).collect()
+		self.0.get_points().map(|point| vec_to_point(&point)).collect()
 	}
 
 	pub fn to_svg(&self) -> String {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -84,7 +84,7 @@ impl WasmBezier {
 	}
 
 	pub fn length(&self) -> f64 {
-		self.0.length()
+		self.0.length(None)
 	}
 
 	pub fn compute(&self, t: f64) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -32,6 +32,12 @@ fn to_js_value<T: Serialize>(data: T) -> JsValue {
 #[wasm_bindgen]
 impl WasmBezier {
 	/// Expect js_points to be a list of 3 pairs.
+	pub fn new_linear(js_points: &JsValue) -> WasmBezier {
+		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+		WasmBezier(Bezier::from_linear_dvec2(points[0], points[1]))
+	}
+
+	/// Expect js_points to be a list of 3 pairs.
 	pub fn new_quadratic(js_points: &JsValue) -> WasmBezier {
 		let points: [DVec2; 3] = js_points.into_serde().unwrap();
 		WasmBezier(Bezier::from_quadratic_dvec2(points[0], points[1], points[2]))
@@ -87,6 +93,10 @@ impl WasmBezier {
 
 	pub fn compute_lookup_table(&self, steps: i32) -> Vec<JsValue> {
 		self.0.compute_lookup_table(Some(steps)).iter().map(vec_to_point).collect()
+	}
+
+	pub fn derivative(&self) -> Option<WasmBezier> {
+		self.0.derivative().map(WasmBezier)
 	}
 
 	pub fn tangent(&self, t: f64) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -21,7 +21,7 @@ fn vec_to_point(p: &DVec2) -> JsValue {
 
 /// Convert a bezier to a list of points.
 fn bezier_to_points(bezier: Bezier) -> Vec<Point> {
-	bezier.get_points().iter().flatten().map(|point| Point { x: point.x, y: point.y }).collect()
+	bezier.get_points().iter().map(|point| Point { x: point.x, y: point.y }).collect()
 }
 
 /// Serialize some data and then convert it to a JsValue.
@@ -76,7 +76,7 @@ impl WasmBezier {
 	}
 
 	pub fn get_points(&self) -> Vec<JsValue> {
-		self.0.get_points().iter().flatten().map(vec_to_point).collect()
+		self.0.get_points().iter().map(vec_to_point).collect()
 	}
 
 	pub fn to_svg(&self) -> String {
@@ -87,8 +87,8 @@ impl WasmBezier {
 		self.0.length(None)
 	}
 
-	pub fn compute(&self, t: f64) -> JsValue {
-		vec_to_point(&self.0.compute(t))
+	pub fn evaluate(&self, t: f64) -> JsValue {
+		vec_to_point(&self.0.evaluate(t))
 	}
 
 	pub fn compute_lookup_table(&self, steps: i32) -> Vec<JsValue> {

--- a/bezier-rs/lib/src/consts.rs
+++ b/bezier-rs/lib/src/consts.rs
@@ -1,19 +1,19 @@
 // Implementation constants
 
-/// Constants used to determine if `f64`'s are equivalent
+/// Constants used to determine if `f64`'s are equivalent.
 pub const MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-3;
-/// Number of distances used in search algorithm for `project`
+/// Number of distances used in search algorithm for `project`.
 pub const NUM_DISTANCES: usize = 5;
-/// Constant for reduce
+/// Maximum allowed angle that the normal of the `start` or `end` point can make with the normal of the corresponding handle for a curve to be considered scalable/simple.
 pub const SCALABLE_CURVE_MAX_ENDPOINT_NORMAL_ANGLE: f64 = std::f64::consts::PI / 3.;
 
 // Method argument defaults
 
-/// Default `t` value used for the `curve_through_points` functions
+/// Default `t` value used for the `curve_through_points` functions.
 pub const DEFAULT_T_VALUE: f64 = 0.5;
-/// Default LUT step size in `compute_lookup_table` function
+/// Default LUT step size in `compute_lookup_table` function.
 pub const DEFAULT_LUT_STEP_SIZE: i32 = 10;
-/// Default number of subdivisions used in `length` calculation
+/// Default number of subdivisions used in `length` calculation.
 pub const DEFAULT_LENGTH_SUBDIVISIONS: i32 = 1000;
-/// Default step size for `reduce` function
+/// Default step size for `reduce` function.
 pub const DEFAULT_REDUCE_STEP_SIZE: f64 = 0.01;

--- a/bezier-rs/lib/src/consts.rs
+++ b/bezier-rs/lib/src/consts.rs
@@ -1,7 +1,9 @@
 // Implementation constants
 
-/// Constants used to determine if `f64`s are equivalent.
+/// Constant used to determine if `f64`s are equivalent.
 pub const MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-3;
+/// A stricter constant used to determine if `f64`s are equivalent.
+pub const STRICT_MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-6;
 /// Number of distances used in search algorithm for `project`.
 pub const NUM_DISTANCES: usize = 5;
 /// Maximum allowed angle that the normal of the `start` or `end` point can make with the normal of the corresponding handle for a curve to be considered scalable/simple.

--- a/bezier-rs/lib/src/consts.rs
+++ b/bezier-rs/lib/src/consts.rs
@@ -1,6 +1,6 @@
 // Implementation constants
 
-/// Constants used to determine if `f64`'s are equivalent.
+/// Constants used to determine if `f64`s are equivalent.
 pub const MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-3;
 /// Number of distances used in search algorithm for `project`.
 pub const NUM_DISTANCES: usize = 5;

--- a/bezier-rs/lib/src/consts.rs
+++ b/bezier-rs/lib/src/consts.rs
@@ -1,20 +1,19 @@
-/// Implementation constants
-pub const SCALABLE_CURVE_MAX_ENDPOINT_NORMAL_ANGLE: f64 = std::f64::consts::PI / 3.;
-
-/// Method argument defaults
-pub const REDUCE_STEP_SIZE_DEFAULT: f64 = 0.01;
-
-/// Default `t` value used for the `curve_through_points` functions
-pub const DEFAULT_T_VALUE: f64 = 0.5;
-
-/// Default LUT step size in `compute_lookup_table` function
-pub const DEFAULT_LUT_STEP_SIZE: i32 = 10;
-
-/// Number of subdivisions used in `length` calculation
-pub const LENGTH_SUBDIVISIONS: i32 = 1000;
-
-/// Number of distances used in search algorithm for `project`
-pub const NUM_DISTANCES: usize = 5;
+// Implementation constants
 
 /// Constants used to determine if `f64`'s are equivalent
 pub const MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-3;
+/// Number of distances used in search algorithm for `project`
+pub const NUM_DISTANCES: usize = 5;
+/// Constant for reduce
+pub const SCALABLE_CURVE_MAX_ENDPOINT_NORMAL_ANGLE: f64 = std::f64::consts::PI / 3.;
+
+// Method argument defaults
+
+/// Default `t` value used for the `curve_through_points` functions
+pub const DEFAULT_T_VALUE: f64 = 0.5;
+/// Default LUT step size in `compute_lookup_table` function
+pub const DEFAULT_LUT_STEP_SIZE: i32 = 10;
+/// Default number of subdivisions used in `length` calculation
+pub const DEFAULT_LENGTH_SUBDIVISIONS: i32 = 1000;
+/// Default step size for `reduce` function
+pub const DEFAULT_REDUCE_STEP_SIZE: f64 = 0.01;

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -9,6 +9,7 @@ use glam::{DMat2, DVec2};
 /// Representation of the handle point(s) in a bezier segment.
 #[derive(Copy, Clone)]
 enum BezierHandles {
+	Linear,
 	/// Handles for a quadratic curve.
 	Quadratic {
 		/// Point representing the location of the single handle.
@@ -59,6 +60,25 @@ pub struct Bezier {
 }
 
 impl Bezier {
+	// TODO: Consider removing this function
+	/// Create a quadratic bezier using the provided coordinates as the start, handle, and end points.
+	pub fn from_linear_coordinates(x1: f64, y1: f64, x2: f64, y2: f64) -> Self {
+		Bezier {
+			start: DVec2::new(x1, y1),
+			handles: BezierHandles::Linear,
+			end: DVec2::new(x2, y2),
+		}
+	}
+
+	/// Create a quadratic bezier using the provided DVec2s as the start, handle, and end points.
+	pub fn from_linear_dvec2(p1: DVec2, p2: DVec2) -> Self {
+		Bezier {
+			start: p1,
+			handles: BezierHandles::Linear,
+			end: p2,
+		}
+	}
+
 	// TODO: Consider removing this function
 	/// Create a quadratic bezier using the provided coordinates as the start, handle, and end points.
 	pub fn from_quadratic_coordinates(x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) -> Self {
@@ -148,14 +168,15 @@ impl Bezier {
 		// TODO: Allow modifying the viewport, width and height
 		let m_path = format!("M {} {}", self.start.x, self.start.y);
 		let handles_path = match self.handles {
+			BezierHandles::Linear => "L".to_string(),
 			BezierHandles::Quadratic { handle } => {
-				format!("Q {} {}", handle.x, handle.y)
+				format!("Q {} {},", handle.x, handle.y)
 			}
 			BezierHandles::Cubic { handle_start, handle_end } => {
-				format!("C {} {}, {} {}", handle_start.x, handle_start.y, handle_end.x, handle_end.y)
+				format!("C {} {}, {} {},", handle_start.x, handle_start.y, handle_end.x, handle_end.y)
 			}
 		};
-		let curve_path = format!("{}, {} {}", handles_path, self.end.x, self.end.y);
+		let curve_path = format!("{} {} {}", handles_path, self.end.x, self.end.y);
 		format!(
 			r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="{} {} {} {}" width="{}px" height="{}px"><path d="{} {} {}" stroke="black" fill="transparent"/></svg>"#,
 			0, 0, 100, 100, 100, 100, "\n", m_path, curve_path
@@ -175,6 +196,9 @@ impl Bezier {
 	/// Set the coordinates of the first handle point. This represents the only handle in a quadratic segment.
 	pub fn set_handle_start(&mut self, h1: DVec2) {
 		match self.handles {
+			BezierHandles::Linear => {
+				self.handles = BezierHandles::Quadratic { handle: h1 };
+			}
 			BezierHandles::Quadratic { ref mut handle } => {
 				*handle = h1;
 			}
@@ -184,9 +208,15 @@ impl Bezier {
 		};
 	}
 
-	/// Set the coordinates of the second handle point. This will convert a quadratic segment into a cubic one.
+	/// Set the coordinates of the second handle point. This will convert both linear and quadratic segments into cubic ones. For the linear segment, the first handle will be set to the start point.
 	pub fn set_handle_end(&mut self, h2: DVec2) {
 		match self.handles {
+			BezierHandles::Linear => {
+				self.handles = BezierHandles::Cubic {
+					handle_start: self.start,
+					handle_end: h2,
+				};
+			}
 			BezierHandles::Quadratic { handle } => {
 				self.handles = BezierHandles::Cubic { handle_start: handle, handle_end: h2 };
 			}
@@ -207,26 +237,30 @@ impl Bezier {
 	}
 
 	/// Get the coordinates of the bezier segment's first handle point. This represents the only handle in a quadratic segment.
-	pub fn handle_start(&self) -> DVec2 {
+	pub fn handle_start(&self) -> Option<DVec2> {
 		match self.handles {
-			BezierHandles::Quadratic { handle } => handle,
-			BezierHandles::Cubic { handle_start, .. } => handle_start,
+			BezierHandles::Linear => None,
+			BezierHandles::Quadratic { handle } => Some(handle),
+			BezierHandles::Cubic { handle_start, .. } => Some(handle_start),
 		}
 	}
 
 	/// Get the coordinates of the second handle point. This will return `None` for a quadratic segment.
 	pub fn handle_end(&self) -> Option<DVec2> {
 		match self.handles {
+			BezierHandles::Linear { .. } => None,
 			BezierHandles::Quadratic { .. } => None,
 			BezierHandles::Cubic { handle_end, .. } => Some(handle_end),
 		}
 	}
 
 	/// Get the coordinates of all points in an array of 4 optional points.
+	/// For a linear segment, the order of the points will be: `start`, `end`. The third and fourth elements will be `None`.
 	/// For a quadratic segment, the order of the points will be: `start`, `handle`, `end`. The fourth element will be `None`.
 	/// For a cubic segment, the order of the points will be: `start`, `handle_start`, `handle_end`, `end`.
 	pub fn get_points(&self) -> [Option<DVec2>; 4] {
 		match self.handles {
+			BezierHandles::Linear => [Some(self.start), Some(self.end), None, None],
 			BezierHandles::Quadratic { handle } => [Some(self.start), Some(handle), Some(self.end), None],
 			BezierHandles::Cubic { handle_start, handle_end } => [Some(self.start), Some(handle_start), Some(handle_end), Some(self.end)],
 		}
@@ -240,6 +274,7 @@ impl Bezier {
 		let squared_one_minus_t = one_minus_t * one_minus_t;
 
 		match self.handles {
+			BezierHandles::Linear => self.start.lerp(self.end, t),
 			BezierHandles::Quadratic { handle } => squared_one_minus_t * self.start + 2.0 * one_minus_t * t * handle + t_squared * self.end,
 			BezierHandles::Cubic { handle_start, handle_end } => {
 				let t_cubed = t_squared * t;
@@ -272,52 +307,62 @@ impl Bezier {
 
 	/// Return an approximation of the length of the bezier curve.
 	pub fn length(&self) -> f64 {
-		// Code example from <https://gamedev.stackexchange.com/questions/5373/moving-ships-between-two-planets-along-a-bezier-missing-some-equations-for-acce/5427#5427>.
+		match self.handles {
+			BezierHandles::Linear => self.start.distance(self.end),
+			_ => {
+				// Code example from <https://gamedev.stackexchange.com/questions/5373/moving-ships-between-two-planets-along-a-bezier-missing-some-equations-for-acce/5427#5427>.
 
-		// We will use an approximate approach where
-		// we split the curve into many subdivisions
-		// and calculate the euclidean distance between the two endpoints of the subdivision
-		let lookup_table = self.compute_lookup_table(Some(LENGTH_SUBDIVISIONS));
-		let mut approx_curve_length = 0.0;
-		let mut prev_point = lookup_table[0];
-		// calculate approximate distance between subdivision
-		for curr_point in lookup_table.iter().skip(1) {
-			// calculate distance of subdivision
-			approx_curve_length += (*curr_point - prev_point).length();
-			// update the prev point
-			prev_point = *curr_point;
+				// We will use an approximate approach where
+				// we split the curve into many subdivisions
+				// and calculate the euclidean distance between the two endpoints of the subdivision
+
+				let lookup_table = self.compute_lookup_table(Some(LENGTH_SUBDIVISIONS));
+				let mut approx_curve_length = 0.0;
+				let mut prev_point = lookup_table[0];
+				// calculate approximate distance between subdivision
+				for curr_point in lookup_table.iter().skip(1) {
+					// calculate distance of subdivision
+					approx_curve_length += (*curr_point - prev_point).length();
+					// update the prev point
+					prev_point = *curr_point;
+				}
+
+				approx_curve_length
+			}
 		}
-
-		approx_curve_length
 	}
 
 	/// Returns a vector representing the derivative at the point designated by `t` on the curve.
-	pub fn derivative(&self, t: f64) -> DVec2 {
-		let one_minus_t = 1. - t;
+	/// Note that this function will return `None` for a linear segment.
+	pub fn derivative(&self) -> Option<Bezier> {
 		match self.handles {
+			BezierHandles::Linear => None,
 			BezierHandles::Quadratic { handle } => {
 				let p1_minus_p0 = handle - self.start;
 				let p2_minus_p1 = self.end - handle;
-				2. * one_minus_t * p1_minus_p0 + 2. * t * p2_minus_p1
+				Some(Bezier::from_linear_dvec2(2. * p1_minus_p0, 2. * p2_minus_p1))
 			}
 			BezierHandles::Cubic { handle_start, handle_end } => {
 				let p1_minus_p0 = handle_start - self.start;
 				let p2_minus_p1 = handle_end - handle_start;
 				let p3_minus_p2 = self.end - handle_end;
-				3. * one_minus_t * one_minus_t * p1_minus_p0 + 6. * t * one_minus_t * p2_minus_p1 + 3. * t * t * p3_minus_p2
+				Some(Bezier::from_quadratic_dvec2(3. * p1_minus_p0, 3. * p2_minus_p1, 3. * p3_minus_p2))
 			}
 		}
 	}
 
 	/// Returns a normalized unit vector representing the tangent at the point designated by `t` on the curve.
 	pub fn tangent(&self, t: f64) -> DVec2 {
-		self.derivative(t).normalize()
+		match self.handles {
+			BezierHandles::Linear => self.end - self.start,
+			_ => self.derivative().unwrap().compute(t),
+		}
+		.normalize()
 	}
 
 	/// Returns a normalized unit vector representing the direction of the normal at the point designated by `t` on the curve.
 	pub fn normal(&self, t: f64) -> DVec2 {
-		let derivative = self.derivative(t);
-		derivative.normalize().perp()
+		self.tangent(t).perp()
 	}
 
 	/// Returns the pair of Bezier curves that result from splitting the original curve at the point corresponding to `t`.
@@ -329,6 +374,7 @@ impl Bezier {
 		let squared_t_minus_one = t_minus_one * t_minus_one;
 
 		match self.handles {
+			BezierHandles::Linear => [Bezier::from_linear_dvec2(self.start, split_point), Bezier::from_linear_dvec2(split_point, self.end)],
 			// TODO: Actually calculate the correct handle locations
 			BezierHandles::Quadratic { handle } => [
 				Bezier::from_quadratic_dvec2(self.start, t * handle - t_minus_one * self.start, split_point),
@@ -463,6 +509,7 @@ impl Bezier {
 	/// The local extrema are defined to be points at which the derivative of the curve is equal to zero.
 	fn unrestricted_local_extrema(&self) -> [Vec<f64>; 2] {
 		match self.handles {
+			BezierHandles::Linear => [Vec::new(), Vec::new()],
 			BezierHandles::Quadratic { handle } => {
 				let a = handle - self.start;
 				let b = self.end - handle;
@@ -499,6 +546,7 @@ impl Bezier {
 		let transformed_start = transformation_function(self.start);
 		let transformed_end = transformation_function(self.end);
 		match self.handles {
+			BezierHandles::Linear => Bezier::from_linear_dvec2(transformed_start, transformed_end),
 			BezierHandles::Quadratic { handle } => {
 				let transformed_handle = transformation_function(handle);
 				Bezier::from_quadratic_dvec2(transformed_start, transformed_handle, transformed_end)
@@ -538,6 +586,11 @@ impl Bezier {
 
 		// Compute the roots of the resulting bezier curve
 		let list_intersection_t = match translated_bezier.handles {
+			BezierHandles::Linear => {
+				let a = translated_bezier.end.y - translated_bezier.start.y;
+				let b = translated_bezier.start.y;
+				utils::solve_linear(a, b)
+			}
 			BezierHandles::Quadratic { handle } => {
 				let a = translated_bezier.start.y - 2. * handle.y + translated_bezier.end.y;
 				let b = 2. * (handle.y - translated_bezier.start.y);
@@ -558,6 +611,7 @@ impl Bezier {
 				utils::solve_cubic(a, b, c, d)
 			}
 		};
+
 		let min = line[0].min(line[1]);
 		let max = line[0].max(line[1]);
 
@@ -594,6 +648,11 @@ impl Bezier {
 	/// - `step_size` - Dictates the granularity at which the function searches for reducible subcurves. The default value is `0.01`.
 	///   A small granularity may increase the chance the function does not introduce gaps, but will increase computation time.
 	pub fn reduce(&self, step_size: Option<f64>) -> Vec<Bezier> {
+		// A linear segment is scalable, so return itself
+		if let BezierHandles::Linear = self.handles {
+			return vec![*self];
+		}
+
 		let step_size = step_size.unwrap_or(REDUCE_STEP_SIZE_DEFAULT);
 
 		let mut extrema: Vec<f64> = self.local_extrema().into_iter().flatten().collect::<Vec<f64>>();
@@ -710,6 +769,23 @@ mod tests {
 
 		let bezier2 = Bezier::from_quadratic_coordinates(0., 0., 0., 100., 100., 100.);
 		assert!(bezier2.project(DVec2::new(100., 0.), project_options) == DVec2::new(0., 0.));
+	}
+	#[test]
+	fn intersect_line_segment_linear() {
+		let p1 = DVec2::new(30., 60.);
+		let p2 = DVec2::new(140., 120.);
+
+		// Intersection at edge of curve
+		let bezier1 = Bezier::from_linear_dvec2(p1, p2);
+		let line1 = [DVec2::new(20., 60.), DVec2::new(70., 60.)];
+		let intersections1 = bezier1.intersect_line_segment(line1);
+		assert!(intersections1.len() == 1);
+		assert!(compare_points(intersections1[0], DVec2::new(30., 60.)));
+
+		// Intersection in the middle of curve
+		let line2 = [DVec2::new(150., 150.), DVec2::new(30., 30.)];
+		let intersections2 = bezier1.intersect_line_segment(line2);
+		assert!(compare_points(intersections2[0], DVec2::new(96., 96.)));
 	}
 
 	#[test]

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -308,22 +308,21 @@ impl Bezier {
 	/// Return an approximation of the length of the bezier curve.
 	/// - `num_subdivisions` - Number of subdivisions used to approximate the curve. The default value is 1000.
 	pub fn length(&self, num_subdivisions: Option<i32>) -> f64 {
-		// Code example from <https://gamedev.stackexchange.com/questions/5373/moving-ships-between-two-planets-along-a-bezier-missing-some-equations-for-acce/5427#5427>.
 		match self.handles {
 			BezierHandles::Linear => self.start.distance(self.end),
 			_ => {
-				// We will use an approximate approach where
-				// we split the curve into many subdivisions
-				// and calculate the euclidean distance between the two endpoints of the subdivision
+				// Code example from <https://gamedev.stackexchange.com/questions/5373/moving-ships-between-two-planets-along-a-bezier-missing-some-equations-for-acce/5427#5427>.
 
+				// We will use an approximate approach where we split the curve into many subdivisions
+				// and calculate the euclidean distance between the two endpoints of the subdivision
 				let lookup_table = self.compute_lookup_table(Some(num_subdivisions.unwrap_or(DEFAULT_LENGTH_SUBDIVISIONS)));
 				let mut approx_curve_length = 0.0;
 				let mut prev_point = lookup_table[0];
-				// calculate approximate distance between subdivision
+				// Calculate approximate distance between subdivision
 				for curr_point in lookup_table.iter().skip(1) {
-					// calculate distance of subdivision
+					// Calculate distance of subdivision
 					approx_curve_length += (*curr_point - prev_point).length();
-					// update the prev point
+					// Update the previous point
 					prev_point = *curr_point;
 				}
 

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -1,7 +1,7 @@
+use crate::consts::{MAX_ABSOLUTE_DIFFERENCE, STRICT_MAX_ABSOLUTE_DIFFERENCE};
+
 use glam::{BVec2, DVec2};
 use std::f64::consts::PI;
-
-use crate::consts::{MAX_ABSOLUTE_DIFFERENCE, STRICT_MAX_ABSOLUTE_DIFFERENCE};
 
 /// Helper to perform the computation of a and c, where b is the provided point on the curve.
 /// Given the correct power of `t` and `(1-t)`, the computation is the same for quadratic and cubic cases.
@@ -42,6 +42,7 @@ pub fn get_closest_point_in_lut(lut: &[DVec2], point: DVec2) -> (i32, f64) {
 		.unwrap()
 }
 
+// TODO: Use an `Option` return type instead of a `Vec`
 /// Find the roots of the linear equation `ax + b`.
 pub fn solve_linear(a: f64, b: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
@@ -52,6 +53,7 @@ pub fn solve_linear(a: f64, b: f64) -> Vec<f64> {
 	roots
 }
 
+// TODO: Use an `impl Iterator` return type instead of a `Vec`
 /// Find the roots of the linear equation `ax^2 + bx + c`.
 /// Precompute the `discriminant` (`b^2 - 4ac`) and `two_times_a` arguments prior to calling this function for efficiency purposes.
 pub fn solve_quadratic(discriminant: f64, two_times_a: f64, b: f64, c: f64) -> Vec<f64> {
@@ -79,6 +81,7 @@ fn cube_root(f: f64) -> f64 {
 	}
 }
 
+// TODO: Use an `impl Iterator` return type instead of a `Vec`
 /// Solve a cubic of the form `x^3 + px + q`, derivation from: <https://trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm>.
 pub fn solve_reformatted_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec<f64> {
 	let mut roots = Vec::new();
@@ -118,6 +121,7 @@ pub fn solve_reformatted_cubic(discriminant: f64, a: f64, p: f64, q: f64) -> Vec
 	roots
 }
 
+// TODO: Use an `impl Iterator` return type instead of a `Vec`
 /// Solve a cubic of the form `ax^3 + bx^2 + ct + d`.
 pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 	if a.abs() <= STRICT_MAX_ABSOLUTE_DIFFERENCE {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

- Add `Linear` as option in `BezierHandles` enum
- Support `Linear` line segments in the existing functions
- Rewrite `derivative` to return an optional `Bezier` (`Linear` ones return `None`)
- Display a section for linear lines in the interactive docs
  - Add functionality to customize which degree of curves are shown per example
  - Refactor `drawBezier` function to handle line segments

