### PR TITLE
Add Alt-dragging to duplicate layers

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -42,7 +42,7 @@ pub fn default_mapping() -> Mapping {
 		//
 		// SelectToolMessage
 		entry!(PointerMove; refresh_keys=[Control, Shift, Alt], action_dispatch=SelectToolMessage::PointerMove { axis_align: Shift, snap_angle: Control, center: Alt }),
-		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift }),
+		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, duplicate: Alt }),
 		entry!(KeyUp(Lmb); action_dispatch=SelectToolMessage::DragStop),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::DragStop),
 		entry!(DoubleClick; action_dispatch=SelectToolMessage::EditLayer),

--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -41,8 +41,8 @@ pub fn default_mapping() -> Mapping {
 		entry!(PointerMove; refresh_keys=[Shift, Control], action_dispatch=TransformLayerMessage::PointerMove { slow_key: Shift, snap_key: Control }),
 		//
 		// SelectToolMessage
-		entry!(PointerMove; refresh_keys=[Control, Shift, Alt], action_dispatch=SelectToolMessage::PointerMove { axis_align: Shift, snap_angle: Control, center: Alt }),
-		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, duplicate: Alt }),
+		entry!(PointerMove; refresh_keys=[Control, Shift, Alt], action_dispatch=SelectToolMessage::PointerMove { axis_align: Shift, snap_angle: Control, center: Alt, duplicate: Alt }),
+		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift }),
 		entry!(KeyUp(Lmb); action_dispatch=SelectToolMessage::DragStop),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::DragStop),
 		entry!(DoubleClick; action_dispatch=SelectToolMessage::EditLayer),

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -517,7 +517,7 @@ impl Fsm for SelectToolFsmState {
 					if input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_none() {
 						tool_data.start_duplicates(document, responses);
 					} else if !input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_some() {
-						tool_data.remove_duplicates(responses);
+						tool_data.stop_duplicates(responses);
 					}
 
 					let closest_move = tool_data.snap_manager.snap_layers(responses, document, snap, mouse_delta);
@@ -906,7 +906,7 @@ impl SelectToolData {
 	}
 
 	/// Removes the duplicated layers. Called when alt is released and the layers have been duplicated.
-	fn remove_duplicates(&mut self, responses: &mut VecDeque<Message>) {
+	fn stop_duplicates(&mut self, responses: &mut VecDeque<Message>) {
 		let origionals = match self.not_duplicated_layers.take() {
 			Some(x) => x,
 			None => return,

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -515,9 +515,9 @@ impl Fsm for SelectToolFsmState {
 						.collect();
 
 					if input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_none() {
-						tool_data.duplicate(document, responses);
+						tool_data.start_duplicates(document, responses);
 					} else if !input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_some() {
-						tool_data.undo_duplicate(responses);
+						tool_data.remove_duplicates(responses);
 					}
 
 					let closest_move = tool_data.snap_manager.snap_layers(responses, document, snap, mouse_delta);
@@ -858,7 +858,7 @@ impl Fsm for SelectToolFsmState {
 
 impl SelectToolData {
 	/// Duplicates the currently dragging layers. Called when alt is pressed and the layers have not yet been duplicated.
-	fn duplicate(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+	fn start_duplicates(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
 		responses.push_back(DocumentMessage::DeselectAllLayers.into());
 
 		self.not_duplicated_layers = Some(self.layers_dragging.clone());
@@ -905,8 +905,8 @@ impl SelectToolData {
 		}
 	}
 
-	/// Removes the duplicated. Called when alt is released and the layers have been duplicated.
-	fn undo_duplicate(&mut self, responses: &mut VecDeque<Message>) {
+	/// Removes the duplicated layers. Called when alt is released and the layers have been duplicated.
+	fn remove_duplicates(&mut self, responses: &mut VecDeque<Message>) {
 		let origionals = match self.not_duplicated_layers.take() {
 			Some(x) => x,
 			None => return,

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -517,7 +517,7 @@ impl Fsm for SelectToolFsmState {
 					if input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_none() {
 						tool_data.duplicate(document, responses);
 					} else if !input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_some() {
-						tool_data.undo_duplicate(document, responses);
+						tool_data.undo_duplicate(responses);
 					}
 
 					let closest_move = tool_data.snap_manager.snap_layers(responses, document, snap, mouse_delta);
@@ -906,7 +906,7 @@ impl SelectToolData {
 	}
 
 	/// Removes the duplicated. Called when alt is released and the layers have been duplicated.
-	fn undo_duplicate(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+	fn undo_duplicate(&mut self, responses: &mut VecDeque<Message>) {
 		let origionals = match self.not_duplicated_layers.take() {
 			Some(x) => x,
 			None => return,

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -50,7 +50,6 @@ pub enum SelectToolMessage {
 	},
 	DragStart {
 		add_to_selection: Key,
-		duplicate: Key,
 	},
 	DragStop,
 	EditLayer,
@@ -60,6 +59,7 @@ pub enum SelectToolMessage {
 		axis_align: Key,
 		snap_angle: Key,
 		center: Key,
+		duplicate: Key,
 	},
 }
 
@@ -319,7 +319,8 @@ impl Default for SelectToolFsmState {
 struct SelectToolData {
 	drag_start: ViewportPosition,
 	drag_current: ViewportPosition,
-	layers_dragging: Vec<Vec<LayerId>>, // Paths and offsets
+	layers_dragging: Vec<Vec<LayerId>>,
+	not_duplicated_layers: Option<Vec<Vec<LayerId>>>,
 	drag_box_overlay_layer: Option<Vec<LayerId>>,
 	path_outlines: PathOutline,
 	bounding_box_overlays: Option<BoundingBoxOverlays>,
@@ -406,7 +407,7 @@ impl Fsm for SelectToolFsmState {
 
 					self
 				}
-				(Ready, DragStart { add_to_selection, duplicate }) => {
+				(Ready, DragStart { add_to_selection }) => {
 					tool_data.path_outlines.clear_hovered(responses);
 
 					tool_data.drag_start = input.mouse.position;
@@ -466,48 +467,6 @@ impl Fsm for SelectToolFsmState {
 					} else if intersection.last().map(|last| selected.contains(last)).unwrap_or(false) {
 						responses.push_back(DocumentMessage::StartTransaction.into());
 
-						if input.keyboard.get(duplicate as usize) {
-							responses.push_back(DocumentMessage::DeselectAllLayers.into());
-
-							// Duplicate each previously selected layer and select the new ones.
-							// Not using the Copy message allows us to retrieve the ids of the new layers to initalise the drag.
-							for layer_path in &mut selected {
-								// If we are also copying the parent of this layer then don't copy the layer.
-								if document
-									.selected_visible_layers()
-									.any(|other_path| layer_path.len() != other_path.len() && layer_path.starts_with(other_path))
-								{
-									continue;
-								}
-
-								let layer = match document.graphene_document.layer(layer_path) {
-									Ok(layer) => layer.clone(),
-									Err(e) => {
-										log::warn!("Could not access selected layer {:?}: {:?}", layer_path, e);
-										continue;
-									}
-								};
-								let layer_metadata = *document.layer_metadata(layer_path);
-								*layer_path.last_mut().unwrap() = generate_uuid();
-
-								responses.push_back(
-									Operation::InsertLayer {
-										layer,
-										destination_path: layer_path.clone(),
-										insert_index: -1,
-									}
-									.into(),
-								);
-
-								responses.push_back(
-									DocumentMessage::UpdateLayerMetadata {
-										layer_path: layer_path.clone(),
-										layer_metadata,
-									}
-									.into(),
-								);
-							}
-						}
 						tool_data.layers_dragging = selected;
 
 						tool_data
@@ -536,10 +495,11 @@ impl Fsm for SelectToolFsmState {
 							DrawingBox
 						}
 					};
+					tool_data.not_duplicated_layers = None;
 
 					state
 				}
-				(Dragging, PointerMove { axis_align, .. }) => {
+				(Dragging, PointerMove { axis_align, duplicate, .. }) => {
 					// TODO: This is a cheat. Break out the relevant functionality from the handler above and call it from there and here.
 					responses.push_front(SelectToolMessage::DocumentIsDirty.into());
 
@@ -553,6 +513,12 @@ impl Fsm for SelectToolFsmState {
 						.filter_map(|path| document.graphene_document.viewport_bounding_box(path, font_cache).ok()?)
 						.flat_map(snapping::expand_bounds)
 						.collect();
+
+					if input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_none() {
+						tool_data.duplicate(document, responses);
+					} else if !input.keyboard.get(duplicate as usize) && tool_data.not_duplicated_layers.is_some() {
+						tool_data.undo_duplicate(document, responses);
+					}
 
 					let closest_move = tool_data.snap_manager.snap_layers(responses, document, snap, mouse_delta);
 					// TODO: Cache the result of `shallowest_unique_layers` to avoid this heavy computation every frame of movement, see https://github.com/GraphiteEditor/Graphite/pull/481
@@ -887,5 +853,91 @@ impl Fsm for SelectToolFsmState {
 
 	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
 		responses.push_back(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default }.into());
+	}
+}
+
+impl SelectToolData {
+	/// Duplicates the currently dragging layers. Called when alt is pressed and the layers have not yet been duplicated.
+	fn duplicate(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+		responses.push_back(DocumentMessage::DeselectAllLayers.into());
+
+		self.not_duplicated_layers = Some(self.layers_dragging.clone());
+
+		// Duplicate each previously selected layer and select the new ones.
+		for layer_path in Document::shallowest_unique_layers(self.layers_dragging.iter_mut()) {
+			// Moves the origional back to its starting position.
+			responses.push_front(
+				Operation::TransformLayerInViewport {
+					path: layer_path.clone(),
+					transform: DAffine2::from_translation(self.drag_start - self.drag_current).to_cols_array(),
+				}
+				.into(),
+			);
+
+			// Copy the layers.
+			// Not using the Copy message allows us to retrieve the ids of the new layers to initalise the drag.
+			let layer = match document.graphene_document.layer(layer_path) {
+				Ok(layer) => layer.clone(),
+				Err(e) => {
+					log::warn!("Could not access selected layer {:?}: {:?}", layer_path, e);
+					continue;
+				}
+			};
+			let layer_metadata = *document.layer_metadata(layer_path);
+			*layer_path.last_mut().unwrap() = generate_uuid();
+
+			responses.push_back(
+				Operation::InsertLayer {
+					layer,
+					destination_path: layer_path.clone(),
+					insert_index: -1,
+				}
+				.into(),
+			);
+
+			responses.push_back(
+				DocumentMessage::UpdateLayerMetadata {
+					layer_path: layer_path.clone(),
+					layer_metadata,
+				}
+				.into(),
+			);
+		}
+	}
+
+	/// Removes the duplicated. Called when alt is released and the layers have been duplicated.
+	fn undo_duplicate(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+		let origionals = match self.not_duplicated_layers.take() {
+			Some(x) => x,
+			None => return,
+		};
+
+		responses.push_back(DocumentMessage::DeselectAllLayers.into());
+
+		// Delete the duplicated layers
+		for layer_path in Document::shallowest_unique_layers(self.layers_dragging.iter()) {
+			responses.push_back(Operation::DeleteLayer { path: layer_path.clone() }.into());
+		}
+
+		// Move the origional to under the mouse
+		for layer_path in Document::shallowest_unique_layers(origionals.iter()) {
+			responses.push_front(
+				Operation::TransformLayerInViewport {
+					path: layer_path.clone(),
+					transform: DAffine2::from_translation(self.drag_current - self.drag_start).to_cols_array(),
+				}
+				.into(),
+			);
+		}
+
+		// Select the origionals
+		responses.push_back(
+			DocumentMessage::SetSelectedLayers {
+				replacement_selected_layers: origionals.clone(),
+			}
+			.into(),
+		);
+
+		self.layers_dragging = origionals;
 	}
 }


### PR DESCRIPTION
Closes #766
> Allow duplication by dragging while holding Alt, since we have a keyboard hint that doesn't say "(Coming Soon)" saying this is possible

Notes:
- Duplicated layers go to the top of the folder of the folder that the previously selected layers were in.
- You drag the duplicated layers and not the originals.
- Dragging a layer as well as its parent duplicates just the parent.