### PR TITLE
Implement bounding box function for bezier-rs

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -364,10 +364,10 @@ export default defineComponent({
 						bboxPoints.forEach((point: Point, index) => {
 							if (index === 0) {
 								const prevPoint: Point = bboxPoints[bboxPoints.length - 1];
-								drawLine(getContextFromCanvas(canvas), point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
+								drawLine(context, point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
 							} else {
 								const prevPoint: Point = bboxPoints[index - 1];
-								drawLine(getContextFromCanvas(canvas), point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
+								drawLine(context, point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
 							}
 						});
 					},

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -361,15 +361,12 @@ export default defineComponent({
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
 						const context = getContextFromCanvas(canvas);
 						const bboxPoints: Point[] = JSON.parse(bezier.bounding_box());
-						bboxPoints.forEach((point: Point, index) => {
-							if (index === 0) {
-								const prevPoint: Point = bboxPoints[bboxPoints.length - 1];
-								drawLine(context, point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
-							} else {
-								const prevPoint: Point = bboxPoints[index - 1];
-								drawLine(context, point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
-							}
-						});
+						const minPoint = bboxPoints[0];
+						const maxPoint = bboxPoints[1];
+						drawLine(context, minPoint, {x: minPoint.x, y: maxPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, minPoint, {x: maxPoint.x, y: minPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, maxPoint, {x: minPoint.x, y: maxPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, maxPoint, {x: maxPoint.x, y: minPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 				},
 			],

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -360,7 +360,7 @@ export default defineComponent({
 					name: "Bounding Box",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
 						const context = getContextFromCanvas(canvas);
-						const bboxPoints: Point[] = JSON.parse(bezier.bbox());
+						const bboxPoints: Point[] = JSON.parse(bezier.bounding_box());
 						bboxPoints.forEach((point: Point, index) => {
 							if (index === 0) {
 								const prevPoint: Point = bboxPoints[bboxPoints.length - 1];

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -356,6 +356,22 @@ export default defineComponent({
 						});
 					},
 				},
+				{
+					name: "Bounding Box",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+						const context = getContextFromCanvas(canvas);
+						const bboxPoints: Point[] = JSON.parse(bezier.bbox());
+						bboxPoints.forEach((point: Point, index) => {
+							if (index === 0) {
+								const prevPoint: Point = bboxPoints[bboxPoints.length - 1];
+								drawLine(getContextFromCanvas(canvas), point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
+							} else {
+								const prevPoint: Point = bboxPoints[index - 1];
+								drawLine(getContextFromCanvas(canvas), point, prevPoint, COLORS.NON_INTERACTIVE.STROKE_1);
+							}
+						});
+					},
+				},
 			],
 			subpathFeatures: [
 				{

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -363,10 +363,10 @@ export default defineComponent({
 						const bboxPoints: Point[] = JSON.parse(bezier.bounding_box());
 						const minPoint = bboxPoints[0];
 						const maxPoint = bboxPoints[1];
-						drawLine(context, minPoint, {x: minPoint.x, y: maxPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
-						drawLine(context, minPoint, {x: maxPoint.x, y: minPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
-						drawLine(context, maxPoint, {x: minPoint.x, y: maxPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
-						drawLine(context, maxPoint, {x: maxPoint.x, y: minPoint.y}, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, minPoint, { x: minPoint.x, y: maxPoint.y }, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, minPoint, { x: maxPoint.x, y: minPoint.y }, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, maxPoint, { x: minPoint.x, y: maxPoint.y }, COLORS.NON_INTERACTIVE.STROKE_1);
+						drawLine(context, maxPoint, { x: maxPoint.x, y: minPoint.y }, COLORS.NON_INTERACTIVE.STROKE_1);
 					},
 				},
 			],

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -153,7 +153,7 @@ impl WasmBezier {
 	}
 
 	pub fn bounding_box(&self) -> JsValue {
-        let bbox_points: [Point; 2] = self.0.bounding_box().map(|p| Point { x: p.x, y: p.y });
+		let bbox_points: [Point; 2] = self.0.bounding_box().map(|p| Point { x: p.x, y: p.y });
 		to_js_value(bbox_points)
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -153,7 +153,7 @@ impl WasmBezier {
 	}
 
 	pub fn bounding_box(&self) -> JsValue {
-		let bbox_points: Vec<Point> = self.0.bounding_box().iter().map(|&p| Point { x: p.x, y: p.y }).collect::<Vec<Point>>();
+        let bbox_points: [Point; 2] = self.0.bounding_box().map(|p| Point { x: p.x, y: p.y });
 		to_js_value(bbox_points)
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -152,8 +152,8 @@ impl WasmBezier {
 		to_js_value(bezier_points)
 	}
 
-	pub fn bbox(&self) -> JsValue {
-		let bbox_points: Vec<Point> = self.0.bbox().iter().map(|&p| Point { x: p.x, y: p.y }).collect::<Vec<Point>>();
+	pub fn bounding_box(&self) -> JsValue {
+		let bbox_points: Vec<Point> = self.0.bounding_box().iter().map(|&p| Point { x: p.x, y: p.y }).collect::<Vec<Point>>();
 		to_js_value(bbox_points)
 	}
 }

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -128,6 +128,16 @@ impl WasmBezier {
 		to_js_value(local_extrema)
 	}
 
+	pub fn de_casteljau_points(&self, t: f64) -> JsValue {
+		let hull = self
+			.0
+			.de_casteljau_points(t)
+			.iter()
+			.map(|level| level.iter().map(|&point| Point { x: point.x, y: point.y }).collect::<Vec<Point>>())
+			.collect::<Vec<Vec<Point>>>();
+		to_js_value(hull)
+	}
+
 	pub fn rotate(&self, angle: f64) -> WasmBezier {
 		WasmBezier(self.0.rotate(angle))
 	}
@@ -142,13 +152,8 @@ impl WasmBezier {
 		to_js_value(bezier_points)
 	}
 
-	pub fn de_casteljau_points(&self, t: f64) -> JsValue {
-		let hull = self
-			.0
-			.de_casteljau_points(t)
-			.iter()
-			.map(|level| level.iter().map(|&point| Point { x: point.x, y: point.y }).collect::<Vec<Point>>())
-			.collect::<Vec<Vec<Point>>>();
-		to_js_value(hull)
+	pub fn bbox(&self) -> JsValue {
+		let bbox_points: Vec<Point> = self.0.bbox().iter().map(|&p| Point { x: p.x, y: p.y }).collect::<Vec<Point>>();
+		to_js_value(bbox_points)
 	}
 }

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -773,6 +773,27 @@ impl Bezier {
 		});
 		result
 	}
+
+	// Return list of points that represent the bounding box of the curve
+	pub fn bbox(&self) -> Vec<DVec2> {
+		// start by taking min/max of endpoints
+		let mut min_point = self.start.min(self.end);
+		let mut max_point = self.start.max(self.end);
+
+		// iterate through extrema points
+		let extrema = self.local_extrema();
+		for t_values in extrema {
+			for t in t_values {
+				let point = self.evaluate(t);
+				// update bounding box if new min/max is found
+				min_point = min_point.min(point);
+				max_point = max_point.max(point);
+			}
+		}
+
+		// Return the 4 points that make up the bounding box
+		return vec![min_point, DVec2::new(min_point.x, max_point.y), max_point, DVec2::new(max_point.x, min_point.y)];
+	}
 }
 
 #[cfg(test)]

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -775,7 +775,7 @@ impl Bezier {
 	}
 
 	// Return list of points that represent the bounding box of the curve
-	pub fn bbox(&self) -> Vec<DVec2> {
+	pub fn bounding_box(&self) -> Vec<DVec2> {
 		// start by taking min/max of endpoints
 		let mut min_point = self.start.min(self.end);
 		let mut max_point = self.start.max(self.end);

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -791,8 +791,8 @@ impl Bezier {
 			}
 		}
 
-        [endpoints_min, endpoints_max]
-    }
+		[endpoints_min, endpoints_max]
+	}
 }
 
 #[cfg(test)]

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -774,26 +774,25 @@ impl Bezier {
 		result
 	}
 
-	// Return list of points that represent the bounding box of the curve
-	pub fn bounding_box(&self) -> Vec<DVec2> {
-		// start by taking min/max of endpoints
-		let mut min_point = self.start.min(self.end);
-		let mut max_point = self.start.max(self.end);
+	/// Return the min and max corners that represent the bounding box of the curve.
+	pub fn bounding_box(&self) -> [DVec2; 2] {
+		// Start by taking min/max of endpoints.
+		let mut endpoints_min = self.start.min(self.end);
+		let mut endpoints_max = self.start.max(self.end);
 
-		// iterate through extrema points
+		// Iterate through extrema points.
 		let extrema = self.local_extrema();
 		for t_values in extrema {
 			for t in t_values {
 				let point = self.evaluate(t);
-				// update bounding box if new min/max is found
-				min_point = min_point.min(point);
-				max_point = max_point.max(point);
+				// Update bounding box if new min/max is found.
+				endpoints_min = endpoints_min.min(point);
+				endpoints_max = endpoints_max.max(point);
 			}
 		}
 
-		// Return the 4 points that make up the bounding box
-		return vec![min_point, DVec2::new(min_point.x, max_point.y), max_point, DVec2::new(max_point.x, min_point.y)];
-	}
+        [endpoints_min, endpoints_max]
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Added `bbox()` function in bezier-rs.
The function returns a list of points that represent the coordinates of the bounding box of the curve.