### PR TITLE
Fix fast drag with path tool eating handles

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -86,7 +86,6 @@ pub enum DocumentMessage {
 	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
-		absolute_position: (f64, f64),
 	},
 	NudgeSelectedLayers {
 		delta_x: f64,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -436,10 +436,10 @@ impl MessageHandler<DocumentMessage, (&InputPreprocessorMessageHandler, &FontCac
 					.into(),
 				);
 			}
-			MoveSelectedManipulatorPoints { layer_path, delta, absolute_position } => {
+			MoveSelectedManipulatorPoints { layer_path, delta } => {
 				self.backup(responses);
 				if let Ok(_layer) = self.graphene_document.layer(&layer_path) {
-					responses.push_back(DocumentOperation::MoveSelectedManipulatorPoints { layer_path, delta, absolute_position }.into());
+					responses.push_back(DocumentOperation::MoveSelectedManipulatorPoints { layer_path, delta }.into());
 				}
 			}
 			NudgeSelectedLayers { delta_x, delta_y } => {

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -100,7 +100,7 @@ impl ShapeEditor {
 				);
 				// Snap the selected point to the cursor
 				if let Ok(viewspace) = document.generate_transform_relative_to_viewport(shape_layer_path) {
-					self.move_selected_points(mouse_position - viewspace.transform_point2(point_position), mouse_position, responses)
+					self.move_selected_points(mouse_position - viewspace.transform_point2(point_position), responses)
 				}
 			} else {
 				responses.push_back(
@@ -169,13 +169,12 @@ impl ShapeEditor {
 	}
 
 	/// Move the selected points by dragging the mouse.
-	pub fn move_selected_points(&self, delta: DVec2, absolute_position: DVec2, responses: &mut VecDeque<Message>) {
+	pub fn move_selected_points(&self, delta: DVec2, responses: &mut VecDeque<Message>) {
 		for layer_path in &self.selected_layers {
 			responses.push_back(
 				DocumentMessage::MoveSelectedManipulatorPoints {
 					layer_path: layer_path.clone(),
 					delta: (delta.x, delta.y),
-					absolute_position: (absolute_position.x, absolute_position.y),
 				}
 				.into(),
 			);

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -260,7 +260,7 @@ impl Fsm for PathToolFsmState {
 
 					// Move the selected points by the mouse position
 					let snapped_position = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos, snapped_position, responses);
+					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos,  responses);
 					tool_data.drag_start_pos = snapped_position;
 					PathToolFsmState::Dragging
 				}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -260,7 +260,7 @@ impl Fsm for PathToolFsmState {
 
 					// Move the selected points by the mouse position
 					let snapped_position = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos,  responses);
+					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos, responses);
 					tool_data.drag_start_pos = snapped_position;
 					PathToolFsmState::Dragging
 				}

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -971,14 +971,13 @@ impl Document {
 				}
 				Some(responses)
 			}
-			Operation::MoveSelectedManipulatorPoints { layer_path, delta, absolute_position } => {
+			Operation::MoveSelectedManipulatorPoints { layer_path, delta } => {
 				if let Ok(viewspace) = self.generate_transform_relative_to_viewport(&layer_path) {
 					let objectspace = &viewspace.inverse();
 					let delta = objectspace.transform_vector2(DVec2::new(delta.0, delta.1));
-					let absolute_position = objectspace.transform_point2(DVec2::new(absolute_position.0, absolute_position.1));
 					let layer = self.layer_mut(&layer_path)?;
 					if let Some(shape) = layer.as_subpath_mut() {
-						shape.move_selected(delta, absolute_position, &viewspace);
+						shape.move_selected(delta);
 					}
 				}
 				self.mark_as_dirty(&layer_path)?;

--- a/graphene/src/layers/vector/manipulator_group.rs
+++ b/graphene/src/layers/vector/manipulator_group.rs
@@ -1,4 +1,6 @@
-use super::{consts::ManipulatorType, manipulator_point::ManipulatorPoint};
+use super::consts::ManipulatorType;
+use super::manipulator_point::ManipulatorPoint;
+
 use glam::{DAffine2, DVec2};
 use serde::{Deserialize, Serialize};
 

--- a/graphene/src/layers/vector/subpath.rs
+++ b/graphene/src/layers/vector/subpath.rs
@@ -179,9 +179,9 @@ impl Subpath {
 	}
 
 	/// Move the selected points by the delta vector
-	pub fn move_selected(&mut self, delta: DVec2, absolute_position: DVec2, viewspace: &DAffine2) {
+	pub fn move_selected(&mut self, delta: DVec2) {
 		self.selected_manipulator_groups_any_points_mut()
-			.for_each(|manipulator_group| manipulator_group.move_selected_points(delta, absolute_position, viewspace));
+			.for_each(|manipulator_group| manipulator_group.move_selected_points(delta));
 	}
 
 	/// Delete the selected points from the [Subpath]

--- a/graphene/src/operation.rs
+++ b/graphene/src/operation.rs
@@ -122,7 +122,6 @@ pub enum Operation {
 	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
-		absolute_position: (f64, f64),
 	},
 	MoveManipulatorPoint {
 		layer_path: Vec<LayerId>,


### PR DESCRIPTION
Fixes:
> If you drag an anchor fast enough towards a handle that is attached to it the handle will disappear.

I removed the absolute position (which is sent through a surprisingly large number of files) so points are now just dragged by a delta. Assuming the input system isn't broken, then all the deltas should add up to exactly the absolute position (the floating point error won't be very much unless you are extremely zoomed in and extremely far away from the origin).
