### PR TITLE
Rename vector components to better match new terminology

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -114,9 +114,9 @@ export default defineComponent({
 					name: "Lookup Table",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const lookupPoints = bezier.compute_lookup_table(options.steps);
-						lookupPoints.forEach((serialisedPoint, index) => {
+						lookupPoints.forEach((serializedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
-								drawPoint(getContextFromCanvas(canvas), JSON.parse(serialisedPoint), 3, COLORS.NON_INTERACTIVE.STROKE_1);
+								drawPoint(getContextFromCanvas(canvas), JSON.parse(serializedPoint), 3, COLORS.NON_INTERACTIVE.STROKE_1);
 							}
 						});
 					},
@@ -339,9 +339,7 @@ export default defineComponent({
 
 <style>
 #app {
-	font-family: Avenir, Helvetica, Arial, sans-serif;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+	font-family: Arial, sans-serif;
 	text-align: center;
 	color: #2c3e50;
 	margin-top: 60px;

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -632,11 +632,11 @@ impl Bezier {
 	}
 
 	/// Determine if it is possible to scale the given curve, using the following conditions:
-	/// 1. All the control points are located on a single side of the curve.
+	/// 1. All the handles are located on a single side of the curve.
 	/// 2. The on-curve point for `t = 0.5` must occur roughly in the center of the polygon defined by the curve's endpoint normals.
 	/// See [the offset section](https://pomax.github.io/bezierinfo/#offsetting) of Pomax's bezier curve primer for more details.
 	fn is_scalable(&self) -> bool {
-		// Verify all the control points are located on a single side of the curve.
+		// Verify all the handles are located on a single side of the curve.
 		if let BezierHandles::Cubic { handle_start, handle_end } = self.handles {
 			let angle_1 = (self.end - self.start).angle_between(handle_start - self.start);
 			let angle_2 = (self.end - self.start).angle_between(handle_end - self.start);

--- a/deny.toml
+++ b/deny.toml
@@ -66,7 +66,7 @@ ignore = [
 [licenses]
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
@@ -74,7 +74,7 @@ allow = [
     "Apache-2.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
-# List of explictly disallowed licenses
+# List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 deny = [

--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -45,7 +45,7 @@ pub const BOUNDS_SELECT_THRESHOLD: f64 = 10.;
 pub const BOUNDS_ROTATE_THRESHOLD: f64 = 20.;
 
 // Path tool
-pub const VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE: f64 = 5.;
+pub const MANIPULATOR_GROUP_MARKER_SIZE: f64 = 5.;
 pub const SELECTION_THRESHOLD: f64 = 10.;
 
 // Pen tool

--- a/editor/src/dialog/dialogs/about_dialog.rs
+++ b/editor/src/dialog/dialogs/about_dialog.rs
@@ -2,7 +2,7 @@ use crate::layout::widgets::*;
 use crate::message_prelude::FrontendMessage;
 use crate::misc::build_metadata::{commit_info_localized, release_series};
 
-/// A dialog for displaying information on [`BuildMetadata`] viewable via *Help* > *About Graphite* in the menu bar.
+/// A dialog for displaying information on [BuildMetadata] viewable via *Help* > *About Graphite* in the menu bar.
 pub struct AboutGraphite {
 	pub localized_commit_date: String,
 }

--- a/editor/src/dialog/dialogs/export_dialog.rs
+++ b/editor/src/dialog/dialogs/export_dialog.rs
@@ -7,7 +7,7 @@ use crate::message_prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-/// A dialog to allow users to customise their file export.
+/// A dialog to allow users to customize their file export.
 #[derive(Debug, Clone, Default)]
 pub struct Export {
 	pub file_name: String,

--- a/editor/src/document/document_message.rs
+++ b/editor/src/document/document_message.rs
@@ -53,9 +53,9 @@ pub enum DocumentMessage {
 		layer_path: Vec<LayerId>,
 	},
 	DeleteSelectedLayers,
-	DeleteSelectedVectorPoints,
+	DeleteSelectedManipulatorPoints,
 	DeselectAllLayers,
-	DeselectAllVectorPoints,
+	DeselectAllManipulatorPoints,
 	DirtyRenderDocument,
 	DirtyRenderDocumentInOutlineView,
 	DocumentHistoryBackward,
@@ -83,7 +83,7 @@ pub enum DocumentMessage {
 		insert_index: isize,
 		reverse_index: bool,
 	},
-	MoveSelectedVectorPoints {
+	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
 		absolute_position: (f64, f64),

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -201,19 +201,19 @@ impl DocumentMessageHandler {
 		})
 	}
 
-	/// Returns a copy of all the currently selected VectorShapes.
-	pub fn selected_vector_shapes(&self) -> Vec<Subpath> {
+	/// Returns a copy of all the currently selected Subpaths.
+	pub fn selected_subpaths(&self) -> Vec<Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
-			.flat_map(|layer| layer.as_vector_shape_copy())
+			.flat_map(|layer| layer.as_subpath_copy())
 			.collect::<Vec<Subpath>>()
 	}
 
-	/// Returns references to all the currently selected VectorShapes.
-	pub fn selected_vector_shapes_ref(&self) -> Vec<&Subpath> {
+	/// Returns references to all the currently selected Subpaths.
+	pub fn selected_subpaths_ref(&self) -> Vec<&Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
-			.flat_map(|layer| layer.as_vector_shape())
+			.flat_map(|layer| layer.as_subpath())
 			.collect::<Vec<&Subpath>>()
 	}
 
@@ -992,11 +992,11 @@ impl MessageHandler<DocumentMessage, (&InputPreprocessorMessageHandler, &FontCac
 				responses.push_front(BroadcastSignal::SelectionChanged.into());
 				responses.push_back(BroadcastSignal::DocumentIsDirty.into());
 			}
-			DeleteSelectedVectorPoints => {
+			DeleteSelectedManipulatorPoints => {
 				responses.push_back(StartTransaction.into());
 
 				responses.push_front(
-					DocumentOperation::DeleteSelectedVectorPoints {
+					DocumentOperation::DeleteSelectedManipulatorPoints {
 						layer_paths: self.selected_layers_without_children().iter().map(|path| path.to_vec()).collect(),
 					}
 					.into(),
@@ -1006,9 +1006,9 @@ impl MessageHandler<DocumentMessage, (&InputPreprocessorMessageHandler, &FontCac
 				responses.push_front(SetSelectedLayers { replacement_selected_layers: vec![] }.into());
 				self.layer_range_selection_reference.clear();
 			}
-			DeselectAllVectorPoints => {
+			DeselectAllManipulatorPoints => {
 				for layer_path in self.selected_layers_without_children() {
-					responses.push_back(DocumentOperation::DeselectAllVectorPoints { layer_path: layer_path.to_vec() }.into());
+					responses.push_back(DocumentOperation::DeselectAllManipulatorPoints { layer_path: layer_path.to_vec() }.into());
 				}
 			}
 			DirtyRenderDocument => {
@@ -1171,10 +1171,10 @@ impl MessageHandler<DocumentMessage, (&InputPreprocessorMessageHandler, &FontCac
 					.into(),
 				);
 			}
-			MoveSelectedVectorPoints { layer_path, delta, absolute_position } => {
+			MoveSelectedManipulatorPoints { layer_path, delta, absolute_position } => {
 				self.backup(responses);
 				if let Ok(_layer) = self.graphene_document.layer(&layer_path) {
-					responses.push_back(DocumentOperation::MoveSelectedVectorPoints { layer_path, delta, absolute_position }.into());
+					responses.push_back(DocumentOperation::MoveSelectedManipulatorPoints { layer_path, delta, absolute_position }.into());
 				}
 			}
 			NudgeSelectedLayers { delta_x, delta_y } => {

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -23,7 +23,7 @@ use graphene::layers::folder_layer::FolderLayer;
 use graphene::layers::layer_info::{LayerDataType, LayerDataTypeDiscriminant};
 use graphene::layers::style::{Fill, RenderData, ViewMode};
 use graphene::layers::text_layer::{Font, FontCache};
-use graphene::layers::vector::vector_shape::VectorShape;
+use graphene::layers::vector::subpath::Subpath;
 use graphene::{DocumentError, DocumentResponse, LayerId, Operation as DocumentOperation};
 
 use glam::{DAffine2, DVec2};
@@ -202,19 +202,19 @@ impl DocumentMessageHandler {
 	}
 
 	/// Returns a copy of all the currently selected VectorShapes.
-	pub fn selected_vector_shapes(&self) -> Vec<VectorShape> {
+	pub fn selected_vector_shapes(&self) -> Vec<Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
 			.flat_map(|layer| layer.as_vector_shape_copy())
-			.collect::<Vec<VectorShape>>()
+			.collect::<Vec<Subpath>>()
 	}
 
 	/// Returns references to all the currently selected VectorShapes.
-	pub fn selected_vector_shapes_ref(&self) -> Vec<&VectorShape> {
+	pub fn selected_vector_shapes_ref(&self) -> Vec<&Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
 			.flat_map(|layer| layer.as_vector_shape())
-			.collect::<Vec<&VectorShape>>()
+			.collect::<Vec<&Subpath>>()
 	}
 
 	/// Returns the bounding boxes for all visible layers and artboards, optionally excluding any paths.

--- a/editor/src/document/document_message_handler.rs
+++ b/editor/src/document/document_message_handler.rs
@@ -201,7 +201,7 @@ impl DocumentMessageHandler {
 		})
 	}
 
-	/// Returns a copy of all the currently selected Subpaths.
+	/// Returns a copy of all the currently selected [Subpath]s.
 	pub fn selected_subpaths(&self) -> Vec<Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
@@ -209,7 +209,7 @@ impl DocumentMessageHandler {
 			.collect::<Vec<Subpath>>()
 	}
 
-	/// Returns references to all the currently selected Subpaths.
+	/// Returns references to all the currently selected [Subpath]s.
 	pub fn selected_subpaths_ref(&self) -> Vec<&Subpath> {
 		self.selected_visible_layers()
 			.flat_map(|layer| self.graphene_document.layer(layer))
@@ -501,7 +501,7 @@ impl DocumentMessageHandler {
 	/// Calculate the path that new layers should be inserted to.
 	/// Depends on the selected layers as well as their types (Folder/Non-Folder)
 	pub fn get_path_for_new_layer(&self) -> Vec<u64> {
-		// If the selected layers dont actually exist, a new uuid for the
+		// If the selected layers don't actually exist, a new uuid for the
 		// root folder will be returned
 		let mut path = self.graphene_document.shallowest_common_folder(self.selected_layers()).map_or(vec![], |v| v.to_vec());
 		path.push(generate_uuid());
@@ -1074,12 +1074,7 @@ impl MessageHandler<DocumentMessage, (&InputPreprocessorMessageHandler, &FontCac
 				let bbox = match bounds {
 					ExportBounds::AllArtwork => self.all_layer_bounds(font_cache),
 					ExportBounds::Selection => self.selected_visible_layers_bounding_box(font_cache),
-					ExportBounds::Artboard(id) => self
-						.artboard_message_handler
-						.artboards_graphene_document
-						.layer(&[id])
-						.ok()
-						.and_then(|layer| layer.aabounding_box(font_cache)),
+					ExportBounds::Artboard(id) => self.artboard_message_handler.artboards_graphene_document.layer(&[id]).ok().and_then(|layer| layer.aabb(font_cache)),
 				}
 				.unwrap_or_default();
 				let size = bbox[1] - bbox[0];

--- a/editor/src/document/transformation.rs
+++ b/editor/src/document/transformation.rs
@@ -226,7 +226,7 @@ impl<'a> Selected<'a> {
 					.document
 					.layer(path)
 					.unwrap()
-					.aabounding_box_for_transform(multiplied_transform, font_cache)
+					.aabb_for_transform(multiplied_transform, font_cache)
 					.unwrap_or([multiplied_transform.translation; 2]);
 
 				(bounds[0] + bounds[1]) / 2.

--- a/editor/src/misc/build_metadata.rs
+++ b/editor/src/misc/build_metadata.rs
@@ -1,6 +1,6 @@
-/// Provides metadata about the build environment.
-///
-/// This data is viewable in the editor via the [`crate::dialog::AboutGraphite`] dialog.
+//! Provides metadata about the build environment.
+//!
+//! This data is viewable in the editor via the [AboutGraphite](crate::dialog::AboutGraphite) dialog.
 
 pub fn release_series() -> String {
 	format!("Release Series: {}", env!("GRAPHITE_RELEASE_SERIES"))

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -254,7 +254,7 @@ impl SnapHandler {
 			let transform = document_message_handler.graphene_document.multiply_transforms(path).unwrap();
 			let snap_points = shape_layer
 				.shape
-				.groups()
+				.manipulator_groups()
 				.enumerate()
 				.flat_map(|(id, shape)| {
 					if include_handles {

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -7,7 +7,7 @@ use crate::message_prelude::*;
 
 use graphene::layers::layer_info::{Layer, LayerDataType};
 use graphene::layers::style::{self, Stroke};
-use graphene::layers::vector::constants::ControlPointType;
+use graphene::layers::vector::constants::ManipulatorType;
 use graphene::{LayerId, Operation};
 
 use glam::{DAffine2, DVec2};
@@ -249,22 +249,22 @@ impl SnapHandler {
 	/// Add the control points (optionally including bézier handles) of the specified shape layer to the snapping points
 	///
 	/// This should be called after start_snap
-	pub fn add_snap_path(&mut self, document_message_handler: &DocumentMessageHandler, layer: &Layer, path: &[LayerId], include_handles: bool, ignore_points: &[(&[LayerId], u64, ControlPointType)]) {
+	pub fn add_snap_path(&mut self, document_message_handler: &DocumentMessageHandler, layer: &Layer, path: &[LayerId], include_handles: bool, ignore_points: &[(&[LayerId], u64, ManipulatorType)]) {
 		if let LayerDataType::Shape(shape_layer) = &layer.data {
 			let transform = document_message_handler.graphene_document.multiply_transforms(path).unwrap();
 			let snap_points = shape_layer
 				.shape
-				.anchors()
+				.groups()
 				.enumerate()
 				.flat_map(|(id, shape)| {
 					if include_handles {
 						[
-							(*id, &shape.points[ControlPointType::Anchor]),
-							(*id, &shape.points[ControlPointType::InHandle]),
-							(*id, &shape.points[ControlPointType::OutHandle]),
+							(*id, &shape.points[ManipulatorType::Anchor]),
+							(*id, &shape.points[ManipulatorType::InHandle]),
+							(*id, &shape.points[ManipulatorType::OutHandle]),
 						]
 					} else {
-						[(*id, &shape.points[ControlPointType::Anchor]), (0, &None), (0, &None)]
+						[(*id, &shape.points[ManipulatorType::Anchor]), (0, &None), (0, &None)]
 					}
 				})
 				.filter_map(|(id, point)| point.as_ref().map(|val| (id, val)))
@@ -281,7 +281,7 @@ impl SnapHandler {
 		document_message_handler: &DocumentMessageHandler,
 		include_handles: &[&[LayerId]],
 		exclude: &[&[LayerId]],
-		ignore_points: &[(&[LayerId], u64, ControlPointType)],
+		ignore_points: &[(&[LayerId], u64, ManipulatorType)],
 	) {
 		for path in document_message_handler.all_layers() {
 			if !exclude.contains(&path) {

--- a/editor/src/viewport_tools/snapping.rs
+++ b/editor/src/viewport_tools/snapping.rs
@@ -246,7 +246,7 @@ impl SnapHandler {
 		}
 	}
 
-	/// Add the control points (optionally including bézier handles) of the specified shape layer to the snapping points
+	/// Add the [ManipulatorGroup]s (optionally including handles) of the specified shape layer to the snapping points
 	///
 	/// This should be called after start_snap
 	pub fn add_snap_path(&mut self, document_message_handler: &DocumentMessageHandler, layer: &Layer, path: &[LayerId], include_handles: bool, ignore_points: &[(&[LayerId], u64, ManipulatorType)]) {

--- a/editor/src/viewport_tools/tools/gradient_tool.rs
+++ b/editor/src/viewport_tools/tools/gradient_tool.rs
@@ -141,7 +141,7 @@ impl Default for GradientToolFsmState {
 
 /// Computes the transform from gradient space to layer space (where gradient space is 0..1 in layer space)
 fn gradient_space_transform(path: &[LayerId], layer: &Layer, document: &DocumentMessageHandler, font_cache: &FontCache) -> DAffine2 {
-	let bounds = layer.aabounding_box_for_transform(DAffine2::IDENTITY, font_cache).unwrap();
+	let bounds = layer.aabb_for_transform(DAffine2::IDENTITY, font_cache).unwrap();
 	let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
 
 	let multiplied = document.graphene_document.multiply_transforms(path).unwrap();

--- a/editor/src/viewport_tools/tools/gradient_tool.rs
+++ b/editor/src/viewport_tools/tools/gradient_tool.rs
@@ -1,4 +1,4 @@
-use crate::consts::{COLOR_ACCENT, LINE_ROTATE_SNAP_ANGLE, SELECTION_TOLERANCE, VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE};
+use crate::consts::{COLOR_ACCENT, LINE_ROTATE_SNAP_ANGLE, MANIPULATOR_GROUP_MARKER_SIZE, SELECTION_TOLERANCE};
 use crate::document::DocumentMessageHandler;
 use crate::frontend::utility_types::MouseCursorIcon;
 use crate::input::keyboard::{Key, MouseMotion};
@@ -163,7 +163,7 @@ impl GradientOverlay {
 	fn generate_overlay_handle(translation: DVec2, responses: &mut VecDeque<Message>, selected: bool) -> Vec<LayerId> {
 		let path = vec![generate_uuid()];
 
-		let size = DVec2::splat(VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE);
+		let size = DVec2::splat(MANIPULATOR_GROUP_MARKER_SIZE);
 
 		let fill = if selected { Fill::solid(COLOR_ACCENT) } else { Fill::solid(Color::WHITE) };
 
@@ -359,7 +359,7 @@ impl Fsm for GradientToolFsmState {
 					responses.push_back(BroadcastSignal::DocumentIsDirty.into());
 
 					let mouse = input.mouse.position;
-					let tolerance = VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE.powi(2);
+					let tolerance = MANIPULATOR_GROUP_MARKER_SIZE.powi(2);
 
 					let mut dragging = false;
 					for overlay in &tool_data.gradient_overlays {

--- a/editor/src/viewport_tools/tools/path_tool.rs
+++ b/editor/src/viewport_tools/tools/path_tool.rs
@@ -10,7 +10,7 @@ use crate::viewport_tools::vector_editor::overlay_renderer::OverlayRenderer;
 use crate::viewport_tools::vector_editor::shape_editor::ShapeEditor;
 
 use graphene::intersection::Quad;
-use graphene::layers::vector::constants::ControlPointType;
+use graphene::layers::vector::constants::ManipulatorType;
 
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
@@ -182,9 +182,9 @@ impl Fsm for PathToolFsmState {
 						// Do not snap against handles when anchor is selected
 						let mut extension = Vec::new();
 						for &(path, id, point_type) in new_selected.iter() {
-							if point_type == ControlPointType::Anchor {
-								extension.push((path, id, ControlPointType::InHandle));
-								extension.push((path, id, ControlPointType::OutHandle));
+							if point_type == ManipulatorType::Anchor {
+								extension.push((path, id, ManipulatorType::InHandle));
+								extension.push((path, id, ManipulatorType::OutHandle));
 							}
 						}
 						new_selected.extend(extension);

--- a/editor/src/viewport_tools/tools/path_tool.rs
+++ b/editor/src/viewport_tools/tools/path_tool.rs
@@ -158,7 +158,7 @@ impl Fsm for PathToolFsmState {
 					// When the document has moved / needs to be redraw, re-render the overlays
 					// TODO the overlay system should probably receive this message instead of the tool
 					for layer_path in document.selected_visible_layers() {
-						tool_data.overlay_renderer.render_vector_shape_overlays(&document.graphene_document, layer_path.to_vec(), responses);
+						tool_data.overlay_renderer.render_subpath_overlays(&document.graphene_document, layer_path.to_vec(), responses);
 					}
 
 					self
@@ -265,14 +265,14 @@ impl Fsm for PathToolFsmState {
 					tool_data.shape_editor.delete_selected_points(responses);
 					responses.push_back(SelectionChanged.into());
 					for layer_path in document.all_layers() {
-						tool_data.overlay_renderer.clear_vector_shape_overlays(&document.graphene_document, layer_path.to_vec(), responses);
+						tool_data.overlay_renderer.clear_subpath_overlays(&document.graphene_document, layer_path.to_vec(), responses);
 					}
 					Ready
 				}
 				(_, Abort) => {
 					// TODO Tell overlay manager to remove the overlays
 					for layer_path in document.all_layers() {
-						tool_data.overlay_renderer.clear_vector_shape_overlays(&document.graphene_document, layer_path.to_vec(), responses);
+						tool_data.overlay_renderer.clear_subpath_overlays(&document.graphene_document, layer_path.to_vec(), responses);
 					}
 					Ready
 				}

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -437,7 +437,7 @@ fn add_manipulator_group(layer_path: &Option<Vec<LayerId>>, group: ManipulatorGr
 	}
 }
 
-/// Gets the currently editing [VectorShape]
+/// Gets the currently editing [Subpath]
 fn get_subpath<'a>(layer_path: &'a [LayerId], document: &'a DocumentMessageHandler) -> Option<&'a Subpath> {
 	document.graphene_document.layer(layer_path).ok().and_then(|layer| layer.as_subpath())
 }

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -248,8 +248,8 @@ impl Fsm for PenToolFsmState {
 						let mouse = tool_data.snap_handler.snap_position(responses, document, input.mouse.position);
 						let mut pos = transform.inverse().transform_point2(mouse);
 						if let Some(((&id, manipulator_group), _previous)) = get_subpath(layer_path, document).and_then(last_2_manipulator_groups) {
-							if let Some(manipulator_point) = manipulator_group.points[ManipulatorType::Anchor as usize].as_ref() {
-								pos = compute_snapped_angle(input, snap_angle, pos, manipulator_point.position);
+							if let Some(anchor) = manipulator_group.points[ManipulatorType::Anchor].as_ref() {
+								pos = compute_snapped_angle(input, snap_angle, pos, anchor.position);
 							}
 
 							// Update points on current segment (to show preview of new handle)
@@ -263,8 +263,8 @@ impl Fsm for PenToolFsmState {
 
 							// Mirror handle of last segment
 							if !input.keyboard.get(break_handle as usize) && get_subpath(layer_path, document).map(|shape| shape.manipulator_groups().len() > 1).unwrap_or_default() {
-								if let Some(manipulator_point) = manipulator_group.points[ManipulatorType::Anchor as usize].as_ref() {
-									pos = manipulator_point.position - (pos - manipulator_point.position);
+								if let Some(anchor) = manipulator_group.points[ManipulatorType::Anchor].as_ref() {
+									pos = anchor.position - (pos - anchor.position);
 								}
 								let msg = Operation::MoveManipulatorPoint {
 									layer_path: layer_path.clone(),
@@ -285,15 +285,15 @@ impl Fsm for PenToolFsmState {
 						let mut pos = transform.inverse().transform_point2(mouse);
 
 						if let Some(((&id, _), previous)) = get_subpath(layer_path, document).and_then(last_2_manipulator_groups) {
-							if let Some(relative) = previous.as_ref().and_then(|(_, manipulator_group)| manipulator_group.points[ManipulatorType::Anchor as usize].as_ref()) {
+							if let Some(relative) = previous.as_ref().and_then(|(_, manipulator_group)| manipulator_group.points[ManipulatorType::Anchor].as_ref()) {
 								pos = compute_snapped_angle(input, snap_angle, pos, relative.position);
 							}
 
-							for control_type in [ManipulatorType::Anchor, ManipulatorType::InHandle, ManipulatorType::OutHandle] {
+							for manipulator_type in [ManipulatorType::Anchor, ManipulatorType::InHandle, ManipulatorType::OutHandle] {
 								let msg = Operation::MoveManipulatorPoint {
 									layer_path: layer_path.clone(),
 									id,
-									manipulator_type: control_type,
+									manipulator_type,
 									position: pos.into(),
 								};
 								responses.push_back(msg.into());
@@ -324,7 +324,7 @@ impl Fsm for PenToolFsmState {
 									layer_path: layer_path.clone(),
 									id,
 									manipulator_type: ManipulatorType::OutHandle,
-									position: manipulator_group.points[ManipulatorType::Anchor as usize].as_ref().unwrap().position.into(),
+									position: manipulator_group.points[ManipulatorType::Anchor].as_ref().unwrap().position.into(),
 								};
 								responses.push_back(op.into());
 							}
@@ -376,7 +376,7 @@ impl Fsm for PenToolFsmState {
 				HintGroup(vec![HintInfo {
 					key_groups: vec![],
 					mouse: Some(MouseMotion::Lmb),
-					label: String::from("Add Control Point"),
+					label: String::from("Add Anchor"),
 					plus: false,
 				}]),
 				HintGroup(vec![HintInfo {

--- a/editor/src/viewport_tools/tools/shared/path_outline.rs
+++ b/editor/src/viewport_tools/tools/shared/path_outline.rs
@@ -37,7 +37,7 @@ impl PathOutline {
 		// Get the bezpath from the shape or text
 		let vector_path = match &document_layer.data {
 			LayerDataType::Shape(layer_shape) => Some(layer_shape.shape.clone()),
-			LayerDataType::Text(text) => Some(text.to_vector_path_nonmut(font_cache)),
+			LayerDataType::Text(text) => Some(text.to_subpath_nonmut(font_cache)),
 			_ => document_layer.aabounding_box_for_transform(DAffine2::IDENTITY, font_cache).map(|[p1, p2]| Subpath::new_rect(p1, p2)),
 		}?;
 

--- a/editor/src/viewport_tools/tools/shared/path_outline.rs
+++ b/editor/src/viewport_tools/tools/shared/path_outline.rs
@@ -7,7 +7,7 @@ use graphene::intersection::Quad;
 use graphene::layers::layer_info::LayerDataType;
 use graphene::layers::style::{self, Fill, Stroke};
 use graphene::layers::text_layer::FontCache;
-use graphene::layers::vector::vector_shape::VectorShape;
+use graphene::layers::vector::subpath::Subpath;
 use graphene::{LayerId, Operation};
 
 use glam::{DAffine2, DVec2};
@@ -38,9 +38,7 @@ impl PathOutline {
 		let vector_path = match &document_layer.data {
 			LayerDataType::Shape(layer_shape) => Some(layer_shape.shape.clone()),
 			LayerDataType::Text(text) => Some(text.to_vector_path_nonmut(font_cache)),
-			_ => document_layer
-				.aabounding_box_for_transform(DAffine2::IDENTITY, font_cache)
-				.map(|[p1, p2]| VectorShape::new_rect(p1, p2)),
+			_ => document_layer.aabounding_box_for_transform(DAffine2::IDENTITY, font_cache).map(|[p1, p2]| Subpath::new_rect(p1, p2)),
 		}?;
 
 		// Generate a new overlay layer if necessary

--- a/editor/src/viewport_tools/tools/shared/path_outline.rs
+++ b/editor/src/viewport_tools/tools/shared/path_outline.rs
@@ -48,7 +48,7 @@ impl PathOutline {
 				let overlay_path = vec![generate_uuid()];
 				let operation = Operation::AddShape {
 					path: overlay_path.clone(),
-					vector_path: Default::default(),
+					subpath: Default::default(),
 					style: style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, PATH_OUTLINE_WEIGHT)), Fill::None),
 					insert_index: -1,
 					transform: DAffine2::IDENTITY.to_cols_array(),
@@ -61,7 +61,10 @@ impl PathOutline {
 		};
 
 		// Update the shape bezpath
-		let operation = Operation::SetShapePath { path: overlay.clone(), vector_path };
+		let operation = Operation::SetShapePath {
+			path: overlay.clone(),
+			subpath: vector_path,
+		};
 		responses.push_back(DocumentMessage::Overlays(operation.into()).into());
 
 		// Update the transform to match the document

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -219,7 +219,7 @@ impl BoundingBoxOverlays {
 		}
 	}
 
-	/// Calculats the transformed handle positions based on the bounding box and the transform
+	/// Calculates the transformed handle positions based on the bounding box and the transform
 	pub fn evaluate_transform_handle_positions(&self) -> [DVec2; 8] {
 		let (left, top): (f64, f64) = self.bounds[0].into();
 		let (right, bottom): (f64, f64) = self.bounds[1].into();

--- a/editor/src/viewport_tools/tools/shared/transformation_cage.rs
+++ b/editor/src/viewport_tools/tools/shared/transformation_cage.rs
@@ -1,4 +1,4 @@
-use crate::consts::{BOUNDS_ROTATE_THRESHOLD, BOUNDS_SELECT_THRESHOLD, COLOR_ACCENT, SELECTION_DRAG_ANGLE, VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE};
+use crate::consts::{BOUNDS_ROTATE_THRESHOLD, BOUNDS_SELECT_THRESHOLD, COLOR_ACCENT, MANIPULATOR_GROUP_MARKER_SIZE, SELECTION_DRAG_ANGLE};
 use crate::document::transformation::OriginalTransforms;
 use crate::frontend::utility_types::MouseCursorIcon;
 use crate::input::InputPreprocessorMessageHandler;
@@ -245,7 +245,7 @@ impl BoundingBoxOverlays {
 		const BIAS: f64 = 0.0001;
 
 		for (position, path) in self.evaluate_transform_handle_positions().into_iter().zip(&self.transform_handles) {
-			let scale = DVec2::splat(VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE);
+			let scale = DVec2::splat(MANIPULATOR_GROUP_MARKER_SIZE);
 			let translation = (position - (scale / 2.) - 0.5 + BIAS).round();
 			let transform = DAffine2::from_scale_angle_translation(scale, 0., translation).to_cols_array();
 			let path = path.clone();

--- a/editor/src/viewport_tools/tools/text_tool.rs
+++ b/editor/src/viewport_tools/tools/text_tool.rs
@@ -238,7 +238,7 @@ fn update_overlays(document: &DocumentMessageHandler, tool_data: &mut TextToolDa
 				.graphene_document
 				.layer(layer_path)
 				.unwrap()
-				.aabounding_box_for_transform(document.graphene_document.multiply_transforms(layer_path).unwrap(), font_cache)
+				.aabb_for_transform(document.graphene_document.multiply_transforms(layer_path).unwrap(), font_cache)
 				.map(|bounds| (bounds, overlay_path))
 		})
 		.collect::<Vec<_>>();

--- a/editor/src/viewport_tools/vector_editor/mod.rs
+++ b/editor/src/viewport_tools/vector_editor/mod.rs
@@ -1,6 +1,6 @@
 pub mod constants;
 pub mod overlay_renderer;
 pub mod shape_editor;
-use graphene::layers::vector::vector_anchor;
-use graphene::layers::vector::vector_control_point;
-use graphene::layers::vector::vector_shape;
+use graphene::layers::vector::manipulator_group;
+use graphene::layers::vector::manipulator_point;
+use graphene::layers::vector::subpath;

--- a/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
+++ b/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
@@ -201,7 +201,7 @@ impl OverlayRenderer {
 		responses.push_back(outline_modify_message);
 	}
 
-	/// Updates the position of the overlays based on the VectorShape points
+	/// Updates the position of the overlays based on the Subpath points
 	fn place_manipulator_group_overlays(group: &ManipulatorGroup, overlays: &mut ManipulatorGroupOverlays, parent_transform: &DAffine2, responses: &mut VecDeque<Message>) {
 		if let Some(manipulator_point) = &group.points[ManipulatorType::Anchor] {
 			// Helper function to keep things DRY

--- a/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
+++ b/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
@@ -1,7 +1,7 @@
 use super::constants::ROUNDING_BIAS;
 use super::manipulator_group::ManipulatorGroup;
 use super::manipulator_point::ManipulatorPoint;
-use crate::consts::{COLOR_ACCENT, PATH_OUTLINE_WEIGHT, VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE};
+use crate::consts::{COLOR_ACCENT, MANIPULATOR_GROUP_MARKER_SIZE, PATH_OUTLINE_WEIGHT};
 use crate::message_prelude::{generate_uuid, DocumentMessage, Message};
 
 use graphene::color::Color;
@@ -14,34 +14,33 @@ use graphene::{LayerId, Operation};
 use glam::{DAffine2, DVec2};
 use std::collections::{HashMap, VecDeque};
 
-/// AnchorOverlay is the collection of overlays that make up an anchor
-/// Notably the anchor point, handles and the lines for the handles
-type AnchorOverlays = [Option<Vec<LayerId>>; 5];
-type AnchorId = u64;
+/// ManipulatorGroupOverlays is the collection of overlays that make up an ManipulatorGroup visible in the editor
+type ManipulatorGroupOverlays = [Option<Vec<LayerId>>; 5];
+type ManipulatorId = u64;
 
 const POINT_STROKE_WEIGHT: f64 = 2.;
 
 #[derive(Clone, Debug, Default)]
 pub struct OverlayRenderer {
 	shape_overlay_cache: HashMap<LayerId, Vec<LayerId>>,
-	anchor_overlay_cache: HashMap<(LayerId, AnchorId), AnchorOverlays>,
+	manipulator_group_overlay_cache: HashMap<(LayerId, ManipulatorId), ManipulatorGroupOverlays>,
 }
 
 impl OverlayRenderer {
 	pub fn new() -> Self {
 		OverlayRenderer {
-			anchor_overlay_cache: HashMap::new(),
+			manipulator_group_overlay_cache: HashMap::new(),
 			shape_overlay_cache: HashMap::new(),
 		}
 	}
 
-	pub fn render_vector_shape_overlays(&mut self, document: &Document, layer_path: Vec<LayerId>, responses: &mut VecDeque<Message>) {
+	pub fn render_subpath_overlays(&mut self, document: &Document, layer_path: Vec<LayerId>, responses: &mut VecDeque<Message>) {
 		let transform = document.generate_transform_relative_to_viewport(&layer_path).ok().unwrap();
 		if let Ok(layer) = document.layer(&layer_path) {
 			let layer_id = layer_path.last().unwrap();
 			self.layer_overlay_visibility(document, layer_path.clone(), true, responses);
 
-			if let Some(shape) = layer.as_vector_shape() {
+			if let Some(shape) = layer.as_subpath() {
 				let outline_cache = self.shape_overlay_cache.get(layer_id);
 				log::trace!("Overlay: Outline cache {:?}", &outline_cache);
 
@@ -58,26 +57,26 @@ impl OverlayRenderer {
 				}
 
 				// Create, place and style the anchor / handle overlays
-				for (anchor_id, anchor) in shape.groups().enumerate() {
-					let anchor_cache = self.anchor_overlay_cache.get_mut(&(*layer_id, *anchor_id));
+				for (group_id, group) in shape.groups().enumerate() {
+					let group_cache = self.manipulator_group_overlay_cache.get_mut(&(*layer_id, *group_id));
 
 					// If cached update placement and style
-					if let Some(anchor_overlays) = anchor_cache {
-						log::trace!("Overlay: Updating detail overlays for {:?}", anchor_overlays);
-						Self::place_anchor_overlays(anchor, anchor_overlays, &transform, responses);
-						Self::style_overlays(anchor, anchor_overlays, responses);
+					if let Some(group_overlays) = group_cache {
+						log::trace!("Overlay: Updating detail overlays for {:?}", group_overlays);
+						Self::place_manipulator_group_overlays(group, group_overlays, &transform, responses);
+						Self::style_overlays(group, group_overlays, responses);
 					} else {
 						// Create if not cached
-						let mut anchor_overlays = [
+						let mut group_overlays = [
 							Some(self.create_anchor_overlay(responses)),
-							Self::create_handle_overlay_if_exists(&anchor.points[ManipulatorType::InHandle], responses),
-							Self::create_handle_overlay_if_exists(&anchor.points[ManipulatorType::OutHandle], responses),
-							Self::create_handle_line_overlay_if_exists(&anchor.points[ManipulatorType::InHandle], responses),
-							Self::create_handle_line_overlay_if_exists(&anchor.points[ManipulatorType::OutHandle], responses),
+							Self::create_handle_overlay_if_exists(&group.points[ManipulatorType::InHandle], responses),
+							Self::create_handle_overlay_if_exists(&group.points[ManipulatorType::OutHandle], responses),
+							Self::create_handle_line_overlay_if_exists(&group.points[ManipulatorType::InHandle], responses),
+							Self::create_handle_line_overlay_if_exists(&group.points[ManipulatorType::OutHandle], responses),
 						];
-						Self::place_anchor_overlays(anchor, &mut anchor_overlays, &transform, responses);
-						Self::style_overlays(anchor, &anchor_overlays, responses);
-						self.anchor_overlay_cache.insert((*layer_id, *anchor_id), anchor_overlays);
+						Self::place_manipulator_group_overlays(group, &mut group_overlays, &transform, responses);
+						Self::style_overlays(group, &group_overlays, responses);
+						self.manipulator_group_overlay_cache.insert((*layer_id, *group_id), group_overlays);
 					}
 				}
 				// TODO Handle removing shapes from cache so we don't memory leak
@@ -86,7 +85,7 @@ impl OverlayRenderer {
 		}
 	}
 
-	pub fn clear_vector_shape_overlays(&mut self, document: &Document, layer_path: Vec<LayerId>, responses: &mut VecDeque<Message>) {
+	pub fn clear_subpath_overlays(&mut self, document: &Document, layer_path: Vec<LayerId>, responses: &mut VecDeque<Message>) {
 		let layer_id = layer_path.last().unwrap();
 
 		// Remove the shape outline overlays
@@ -95,13 +94,13 @@ impl OverlayRenderer {
 		}
 		self.shape_overlay_cache.remove(layer_id);
 
-		// Remove the anchor overlays
+		// Remove the ManipulatorGroup overlays
 		if let Ok(layer) = document.layer(&layer_path) {
-			if let Some(shape) = layer.as_vector_shape() {
+			if let Some(shape) = layer.as_subpath() {
 				for (id, _) in shape.groups().enumerate() {
-					if let Some(anchor_overlays) = self.anchor_overlay_cache.get(&(*layer_id, *id)) {
-						Self::remove_anchor_overlays(anchor_overlays, responses);
-						self.anchor_overlay_cache.remove(&(*layer_id, *id));
+					if let Some(group_overlays) = self.manipulator_group_overlay_cache.get(&(*layer_id, *id)) {
+						Self::remove_manipulator_group_overlays(group_overlays, responses);
+						self.manipulator_group_overlay_cache.remove(&(*layer_id, *id));
 					}
 				}
 			}
@@ -116,12 +115,12 @@ impl OverlayRenderer {
 			Self::set_outline_overlay_visibility(overlay_path.clone(), visibility, responses);
 		}
 
-		// Hide the anchor overlays
+		// Hide the manipulator group overlays
 		if let Ok(layer) = document.layer(&layer_path) {
-			if let Some(shape) = layer.as_vector_shape() {
+			if let Some(shape) = layer.as_subpath() {
 				for (id, _) in shape.groups().enumerate() {
-					if let Some(anchor_overlays) = self.anchor_overlay_cache.get(&(*layer_id, *id)) {
-						Self::set_anchor_overlay_visibility(anchor_overlays, visibility, responses);
+					if let Some(manipulator_group_overlays) = self.manipulator_group_overlay_cache.get(&(*layer_id, *id)) {
+						Self::set_manipulator_group_overlay_visibility(manipulator_group_overlays, visibility, responses);
 					}
 				}
 			}
@@ -133,7 +132,7 @@ impl OverlayRenderer {
 		let layer_path = vec![generate_uuid()];
 		let operation = Operation::AddShape {
 			path: layer_path.clone(),
-			vector_path,
+			subpath: vector_path,
 			style: style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, PATH_OUTLINE_WEIGHT)), Fill::None),
 			insert_index: -1,
 			transform: DAffine2::IDENTITY.to_cols_array(),
@@ -203,12 +202,12 @@ impl OverlayRenderer {
 	}
 
 	/// Updates the position of the overlays based on the VectorShape points
-	fn place_anchor_overlays(anchor: &ManipulatorGroup, overlays: &mut AnchorOverlays, parent_transform: &DAffine2, responses: &mut VecDeque<Message>) {
-		if let Some(anchor_point) = &anchor.points[ManipulatorType::Anchor] {
+	fn place_manipulator_group_overlays(group: &ManipulatorGroup, overlays: &mut ManipulatorGroupOverlays, parent_transform: &DAffine2, responses: &mut VecDeque<Message>) {
+		if let Some(manipulator_point) = &group.points[ManipulatorType::Anchor] {
 			// Helper function to keep things DRY
 			let mut place_handle_and_line = |handle: &ManipulatorPoint, line_source: &mut Option<Vec<LayerId>>, marker_source: &mut Option<Vec<LayerId>>| {
 				let line_overlay = line_source.take().unwrap_or_else(|| Self::create_handle_line_overlay(responses));
-				let line_vector = parent_transform.transform_point2(anchor_point.position) - parent_transform.transform_point2(handle.position);
+				let line_vector = parent_transform.transform_point2(manipulator_point.position) - parent_transform.transform_point2(handle.position);
 				let scale = DVec2::splat(line_vector.length());
 				let angle = -line_vector.angle_between(DVec2::X);
 				let translation = (parent_transform.transform_point2(handle.position) + ROUNDING_BIAS).round() + DVec2::splat(0.5);
@@ -217,7 +216,7 @@ impl OverlayRenderer {
 				*line_source = Some(line_overlay);
 
 				let marker_overlay = marker_source.take().unwrap_or_else(|| Self::create_handle_overlay(responses));
-				let scale = DVec2::splat(VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE);
+				let scale = DVec2::splat(MANIPULATOR_GROUP_MARKER_SIZE);
 				let angle = 0.;
 				let translation = (parent_transform.transform_point2(handle.position) - (scale / 2.) + ROUNDING_BIAS).round();
 				let transform = DAffine2::from_scale_angle_translation(scale, angle, translation).to_cols_array();
@@ -226,7 +225,7 @@ impl OverlayRenderer {
 			};
 
 			// Place the handle overlays
-			let [_, h1, h2] = &anchor.points;
+			let [_, h1, h2] = &group.points;
 			let [a, b, c, line1, line2] = overlays;
 			let markers = [a, b, c];
 			if let Some(handle) = &h1 {
@@ -238,9 +237,9 @@ impl OverlayRenderer {
 
 			// Place the anchor point overlay
 			if let Some(anchor_overlay) = &overlays[ManipulatorType::Anchor as usize] {
-				let scale = DVec2::splat(VECTOR_MANIPULATOR_ANCHOR_MARKER_SIZE);
+				let scale = DVec2::splat(MANIPULATOR_GROUP_MARKER_SIZE);
 				let angle = 0.;
-				let translation = (parent_transform.transform_point2(anchor_point.position) - (scale / 2.) + ROUNDING_BIAS).round();
+				let translation = (parent_transform.transform_point2(manipulator_point.position) - (scale / 2.) + ROUNDING_BIAS).round();
 				let transform = DAffine2::from_scale_angle_translation(scale, angle, translation).to_cols_array();
 
 				let message = Self::overlay_transform_message(anchor_overlay.clone(), transform);
@@ -250,7 +249,7 @@ impl OverlayRenderer {
 	}
 
 	/// Removes the anchor / handle overlays from the overlay document
-	fn remove_anchor_overlays(overlay_paths: &AnchorOverlays, responses: &mut VecDeque<Message>) {
+	fn remove_manipulator_group_overlays(overlay_paths: &ManipulatorGroupOverlays, responses: &mut VecDeque<Message>) {
 		overlay_paths.iter().flatten().for_each(|layer_id| {
 			log::trace!("Overlay: Sending delete message for: {:?}", layer_id);
 			responses.push_back(DocumentMessage::Overlays(Operation::DeleteLayer { path: layer_id.clone() }.into()).into());
@@ -262,8 +261,8 @@ impl OverlayRenderer {
 	}
 
 	/// Sets the visibility of the handles overlay
-	fn set_anchor_overlay_visibility(anchor_overlays: &AnchorOverlays, visibility: bool, responses: &mut VecDeque<Message>) {
-		anchor_overlays.iter().flatten().for_each(|layer_id| {
+	fn set_manipulator_group_overlay_visibility(manipulator_group_overlays: &ManipulatorGroupOverlays, visibility: bool, responses: &mut VecDeque<Message>) {
+		manipulator_group_overlays.iter().flatten().for_each(|layer_id| {
 			responses.push_back(Self::overlay_visibility_message(layer_id.clone(), visibility));
 		});
 	}
@@ -291,21 +290,27 @@ impl OverlayRenderer {
 
 	/// Create an update message for an overlay
 	fn overlay_modify_message(layer_path: Vec<LayerId>, vector_path: Subpath) -> Message {
-		DocumentMessage::Overlays(Operation::SetShapePath { path: layer_path, vector_path }.into()).into()
+		DocumentMessage::Overlays(
+			Operation::SetShapePath {
+				path: layer_path,
+				subpath: vector_path,
+			}
+			.into(),
+		)
+		.into()
 	}
 
 	/// Sets the overlay style for this point
-	fn style_overlays(anchor: &ManipulatorGroup, overlays: &AnchorOverlays, responses: &mut VecDeque<Message>) {
+	fn style_overlays(group: &ManipulatorGroup, overlays: &ManipulatorGroupOverlays, responses: &mut VecDeque<Message>) {
 		// TODO Move the style definitions out of the VectorShape, should be looked up from a stylesheet or similar
 		let selected_style = style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, POINT_STROKE_WEIGHT + 1.0)), Fill::solid(COLOR_ACCENT));
 		let deselected_style = style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, POINT_STROKE_WEIGHT)), Fill::solid(Color::WHITE));
 
 		// Update if the anchor / handle points are shown as selected
 		// Here the index is important, even though overlays[..] has five elements we only care about the first three
-		for (index, point) in anchor.points.iter().enumerate() {
+		for (index, point) in group.points.iter().enumerate() {
 			if let Some(point) = point {
 				if let Some(overlay) = &overlays[index] {
-					// log::debug!("style_overlays: {:?}", &overlay);
 					let style = if point.editor_state.is_selected { selected_style.clone() } else { deselected_style.clone() };
 					responses.push_back(DocumentMessage::Overlays(Operation::SetLayerStyle { path: overlay.clone(), style }.into()).into());
 				}

--- a/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
+++ b/editor/src/viewport_tools/vector_editor/overlay_renderer.rs
@@ -302,7 +302,7 @@ impl OverlayRenderer {
 
 	/// Sets the overlay style for this point
 	fn style_overlays(group: &ManipulatorGroup, overlays: &ManipulatorGroupOverlays, responses: &mut VecDeque<Message>) {
-		// TODO Move the style definitions out of the VectorShape, should be looked up from a stylesheet or similar
+		// TODO Move the style definitions out of the Subpath, should be looked up from a stylesheet or similar
 		let selected_style = style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, POINT_STROKE_WEIGHT + 1.0)), Fill::solid(COLOR_ACCENT));
 		let deselected_style = style::PathStyle::new(Some(Stroke::new(COLOR_ACCENT, POINT_STROKE_WEIGHT)), Fill::solid(Color::WHITE));
 

--- a/editor/src/viewport_tools/vector_editor/shape_editor.rs
+++ b/editor/src/viewport_tools/vector_editor/shape_editor.rs
@@ -213,7 +213,7 @@ impl ShapeEditor {
 	}
 
 	/// Find a [ManipulatorPoint] that is within the selection threshold and return the layer path, an index to the [ManipulatorGroup], and an enum index for [ManipulatorPoint].
-	/// Return value is an `Option` of the tuple representing `(layer path, [ManipulatorGroup] ID, [ManipulatorType] enum index)`.
+	/// Return value is an `Option` of the tuple representing `(layer path, ManipulatorGroup ID, ManipulatorType enum index)`.
 	fn find_nearest_point_indices(&self, document: &Document, mouse_position: DVec2, select_threshold: f64) -> Option<(&[LayerId], u64, usize)> {
 		if self.selected_layers.is_empty() {
 			return None;

--- a/editor/src/viewport_tools/vector_editor/shape_editor.rs
+++ b/editor/src/viewport_tools/vector_editor/shape_editor.rs
@@ -1,12 +1,3 @@
-// Overview:
-//          ShapeEditor
-//         /          \
-//      selected_shape_layers <- Paths to selected layers that may contain Subpaths
-//        |               |
-//     Subpath   ...   Subpath  <- Reference from layer paths, one Subpath per layer (for now, will eventually be a CompoundPath)
-//      /                 \
-// ManipulatorGroup ... ManipulatorGroup <- Subpath contains many ManipulatorGroup
-
 use super::manipulator_group::ManipulatorGroup;
 use super::manipulator_point::ManipulatorPoint;
 use super::subpath::Subpath;
@@ -19,19 +10,29 @@ use glam::DVec2;
 use graphene::document::Document;
 use std::collections::VecDeque;
 
-/// ShapeEditor is the container for all of the layer paths that are
-/// represented as Subpaths and provides functionality required
-/// to query and create the Subpath / ManipulatorGroups / ManipulatorPoints
+/// ShapeEditor is the container for all of the layer paths that are represented as [Subpath]s and provides
+/// functionality required to query and create the [Subpath] / [ManipulatorGroup]s / [ManipulatorPoint]s.
+///
+/// Overview:
+/// ```text
+///              ShapeEditor
+///                   |
+///            selected_layers               <- Paths to selected layers that may contain Subpaths
+///              /    |    \
+///          Subpath ... Subpath             <- Reference from layer paths, one Subpath per layer (for now, will eventually be a CompoundPath)
+///            /      |      \
+/// ManipulatorGroup ... ManipulatorGroup    <- Subpath contains many ManipulatorGroups
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct ShapeEditor {
-	// The layers we can select and edit anchors / handles from
+	// The layers we can select and edit manipulators (anchors and handles) from
 	selected_layers: Vec<Vec<LayerId>>,
 }
 
-// TODO Consider keeping a list of selected anchors to minimize traversals of the layers
+// TODO Consider keeping a list of selected manipulators to minimize traversals of the layers
 impl ShapeEditor {
-	/// Select the first point within the selection threshold
-	/// Returns the points if found, none otherwise
+	/// Select the first point within the selection threshold.
+	/// Returns the points if found, None otherwise.
 	pub fn select_point(
 		&self,
 		document: &Document,
@@ -44,18 +45,18 @@ impl ShapeEditor {
 			return None;
 		}
 
-		if let Some((shape_layer_path, group_id, point_index)) = self.find_nearest_point_indicies(document, mouse_position, select_threshold) {
-			log::trace!("Selecting: anchor {} / point {}", group_id, point_index);
+		if let Some((shape_layer_path, manipulator_group_id, manipulator_point_index)) = self.find_nearest_point_indices(document, mouse_position, select_threshold) {
+			log::trace!("Selecting... manipulator group ID: {}, manipulator point index: {}", manipulator_group_id, manipulator_point_index);
 
 			// If the point we're selecting has already been selected
-			// we can assume this point exists.. since we did just click on it hense the unwrap
-			let is_point_selected = self.shape(document, shape_layer_path).unwrap().groups().by_id(group_id).unwrap().points[point_index]
+			// we can assume this point exists.. since we did just click on it hence the unwrap
+			let is_point_selected = self.shape(document, shape_layer_path).unwrap().manipulator_groups().by_id(manipulator_group_id).unwrap().points[manipulator_point_index]
 				.as_ref()
 				.unwrap()
 				.editor_state
 				.is_selected;
 
-			let point_position = self.shape(document, shape_layer_path).unwrap().groups().by_id(group_id).unwrap().points[point_index]
+			let point_position = self.shape(document, shape_layer_path).unwrap().manipulator_groups().by_id(manipulator_group_id).unwrap().points[manipulator_point_index]
 				.as_ref()
 				.unwrap()
 				.position;
@@ -68,10 +69,10 @@ impl ShapeEditor {
 				.filter_map(|(path, shape)| shape.as_subpath().map(|subpath| (path, subpath)))
 				.flat_map(|(path, shape)| {
 					shape
-						.groups()
+						.manipulator_groups()
 						.enumerate()
-						.filter(|(_id, group)| group.is_anchor_selected())
-						.flat_map(|(id, group)| group.selected_points().map(move |point| (id, point.manipulator_type)))
+						.filter(|(_id, manipulator_group)| manipulator_group.is_anchor_selected())
+						.flat_map(|(id, manipulator_group)| manipulator_group.selected_points().map(move |point| (id, point.manipulator_type)))
 						.map(|(anchor, manipulator_point)| (path.as_slice(), *anchor, manipulator_point))
 				})
 				.collect::<Vec<_>>();
@@ -79,12 +80,12 @@ impl ShapeEditor {
 			// Should we select or deselect the point?
 			let should_select = if is_point_selected { !add_to_selection } else { true };
 
-			// This is selecting the anchor only for now, next to generalize to points
+			// This is selecting the manipulator only for now, next to generalize to points
 			if should_select {
 				let add = add_to_selection || is_point_selected;
-				let point = (group_id, ManipulatorType::from_index(point_index));
+				let point = (manipulator_group_id, ManipulatorType::from_index(manipulator_point_index));
 				// Clear all point in other selected shapes
-				if !(add) {
+				if !add {
 					responses.push_back(DocumentMessage::DeselectAllManipulatorPoints.into());
 					points = vec![(shape_layer_path, point.0, point.1)];
 				} else {
@@ -106,11 +107,11 @@ impl ShapeEditor {
 				responses.push_back(
 					Operation::DeselectManipulatorPoints {
 						layer_path: shape_layer_path.to_vec(),
-						point_ids: vec![(group_id, ManipulatorType::from_index(point_index))],
+						point_ids: vec![(manipulator_group_id, ManipulatorType::from_index(manipulator_point_index))],
 					}
 					.into(),
 				);
-				points.retain(|x| *x != (shape_layer_path, group_id, ManipulatorType::from_index(point_index)))
+				points.retain(|x| *x != (shape_layer_path, manipulator_group_id, ManipulatorType::from_index(manipulator_point_index)))
 			}
 
 			return Some(points);
@@ -121,17 +122,17 @@ impl ShapeEditor {
 		None
 	}
 
-	/// A wrapper for find_nearest_point_indicies and returns a ManipulatorPoint
+	/// A wrapper for `find_nearest_point_indices()` and returns a [ManipulatorPoint].
 	pub fn find_nearest_point<'a>(&'a self, document: &'a Document, mouse_position: DVec2, select_threshold: f64) -> Option<&'a ManipulatorPoint> {
-		let (shape_layer_path, group_id, point_index) = self.find_nearest_point_indicies(document, mouse_position, select_threshold)?;
+		let (shape_layer_path, manipulator_group_id, manipulator_point_index) = self.find_nearest_point_indices(document, mouse_position, select_threshold)?;
 		let selected_shape = self.shape(document, shape_layer_path).unwrap();
-		if let Some(group) = selected_shape.groups().by_id(group_id) {
-			return group.points[point_index].as_ref();
+		if let Some(manipulator_group) = selected_shape.manipulator_groups().by_id(manipulator_group_id) {
+			return manipulator_group.points[manipulator_point_index].as_ref();
 		}
 		None
 	}
 
-	/// Set the shapes we consider for selection, we will choose draggable handles / anchors from these shapes.
+	/// Set the shapes we consider for selection, we will choose draggable manipulators from these shapes.
 	pub fn set_selected_layers(&mut self, target_layers: Vec<Vec<LayerId>>) {
 		self.selected_layers = target_layers;
 	}
@@ -144,7 +145,7 @@ impl ShapeEditor {
 		self.selected_layers.iter().map(|l| l.as_slice()).collect::<Vec<_>>()
 	}
 
-	/// Clear all of the shapes we can modify
+	/// Clear all of the shapes we can modify.
 	pub fn clear_selected_layers(&mut self) {
 		self.selected_layers.clear();
 	}
@@ -153,22 +154,22 @@ impl ShapeEditor {
 		!self.selected_layers.is_empty()
 	}
 
-	/// Provide the currently selected anchor by reference
-	pub fn selected_groups<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a ManipulatorGroup> {
-		self.iter(document).flat_map(|shape| shape.selected_groups())
+	/// Provide the currently selected manipulators by reference.
+	pub fn selected_manipulator_groups<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a ManipulatorGroup> {
+		self.iter(document).flat_map(|shape| shape.selected_manipulator_groups())
 	}
 
-	/// A mutable iterator of all the anchors, regardless of selection
-	pub fn groups<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a ManipulatorGroup> {
-		self.iter(document).flat_map(|shape| shape.groups().iter())
+	/// A mutable iterator of all the manipulators, regardless of selection.
+	pub fn manipulator_groups<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a ManipulatorGroup> {
+		self.iter(document).flat_map(|shape| shape.manipulator_groups().iter())
 	}
 
-	/// Provide the currently selected points by reference
+	/// Provide the currently selected points by reference.
 	pub fn selected_points<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a ManipulatorPoint> {
-		self.selected_groups(document).flat_map(|group| group.selected_points())
+		self.selected_manipulator_groups(document).flat_map(|manipulator_group| manipulator_group.selected_points())
 	}
 
-	/// Move the selected points by dragging the moue
+	/// Move the selected points by dragging the mouse.
 	pub fn move_selected_points(&self, delta: DVec2, absolute_position: DVec2, responses: &mut VecDeque<Message>) {
 		for layer_path in &self.selected_layers {
 			responses.push_back(
@@ -182,12 +183,12 @@ impl ShapeEditor {
 		}
 	}
 
-	/// Dissolve the selected points
+	/// Dissolve the selected points.
 	pub fn delete_selected_points(&self, responses: &mut VecDeque<Message>) {
 		responses.push_back(DocumentMessage::DeleteSelectedManipulatorPoints.into());
 	}
 
-	/// Toggle if the handles should mirror angle across the anchor positon
+	/// Toggle if the handles should mirror angle across the anchor position.
 	pub fn toggle_handle_mirroring_on_selected(&self, toggle_angle: bool, toggle_distance: bool, responses: &mut VecDeque<Message>) {
 		for layer_path in &self.selected_layers {
 			responses.push_back(
@@ -201,18 +202,19 @@ impl ShapeEditor {
 		}
 	}
 
-	/// Deselect all anchors from the shapes the manipulation handler has created
+	/// Deselect all manipulators from the shapes that the manipulation handler has created.
 	pub fn deselect_all_points(&self, responses: &mut VecDeque<Message>) {
 		responses.push_back(DocumentMessage::DeselectAllManipulatorPoints.into());
 	}
 
-	/// Iterate over the shapes
+	/// Iterate over the shapes.
 	pub fn iter<'a>(&'a self, document: &'a Document) -> impl Iterator<Item = &'a Subpath> + 'a {
 		self.selected_layers.iter().flat_map(|layer_id| document.layer(layer_id)).filter_map(|shape| shape.as_subpath())
 	}
 
-	/// Find a point that is within the selection threshold and return an index to the shape, anchor, and point
-	fn find_nearest_point_indicies(&self, document: &Document, mouse_position: DVec2, select_threshold: f64) -> Option<(&[LayerId], u64, usize)> {
+	/// Find a point that is within the selection threshold and return an index to the shape, manipulator, and point.
+	/// Return value is an `Option` of the tuple representing `(layer path, manipulator ID, manipulator point index)`.
+	fn find_nearest_point_indices(&self, document: &Document, mouse_position: DVec2, select_threshold: f64) -> Option<(&[LayerId], u64, usize)> {
 		if self.selected_layers.is_empty() {
 			return None;
 		}
@@ -220,34 +222,36 @@ impl ShapeEditor {
 		let select_threshold_squared = select_threshold * select_threshold;
 		// Find the closest control point among all elements of shapes_to_modify
 		for layer in self.selected_layers.iter() {
-			if let Some((anchor_id, point_index, distance_squared)) = self.closest_point_in_layer(document, layer, mouse_position) {
+			if let Some((manipulator_id, manipulator_point_index, distance_squared)) = self.closest_point_in_layer(document, layer, mouse_position) {
 				// Choose the first point under the threshold
 				if distance_squared < select_threshold_squared {
-					log::trace!("Selecting: anchor {} / point {}", anchor_id, point_index);
-					return Some((layer, anchor_id, point_index));
+					log::trace!("Selecting... manipulator ID: {}, manipulator point index: {}", manipulator_id, manipulator_point_index);
+					return Some((layer, manipulator_id, manipulator_point_index));
 				}
 			}
 		}
+
 		None
 	}
 
 	// TODO Use quadtree or some equivalent spatial acceleration structure to improve this to O(log(n))
-	/// Find the closest point, anchor and distance so we can select path elements
-	/// Brute force comparison to determine which handle / anchor we want to select, O(n)
+	/// Find the closest manipulator, manipulator point, and distance so we can select path elements.
+	/// Brute force comparison to determine which manipulator (handle or anchor) we want to select taking O(n) time.
+	/// Return value is an `Option` of the tuple representing `(manipulator ID, manipulator point index, distance squared)`.
 	fn closest_point_in_layer(&self, document: &Document, layer_path: &[LayerId], pos: glam::DVec2) -> Option<(u64, usize, f64)> {
 		let mut closest_distance_squared: f64 = f64::MAX; // Not ideal
 		let mut result: Option<(u64, usize, f64)> = None;
 
 		if let Some(shape) = document.layer(layer_path).ok()?.as_subpath() {
 			let viewspace = document.generate_transform_relative_to_viewport(layer_path).ok()?;
-			for (anchor_id, anchor) in shape.groups().enumerate() {
-				let point_index = anchor.closest_point(&viewspace, pos);
-				if let Some(point) = &anchor.points[point_index] {
+			for (manipulator_id, manipulator) in shape.manipulator_groups().enumerate() {
+				let manipulator_point_index = manipulator.closest_point(&viewspace, pos);
+				if let Some(point) = &manipulator.points[manipulator_point_index] {
 					if point.editor_state.can_be_selected {
 						let distance_squared = viewspace.transform_point2(point.position).distance_squared(pos);
 						if distance_squared < closest_distance_squared {
 							closest_distance_squared = distance_squared;
-							result = Some((*anchor_id, point_index, distance_squared));
+							result = Some((*manipulator_id, manipulator_point_index, distance_squared));
 						}
 					}
 				}

--- a/editor/src/viewport_tools/vector_editor/shape_editor.rs
+++ b/editor/src/viewport_tools/vector_editor/shape_editor.rs
@@ -212,8 +212,8 @@ impl ShapeEditor {
 		self.selected_layers.iter().flat_map(|layer_id| document.layer(layer_id)).filter_map(|shape| shape.as_subpath())
 	}
 
-	/// Find a point that is within the selection threshold and return an index to the shape, manipulator, and point.
-	/// Return value is an `Option` of the tuple representing `(layer path, manipulator ID, manipulator point index)`.
+	/// Find a [ManipulatorPoint] that is within the selection threshold and return the layer path, an index to the [ManipulatorGroup], and an enum index for [ManipulatorPoint].
+	/// Return value is an `Option` of the tuple representing `(layer path, [ManipulatorGroup] ID, [ManipulatorType] enum index)`.
 	fn find_nearest_point_indices(&self, document: &Document, mouse_position: DVec2, select_threshold: f64) -> Option<(&[LayerId], u64, usize)> {
 		if self.selected_layers.is_empty() {
 			return None;

--- a/graphene/src/boolean_ops.rs
+++ b/graphene/src/boolean_ops.rs
@@ -535,7 +535,7 @@ pub fn composite_boolean_operation(mut select: BooleanOperation, shapes: &mut Ve
 // TODO: check if shapes are filled
 // TODO: Bug: shape with at least two subpaths and comprised of many unions sometimes has erroneous movetos embedded in edges
 pub fn boolean_operation(mut select: BooleanOperation, alpha: &mut ShapeLayer, beta: &mut ShapeLayer) -> Result<Vec<ShapeLayer>, BooleanOperationError> {
-	if alpha.shape.anchors().is_empty() || beta.shape.anchors().is_empty() {
+	if alpha.shape.groups().is_empty() || beta.shape.groups().is_empty() {
 		return Err(BooleanOperationError::InvalidSelection);
 	}
 	if select == BooleanOperation::SubtractBack {

--- a/graphene/src/boolean_ops.rs
+++ b/graphene/src/boolean_ops.rs
@@ -535,7 +535,7 @@ pub fn composite_boolean_operation(mut select: BooleanOperation, shapes: &mut Ve
 // TODO: check if shapes are filled
 // TODO: Bug: shape with at least two subpaths and comprised of many unions sometimes has erroneous movetos embedded in edges
 pub fn boolean_operation(mut select: BooleanOperation, alpha: &mut ShapeLayer, beta: &mut ShapeLayer) -> Result<Vec<ShapeLayer>, BooleanOperationError> {
-	if alpha.shape.groups().is_empty() || beta.shape.groups().is_empty() {
+	if alpha.shape.manipulator_groups().is_empty() || beta.shape.manipulator_groups().is_empty() {
 		return Err(BooleanOperationError::InvalidSelection);
 	}
 	if select == BooleanOperation::SubtractBack {

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -126,27 +126,27 @@ impl Document {
 		Ok(shapes)
 	}
 
-	/// Return a copy of all VectorShapes currently in the document.
+	/// Return a copy of all Subpaths currently in the document.
 	pub fn all_subpaths(&self) -> Vec<Subpath> {
 		self.root.iter().flat_map(|layer| layer.as_subpath_copy()).collect::<Vec<Subpath>>()
 	}
 
-	/// Returns references to all VectorShapes currently in the document.
+	/// Returns references to all Subpaths currently in the document.
 	pub fn all_subpaths_ref(&self) -> Vec<&Subpath> {
 		self.root.iter().flat_map(|layer| layer.as_subpath()).collect::<Vec<&Subpath>>()
 	}
 
-	/// Returns a reference to the requested VectorShape by providing a path to its owner layer.
+	/// Returns a reference to the requested Subpath by providing a path to its owner layer.
 	pub fn subpath_ref<'a>(&'a self, path: &[LayerId]) -> Option<&'a Subpath> {
 		self.layer(path).ok()?.as_subpath()
 	}
 
-	/// Returns a mutable reference of the requested VectorShape by providing a path to its owner layer.
+	/// Returns a mutable reference of the requested Subpath by providing a path to its owner layer.
 	pub fn subpath_mut<'a>(&'a mut self, path: &'a [LayerId]) -> Option<&'a mut Subpath> {
 		self.layer_mut(path).ok()?.as_subpath_mut()
 	}
 
-	/// Set a VectorShape at the specified path.
+	/// Set a Subpath at the specified path.
 	pub fn set_subpath(&mut self, path: &[LayerId], shape: Subpath) {
 		let layer = self.layer_mut(path);
 		if let Ok(layer) = layer {
@@ -158,7 +158,7 @@ impl Document {
 		}
 	}
 
-	/// Set VectorShapes for multiple paths at once.
+	/// Set Subpaths for multiple paths at once.
 	pub fn set_subpaths<'a>(&'a mut self, paths: impl Iterator<Item = &'a [LayerId]>, shapes: Vec<Subpath>) {
 		paths.zip(shapes).for_each(|(path, shape)| self.set_subpath(path, shape));
 	}

--- a/graphene/src/intersection.rs
+++ b/graphene/src/intersection.rs
@@ -1,6 +1,6 @@
 use crate::boolean_ops::{split_path_seg, subdivide_path_seg};
 use crate::consts::{F64LOOSE, F64PRECISE};
-use crate::layers::vector::vector_shape::VectorShape;
+use crate::layers::vector::subpath::Subpath;
 
 use glam::{DAffine2, DMat2, DVec2};
 use kurbo::{BezPath, CubicBez, Line, ParamCurve, ParamCurveDeriv, ParamCurveExtrema, PathSeg, Point, QuadBez, Rect, Shape, Vec2};
@@ -40,8 +40,8 @@ impl Quad {
 	}
 
 	/// Generates a [VectorShape] of the quad
-	pub fn vector_shape(&self) -> VectorShape {
-		VectorShape::from_points(self.0.into_iter(), true)
+	pub fn vector_shape(&self) -> Subpath {
+		Subpath::from_points(self.0.into_iter(), true)
 	}
 
 	/// Generates the axis aligned bounding box of the quad

--- a/graphene/src/intersection.rs
+++ b/graphene/src/intersection.rs
@@ -39,8 +39,8 @@ impl Quad {
 		path
 	}
 
-	/// Generates a [VectorShape] of the quad
-	pub fn vector_shape(&self) -> Subpath {
+	/// Generates a [subpath] of the quad
+	pub fn subpath(&self) -> Subpath {
 		Subpath::from_points(self.0.into_iter(), true)
 	}
 

--- a/graphene/src/layers/id_vec.rs
+++ b/graphene/src/layers/id_vec.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 /// - Access data by providing Unique ID.
 /// - Maintain ordering among the elements.
 /// - Remove elements without changing Unique IDs.
-/// This data structure is somewhat similar to a linked list in terms of invarients.
+/// This data structure is somewhat similar to a linked list in terms of invariants.
 /// The downside is that currently it requires a lot of iteration.
 
 type ElementId = u64;
@@ -54,7 +54,7 @@ impl<T> IdBackedVec<T> {
 	}
 
 	/// Push an element to the end of the vector
-	/// Overriden from Vec, so adding values without creating an id cannot occur
+	/// Overridden from Vec, so adding values without creating an id cannot occur
 	pub fn push(&mut self, element: T) -> Option<ElementId> {
 		self.push_end(element)
 	}

--- a/graphene/src/layers/layer_info.rs
+++ b/graphene/src/layers/layer_info.rs
@@ -372,21 +372,21 @@ impl Layer {
 		}
 	}
 
-	pub fn as_vector_shape(&self) -> Option<&Subpath> {
+	pub fn as_subpath(&self) -> Option<&Subpath> {
 		match &self.data {
 			LayerDataType::Shape(s) => Some(&s.shape),
 			_ => None,
 		}
 	}
 
-	pub fn as_vector_shape_copy(&self) -> Option<Subpath> {
+	pub fn as_subpath_copy(&self) -> Option<Subpath> {
 		match &self.data {
 			LayerDataType::Shape(s) => Some(s.shape.clone()),
 			_ => None,
 		}
 	}
 
-	pub fn as_vector_shape_mut(&mut self) -> Option<&mut Subpath> {
+	pub fn as_subpath_mut(&mut self) -> Option<&mut Subpath> {
 		match &mut self.data {
 			LayerDataType::Shape(s) => Some(&mut s.shape),
 			_ => None,

--- a/graphene/src/layers/layer_info.rs
+++ b/graphene/src/layers/layer_info.rs
@@ -4,7 +4,7 @@ use super::image_layer::ImageLayer;
 use super::shape_layer::ShapeLayer;
 use super::style::{PathStyle, RenderData};
 use super::text_layer::TextLayer;
-use super::vector::vector_shape::VectorShape;
+use super::vector::subpath::Subpath;
 use crate::intersection::Quad;
 use crate::layers::text_layer::FontCache;
 use crate::DocumentError;
@@ -372,21 +372,21 @@ impl Layer {
 		}
 	}
 
-	pub fn as_vector_shape(&self) -> Option<&VectorShape> {
+	pub fn as_vector_shape(&self) -> Option<&Subpath> {
 		match &self.data {
 			LayerDataType::Shape(s) => Some(&s.shape),
 			_ => None,
 		}
 	}
 
-	pub fn as_vector_shape_copy(&self) -> Option<VectorShape> {
+	pub fn as_vector_shape_copy(&self) -> Option<Subpath> {
 		match &self.data {
 			LayerDataType::Shape(s) => Some(s.shape.clone()),
 			_ => None,
 		}
 	}
 
-	pub fn as_vector_shape_mut(&mut self) -> Option<&mut VectorShape> {
+	pub fn as_vector_shape_mut(&mut self) -> Option<&mut Subpath> {
 		match &mut self.data {
 			LayerDataType::Shape(s) => Some(&mut s.shape),
 			_ => None,

--- a/graphene/src/layers/layer_info.rs
+++ b/graphene/src/layers/layer_info.rs
@@ -333,26 +333,26 @@ impl Layer {
 	///
 	/// // Apply the Identity transform, which leaves the points unchanged
 	/// assert_eq!(
-	///     layer.aabounding_box_for_transform(DAffine2::IDENTITY, &Default::default()),
+	///     layer.aabb_for_transform(DAffine2::IDENTITY, &Default::default()),
 	///     Some([DVec2::ZERO, DVec2::ONE]),
 	/// );
 	///
 	/// // Apply a transform that scales every point by a factor of two
 	/// let transform = DAffine2::from_scale(DVec2::ONE * 2.);
 	/// assert_eq!(
-	///     layer.aabounding_box_for_transform(transform, &Default::default()),
+	///     layer.aabb_for_transform(transform, &Default::default()),
 	///     Some([DVec2::ZERO, DVec2::ONE * 2.]),
 	/// );
-	pub fn aabounding_box_for_transform(&self, transform: DAffine2, font_cache: &FontCache) -> Option<[DVec2; 2]> {
+	pub fn aabb_for_transform(&self, transform: DAffine2, font_cache: &FontCache) -> Option<[DVec2; 2]> {
 		self.data.bounding_box(transform, font_cache)
 	}
 
-	pub fn aabounding_box(&self, font_cache: &FontCache) -> Option<[DVec2; 2]> {
-		self.aabounding_box_for_transform(self.transform, font_cache)
+	pub fn aabb(&self, font_cache: &FontCache) -> Option<[DVec2; 2]> {
+		self.aabb_for_transform(self.transform, font_cache)
 	}
 
 	pub fn bounding_transform(&self, font_cache: &FontCache) -> DAffine2 {
-		let scale = match self.aabounding_box_for_transform(DAffine2::IDENTITY, font_cache) {
+		let scale = match self.aabb_for_transform(DAffine2::IDENTITY, font_cache) {
 			Some([a, b]) => {
 				let dimensions = b - a;
 				DAffine2::from_scale(dimensions)

--- a/graphene/src/layers/shape_layer.rs
+++ b/graphene/src/layers/shape_layer.rs
@@ -69,7 +69,7 @@ impl LayerData for ShapeLayer {
 	}
 
 	fn intersects_quad(&self, quad: Quad, path: &mut Vec<LayerId>, intersections: &mut Vec<Vec<LayerId>>, _font_cache: &FontCache) {
-		let filled = self.style.fill().is_some() || self.shape.groups().last().filter(|anchor| anchor.is_close()).is_some();
+		let filled = self.style.fill().is_some() || self.shape.manipulator_groups().last().filter(|manipulator_group| manipulator_group.is_close()).is_some();
 		if intersect_quad_bez_path(quad, &(&self.shape).into(), filled) {
 			intersections.push(path.clone());
 		}

--- a/graphene/src/layers/shape_layer.rs
+++ b/graphene/src/layers/shape_layer.rs
@@ -27,9 +27,9 @@ pub struct ShapeLayer {
 
 impl LayerData for ShapeLayer {
 	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) {
-		let mut vector_shape = self.shape.clone();
+		let mut subpath = self.shape.clone();
 
-		let kurbo::Rect { x0, y0, x1, y1 } = vector_shape.bounding_box();
+		let kurbo::Rect { x0, y0, x1, y1 } = subpath.bounding_box();
 		let layer_bounds = [(x0, y0).into(), (x1, y1).into()];
 
 		let transform = self.transform(transforms, render_data.view_mode);
@@ -38,9 +38,9 @@ impl LayerData for ShapeLayer {
 			let _ = write!(svg, "<!-- SVG shape has an invalid transform -->");
 			return;
 		}
-		vector_shape.apply_affine(transform);
+		subpath.apply_affine(transform);
 
-		let kurbo::Rect { x0, y0, x1, y1 } = vector_shape.bounding_box();
+		let kurbo::Rect { x0, y0, x1, y1 } = subpath.bounding_box();
 		let transformed_bounds = [(x0, y0).into(), (x1, y1).into()];
 
 		let _ = writeln!(svg, r#"<g transform="matrix("#);
@@ -51,20 +51,20 @@ impl LayerData for ShapeLayer {
 		let _ = write!(
 			svg,
 			r#"<path d="{}" {} />"#,
-			vector_shape.to_svg(),
+			subpath.to_svg(),
 			self.style.render(render_data.view_mode, svg_defs, transform, layer_bounds, transformed_bounds)
 		);
 		let _ = svg.write_str("</g>");
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {
-		let mut vector_shape = self.shape.clone();
+		let mut subpath = self.shape.clone();
 		if transform.matrix2 == DMat2::ZERO {
 			return None;
 		}
-		vector_shape.apply_affine(transform);
+		subpath.apply_affine(transform);
 
-		let kurbo::Rect { x0, y0, x1, y1 } = vector_shape.bounding_box();
+		let kurbo::Rect { x0, y0, x1, y1 } = subpath.bounding_box();
 		Some([(x0, y0).into(), (x1, y1).into()])
 	}
 

--- a/graphene/src/layers/shape_layer.rs
+++ b/graphene/src/layers/shape_layer.rs
@@ -77,7 +77,7 @@ impl LayerData for ShapeLayer {
 }
 
 impl ShapeLayer {
-	/// Construct a new [ShapeLayer] with the specified [VectorShape] and [PathStyle]
+	/// Construct a new [ShapeLayer] with the specified [Subpath] and [PathStyle]
 	pub fn new(shape: Subpath, style: PathStyle) -> Self {
 		Self { shape, style, render_index: 1 }
 	}

--- a/graphene/src/layers/shape_layer.rs
+++ b/graphene/src/layers/shape_layer.rs
@@ -1,6 +1,6 @@
 use super::layer_info::LayerData;
 use super::style::{self, PathStyle, RenderData, ViewMode};
-use super::vector::vector_shape::VectorShape;
+use super::vector::subpath::Subpath;
 use crate::intersection::{intersect_quad_bez_path, Quad};
 use crate::layers::text_layer::FontCache;
 use crate::LayerId;
@@ -18,7 +18,7 @@ use std::fmt::Write;
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ShapeLayer {
 	/// The geometry of the layer.
-	pub shape: VectorShape,
+	pub shape: Subpath,
 	/// The visual style of the shape.
 	pub style: style::PathStyle,
 	// TODO: We might be able to remove this in a future refactor
@@ -69,7 +69,7 @@ impl LayerData for ShapeLayer {
 	}
 
 	fn intersects_quad(&self, quad: Quad, path: &mut Vec<LayerId>, intersections: &mut Vec<Vec<LayerId>>, _font_cache: &FontCache) {
-		let filled = self.style.fill().is_some() || self.shape.anchors().last().filter(|anchor| anchor.is_close()).is_some();
+		let filled = self.style.fill().is_some() || self.shape.groups().last().filter(|anchor| anchor.is_close()).is_some();
 		if intersect_quad_bez_path(quad, &(&self.shape).into(), filled) {
 			intersections.push(path.clone());
 		}
@@ -78,7 +78,7 @@ impl LayerData for ShapeLayer {
 
 impl ShapeLayer {
 	/// Construct a new [ShapeLayer] with the specified [VectorShape] and [PathStyle]
-	pub fn new(shape: VectorShape, style: PathStyle) -> Self {
+	pub fn new(shape: Subpath, style: PathStyle) -> Self {
 		Self { shape, style, render_index: 1 }
 	}
 
@@ -122,7 +122,7 @@ impl ShapeLayer {
 		path.close_path();
 
 		Self {
-			shape: VectorShape::new_ngon(DVec2::new(0., 0.), sides.into(), 1.),
+			shape: Subpath::new_ngon(DVec2::new(0., 0.), sides.into(), 1.),
 			style,
 			render_index: 1,
 		}
@@ -131,7 +131,7 @@ impl ShapeLayer {
 	/// Create a rectangular shape.
 	pub fn rectangle(style: PathStyle) -> Self {
 		Self {
-			shape: VectorShape::new_rect(DVec2::new(0., 0.), DVec2::new(1., 1.)),
+			shape: Subpath::new_rect(DVec2::new(0., 0.), DVec2::new(1., 1.)),
 			style,
 			render_index: 1,
 		}
@@ -140,7 +140,7 @@ impl ShapeLayer {
 	/// Create an elliptical shape.
 	pub fn ellipse(style: PathStyle) -> Self {
 		Self {
-			shape: VectorShape::new_ellipse(DVec2::new(0., 0.), DVec2::new(1., 1.)),
+			shape: Subpath::new_ellipse(DVec2::new(0., 0.), DVec2::new(1., 1.)),
 			style,
 			render_index: 1,
 		}
@@ -149,7 +149,7 @@ impl ShapeLayer {
 	/// Create a straight line from (0, 0) to (1, 0).
 	pub fn line(style: PathStyle) -> Self {
 		Self {
-			shape: VectorShape::new_line(DVec2::new(0., 0.), DVec2::new(1., 0.)),
+			shape: Subpath::new_line(DVec2::new(0., 0.), DVec2::new(1., 0.)),
 			style,
 			render_index: 1,
 		}
@@ -158,7 +158,7 @@ impl ShapeLayer {
 	/// Create a polygonal line that visits each provided point.
 	pub fn poly_line(points: Vec<impl Into<glam::DVec2>>, style: PathStyle) -> Self {
 		Self {
-			shape: VectorShape::new_poly_line(points),
+			shape: Subpath::new_poly_line(points),
 			style,
 			render_index: 0,
 		}
@@ -168,7 +168,7 @@ impl ShapeLayer {
 	/// The algorithm used in this implementation is described here: <https://www.particleincell.com/2012/bezier-splines/>
 	pub fn spline(points: Vec<impl Into<glam::DVec2>>, style: PathStyle) -> Self {
 		Self {
-			shape: VectorShape::new_spline(points),
+			shape: Subpath::new_spline(points),
 			style,
 			render_index: 0,
 		}

--- a/graphene/src/layers/text_layer.rs
+++ b/graphene/src/layers/text_layer.rs
@@ -139,7 +139,7 @@ impl TextLayer {
 	/// Converts to a [Subpath], populating the cache if necessary.
 	#[inline]
 	pub fn to_subpath(&mut self, buzz_face: Option<Face>) -> Subpath {
-		if self.cached_path.as_ref().filter(|x| !x.groups().is_empty()).is_none() {
+		if self.cached_path.as_ref().filter(|subpath| !subpath.manipulator_groups().is_empty()).is_none() {
 			let path = self.generate_path(buzz_face);
 			self.cached_path = Some(path.clone());
 			return path;
@@ -152,7 +152,10 @@ impl TextLayer {
 	pub fn to_subpath_nonmut(&self, font_cache: &FontCache) -> Subpath {
 		let buzz_face = self.load_face(font_cache);
 
-		self.cached_path.clone().filter(|x| !x.groups().is_empty()).unwrap_or_else(|| self.generate_path(buzz_face))
+		self.cached_path
+			.clone()
+			.filter(|subpath| !subpath.manipulator_groups().is_empty())
+			.unwrap_or_else(|| self.generate_path(buzz_face))
 	}
 
 	#[inline]

--- a/graphene/src/layers/text_layer.rs
+++ b/graphene/src/layers/text_layer.rs
@@ -149,7 +149,7 @@ impl TextLayer {
 
 	/// Converts to a [VectorShape], without populating the cache.
 	#[inline]
-	pub fn to_vector_path_nonmut(&self, font_cache: &FontCache) -> Subpath {
+	pub fn to_subpath_nonmut(&self, font_cache: &FontCache) -> Subpath {
 		let buzz_face = self.load_face(font_cache);
 
 		self.cached_path.clone().filter(|x| !x.groups().is_empty()).unwrap_or_else(|| self.generate_path(buzz_face))

--- a/graphene/src/layers/text_layer.rs
+++ b/graphene/src/layers/text_layer.rs
@@ -68,7 +68,7 @@ impl LayerData for TextLayer {
 		} else {
 			let buzz_face = self.load_face(render_data.font_cache);
 
-			let mut path = self.to_vector_path(buzz_face);
+			let mut path = self.to_subpath(buzz_face);
 
 			let kurbo::Rect { x0, y0, x1, y1 } = path.bounding_box();
 			let bounds = [(x0, y0).into(), (x1, y1).into()];
@@ -136,9 +136,9 @@ impl TextLayer {
 		new
 	}
 
-	/// Converts to a [VectorShape], populating the cache if necessary.
+	/// Converts to a [Subpath], populating the cache if necessary.
 	#[inline]
-	pub fn to_vector_path(&mut self, buzz_face: Option<Face>) -> Subpath {
+	pub fn to_subpath(&mut self, buzz_face: Option<Face>) -> Subpath {
 		if self.cached_path.as_ref().filter(|x| !x.groups().is_empty()).is_none() {
 			let path = self.generate_path(buzz_face);
 			self.cached_path = Some(path.clone());
@@ -147,7 +147,7 @@ impl TextLayer {
 		self.cached_path.clone().unwrap()
 	}
 
-	/// Converts to a [VectorShape], without populating the cache.
+	/// Converts to a [Subpath], without populating the cache.
 	#[inline]
 	pub fn to_subpath_nonmut(&self, font_cache: &FontCache) -> Subpath {
 		let buzz_face = self.load_face(font_cache);

--- a/graphene/src/layers/text_layer.rs
+++ b/graphene/src/layers/text_layer.rs
@@ -1,6 +1,6 @@
 use super::layer_info::LayerData;
 use super::style::{PathStyle, RenderData, ViewMode};
-use super::vector::vector_shape::VectorShape;
+use super::vector::subpath::Subpath;
 use crate::intersection::{intersect_quad_bez_path, Quad};
 use crate::LayerId;
 pub use font_cache::{Font, FontCache};
@@ -29,7 +29,7 @@ pub struct TextLayer {
 	#[serde(skip)]
 	pub editable: bool,
 	#[serde(skip)]
-	pub cached_path: Option<VectorShape>,
+	pub cached_path: Option<Subpath>,
 }
 
 impl LayerData for TextLayer {
@@ -138,8 +138,8 @@ impl TextLayer {
 
 	/// Converts to a [VectorShape], populating the cache if necessary.
 	#[inline]
-	pub fn to_vector_path(&mut self, buzz_face: Option<Face>) -> VectorShape {
-		if self.cached_path.as_ref().filter(|x| !x.anchors().is_empty()).is_none() {
+	pub fn to_vector_path(&mut self, buzz_face: Option<Face>) -> Subpath {
+		if self.cached_path.as_ref().filter(|x| !x.groups().is_empty()).is_none() {
 			let path = self.generate_path(buzz_face);
 			self.cached_path = Some(path.clone());
 			return path;
@@ -149,14 +149,14 @@ impl TextLayer {
 
 	/// Converts to a [VectorShape], without populating the cache.
 	#[inline]
-	pub fn to_vector_path_nonmut(&self, font_cache: &FontCache) -> VectorShape {
+	pub fn to_vector_path_nonmut(&self, font_cache: &FontCache) -> Subpath {
 		let buzz_face = self.load_face(font_cache);
 
-		self.cached_path.clone().filter(|x| !x.anchors().is_empty()).unwrap_or_else(|| self.generate_path(buzz_face))
+		self.cached_path.clone().filter(|x| !x.groups().is_empty()).unwrap_or_else(|| self.generate_path(buzz_face))
 	}
 
 	#[inline]
-	pub fn generate_path(&self, buzz_face: Option<Face>) -> VectorShape {
+	pub fn generate_path(&self, buzz_face: Option<Face>) -> Subpath {
 		to_path::to_path(&self.text, buzz_face, self.size, self.line_width)
 	}
 

--- a/graphene/src/layers/text_layer/to_path.rs
+++ b/graphene/src/layers/text_layer/to_path.rs
@@ -24,32 +24,32 @@ impl Builder {
 impl OutlineBuilder for Builder {
 	fn move_to(&mut self, x: f32, y: f32) {
 		let anchor = self.point(x, y);
-		if self.path.groups().last().filter(|el| el.points.iter().any(Option::is_some)).is_some() {
-			self.path.groups_mut().push_end(ManipulatorGroup::closed());
+		if self.path.manipulator_groups().last().filter(|el| el.points.iter().any(Option::is_some)).is_some() {
+			self.path.manipulator_groups_mut().push_end(ManipulatorGroup::closed());
 		}
-		self.path.groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
+		self.path.manipulator_groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
 	}
 
 	fn line_to(&mut self, x: f32, y: f32) {
 		let anchor = self.point(x, y);
-		self.path.groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
+		self.path.manipulator_groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
 	}
 
 	fn quad_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32) {
 		let [handle, anchor] = [self.point(x1, y1), self.point(x2, y2)];
-		self.path.groups_mut().last_mut().unwrap().points[ManipulatorType::OutHandle] = Some(ManipulatorPoint::new(handle, ManipulatorType::OutHandle));
-		self.path.groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
+		self.path.manipulator_groups_mut().last_mut().unwrap().points[ManipulatorType::OutHandle] = Some(ManipulatorPoint::new(handle, ManipulatorType::OutHandle));
+		self.path.manipulator_groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
 	}
 
 	fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) {
 		let [handle1, handle2, anchor] = [self.point(x1, y1), self.point(x2, y2), self.point(x3, y3)];
-		self.path.groups_mut().last_mut().unwrap().points[ManipulatorType::OutHandle] = Some(ManipulatorPoint::new(handle1, ManipulatorType::OutHandle));
-		self.path.groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
-		self.path.groups_mut().last_mut().unwrap().points[ManipulatorType::InHandle] = Some(ManipulatorPoint::new(handle2, ManipulatorType::InHandle));
+		self.path.manipulator_groups_mut().last_mut().unwrap().points[ManipulatorType::OutHandle] = Some(ManipulatorPoint::new(handle1, ManipulatorType::OutHandle));
+		self.path.manipulator_groups_mut().push_end(ManipulatorGroup::new_with_anchor(anchor));
+		self.path.manipulator_groups_mut().last_mut().unwrap().points[ManipulatorType::InHandle] = Some(ManipulatorPoint::new(handle2, ManipulatorType::InHandle));
 	}
 
 	fn close(&mut self) {
-		self.path.groups_mut().push_end(ManipulatorGroup::closed());
+		self.path.manipulator_groups_mut().push_end(ManipulatorGroup::closed());
 	}
 }
 

--- a/graphene/src/layers/vector/constants.rs
+++ b/graphene/src/layers/vector/constants.rs
@@ -1,4 +1,4 @@
-use std::ops::{Index, IndexMut, Not};
+use std::ops::{Index, IndexMut};
 
 use serde::{Deserialize, Serialize};
 

--- a/graphene/src/layers/vector/constants.rs
+++ b/graphene/src/layers/vector/constants.rs
@@ -39,7 +39,7 @@ impl<T> Index<ManipulatorType> for [T; 3] {
 		&self[mt as usize]
 	}
 }
-// Allows us to use ControlPointType for indexing, mutably
+// Allows us to use ManipulatorType for indexing, mutably
 impl<T> IndexMut<ManipulatorType> for [T; 3] {
 	fn index_mut(&mut self, mt: ManipulatorType) -> &mut T {
 		&mut self[mt as usize]

--- a/graphene/src/layers/vector/constants.rs
+++ b/graphene/src/layers/vector/constants.rs
@@ -4,44 +4,44 @@ use serde::{Deserialize, Serialize};
 
 #[repr(usize)]
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Serialize, Deserialize)]
-pub enum ControlPointType {
+pub enum ManipulatorType {
 	Anchor = 0,
 	InHandle = 1,
 	OutHandle = 2,
 }
 
-impl ControlPointType {
-	pub fn from_index(index: usize) -> ControlPointType {
+impl ManipulatorType {
+	pub fn from_index(index: usize) -> ManipulatorType {
 		match index {
-			0 => ControlPointType::Anchor,
-			1 => ControlPointType::InHandle,
-			2 => ControlPointType::OutHandle,
-			_ => ControlPointType::Anchor,
+			0 => ManipulatorType::Anchor,
+			1 => ManipulatorType::InHandle,
+			2 => ManipulatorType::OutHandle,
+			_ => ManipulatorType::Anchor,
 		}
 	}
 }
 
-impl Not for ControlPointType {
+impl Not for ManipulatorType {
 	type Output = Self;
 	fn not(self) -> Self::Output {
 		match self {
-			ControlPointType::InHandle => ControlPointType::OutHandle,
-			ControlPointType::OutHandle => ControlPointType::InHandle,
-			_ => ControlPointType::Anchor,
+			ManipulatorType::InHandle => ManipulatorType::OutHandle,
+			ManipulatorType::OutHandle => ManipulatorType::InHandle,
+			_ => ManipulatorType::Anchor,
 		}
 	}
 }
 
 // Allows us to use ManipulatorType for indexing
-impl<T> Index<ControlPointType> for [T; 3] {
+impl<T> Index<ManipulatorType> for [T; 3] {
 	type Output = T;
-	fn index(&self, mt: ControlPointType) -> &T {
+	fn index(&self, mt: ManipulatorType) -> &T {
 		&self[mt as usize]
 	}
 }
 // Allows us to use ControlPointType for indexing, mutably
-impl<T> IndexMut<ControlPointType> for [T; 3] {
-	fn index_mut(&mut self, mt: ControlPointType) -> &mut T {
+impl<T> IndexMut<ManipulatorType> for [T; 3] {
+	fn index_mut(&mut self, mt: ManipulatorType) -> &mut T {
 		&mut self[mt as usize]
 	}
 }

--- a/graphene/src/layers/vector/constants.rs
+++ b/graphene/src/layers/vector/constants.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 #[repr(usize)]
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Serialize, Deserialize)]
 pub enum ManipulatorType {
-	Anchor = 0,
-	InHandle = 1,
-	OutHandle = 2,
+	Anchor,
+	InHandle,
+	OutHandle,
 }
 
 impl ManipulatorType {
@@ -19,15 +19,12 @@ impl ManipulatorType {
 			_ => ManipulatorType::Anchor,
 		}
 	}
-}
 
-impl Not for ManipulatorType {
-	type Output = Self;
-	fn not(self) -> Self::Output {
+	pub fn opposite_handle(self) -> ManipulatorType {
 		match self {
+			ManipulatorType::Anchor => ManipulatorType::Anchor,
 			ManipulatorType::InHandle => ManipulatorType::OutHandle,
 			ManipulatorType::OutHandle => ManipulatorType::InHandle,
-			_ => ManipulatorType::Anchor,
 		}
 	}
 }

--- a/graphene/src/layers/vector/manipulator_group.rs
+++ b/graphene/src/layers/vector/manipulator_group.rs
@@ -249,19 +249,23 @@ impl ManipulatorGroup {
 	}
 
 	/// Returns the opposing handle to the handle provided.
-	/// Returns the anchor handle if the anchor is provided.
+	/// Returns [None] if the provided handle is of type [ManipulatorType::Anchor].
+	/// Returns [None] if the opposing handle doesn't exist.
 	pub fn opposing_handle(&self, handle: &ManipulatorPoint) -> Option<&ManipulatorPoint> {
-		// TODO: Usage of `!` here is confusing, error-prone, and a maintainability hazard.
-		// TODO: This function should also probably return None if given an anchor, if I understand its intent?
-		self.points[!handle.manipulator_type].as_ref()
+		if handle.manipulator_type == ManipulatorType::Anchor {
+			return None;
+		}
+		self.points[handle.manipulator_type.opposite_handle()].as_ref()
 	}
 
 	/// Returns the opposing handle to the handle provided, mutable.
-	/// Returns the anchor handle if the anchor is provided, mutable.
+	/// Returns [None] if the provided handle is of type [ManipulatorType::Anchor]
+	/// Returns [None] if the opposing handle doesn't exist.
 	pub fn opposing_handle_mut(&mut self, handle: &ManipulatorPoint) -> Option<&mut ManipulatorPoint> {
-		// TODO: Usage of `!` here is confusing, error-prone, and a maintainability hazard.
-		// TODO: This function should also probably return None if given an anchor, if I understand its intent?
-		self.points[!handle.manipulator_type].as_mut()
+		if handle.manipulator_type == ManipulatorType::Anchor {
+			return None;
+		}
+		self.points[handle.manipulator_type.opposite_handle()].as_mut()
 	}
 
 	/// Set the mirroring state

--- a/graphene/src/layers/vector/manipulator_group.rs
+++ b/graphene/src/layers/vector/manipulator_group.rs
@@ -5,28 +5,31 @@ use super::{
 use glam::{DAffine2, DVec2};
 use serde::{Deserialize, Serialize};
 
-/// Brief overview of ManipulatorGroup
-///                    ManipulatorGroup <- Container for the anchor metadata and optional ManipulatorPoint
-///                          /
-///            [Option<ManipulatorPoint>; 3] <- [0] is the anchor's draggable point (but not metadata), [1] is the InHandle's draggable point, [2] is the OutHandle's draggable point
-///          /              |                  \
-///      "Anchor"       "InHandle"         "OutHandle" <- These are ManipulatorPoints and the only editable "primitive"
-
-/// ManipulatorGroup is used to represent an anchor point + handles on the path that can be moved.
+/// [ManipulatorGroup] is used to represent an anchor point + handles on the path that can be moved.
 /// It contains 0-2 handles that are optionally available.
+///
+/// Overview:
+/// ```text
+///          ManipulatorGroup                <- Container for the anchor metadata and optional ManipulatorPoint
+///                  |
+///    [Option<ManipulatorPoint>; 3]         <- [0] is the anchor's draggable point (but not metadata), [1] is the
+///      /           |           \              InHandle's draggable point, [2] is the OutHandle's draggable point
+///     /            |            \
+/// "Anchor"    "InHandle"    "OutHandle"    <- These are ManipulatorPoints and the only editable "primitive"
+/// ```
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, Default)]
 pub struct ManipulatorGroup {
-	// Editable points for the anchor & handles
+	/// Editable points for the anchor and handles.
 	pub points: [Option<ManipulatorPoint>; 3],
 
 	#[serde(skip)]
-	// The editor state of the anchor and handles
-	// TODO Remove this from Graphene, editor state should be stored in the frontend if possible.
+	// TODO: Remove this from Graphene, editor state should be stored in the frontend if possible.
+	/// The editor state of the anchor and handles.
 	pub editor_state: ManipulatorGroupEditorState,
 }
 
 impl ManipulatorGroup {
-	/// Create a new anchor with the given position
+	/// Create a new anchor with the given position.
 	pub fn new_with_anchor(anchor_pos: DVec2) -> Self {
 		Self {
 			// An anchor and 2x None's which represent non-existent handles
@@ -35,7 +38,7 @@ impl ManipulatorGroup {
 		}
 	}
 
-	/// Create a new anchor with the given anchor position and handles
+	/// Create a new anchor with the given anchor position and handles.
 	pub fn new_with_handles(anchor_pos: DVec2, handle_in_pos: Option<DVec2>, handle_out_pos: Option<DVec2>) -> Self {
 		Self {
 			points: match (handle_in_pos, handle_out_pos) {
@@ -61,21 +64,21 @@ impl ManipulatorGroup {
 	}
 
 	// TODO Convert into bool in subpath
-	/// Create a ManipulatorGroup that represents a close path signal
+	/// Create a [ManipulatorGroup] that represents a close path signal.
 	pub fn closed() -> Self {
 		Self {
-			// An anchor being None indicates a ClosePath (aka a path end)
+			// An anchor (the first element) being `None` indicates a ClosePath (i.e. a path end command)
 			points: [None, None, None],
 			editor_state: ManipulatorGroupEditorState::default(),
 		}
 	}
 
-	/// Does this [ManipulatorGroup] represent a close signal?
+	/// Answers whether this [ManipulatorGroup] represent a close shape command.
 	pub fn is_close(&self) -> bool {
 		self.points[ManipulatorType::Anchor].is_none() && self.points[ManipulatorType::InHandle].is_none()
 	}
 
-	/// Finds the closest ManipulatorPoint owned by this anchor. This can be the handles or the anchor itself
+	/// Finds the closest [ManipulatorPoint] owned by this [ManipulatorGroup]. This may return the anchor or either handle.
 	pub fn closest_point(&self, transform_space: &DAffine2, target: glam::DVec2) -> usize {
 		let mut closest_index: usize = 0;
 		let mut closest_distance_squared: f64 = f64::MAX; // Not ideal
@@ -91,7 +94,7 @@ impl ManipulatorGroup {
 		closest_index
 	}
 
-	/// Move the selected points by the provided transform
+	/// Move the selected points by the provided transform.
 	pub fn move_selected_points(&mut self, delta: DVec2, absolute_position: DVec2, viewspace: &DAffine2) {
 		let mirror_angle = self.editor_state.mirror_angle_between_handles;
 		// Invert distance since we want it to start disabled
@@ -133,8 +136,7 @@ impl ManipulatorGroup {
 			return;
 		}
 
-		// If the anchor is selected ignore any handle mirroring / dragging
-		// Drag all points
+		// If the anchor is selected, ignore any handle mirroring/dragging and drag all points
 		if self.is_anchor_selected() {
 			for point in self.points_mut() {
 				move_point(point, delta, absolute_position);
@@ -142,8 +144,7 @@ impl ManipulatorGroup {
 			return;
 		}
 
-		// If the anchor isn't selected, but both handles are
-		// Drag only handles
+		// If the anchor isn't selected, but both handles are, drag only handles
 		if self.both_handles_selected() {
 			for point in self.selected_handles_mut() {
 				move_point(point, delta, absolute_position);
@@ -163,7 +164,7 @@ impl ManipulatorGroup {
 		move_symmetrical_handle(selected_handle.position, opposing_handle, reflect_center);
 	}
 
-	/// Delete any ManipulatorPoint that are selected, this includes handles or the anchor
+	/// Delete any [ManipulatorPoint] that are selected, this includes handles or the anchor.
 	pub fn delete_selected(&mut self) {
 		for point_option in self.points.iter_mut() {
 			if let Some(point) = point_option {
@@ -174,12 +175,12 @@ impl ManipulatorGroup {
 		}
 	}
 
-	/// Returns true if any points in this anchor are selected
+	/// Returns true if any points in this [ManipulatorGroup] are selected.
 	pub fn any_points_selected(&self) -> bool {
-		self.points.iter().flatten().any(|pnt| pnt.editor_state.is_selected)
+		self.points.iter().flatten().any(|point| point.editor_state.is_selected)
 	}
 
-	/// Returns true if the anchor point is selected
+	/// Returns true if the anchor point is selected.
 	pub fn is_anchor_selected(&self) -> bool {
 		if let Some(anchor) = &self.points[0] {
 			anchor.editor_state.is_selected
@@ -188,12 +189,12 @@ impl ManipulatorGroup {
 		}
 	}
 
-	/// Determines if two handle points are selected
+	/// Determines if the two handle points are selected.
 	pub fn both_handles_selected(&self) -> bool {
 		self.points.iter().skip(1).flatten().filter(|pnt| pnt.editor_state.is_selected).count() == 2
 	}
 
-	/// Set a point to selected by ID
+	/// Set a point, given its [ManipulatorType] enum integer ID, to a chosen selected state.
 	pub fn select_point(&mut self, point_id: usize, selected: bool) -> Option<&mut ManipulatorPoint> {
 		if let Some(point) = self.points[point_id].as_mut() {
 			point.set_selected(selected);
@@ -201,59 +202,65 @@ impl ManipulatorGroup {
 		self.points[point_id].as_mut()
 	}
 
-	/// Clear the selected points for this anchor
+	/// Clear the selected points for this [ManipulatorGroup].
 	pub fn clear_selected_points(&mut self) {
 		for point in self.points.iter_mut().flatten() {
 			point.set_selected(false);
 		}
 	}
 
-	/// Provides the points in this anchor
+	/// Provides the points in this [ManipulatorGroup].
 	pub fn points(&self) -> impl Iterator<Item = &ManipulatorPoint> {
 		self.points.iter().flatten()
 	}
 
-	/// Provides the points in this anchor
+	/// Provides the points in this [ManipulatorGroup] as mutable.
 	pub fn points_mut(&mut self) -> impl Iterator<Item = &mut ManipulatorPoint> {
 		self.points.iter_mut().flatten()
 	}
 
-	/// Provides the selected points in this anchor
+	/// Provides the selected points in this [ManipulatorGroup].
 	pub fn selected_points(&self) -> impl Iterator<Item = &ManipulatorPoint> {
 		self.points.iter().flatten().filter(|pnt| pnt.editor_state.is_selected)
 	}
 
-	/// Provides mutable selected points in this anchor
+	/// Provides mutable selected points in this [ManipulatorGroup].
 	pub fn selected_points_mut(&mut self) -> impl Iterator<Item = &mut ManipulatorPoint> {
 		self.points.iter_mut().flatten().filter(|pnt| pnt.editor_state.is_selected)
 	}
 
-	/// Provides the selected handles attached to this anchor
+	/// Provides the selected handles attached to this [ManipulatorGroup].
 	pub fn selected_handles(&self) -> impl Iterator<Item = &ManipulatorPoint> {
 		self.points.iter().skip(1).flatten().filter(|pnt| pnt.editor_state.is_selected)
 	}
 
-	/// Provides the mutable selected handles attached to this anchor
+	/// Provides the mutable selected handles attached to this [ManipulatorGroup].
 	pub fn selected_handles_mut(&mut self) -> impl Iterator<Item = &mut ManipulatorPoint> {
 		self.points.iter_mut().skip(1).flatten().filter(|pnt| pnt.editor_state.is_selected)
 	}
 
-	/// Angle between handles in radians
+	/// Angle between handles, in radians.
 	pub fn angle_between_handles(&self) -> f64 {
 		if let [Some(a1), Some(h1), Some(h2)] = &self.points {
-			return (a1.position - h1.position).angle_between(a1.position - h2.position);
+			(a1.position - h1.position).angle_between(a1.position - h2.position)
+		} else {
+			0.
 		}
-		0.0
 	}
 
-	/// Returns the opposing handle to the handle provided
-	/// Returns the anchor handle if the anchor is provided
+	/// Returns the opposing handle to the handle provided.
+	/// Returns the anchor handle if the anchor is provided.
 	pub fn opposing_handle(&self, handle: &ManipulatorPoint) -> Option<&ManipulatorPoint> {
+		// TODO: Usage of `!` here is confusing, error-prone, and a maintainability hazard.
+		// TODO: This function should also probably return None if given an anchor, if I understand its intent?
 		self.points[!handle.manipulator_type].as_ref()
 	}
-	/// Returns the opposing handle to the handle provided, mutable
-	/// Returns the anchor handle if the anchor is provided, mutable
+
+	/// Returns the opposing handle to the handle provided, mutable.
+	/// Returns the anchor handle if the anchor is provided, mutable.
 	pub fn opposing_handle_mut(&mut self, handle: &ManipulatorPoint) -> Option<&mut ManipulatorPoint> {
+		// TODO: Usage of `!` here is confusing, error-prone, and a maintainability hazard.
+		// TODO: This function should also probably return None if given an anchor, if I understand its intent?
 		self.points[!handle.manipulator_type].as_mut()
 	}
 
@@ -267,7 +274,7 @@ impl ManipulatorGroup {
 		}
 	}
 
-	/// Helper function to more easily set position of ManipulatorPoints
+	/// Helper function to more easily set position of [ManipulatorPoints]
 	pub fn set_point_position(&mut self, point_index: usize, position: DVec2) {
 		assert!(position.is_finite(), "Tried to set_point_position to non finite");
 		if let Some(point) = &mut self.points[point_index] {
@@ -287,9 +294,9 @@ impl ManipulatorGroup {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ManipulatorGroupEditorState {
-	// If we should maintain the angle between the handles
+	// Whether the angle between the handles should be maintained
 	pub mirror_angle_between_handles: bool,
-	// If we should make the handles equidistance from the anchor?
+	// Whether the distance between the handles should be equidistant to the anchor
 	pub mirror_distance_between_handles: bool,
 }
 

--- a/graphene/src/layers/vector/manipulator_group.rs
+++ b/graphene/src/layers/vector/manipulator_group.rs
@@ -259,7 +259,7 @@ impl ManipulatorGroup {
 	}
 
 	/// Returns the opposing handle to the handle provided, mutable.
-	/// Returns [None] if the provided handle is of type [ManipulatorType::Anchor]
+	/// Returns [None] if the provided handle is of type [ManipulatorType::Anchor].
 	/// Returns [None] if the opposing handle doesn't exist.
 	pub fn opposing_handle_mut(&mut self, handle: &ManipulatorPoint) -> Option<&mut ManipulatorPoint> {
 		if handle.manipulator_type == ManipulatorType::Anchor {

--- a/graphene/src/layers/vector/manipulator_point.rs
+++ b/graphene/src/layers/vector/manipulator_point.rs
@@ -2,7 +2,7 @@ use super::constants::ManipulatorType;
 use glam::{DAffine2, DVec2};
 use serde::{Deserialize, Serialize};
 
-/// ManipulatorPoint represents any editable point, anchor or handle
+/// [ManipulatorPoint] represents any editable Bezier point, either an anchor or handle
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct ManipulatorPoint {
 	/// The sibling element if this is a handle
@@ -27,7 +27,7 @@ impl Default for ManipulatorPoint {
 }
 
 impl ManipulatorPoint {
-	/// Initialize a new control point
+	/// Initialize a new [ManipulatorPoint].
 	pub fn new(position: glam::DVec2, manipulator_type: ManipulatorType) -> Self {
 		assert!(position.is_finite(), "tried to create point with non finite position");
 		Self {
@@ -37,11 +37,12 @@ impl ManipulatorPoint {
 		}
 	}
 
-	/// Sets if this point is selected
+	/// Sets this [ManipulatorPoint] to a chosen selection state.
 	pub fn set_selected(&mut self, selected: bool) {
 		self.editor_state.is_selected = selected;
 	}
 
+	/// Whether this [ManipulatorPoint] is currently selected.
 	pub fn is_selected(&self) -> bool {
 		self.editor_state.is_selected
 	}
@@ -61,9 +62,9 @@ impl ManipulatorPoint {
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ManipulatorPointEditorState {
-	/// If this control point can be selected
+	/// Whether or not this manipulator point can be selected.
 	pub can_be_selected: bool,
-	/// Is this control point currently selected
+	/// Whether or not this manipulator point is currently selected.
 	pub is_selected: bool,
 }
 

--- a/graphene/src/layers/vector/manipulator_point.rs
+++ b/graphene/src/layers/vector/manipulator_point.rs
@@ -1,38 +1,39 @@
-use super::constants::ControlPointType;
+use super::constants::ManipulatorType;
 use glam::{DAffine2, DVec2};
 use serde::{Deserialize, Serialize};
 
-/// VectorControlPoint represents any editable point, anchor or handle
+/// ManipulatorPoint represents any editable point, anchor or handle
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct VectorControlPoint {
+pub struct ManipulatorPoint {
 	/// The sibling element if this is a handle
 	pub position: glam::DVec2,
 	/// The type of manipulator this point is
-	pub manipulator_type: ControlPointType,
+	pub manipulator_type: ManipulatorType,
 
 	#[serde(skip)]
 	/// The state specific to the editor
-	pub editor_state: VectorControlPointState,
+	// TODO Remove this from Graphene, editor state should be stored in the frontend if possible.
+	pub editor_state: ManipulatorPointEditorState,
 }
 
-impl Default for VectorControlPoint {
+impl Default for ManipulatorPoint {
 	fn default() -> Self {
 		Self {
 			position: DVec2::ZERO,
-			manipulator_type: ControlPointType::Anchor,
-			editor_state: VectorControlPointState::default(),
+			manipulator_type: ManipulatorType::Anchor,
+			editor_state: ManipulatorPointEditorState::default(),
 		}
 	}
 }
 
-impl VectorControlPoint {
+impl ManipulatorPoint {
 	/// Initialize a new control point
-	pub fn new(position: glam::DVec2, manipulator_type: ControlPointType) -> Self {
+	pub fn new(position: glam::DVec2, manipulator_type: ManipulatorType) -> Self {
 		assert!(position.is_finite(), "tried to create point with non finite position");
 		Self {
 			position,
 			manipulator_type,
-			editor_state: VectorControlPointState::default(),
+			editor_state: ManipulatorPointEditorState::default(),
 		}
 	}
 
@@ -59,14 +60,14 @@ impl VectorControlPoint {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct VectorControlPointState {
+pub struct ManipulatorPointEditorState {
 	/// If this control point can be selected
 	pub can_be_selected: bool,
 	/// Is this control point currently selected
 	pub is_selected: bool,
 }
 
-impl Default for VectorControlPointState {
+impl Default for ManipulatorPointEditorState {
 	fn default() -> Self {
 		Self {
 			can_be_selected: true,

--- a/graphene/src/layers/vector/mod.rs
+++ b/graphene/src/layers/vector/mod.rs
@@ -1,4 +1,4 @@
 pub mod constants;
-pub mod vector_anchor;
-pub mod vector_control_point;
-pub mod vector_shape;
+pub mod manipulator_group;
+pub mod manipulator_point;
+pub mod subpath;

--- a/graphene/src/layers/vector/subpath.rs
+++ b/graphene/src/layers/vector/subpath.rs
@@ -277,22 +277,22 @@ impl Subpath {
 		&self.0
 	}
 
-	/// Returns a [VectorControlPoint] from the last [ManipulatorGroup] in the Subpath.
+	/// Returns a [ManipulatorPoint] from the last [ManipulatorGroup] in the Subpath.
 	pub fn last_point(&self, control_type: ManipulatorType) -> Option<&ManipulatorPoint> {
 		self.groups().last().and_then(|group| group.points[control_type].as_ref())
 	}
 
-	/// Returns a [VectorControlPoint] from the last [ManipulatorGroup], mutably
+	/// Returns a [ManipulatorPoint] from the last [ManipulatorGroup], mutably
 	pub fn last_point_mut(&mut self, control_type: ManipulatorType) -> Option<&mut ManipulatorPoint> {
 		self.groups_mut().last_mut().and_then(|group| group.points[control_type].as_mut())
 	}
 
-	/// Returns a [VectorControlPoint]  from the first [ManipulatorGroup]
+	/// Returns a [ManipulatorPoint]  from the first [ManipulatorGroup]
 	pub fn first_point(&self, control_type: ManipulatorType) -> Option<&ManipulatorPoint> {
 		self.groups().first().and_then(|group| group.points[control_type].as_ref())
 	}
 
-	/// Returns a [VectorControlPoint] from the first [ManipulatorGroup]
+	/// Returns a [ManipulatorPoint] from the first [ManipulatorGroup]
 	pub fn first_point_mut(&mut self, control_type: ManipulatorType) -> Option<&mut ManipulatorPoint> {
 		self.groups_mut().first_mut().and_then(|group| group.points[control_type].as_mut())
 	}

--- a/graphene/src/layers/vector/subpath.rs
+++ b/graphene/src/layers/vector/subpath.rs
@@ -8,7 +8,7 @@ use glam::{DAffine2, DVec2};
 use kurbo::{BezPath, PathEl, Rect, Shape};
 use serde::{Deserialize, Serialize};
 
-/// Subpath represents a single vector shape, containing many ManipulatorGroups
+/// Subpath represents a single vector path, containing many ManipulatorGroups
 /// For each closed shape we keep a Subpath which contains the ManipulatorGroups (handles and anchors) that define that shape.
 // TODO Add "closed" bool to subpath
 #[derive(PartialEq, Clone, Debug, Default, Serialize, Deserialize)]

--- a/graphene/src/operation.rs
+++ b/graphene/src/operation.rs
@@ -89,7 +89,8 @@ pub enum Operation {
 		path: Vec<LayerId>,
 		transform: [f64; 6],
 		insert_index: isize,
-		vector_path: Subpath,
+		// TODO This will become a compound path once we support them.
+		subpath: Subpath,
 		style: style::PathStyle,
 	},
 	BooleanOperation {
@@ -99,14 +100,14 @@ pub enum Operation {
 	DeleteLayer {
 		path: Vec<LayerId>,
 	},
-	DeleteSelectedVectorPoints {
+	DeleteSelectedManipulatorPoints {
 		layer_paths: Vec<Vec<LayerId>>,
 	},
-	DeselectVectorPoints {
+	DeselectManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		point_ids: Vec<(u64, ManipulatorType)>,
 	},
-	DeselectAllVectorPoints {
+	DeselectAllManipulatorPoints {
 		layer_path: Vec<LayerId>,
 	},
 	DuplicateLayer {
@@ -118,10 +119,16 @@ pub enum Operation {
 		font_style: String,
 		size: f64,
 	},
-	MoveSelectedVectorPoints {
+	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
 		absolute_position: (f64, f64),
+	},
+	MoveManipulatorPoint {
+		layer_path: Vec<LayerId>,
+		id: u64,
+		manipulator_type: ManipulatorType,
+		position: (f64, f64),
 	},
 	RenameLayer {
 		layer_path: Vec<LayerId>,
@@ -147,38 +154,32 @@ pub enum Operation {
 		path: Vec<LayerId>,
 		transform: [f64; 6],
 	},
-	SelectVectorPoints {
+	SelectManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		point_ids: Vec<(u64, ManipulatorType)>,
 		add: bool,
 	},
 	SetShapePath {
 		path: Vec<LayerId>,
-		vector_path: Subpath,
+		subpath: Subpath,
 	},
-	InsertVectorAnchor {
+	InsertManipulatorGroup {
 		layer_path: Vec<LayerId>,
-		anchor: ManipulatorGroup,
+		manipulator_group: ManipulatorGroup,
 		after_id: u64,
 	},
-	PushVectorAnchor {
+	PushManipulatorGroup {
 		layer_path: Vec<LayerId>,
-		anchor: ManipulatorGroup,
+		manipulator_group: ManipulatorGroup,
 	},
-	RemoveVectorAnchor {
+	RemoveManipulatorGroup {
 		layer_path: Vec<LayerId>,
 		id: u64,
 	},
-	MoveVectorPoint {
+	RemoveManipulatorPoint {
 		layer_path: Vec<LayerId>,
 		id: u64,
-		control_type: ManipulatorType,
-		position: (f64, f64),
-	},
-	RemoveVectorPoint {
-		layer_path: Vec<LayerId>,
-		id: u64,
-		control_type: ManipulatorType,
+		manipulator_type: ManipulatorType,
 	},
 	TransformLayerInScope {
 		path: Vec<LayerId>,

--- a/graphene/src/operation.rs
+++ b/graphene/src/operation.rs
@@ -2,9 +2,9 @@ use crate::boolean_ops::BooleanOperation as BooleanOperationType;
 use crate::layers::blend_mode::BlendMode;
 use crate::layers::layer_info::Layer;
 use crate::layers::style::{self, Stroke};
-use crate::layers::vector::constants::ControlPointType;
-use crate::layers::vector::vector_anchor::VectorAnchor;
-use crate::layers::vector::vector_shape::VectorShape;
+use crate::layers::vector::constants::ManipulatorType;
+use crate::layers::vector::manipulator_group::ManipulatorGroup;
+use crate::layers::vector::subpath::Subpath;
 use crate::LayerId;
 
 use serde::{Deserialize, Serialize};
@@ -89,7 +89,7 @@ pub enum Operation {
 		path: Vec<LayerId>,
 		transform: [f64; 6],
 		insert_index: isize,
-		vector_path: VectorShape,
+		vector_path: Subpath,
 		style: style::PathStyle,
 	},
 	BooleanOperation {
@@ -104,7 +104,7 @@ pub enum Operation {
 	},
 	DeselectVectorPoints {
 		layer_path: Vec<LayerId>,
-		point_ids: Vec<(u64, ControlPointType)>,
+		point_ids: Vec<(u64, ManipulatorType)>,
 	},
 	DeselectAllVectorPoints {
 		layer_path: Vec<LayerId>,
@@ -149,21 +149,21 @@ pub enum Operation {
 	},
 	SelectVectorPoints {
 		layer_path: Vec<LayerId>,
-		point_ids: Vec<(u64, ControlPointType)>,
+		point_ids: Vec<(u64, ManipulatorType)>,
 		add: bool,
 	},
 	SetShapePath {
 		path: Vec<LayerId>,
-		vector_path: VectorShape,
+		vector_path: Subpath,
 	},
 	InsertVectorAnchor {
 		layer_path: Vec<LayerId>,
-		anchor: VectorAnchor,
+		anchor: ManipulatorGroup,
 		after_id: u64,
 	},
 	PushVectorAnchor {
 		layer_path: Vec<LayerId>,
-		anchor: VectorAnchor,
+		anchor: ManipulatorGroup,
 	},
 	RemoveVectorAnchor {
 		layer_path: Vec<LayerId>,
@@ -172,13 +172,13 @@ pub enum Operation {
 	MoveVectorPoint {
 		layer_path: Vec<LayerId>,
 		id: u64,
-		control_type: ControlPointType,
+		control_type: ManipulatorType,
 		position: (f64, f64),
 	},
 	RemoveVectorPoint {
 		layer_path: Vec<LayerId>,
 		id: u64,
-		control_type: ControlPointType,
+		control_type: ManipulatorType,
 	},
 	TransformLayerInScope {
 		path: Vec<LayerId>,

--- a/proc-macros/src/helper_structs.rs
+++ b/proc-macros/src/helper_structs.rs
@@ -138,8 +138,8 @@ pub struct SimpleCommaDelimeted<T>(pub Vec<T>);
 
 impl<T: Parse> Parse for SimpleCommaDelimeted<T> {
 	fn parse(input: ParseStream) -> syn::Result<Self> {
-		let punct = Punctuated::<T, Token![,]>::parse_terminated(input)?;
-		Ok(Self(punct.into_iter().collect()))
+		let punctuated = Punctuated::<T, Token![,]>::parse_terminated(input)?;
+		Ok(Self(punctuated.into_iter().collect()))
 	}
 }
 

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -24,7 +24,7 @@ pub fn call_site_ident<S: AsRef<str>>(s: S) -> Ident {
 	Ident::new(s.as_ref(), Span::call_site())
 }
 
-/// Creates the path `left::right` from the idents `left` and `right`
+/// Creates the path `left::right` from the identifiers `left` and `right`
 pub fn two_segment_path(left_ident: Ident, right_ident: Ident) -> Path {
 	let mut segments: Punctuated<PathSegment, Token![::]> = Punctuated::new();
 	segments.push(PathSegment {

--- a/proc-macros/src/lib.rs
+++ b/proc-macros/src/lib.rs
@@ -187,7 +187,7 @@ pub fn derive_message(input_item: TokenStream) -> TokenStream {
 	TokenStream::from(derive_as_message_impl(input_item.into()).unwrap_or_else(|err| err.to_compile_error()))
 }
 
-/// This macro is basically an abbreviation for the usual [`ToDiscriminant`], [`TransitiveChild`] and [`AsMessage`] invocations
+/// This macro is basically an abbreviation for the usual [ToDiscriminant], [TransitiveChild] and [AsMessage] invocations.
 ///
 /// This macro is enum-only.
 ///

--- a/website/config.toml
+++ b/website/config.toml
@@ -8,7 +8,7 @@ feed_filename = "rss.xml"
 
 [markdown]
 # Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+# Theme can be customized by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
 highlight_theme = "css"
 


### PR DESCRIPTION
Renames VectorAnchor, VectorShape and VectorControlPoint to improve consistency with newly formed verbiage.

Cleanup and comment improvements were also made.

![capture](https://user-images.githubusercontent.com/3145170/178087898-0a473673-d8d4-4671-8c5e-d54130b225da.png)
![capture (1)](https://user-images.githubusercontent.com/3145170/178087899-3ecd2372-c798-40f9-b379-a89ca14189db.png)
![capture (2)](https://user-images.githubusercontent.com/3145170/178087900-85b471e7-f664-4f86-9e09-f1ed76e5fa2e.png)

