### PR TITLE
Fix a new non-infinite document getting a NaN zoom

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -61,11 +61,7 @@ impl Dispatcher {
 	pub fn handle_message<T: Into<Message>>(&mut self, message: T) {
 		use Message::*;
 
-		if let Some(first) = self.message_queues.first_mut() {
-			first.push_back(message.into());
-		} else {
-			self.message_queues.push(VecDeque::from_iter([message.into()]));
-		}
+		self.message_queues.push(VecDeque::from_iter([message.into()]));
 
 		while let Some(message) = self.message_queues.last_mut().and_then(VecDeque::pop_front) {
 			// Skip processing of this message if it will be processed later (at the end of the shallowest level queue)


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #749

We were trying to zoom the document based on a viewport size of 0 leading to a NaN for the document zoom. This was due to a mistake in the ordering when resuming message handling if there were still previously unprocessed messages.