### PR TITLE
Fix desynced UI

### DIFF
--- a/editor/src/layout/layout_message.rs
+++ b/editor/src/layout/layout_message.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[impl_message(Message, Layout)]
 #[derive(PartialEq, Clone, Deserialize, Serialize, Debug)]
 pub enum LayoutMessage {
+	RefreshLayout { layout_target: LayoutTarget },
 	SendLayout { layout: Layout, layout_target: LayoutTarget },
 	UpdateLayout { layout_target: LayoutTarget, widget_id: u64, value: serde_json::Value },
 }

--- a/editor/src/layout/layout_message_handler.rs
+++ b/editor/src/layout/layout_message_handler.rs
@@ -69,13 +69,15 @@ impl MessageHandler<LayoutMessage, ()> for LayoutMessageHandler {
 		use LayoutMessage::*;
 		#[remain::sorted]
 		match action {
+			RefreshLayout { layout_target } => {
+				self.send_layout(layout_target, responses);
+			}
 			SendLayout { layout, layout_target } => {
 				self.layouts[layout_target as usize] = layout;
 
 				self.send_layout(layout_target, responses);
 			}
 			UpdateLayout { layout_target, widget_id, value } => {
-				self.send_layout(layout_target, responses);
 				let layout = &mut self.layouts[layout_target as usize];
 				let widget_holder = layout.iter_mut().find(|widget| widget.widget_id == widget_id);
 				if widget_holder.is_none() {
@@ -184,6 +186,7 @@ impl MessageHandler<LayoutMessage, ()> for LayoutMessageHandler {
 					}
 					Widget::TextLabel(_) => {}
 				};
+				responses.push_back(RefreshLayout { layout_target }.into());
 			}
 		}
 	}


### PR DESCRIPTION
Resolves de-synced outline/fill mode buttons. This was introduced by the new message ordering. In the main branch we sent the message with the layout before the message that updates the widgets. A new message had to be introduced to refresh the widgets after the widget update message was handled.

Before the new message ordering, we dispatched the widget update and then update layout. However some widget updates (like the toolbar) would then send a sub message that would be added to the queue after the widget update event.