### PR TITLE
Stop dragging after deselecting point with Shift key

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -102,6 +102,8 @@ impl ShapeEditor {
 				if let Ok(viewspace) = document.generate_transform_relative_to_viewport(shape_layer_path) {
 					self.move_selected_points(mouse_position - viewspace.transform_point2(point_position), mouse_position, responses)
 				}
+
+				return Some(points);
 			} else {
 				responses.push_back(
 					Operation::DeselectManipulatorPoints {
@@ -110,10 +112,10 @@ impl ShapeEditor {
 					}
 					.into(),
 				);
-				points.retain(|x| *x != (shape_layer_path, manipulator_group_id, ManipulatorType::from_index(manipulator_point_index)))
-			}
+				points.retain(|x| *x != (shape_layer_path, manipulator_group_id, ManipulatorType::from_index(manipulator_point_index)));
 
-			return Some(points);
+				return None;
+			}
 		}
 
 		// Deselect all points if no nearby point


### PR DESCRIPTION
Fixes:
> If you select a point in the path tool and then shift drag it then overlays are shown but no points are moved

I just returned None from `select_point` when deselecting.