### PR TITLE
Improve behavior of occluded layer selection and dragging

### DIFF
--- a/editor/src/viewport_tools/tools/select_tool.rs
+++ b/editor/src/viewport_tools/tools/select_tool.rs
@@ -445,7 +445,7 @@ impl Fsm for SelectToolFsmState {
 						tool_data.layers_dragging = selected;
 
 						RotatingBounds
-					} else if selected.iter().any(|path| intersection.contains(path)) {
+					} else if intersection.last().map(|last| selected.contains(last)).unwrap_or(false) {
 						responses.push_back(DocumentMessage::StartTransaction.into());
 						tool_data.layers_dragging = selected;
 


### PR DESCRIPTION
Layers or groups of layers can only be dragged if they are
not occluded at the point of dragging. Otherwise the layer(s)
are deselected and the occluding layer is selected instead.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #705
