### PR TITLE
Handle intersections between two bezier curves

### DIFF
--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -115,7 +115,7 @@ export default defineComponent({
 				{
 					name: "Lookup Table",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
-						const lookupPoints = bezier.compute_lookup_table(options.steps);
+						const lookupPoints: string[] = bezier.compute_lookup_table(options.steps);
 						lookupPoints.forEach((serializedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
 								drawPoint(getContextFromCanvas(canvas), JSON.parse(serializedPoint), 3, COLORS.NON_INTERACTIVE.STROKE_1);
@@ -142,7 +142,7 @@ export default defineComponent({
 
 						const derivativeBezier = bezier.derivative();
 						if (derivativeBezier) {
-							const points: Point[] = derivativeBezier.get_points().map((p) => JSON.parse(p));
+							const points: Point[] = derivativeBezier.get_points().map((p: string) => JSON.parse(p));
 							if (points.length === 2) {
 								drawLine(context, points[0], points[1], COLORS.NON_INTERACTIVE.STROKE_1);
 							} else {
@@ -338,7 +338,7 @@ export default defineComponent({
 						const rotatedBezier = bezier
 							.rotate(options.angle * Math.PI)
 							.get_points()
-							.map((p) => JSON.parse(p));
+							.map((p: string) => JSON.parse(p));
 						drawBezier(context, rotatedBezier, null, { curveStrokeColor: COLORS.NON_INTERACTIVE.STROKE_1, radius: 3.5 });
 					},
 					template: markRaw(SliderExample),
@@ -356,7 +356,7 @@ export default defineComponent({
 					},
 				},
 				{
-					name: "Intersect Line Segment",
+					name: "Intersect (Line Segment)",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
 						const context = getContextFromCanvas(canvas);
 						const line = [
@@ -365,7 +365,25 @@ export default defineComponent({
 						];
 						const mappedLine = line.map((p) => [p.x, p.y]);
 						drawLine(context, line[0], line[1], COLORS.NON_INTERACTIVE.STROKE_1);
-						const intersections: Point[] = bezier.intersect_line_segment(mappedLine).map((p) => JSON.parse(p));
+						const intersections: Point[] = bezier.intersect_line_segment(mappedLine).map((p: string) => JSON.parse(p));
+						intersections.forEach((p: Point) => {
+							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
+						});
+					},
+				},
+				{
+					name: "Intersect (Cubic Segment)",
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+						const context = getContextFromCanvas(canvas);
+						const points = [
+							{ x: 40, y: 20 },
+							{ x: 100, y: 40 },
+							{ x: 40, y: 120 },
+							{ x: 175, y: 140 },
+						];
+						const mappedPoints = points.map((p) => [p.x, p.y]);
+						drawCurve(context, points, COLORS.NON_INTERACTIVE.STROKE_1);
+						const intersections: Point[] = bezier.intersect_cubic_segment(mappedPoints).map((p: string) => JSON.parse(p));
 						intersections.forEach((p: Point) => {
 							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
 						});

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -375,7 +375,7 @@ export default defineComponent({
 				},
 				{
 					name: "Intersect (Cubic Segment)",
-					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {
+					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
 						const context = getContextFromCanvas(canvas);
 						const points = [
 							{ x: 40, y: 20 },
@@ -385,11 +385,23 @@ export default defineComponent({
 						];
 						const mappedPoints = points.map((p) => [p.x, p.y]);
 						drawCurve(context, points, COLORS.NON_INTERACTIVE.STROKE_1, 1);
-						const intersections: Float64Array = bezier.intersect_cubic_segment(mappedPoints);
+						const intersections: Float64Array = bezier.intersect_cubic_segment(mappedPoints, options.error);
 						intersections.forEach((t: number) => {
 							const p = JSON.parse(bezier.evaluate(t));
 							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
 						});
+					},
+					template: markRaw(SliderExample),
+					templateOptions: {
+						sliders: [
+							{
+								variable: "error",
+								min: 0.1,
+								max: 2,
+								step: 0.1,
+								default: 0.5,
+							},
+						],
 					},
 				},
 				{

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -249,7 +249,8 @@ export default defineComponent({
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point): void => {
 						if (mouseLocation != null) {
 							const context = getContextFromCanvas(canvas);
-							const closestPoint = JSON.parse(bezier.project(mouseLocation.x, mouseLocation.y));
+							const t = bezier.project(mouseLocation.x, mouseLocation.y);
+							const closestPoint = JSON.parse(bezier.evaluate(t));
 							drawLine(context, mouseLocation, closestPoint, COLORS.NON_INTERACTIVE.STROKE_1);
 						}
 					},

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -365,8 +365,9 @@ export default defineComponent({
 						];
 						const mappedLine = line.map((p) => [p.x, p.y]);
 						drawLine(context, line[0], line[1], COLORS.NON_INTERACTIVE.STROKE_1);
-						const intersections: Point[] = bezier.intersect_line_segment(mappedLine).map((p: string) => JSON.parse(p));
-						intersections.forEach((p: Point) => {
+						const intersections: Float64Array = bezier.intersect_line_segment(mappedLine);
+						intersections.forEach((t: number) => {
+							const p = JSON.parse(bezier.evaluate(t));
 							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
 						});
 					},
@@ -382,9 +383,10 @@ export default defineComponent({
 							{ x: 175, y: 140 },
 						];
 						const mappedPoints = points.map((p) => [p.x, p.y]);
-						drawCurve(context, points, COLORS.NON_INTERACTIVE.STROKE_1);
-						const intersections: Point[] = bezier.intersect_cubic_segment(mappedPoints).map((p: string) => JSON.parse(p));
-						intersections.forEach((p: Point) => {
+						drawCurve(context, points, COLORS.NON_INTERACTIVE.STROKE_1, 1);
+						const intersections: Float64Array = bezier.intersect_cubic_segment(mappedPoints);
+						intersections.forEach((t: number) => {
+							const p = JSON.parse(bezier.evaluate(t));
 							drawPoint(context, p, 3, COLORS.NON_INTERACTIVE.STROKE_2);
 						});
 					},

--- a/bezier-rs/docs/interactive-docs/src/App.vue
+++ b/bezier-rs/docs/interactive-docs/src/App.vue
@@ -115,7 +115,7 @@ export default defineComponent({
 				{
 					name: "Lookup Table",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>): void => {
-						const lookupPoints: string[] = bezier.compute_lookup_table(options.steps);
+						const lookupPoints = bezier.compute_lookup_table(options.steps);
 						lookupPoints.forEach((serializedPoint, index) => {
 							if (index !== 0 && index !== lookupPoints.length - 1) {
 								drawPoint(getContextFromCanvas(canvas), JSON.parse(serializedPoint), 3, COLORS.NON_INTERACTIVE.STROKE_1);
@@ -142,7 +142,7 @@ export default defineComponent({
 
 						const derivativeBezier = bezier.derivative();
 						if (derivativeBezier) {
-							const points: Point[] = derivativeBezier.get_points().map((p: string) => JSON.parse(p));
+							const points: Point[] = derivativeBezier.get_points().map((p) => JSON.parse(p));
 							if (points.length === 2) {
 								drawLine(context, points[0], points[1], COLORS.NON_INTERACTIVE.STROKE_1);
 							} else {
@@ -339,7 +339,7 @@ export default defineComponent({
 						const rotatedBezier = bezier
 							.rotate(options.angle * Math.PI)
 							.get_points()
-							.map((p: string) => JSON.parse(p));
+							.map((p) => JSON.parse(p));
 						drawBezier(context, rotatedBezier, null, { curveStrokeColor: COLORS.NON_INTERACTIVE.STROKE_1, radius: 3.5 });
 					},
 					template: markRaw(SliderExample),

--- a/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
+++ b/bezier-rs/docs/interactive-docs/src/utils/drawing.ts
@@ -59,9 +59,9 @@ export const drawText = (ctx: CanvasRenderingContext2D, text: string, x: number,
 	ctx.fillText(text, x, y);
 };
 
-export const drawCurve = (ctx: CanvasRenderingContext2D, points: Point[], strokeColor = COLORS.INTERACTIVE.STROKE_1): void => {
+export const drawCurve = (ctx: CanvasRenderingContext2D, points: Point[], strokeColor = COLORS.INTERACTIVE.STROKE_1, lineWidth = 2): void => {
 	ctx.strokeStyle = strokeColor;
-	ctx.lineWidth = 2;
+	ctx.lineWidth = lineWidth;
 
 	ctx.beginPath();
 	ctx.moveTo(points[0].x, points[0].y);

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -152,26 +152,26 @@ impl WasmBezier {
 		WasmBezier(self.0.rotate(angle))
 	}
 
-	fn intersect(&self, curve: &Bezier) -> Vec<f64> {
-		self.0.intersections(curve)
+	fn intersect(&self, curve: &Bezier, error: Option<f64>) -> Vec<f64> {
+		self.0.intersections(curve, error)
 	}
 
 	pub fn intersect_line_segment(&self, js_points: &JsValue) -> Vec<f64> {
 		let points: [DVec2; 2] = js_points.into_serde().unwrap();
 		let line = Bezier::from_linear_dvec2(points[0], points[1]);
-		self.intersect(&line)
+		self.intersect(&line, None)
 	}
 
-	pub fn intersect_quadratic_segment(&self, js_points: &JsValue) -> Vec<f64> {
+	pub fn intersect_quadratic_segment(&self, js_points: &JsValue, error: f64) -> Vec<f64> {
 		let points: [DVec2; 3] = js_points.into_serde().unwrap();
 		let quadratic = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
-		self.intersect(&quadratic)
+		self.intersect(&quadratic, Some(error))
 	}
 
-	pub fn intersect_cubic_segment(&self, js_points: &JsValue) -> Vec<f64> {
+	pub fn intersect_cubic_segment(&self, js_points: &JsValue, error: f64) -> Vec<f64> {
 		let points: [DVec2; 4] = js_points.into_serde().unwrap();
 		let cubic = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
-		self.intersect(&cubic)
+		self.intersect(&cubic, Some(error))
 	}
 
 	pub fn reduce(&self) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -119,8 +119,8 @@ impl WasmBezier {
 		WasmBezier(self.0.trim(t1, t2))
 	}
 
-	pub fn project(&self, x: f64, y: f64) -> JsValue {
-		vec_to_point(&self.0.project(DVec2::new(x, y), ProjectionOptions::default()))
+	pub fn project(&self, x: f64, y: f64) -> f64 {
+		self.0.project(DVec2::new(x, y), ProjectionOptions::default())
 	}
 
 	pub fn local_extrema(&self) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -152,13 +152,26 @@ impl WasmBezier {
 		WasmBezier(self.0.rotate(angle))
 	}
 
+	fn intersect(&self, curve: &Bezier) -> Vec<JsValue> {
+		self.0.intersections(curve).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
+	}
+
 	pub fn intersect_line_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
-		let line: [DVec2; 2] = js_points.into_serde().unwrap();
-		self.0
-			.intersections(&Bezier::from_linear_dvec2(line[0], line[1]))
-			.iter()
-			.map(|&p| vec_to_point(&p))
-			.collect::<Vec<JsValue>>()
+		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+		let line = Bezier::from_linear_dvec2(points[0], points[1]);
+		self.intersect(&line)
+	}
+
+	pub fn intersect_quadratic_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
+		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+		let quadratic = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
+		self.intersect(&quadratic)
+	}
+
+	pub fn intersect_cubic_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
+		let points: [DVec2; 4] = js_points.into_serde().unwrap();
+		let cubic = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
+		self.intersect(&cubic)
 	}
 
 	pub fn reduce(&self) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -154,7 +154,11 @@ impl WasmBezier {
 
 	pub fn intersect_line_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
 		let line: [DVec2; 2] = js_points.into_serde().unwrap();
-		self.0.intersect_line_segment(line).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
+		self.0
+			.intersections(&Bezier::from_linear_dvec2(line[0], line[1]))
+			.iter()
+			.map(|&p| vec_to_point(&p))
+			.collect::<Vec<JsValue>>()
 	}
 
 	pub fn reduce(&self) -> JsValue {

--- a/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/lib.rs
@@ -152,23 +152,23 @@ impl WasmBezier {
 		WasmBezier(self.0.rotate(angle))
 	}
 
-	fn intersect(&self, curve: &Bezier) -> Vec<JsValue> {
-		self.0.intersections(curve).iter().map(|&p| vec_to_point(&p)).collect::<Vec<JsValue>>()
+	fn intersect(&self, curve: &Bezier) -> Vec<f64> {
+		self.0.intersections(curve)
 	}
 
-	pub fn intersect_line_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
+	pub fn intersect_line_segment(&self, js_points: &JsValue) -> Vec<f64> {
 		let points: [DVec2; 2] = js_points.into_serde().unwrap();
 		let line = Bezier::from_linear_dvec2(points[0], points[1]);
 		self.intersect(&line)
 	}
 
-	pub fn intersect_quadratic_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
+	pub fn intersect_quadratic_segment(&self, js_points: &JsValue) -> Vec<f64> {
 		let points: [DVec2; 3] = js_points.into_serde().unwrap();
 		let quadratic = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
 		self.intersect(&quadratic)
 	}
 
-	pub fn intersect_cubic_segment(&self, js_points: &JsValue) -> Vec<JsValue> {
+	pub fn intersect_cubic_segment(&self, js_points: &JsValue) -> Vec<f64> {
 		let points: [DVec2; 4] = js_points.into_serde().unwrap();
 		let cubic = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
 		self.intersect(&cubic)

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -446,9 +446,9 @@ impl Bezier {
 		bezier_starting_at_t1.split(adjusted_t2)[t2_split_side]
 	}
 
-	/// Returns the closest point on the curve to the provided point.
+	/// Returns the t value that corresponds to the closest point on the curve to the provided point.
 	/// Uses a searching algorithm akin to binary search that can be customized using the [ProjectionOptions] structure.
-	pub fn project(&self, point: DVec2, options: ProjectionOptions) -> DVec2 {
+	pub fn project(&self, point: DVec2, options: ProjectionOptions) -> f64 {
 		let ProjectionOptions {
 			lut_size,
 			convergence_epsilon,
@@ -534,7 +534,7 @@ impl Bezier {
 			}
 		}
 
-		self.evaluate(final_t)
+		final_t
 	}
 
 	/// Returns two lists of `t`-values representing the local extrema of the `x` and `y` parametric curves respectively.
@@ -985,11 +985,11 @@ mod tests {
 		let project_options = ProjectionOptions::default();
 
 		let bezier1 = Bezier::from_cubic_coordinates(4., 4., 23., 45., 10., 30., 56., 90.);
-		assert!(bezier1.project(DVec2::new(100., 100.), project_options) == DVec2::new(56., 90.));
-		assert!(bezier1.project(DVec2::new(0., 0.), project_options) == DVec2::new(4., 4.));
+		assert!(bezier1.evaluate(bezier1.project(DVec2::new(100., 100.), project_options)) == DVec2::new(56., 90.));
+		assert!(bezier1.evaluate(bezier1.project(DVec2::new(0., 0.), project_options)) == DVec2::new(4., 4.));
 
 		let bezier2 = Bezier::from_quadratic_coordinates(0., 0., 0., 100., 100., 100.);
-		assert!(bezier2.project(DVec2::new(100., 0.), project_options) == DVec2::new(0., 0.));
+		assert!(bezier2.evaluate(bezier2.project(DVec2::new(100., 0.), project_options)) == DVec2::new(0., 0.));
 	}
 	#[test]
 	fn intersect_line_segment_linear() {

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -603,7 +603,7 @@ impl Bezier {
 	}
 
 	/// Implementation of the algorithm to find curve intersections by iterating on bounding boxes.
-	/// `self_original_t_interval` is used to identify the `t` values of the original parent of `self` that the current iteration is representing.
+	/// - `self_original_t_interval` - Used to identify the `t` values of the original parent of `self` that the current iteration is representing.
 	/// Note that the `t` interval the other curve is not needed since we want to return `t` with respect to it.
 	fn intersections_between_subcurves(&self, self_original_t_interval: [f64; 2], other: &Bezier, error: f64) -> Vec<f64> {
 		let bounding_box1 = self.bounding_box();

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -710,7 +710,7 @@ impl Bezier {
 		}
 
 		// Otherwise, use bounding box to determine intersections
-		Bezier::intersections_between_subcurves(self, [0., 1.], curve, error)
+		self.intersections_between_subcurves([0., 1.], curve, error)
 	}
 
 	/// Returns a list of lists of points representing the De Casteljau points for all iterations at the point corresponding to `t` using De Casteljau's algorithm.

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -705,7 +705,7 @@ impl Bezier {
 		}
 
 		// If the self is linear, then use the implementation for intersections with linear lines
-		if let BezierHandles::Linear = self.handles {
+		if self.handles == BezierHandles::Linear {
 			return curve.intersections(self, Some(error));
 		}
 

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -648,7 +648,7 @@ impl Bezier {
 	/// - `error` - For intersections with non-linear beziers, `error` defines the threshold for bounding boxes to be considered an intersection point.
 	pub fn intersections(&self, curve: &Bezier, error: Option<f64>) -> Vec<f64> {
 		let error = error.unwrap_or(0.5);
-		if let BezierHandles::Linear {} = curve.handles {
+		if curve.handles == BezierHandles::Linear {
 			// Rotate the bezier and the line by the angle that the line makes with the x axis
 			let slope = curve.end - curve.start;
 			let angle = slope.angle_between(DVec2::new(1., 0.));
@@ -693,15 +693,15 @@ impl Bezier {
 			let max = curve.start.max(curve.end);
 
 			return list_intersection_t
-        .into_iter()
-        // Accept the t value if it is approximately in [0, 1] and if the coresponding coordinates are within the range of the linear line
-        .filter(|&t| {
-          utils::f64_approximately_in_range(t, 0., 1., MAX_ABSOLUTE_DIFFERENCE)
-            && utils::dvec2_approximately_in_range(self.unrestricted_evaluate(t), min, max, MAX_ABSOLUTE_DIFFERENCE).all()
-        })
-        // Ensure the returned value is within the correct range
-        .map(|t| t.max(0.).min(1.))
-        .collect::<Vec<f64>>();
+				.into_iter()
+				// Accept the t value if it is approximately in [0, 1] and if the coresponding coordinates are within the range of the linear line
+				.filter(|&t| {
+					utils::f64_approximately_in_range(t, 0., 1., MAX_ABSOLUTE_DIFFERENCE)
+						&& utils::dvec2_approximately_in_range(self.unrestricted_evaluate(t), min, max, MAX_ABSOLUTE_DIFFERENCE).all()
+				})
+				// Ensure the returned value is within the correct range
+				.map(|t| t.max(0.).min(1.))
+				.collect::<Vec<f64>>();
 		}
 
 		// If the self is linear, then use the implementation for intersections with linear lines

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -605,7 +605,7 @@ impl Bezier {
 	/// Implementation of the algorithm to find curve intersections by iterating on bounding boxes.
 	/// `curve1_t_interval` is used to identify the t values of the original `curve1` that the current iteration is representing.
 	/// Note that the `t` interval for only the first curve is needed since we want to return `t` with respect to it.
-	fn subcurve_intersection(curve1: &Bezier, original_curve1_t_interval: [f64; 2], curve2: &Bezier, error: f64) -> Vec<f64> {
+	fn intersections_between_subcurves(curve1: &Bezier, original_curve1_t_interval: [f64; 2], curve2: &Bezier, error: f64) -> Vec<f64> {
 		let bounding_box1 = curve1.bounding_box();
 		let bounding_box2 = curve2.bounding_box();
 
@@ -631,10 +631,10 @@ impl Bezier {
 			let interval_1a = [curve1_start_t, curve1_mid_t];
 			let interval_1b = [curve1_mid_t, curve1_end_t];
 			[
-				Bezier::subcurve_intersection(&split1a, interval_1a, &split2a, error),
-				Bezier::subcurve_intersection(&split1a, interval_1a, &split2b, error),
-				Bezier::subcurve_intersection(&split1b, interval_1b, &split2a, error),
-				Bezier::subcurve_intersection(&split1b, interval_1b, &split2b, error),
+				Bezier::intersections_between_subcurves(&split1a, interval_1a, &split2a, error),
+				Bezier::intersections_between_subcurves(&split1a, interval_1a, &split2b, error),
+				Bezier::intersections_between_subcurves(&split1b, interval_1b, &split2a, error),
+				Bezier::intersections_between_subcurves(&split1b, interval_1b, &split2b, error),
 			]
 			.concat()
 		} else {
@@ -710,7 +710,7 @@ impl Bezier {
 		}
 
 		// Otherwise, use bounding box to determine intersections
-		Bezier::subcurve_intersection(self, [0., 1.], curve, error)
+		Bezier::intersections_between_subcurves(self, [0., 1.], curve, error)
 	}
 
 	/// Returns a list of lists of points representing the De Casteljau points for all iterations at the point corresponding to `t` using De Casteljau's algorithm.

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -609,7 +609,7 @@ impl Bezier {
 		let bounding_box1 = self.bounding_box();
 		let bounding_box2 = other.bounding_box();
 
-		// Determine the `t` interval of the original curve for the split curve1
+		// Get the `t` interval of the original parent of `self` and determine the middle `t` value
 		let [curve1_start_t, curve1_end_t] = self_original_t_interval;
 		let curve1_mid_t = curve1_start_t + (curve1_end_t - curve1_start_t) / 2.;
 
@@ -627,7 +627,7 @@ impl Bezier {
 			let [split_1_a, split_1_b] = self.split(0.5);
 			let [split_2_a, split_2_b] = other.split(0.5);
 
-			// Get the new `t` intervals for
+			// Get the new `t` intervals for the split halves of `self`
 			let interval_1_a = [curve1_start_t, curve1_mid_t];
 			let interval_1_b = [curve1_mid_t, curve1_end_t];
 			[

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -146,6 +146,14 @@ pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 	}
 }
 
+/// Determine if two rectangles have any overlap. The rectangles are represnted by a pair of coordinates that designate the top left and bottom right corners (in a graphical coordinate system).
+pub fn do_rectangles_overlap(rectangle1: [DVec2; 2], rectangle2: [DVec2; 2]) -> bool {
+	let [bottom_left1, top_right1] = rectangle1;
+	let [bottom_left2, top_right2] = rectangle2;
+
+	top_right1.x >= bottom_left2.x && top_right2.x >= bottom_left1.x && top_right2.y >= bottom_left1.y && top_right1.y >= bottom_left2.y
+}
+
 /// Returns the intersection of two lines. The lines are given by a point on the line and its slope (represented by a vector).
 pub fn line_intersection(point1: DVec2, point1_slope_vector: DVec2, point2: DVec2, point2_slope_vector: DVec2) -> DVec2 {
 	assert!(point1_slope_vector.normalize() != point2_slope_vector.normalize());
@@ -241,6 +249,19 @@ mod tests {
 		// linear
 		let roots7 = solve_cubic(0., 0., 1., -1.);
 		assert!(roots7 == vec![1.]);
+	}
+
+	fn test_do_rectangles_overlap() {
+		// Rectangles overlap
+		assert!(do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(20., 20.)], [DVec2::new(10., 10.), DVec2::new(30., 20.)]));
+		// Rectangles share a side
+		assert!(do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(10., 10.)], [DVec2::new(10., 10.), DVec2::new(30., 30.)]));
+		// Rectangle inside the other
+		assert!(do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(10., 10.)], [DVec2::new(2., 2.), DVec2::new(6., 4.)]));
+		// No overlap, rectangles are beside each other
+		assert!(!do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(10., 10.)], [DVec2::new(20., 0.), DVec2::new(30., 10.)]));
+		// No overlap, rectangles are above and below each other
+		assert!(!do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(10., 10.)], [DVec2::new(0., 20.), DVec2::new(20., 30.)]));
 	}
 
 	#[test]

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -251,6 +251,7 @@ mod tests {
 		assert!(roots7 == vec![1.]);
 	}
 
+	#[test]
 	fn test_do_rectangles_overlap() {
 		// Rectangles overlap
 		assert!(do_rectangles_overlap([DVec2::new(0., 0.), DVec2::new(20., 20.)], [DVec2::new(10., 10.), DVec2::new(30., 20.)]));

--- a/bezier-rs/lib/src/utils.rs
+++ b/bezier-rs/lib/src/utils.rs
@@ -146,7 +146,7 @@ pub fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> Vec<f64> {
 	}
 }
 
-/// Determine if two rectangles have any overlap. The rectangles are represnted by a pair of coordinates that designate the top left and bottom right corners (in a graphical coordinate system).
+/// Determine if two rectangles have any overlap. The rectangles are represented by a pair of coordinates that designate the top left and bottom right corners (in a graphical coordinate system).
 pub fn do_rectangles_overlap(rectangle1: [DVec2; 2], rectangle2: [DVec2; 2]) -> bool {
 	let [bottom_left1, top_right1] = rectangle1;
 	let [bottom_left2, top_right2] = rectangle2;


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Refactor `intersect_line_segments` to a new `intersections` function that takes in a `Bezier` as the parameter.
- Handle intersections between quadratics and cubics in addition to linear lines 
   - Uses an algorithm akin to binary search with a curve's bounding box to locate the intersection points
