### PR TITLE
Fix misc. typos

### DIFF
--- a/bezier-rs/docs/interactive-docs/wasm/src/svg_drawing.rs
+++ b/bezier-rs/docs/interactive-docs/wasm/src/svg_drawing.rs
@@ -2,7 +2,7 @@
 pub const SVG_OPEN_TAG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" width="200px" height="200px">"#;
 pub const SVG_CLOSE_TAG: &str = "</svg>";
 
-// Sylistic constants
+// Stylistic constants
 pub const BLACK: &str = "black";
 
 /// Helper function to create an SVG text entitty.

--- a/bezier-rs/lib/src/lib.rs
+++ b/bezier-rs/lib/src/lib.rs
@@ -610,7 +610,7 @@ impl Bezier {
 			.unwrap()
 	}
 
-	/// Returns a Bezier curve that results from applying the tranformation function to each point in the Bezier.
+	/// Returns a Bezier curve that results from applying the transformation function to each point in the Bezier.
 	pub fn apply_transformation(&self, transformation_function: &dyn Fn(DVec2) -> DVec2) -> Bezier {
 		let transformed_start = transformation_function(self.start);
 		let transformed_end = transformation_function(self.end);
@@ -735,7 +735,7 @@ impl Bezier {
 
 			return list_intersection_t
 				.into_iter()
-				// Accept the t value if it is approximately in [0, 1] and if the coresponding coordinates are within the range of the linear line
+				// Accept the t value if it is approximately in [0, 1] and if the corresponding coordinates are within the range of the linear line
 				.filter(|&t| {
 					utils::f64_approximately_in_range(t, 0., 1., MAX_ABSOLUTE_DIFFERENCE)
 						&& utils::dvec2_approximately_in_range(self.unrestricted_evaluate(t), min, max, MAX_ABSOLUTE_DIFFERENCE).all()

--- a/frontend/src/io-managers/input.ts
+++ b/frontend/src/io-managers/input.ts
@@ -289,7 +289,7 @@ export function createInputManager(editor: Editor, container: HTMLElement, dialo
 		// In the catch block, explain to the user why the paste failed and how to fix or work around the problem
 		try {
 			// Attempt to check if the clipboard permission is denied, and throw an error if that is the case
-			// In Firefox, the `clipboard-read` permission isn't supported, so attemping to query it throws an error
+			// In Firefox, the `clipboard-read` permission isn't supported, so attempting to query it throws an error
 			// In Safari, the entire Permissions API isn't supported, so the query never occurs and this block is skipped without an error and we assume we might have permission
 			const clipboardRead = "clipboard-read" as PermissionName;
 			const permission = await navigator.permissions?.query({ name: clipboardRead });

--- a/frontend/src/utility-functions/keyboard-entry.ts
+++ b/frontend/src/utility-functions/keyboard-entry.ts
@@ -29,7 +29,7 @@ export function getLatinKey(e: KeyboardEvent): string | null {
 	const LAST_LATIN_UNICODE_CHAR = 0x024f;
 	if (key.length > 1 || key.charCodeAt(0) > LAST_LATIN_UNICODE_CHAR) return keyCodeToKey(e.code);
 
-	// Otherwise, ths is a printable Latin character
+	// Otherwise, this is a printable Latin character
 	return e.key.toLowerCase();
 }
 


### PR DESCRIPTION
Found via `codespell -q 3 -L complies,crate,doubleclick,ist,ser,vew`