### PR TITLE
Prevent using G/R/S without any layers selected

### DIFF
--- a/editor/src/messages/portfolio/document/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/portfolio/document/transform_layer/transform_layer_message_handler.rs
@@ -61,6 +61,11 @@ impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformL
 					return;
 				}
 
+				// Don't allow grab with no selected layers
+				if selected_layers.len() == 0 {
+					return;
+				}
+
 				begin_operation(self.transform_operation, &mut self.typing, &mut self.mouse_position, &mut self.start_mouse);
 
 				self.transform_operation = TransformOperation::Grabbing(Default::default());
@@ -72,6 +77,11 @@ impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformL
 					return;
 				}
 
+				// Don't allow rotate with no selected layers
+				if selected_layers.len() == 0 {
+					return;
+				}
+
 				begin_operation(self.transform_operation, &mut self.typing, &mut self.mouse_position, &mut self.start_mouse);
 
 				self.transform_operation = TransformOperation::Rotating(Default::default());
@@ -80,6 +90,11 @@ impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformL
 			}
 			BeginScale => {
 				if let TransformOperation::Scaling(_) = self.transform_operation {
+					return;
+				}
+
+				// Don't allow scale with no selected layers
+				if selected_layers.len() == 0 {
 					return;
 				}
 


### PR DESCRIPTION
Fixes:
> It is possible to enter G/R/S transformation modes with nothing selected, even though that shouldn't be allowed. When you are in that mode, you have to click to get out of it before subsequent clicks are respected for targeting layers for selection. So if you hit G, R, or S, then try clicking on a layer, you'll have to click two times instead of once for that to work.