### PR TITLE
Fix path overlays and pen tool click

### DIFF
--- a/editor/src/viewport_tools/tools/path_tool.rs
+++ b/editor/src/viewport_tools/tools/path_tool.rs
@@ -150,6 +150,10 @@ impl Fsm for PathToolFsmState {
 					// Set the newly targeted layers to visible
 					let layer_paths = document.selected_visible_layers().map(|layer_path| layer_path.to_vec()).collect();
 					tool_data.shape_editor.set_selected_layers(layer_paths);
+					// Render the new overlays
+					for layer_path in tool_data.shape_editor.selected_layers() {
+						tool_data.overlay_renderer.render_vector_shape_overlays(&document.graphene_document, layer_path.to_vec(), responses);
+					}
 
 					// This can happen in any state (which is why we return self)
 					self

--- a/editor/src/viewport_tools/tools/pen_tool.rs
+++ b/editor/src/viewport_tools/tools/pen_tool.rs
@@ -222,7 +222,7 @@ impl Fsm for PenToolFsmState {
 							}
 							.into(),
 						);
-						responses.push_back(add_anchor(&tool_data.path, VectorAnchor::new(start_position)));
+						responses.push_back(add_anchor(&tool_data.path, VectorAnchor::new_with_handles(start_position, Some(start_position), Some(start_position))));
 					}
 
 					PenToolFsmState::DraggingHandle


### PR DESCRIPTION
Fix path overlays (we didn't rerender the new overlays on selection change) and pen tool click.