### PR TITLE
Fix licenses

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -1,6 +1,8 @@
 accepted = [
 	"Apache-2.0",
 	"MIT",
+	"BSD-3-Clause",
+	"Zlib",
 ]
 ignore-build-dependencies = true
 ignore-dev-dependencies = true


### PR DESCRIPTION
Some licenses had not been added to `about.toml` breaking the build on `main` branch.