### PR TITLE
Use .then() instead of .after() for sequencing nodes

### DIFF
--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -167,27 +167,27 @@ mod test {
 	#[test]
 	pub fn dup_node() {
 		let value = ValueNode(4u32);
-		let dup = DupNode.after(value);
+		let dup = value.then(DupNode);
 		assert_eq!(dup.eval(()), (4, 4));
 	}
 	#[test]
 	pub fn id_node() {
-		let value = IdNode.after(ValueNode(4u32));
+		let value = ValueNode(4u32).then(IdNode);
 		assert_eq!(value.eval(()), 4);
 	}
 	#[test]
 	pub fn clone_node() {
-		let cloned = CloneNode.after(&ValueNode(4u32));
+		let cloned = (&ValueNode(4u32)).then(CloneNode);
 		assert_eq!(cloned.eval(()), 4);
 	}
 	#[test]
 	pub fn fst_node() {
-		let fst = FstNode.after(ValueNode((4u32, "a")));
+		let fst = ValueNode((4u32, "a")).then(FstNode);
 		assert_eq!(fst.eval(()), 4);
 	}
 	#[test]
 	pub fn snd_node() {
-		let fst = SndNode.after(ValueNode((4u32, "a")));
+		let fst = ValueNode((4u32, "a")).then(SndNode);
 		assert_eq!(fst.eval(()), "a");
 	}
 	#[test]
@@ -195,7 +195,8 @@ mod test {
 		let a = ValueNode(42u32);
 		let b = ValueNode(6u32);
 		let cons_a = ConsNode(a);
-		let sum = AddNode.after(cons_a).after(b);
+
+		let sum = b.then(cons_a).then(AddNode);
 
 		assert_eq!(sum.eval(()), 48);
 	}

--- a/node-graph/gcore/src/structural.rs
+++ b/node-graph/gcore/src/structural.rs
@@ -64,6 +64,23 @@ impl<'n, Input, First: 'n, Second: 'n> ComposeNode<First, Second, Input> {
 		ComposeNode::<First, Second, Input> { first, second, _phantom: PhantomData }
 	}
 }
+
+pub trait Then<Inter, Input>: Sized {
+	fn then<Second>(self, second: Second) -> ComposeNode<Self, Second, Input>
+	where
+		Self: Node<Input, Output = Inter>,
+		Second: Node<Inter>,
+	{
+		ComposeNode::<Self, Second, Input> {
+			first: self,
+			second,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<First: Node<Input, Output = Inter>, Inter, Input> Then<Inter, Input> for First {}
+
 pub trait After<Inter>: Sized {
 	fn after<First, Input>(self, first: First) -> ComposeNode<First, Self, Input>
 	where

--- a/node-graph/gcore/src/structural.rs
+++ b/node-graph/gcore/src/structural.rs
@@ -81,54 +81,39 @@ pub trait Then<Inter, Input>: Sized {
 
 impl<First: Node<Input, Output = Inter>, Inter, Input> Then<Inter, Input> for First {}
 
-pub trait After<Inter>: Sized {
-	fn after<First, Input>(self, first: First) -> ComposeNode<First, Self, Input>
+pub trait ThenRef<Inter, Input>: Sized {
+	fn after<'n, Second: 'n>(&'n self, second: Second) -> ComposeNode<&'n Self, Second, Input>
 	where
-		First: Node<Input, Output = Inter>,
-		Self: Node<Inter>,
-	{
-		ComposeNode::<First, Self, Input> {
-			first,
-			second: self,
-			_phantom: PhantomData,
-		}
-	}
-}
-impl<Second: Node<I>, I> After<I> for Second {}
-
-pub trait AfterRef<Inter>: Sized {
-	fn after<'n, First: 'n, Input>(&'n self, first: First) -> ComposeNode<First, &'n Self, Input>
-	where
-		First: Node<Input, Output = Inter> + Copy,
-		&'n Self: Node<Inter>,
+		&'n Self: Node<Input, Output = Inter> + Copy,
+		Second: Node<Inter>,
 		Self: 'n,
 	{
-		ComposeNode::<First, &'n Self, Input> {
-			first,
-			second: self,
+		ComposeNode::<&'n Self, Second, Input> {
+			first: self,
+			second,
 			_phantom: PhantomData,
 		}
 	}
 }
-impl<'n, Second: 'n, I> AfterRef<I> for Second where &'n Second: Node<I> {}
+impl<'n, First: 'n, Inter, Input> ThenRef<Inter, Input> for First where &'n First: Node<Input, Output = Inter> {}
 
 #[cfg(feature = "async")]
-pub trait AfterBox<Inter> {
-	fn after<'n, First: 'n, Input>(self, first: First) -> ComposeNode<First, Self, Input>
+pub trait ThenBox<Inter, Input> {
+	fn then<'n, Second: 'n>(self, second: Second) -> ComposeNode<Self, Second, Input>
 	where
-		First: Node<Input, Output = Inter> + Copy,
-		alloc::boxed::Box<Self>: Node<Inter>,
+		alloc::boxed::Box<Self>: Node<Input, Output = Inter>,
+		Second: Node<Inter> + Copy,
 		Self: Sized,
 	{
-		ComposeNode::<First, Self, Input> {
-			first,
-			second: self,
+		ComposeNode::<Self, Second, Input> {
+			first: self,
+			second,
 			_phantom: PhantomData,
 		}
 	}
 }
 #[cfg(feature = "async")]
-impl<'n, Second: 'n, I> AfterBox<I> for alloc::boxed::Box<Second> where &'n alloc::boxed::Box<Second>: Node<I> {}
+impl<'n, First: 'n, Inter, Input> ThenBox<Inter, Input> for alloc::boxed::Box<First> where &'n alloc::boxed::Box<First>: Node<Input, Output = Inter> {}
 
 pub struct ConsNode<Root>(pub Root);
 

--- a/node-graph/gstd/src/any.rs
+++ b/node-graph/gstd/src/any.rs
@@ -105,7 +105,7 @@ mod test {
 		let value = value.as_owned();
 
 		/*let computation = ComposeNode::new(value, add);
-		let computation = id.after(add.after(value));
+		let computation = value.then(add).then(id);
 		let result: u32 = *dyn_any::downcast(computation.eval(&())).unwrap();*/
 	}*/
 	#[test]


### PR DESCRIPTION
I think it provides a clearer ordering but I don't really mind sticking with .after().
