### PR TITLE
Add a pivot widget to selected layer(s) to control the origin(s)

### DIFF
--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -43,7 +43,8 @@ pub const BIG_NUDGE_AMOUNT: f64 = 10.;
 // Select tool
 pub const SELECTION_TOLERANCE: f64 = 5.;
 pub const SELECTION_DRAG_ANGLE: f64 = 90.;
-pub const PIVOT_OUTER: f64 = 8.;
+pub const PIVOT_OUTER_OUTLINE_THICKNESS: f64 = 1.;
+pub const PIVOT_OUTER: f64 = 9.;
 pub const PIVOT_INNER: f64 = 3.;
 
 // Transformation cage

--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -43,6 +43,8 @@ pub const BIG_NUDGE_AMOUNT: f64 = 10.;
 // Select tool
 pub const SELECTION_TOLERANCE: f64 = 5.;
 pub const SELECTION_DRAG_ANGLE: f64 = 90.;
+pub const PIVOT_WIDTH: f64 = 5.;
+pub const PIVOT_SIZE: f64 = 20.;
 
 // Transformation cage
 pub const BOUNDS_SELECT_THRESHOLD: f64 = 10.;

--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -43,8 +43,8 @@ pub const BIG_NUDGE_AMOUNT: f64 = 10.;
 // Select tool
 pub const SELECTION_TOLERANCE: f64 = 5.;
 pub const SELECTION_DRAG_ANGLE: f64 = 90.;
-pub const PIVOT_WIDTH: f64 = 5.;
-pub const PIVOT_SIZE: f64 = 20.;
+pub const PIVOT_OUTER: f64 = 7.;
+pub const PIVOT_INNER: f64 = 3.;
 
 // Transformation cage
 pub const BOUNDS_SELECT_THRESHOLD: f64 = 10.;

--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -43,7 +43,7 @@ pub const BIG_NUDGE_AMOUNT: f64 = 10.;
 // Select tool
 pub const SELECTION_TOLERANCE: f64 = 5.;
 pub const SELECTION_DRAG_ANGLE: f64 = 90.;
-pub const PIVOT_OUTER: f64 = 7.;
+pub const PIVOT_OUTER: f64 = 8.;
 pub const PIVOT_INNER: f64 = 3.;
 
 // Transformation cage

--- a/editor/src/messages/frontend/utility_types.rs
+++ b/editor/src/messages/frontend/utility_types.rs
@@ -25,6 +25,7 @@ pub enum MouseCursorIcon {
 	Grabbing,
 	Crosshair,
 	Text,
+	Move,
 	NSResize,
 	EWResize,
 	NESWResize,

--- a/editor/src/messages/layout/utility_types/widgets/assist_widgets.rs
+++ b/editor/src/messages/layout/utility_types/widgets/assist_widgets.rs
@@ -1,4 +1,5 @@
 use derivative::*;
+use glam::DVec2;
 use serde::{Deserialize, Serialize};
 
 use crate::messages::layout::utility_types::layout_widget::WidgetCallback;
@@ -14,7 +15,7 @@ pub struct PivotAssist {
 	pub on_update: WidgetCallback<PivotAssist>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
 pub enum PivotPosition {
 	#[default]
 	None,
@@ -44,5 +45,54 @@ impl From<&str> for PivotPosition {
 			"BottomRight" => PivotPosition::BottomRight,
 			_ => panic!("Failed parsing unrecognized PivotPosition enum value '{}'", input),
 		}
+	}
+}
+
+impl From<PivotPosition> for Option<DVec2> {
+	fn from(input: PivotPosition) -> Self {
+		match input {
+			PivotPosition::None => None,
+			PivotPosition::TopLeft => Some(DVec2::new(0., 0.)),
+			PivotPosition::TopCenter => Some(DVec2::new(0.5, 0.)),
+			PivotPosition::TopRight => Some(DVec2::new(1., 0.)),
+			PivotPosition::CenterLeft => Some(DVec2::new(0., 0.5)),
+			PivotPosition::Center => Some(DVec2::new(0.5, 0.5)),
+			PivotPosition::CenterRight => Some(DVec2::new(1., 0.5)),
+			PivotPosition::BottomLeft => Some(DVec2::new(0., 1.)),
+			PivotPosition::BottomCenter => Some(DVec2::new(0.5, 1.)),
+			PivotPosition::BottomRight => Some(DVec2::new(1., 1.)),
+		}
+	}
+}
+
+impl From<DVec2> for PivotPosition {
+	fn from(input: DVec2) -> Self {
+		const TOLERANCE: f64 = 1e-5f64;
+		if input.y.abs() < TOLERANCE {
+			if input.x.abs() < TOLERANCE {
+				return PivotPosition::TopLeft;
+			} else if (input.x - 0.5).abs() < TOLERANCE {
+				return PivotPosition::TopCenter;
+			} else if (input.x - 1.).abs() < TOLERANCE {
+				return PivotPosition::TopRight;
+			}
+		} else if (input.y - 0.5).abs() < TOLERANCE {
+			if input.x.abs() < TOLERANCE {
+				return PivotPosition::CenterLeft;
+			} else if (input.x - 0.5).abs() < TOLERANCE {
+				return PivotPosition::Center;
+			} else if (input.x - 1.).abs() < TOLERANCE {
+				return PivotPosition::CenterRight;
+			}
+		} else if (input.y - 1.).abs() < TOLERANCE {
+			if input.x.abs() < TOLERANCE {
+				return PivotPosition::BottomLeft;
+			} else if (input.x - 0.5).abs() < TOLERANCE {
+				return PivotPosition::BottomCenter;
+			} else if (input.x - 1.).abs() < TOLERANCE {
+				return PivotPosition::BottomRight;
+			}
+		}
+		PivotPosition::None
 	}
 }

--- a/editor/src/messages/layout/utility_types/widgets/assist_widgets.rs
+++ b/editor/src/messages/layout/utility_types/widgets/assist_widgets.rs
@@ -67,7 +67,7 @@ impl From<PivotPosition> for Option<DVec2> {
 
 impl From<DVec2> for PivotPosition {
 	fn from(input: DVec2) -> Self {
-		const TOLERANCE: f64 = 1e-5f64;
+		const TOLERANCE: f64 = 1e-5_f64;
 		if input.y.abs() < TOLERANCE {
 			if input.x.abs() < TOLERANCE {
 				return PivotPosition::TopLeft;

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message.rs
@@ -1,4 +1,5 @@
 use super::utility_types::TransformOp;
+use crate::messages::layout::utility_types::widgets::assist_widgets::PivotPosition;
 use crate::messages::portfolio::document::utility_types::misc::TargetDocument;
 use crate::messages::prelude::*;
 
@@ -25,5 +26,6 @@ pub enum PropertiesPanelMessage {
 	ModifyTransform { value: f64, transform_op: TransformOp },
 	ResendActiveProperties,
 	SetActiveLayers { paths: Vec<Vec<LayerId>>, document: TargetDocument },
+	SetPivot { new_position: PivotPosition },
 	UpdateSelectedDocumentProperties,
 }

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
@@ -101,6 +101,13 @@ impl<'a> MessageHandler<PropertiesPanelMessage, PropertiesPanelMessageHandlerDat
 				let (path, _) = self.active_selection.clone().expect("Received update for properties panel with no active layer");
 				responses.push_back(Operation::SetTextContent { path, new_text }.into())
 			}
+			SetPivot { new_position } => {
+				let (layer_path, _) = self.active_selection.clone().expect("Received update for properties panel with no active layer");
+				let position: Option<glam::DVec2> = new_position.into();
+				let pivot = position.unwrap().into();
+
+				responses.push_back(Operation::SetPivot { layer_path, pivot }.into());
+			}
 			CheckSelectedWasUpdated { path } => {
 				if self.matches_selected(&path) {
 					responses.push_back(PropertiesPanelMessage::ResendActiveProperties.into())

--- a/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
@@ -80,6 +80,7 @@ pub fn register_artboard_layer_properties(layer: &Layer, responses: &mut VecDequ
 		} else {
 			panic!("Artboard must have a solid fill")
 		};
+		let pivot = layer.transform.transform_vector2(layer.layerspace_pivot(font_cache));
 
 		vec![LayoutGroup::Section {
 			name: "Artboard".into(),
@@ -95,12 +96,12 @@ pub fn register_artboard_layer_properties(layer: &Layer, responses: &mut VecDequ
 							direction: SeparatorDirection::Horizontal,
 						})),
 						WidgetHolder::new(Widget::NumberInput(NumberInput {
-							value: Some(layer.transform.x()),
+							value: Some(layer.transform.x() + pivot.x),
 							label: "X".into(),
 							unit: " px".into(),
-							on_update: WidgetCallback::new(|number_input: &NumberInput| {
+							on_update: WidgetCallback::new(move |number_input: &NumberInput| {
 								PropertiesPanelMessage::ModifyTransform {
-									value: number_input.value.unwrap(),
+									value: number_input.value.unwrap() - pivot.x,
 									transform_op: TransformOp::X,
 								}
 								.into()
@@ -112,12 +113,12 @@ pub fn register_artboard_layer_properties(layer: &Layer, responses: &mut VecDequ
 							direction: SeparatorDirection::Horizontal,
 						})),
 						WidgetHolder::new(Widget::NumberInput(NumberInput {
-							value: Some(layer.transform.y()),
+							value: Some(layer.transform.y() + pivot.y),
 							label: "Y".into(),
 							unit: " px".into(),
-							on_update: WidgetCallback::new(|number_input: &NumberInput| {
+							on_update: WidgetCallback::new(move |number_input: &NumberInput| {
 								PropertiesPanelMessage::ModifyTransform {
-									value: number_input.value.unwrap(),
+									value: number_input.value.unwrap() - pivot.y,
 									transform_op: TransformOp::Y,
 								}
 								.into()
@@ -308,6 +309,7 @@ pub fn register_artwork_layer_properties(layer: &Layer, responses: &mut VecDeque
 }
 
 fn node_section_transform(layer: &Layer, font_cache: &FontCache) -> LayoutGroup {
+	let pivot = layer.transform.transform_vector2(layer.layerspace_pivot(font_cache));
 	LayoutGroup::Section {
 		name: "Transform".into(),
 		layout: vec![
@@ -322,12 +324,12 @@ fn node_section_transform(layer: &Layer, font_cache: &FontCache) -> LayoutGroup 
 						direction: SeparatorDirection::Horizontal,
 					})),
 					WidgetHolder::new(Widget::NumberInput(NumberInput {
-						value: Some(layer.transform.x()),
+						value: Some(layer.transform.x() + pivot.x),
 						label: "X".into(),
 						unit: " px".into(),
-						on_update: WidgetCallback::new(|number_input: &NumberInput| {
+						on_update: WidgetCallback::new(move |number_input: &NumberInput| {
 							PropertiesPanelMessage::ModifyTransform {
-								value: number_input.value.unwrap(),
+								value: number_input.value.unwrap() - pivot.x,
 								transform_op: TransformOp::X,
 							}
 							.into()
@@ -339,12 +341,12 @@ fn node_section_transform(layer: &Layer, font_cache: &FontCache) -> LayoutGroup 
 						direction: SeparatorDirection::Horizontal,
 					})),
 					WidgetHolder::new(Widget::NumberInput(NumberInput {
-						value: Some(layer.transform.y()),
+						value: Some(layer.transform.y() + pivot.y),
 						label: "Y".into(),
 						unit: " px".into(),
-						on_update: WidgetCallback::new(|number_input: &NumberInput| {
+						on_update: WidgetCallback::new(move |number_input: &NumberInput| {
 							PropertiesPanelMessage::ModifyTransform {
-								value: number_input.value.unwrap(),
+								value: number_input.value.unwrap() - pivot.y,
 								transform_op: TransformOp::Y,
 							}
 							.into()

--- a/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
@@ -1,6 +1,7 @@
 use super::utility_types::TransformOp;
 use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
 use crate::messages::layout::utility_types::misc::LayoutTarget;
+use crate::messages::layout::utility_types::widgets::assist_widgets::PivotAssist;
 use crate::messages::layout::utility_types::widgets::button_widgets::PopoverButton;
 use crate::messages::layout::utility_types::widgets::input_widgets::{ColorInput, FontInput, NumberInput, RadioEntryData, RadioInput, TextAreaInput, TextInput};
 use crate::messages::layout::utility_types::widgets::label_widgets::{IconLabel, IconStyle, Separator, SeparatorDirection, SeparatorType, TextLabel};
@@ -318,6 +319,14 @@ fn node_section_transform(layer: &Layer, font_cache: &FontCache) -> LayoutGroup 
 					WidgetHolder::new(Widget::TextLabel(TextLabel {
 						value: "Location".into(),
 						..TextLabel::default()
+					})),
+					WidgetHolder::new(Widget::Separator(Separator {
+						separator_type: SeparatorType::Related,
+						direction: SeparatorDirection::Horizontal,
+					})),
+					WidgetHolder::new(Widget::PivotAssist(PivotAssist {
+						position: layer.pivot.into(),
+						on_update: WidgetCallback::new(|pivot_assist: &PivotAssist| PropertiesPanelMessage::SetPivot { new_position: pivot_assist.position }.into()),
 					})),
 					WidgetHolder::new(Widget::Separator(Separator {
 						separator_type: SeparatorType::Unrelated,

--- a/editor/src/messages/tool/common_functionality/mod.rs
+++ b/editor/src/messages/tool/common_functionality/mod.rs
@@ -1,5 +1,6 @@
 pub mod overlay_renderer;
 pub mod path_outline;
+pub mod pivot;
 pub mod resize;
 pub mod shape_editor;
 pub mod snapping;

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -9,6 +9,9 @@ use graphene::{layers::text_layer::FontCache, LayerId};
 use glam::{DAffine2, DVec2};
 use std::collections::VecDeque;
 
+const PIVOT_WIDTH: f64 = 10.;
+const PIVOT_SIZE: f64 = 40.;
+
 #[derive(Clone, Debug)]
 pub struct Pivot {
 	/// Pivot between (0,0) and (1,1)
@@ -95,9 +98,6 @@ impl Pivot {
 			}
 		};
 
-		const PIVOT_WIDTH: f64 = 10.;
-		const PIVOT_SIZE: f64 = 40.;
-
 		let layer_paths = [vec![generate_uuid()], vec![generate_uuid()]];
 		for index in 0..=1 {
 			responses.push_back(
@@ -152,5 +152,9 @@ impl Pivot {
 
 	pub fn set_normalised_position(&self, position: DVec2, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
 		self.set_viewport_position(self.transform_from_normalized.transform_point2(position), document, font_cache, responses);
+	}
+
+	pub fn is_over(&self, mouse: DVec2) -> bool {
+		self.pivot.filter(|&pivot| mouse.distance_squared(pivot) < (PIVOT_SIZE / 2.).powi(2)).is_some()
 	}
 }

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -1,0 +1,156 @@
+use crate::application::generate_uuid;
+use crate::consts::COLOR_ACCENT;
+use crate::messages::layout::utility_types::widgets::assist_widgets::PivotPosition;
+use crate::messages::prelude::*;
+
+use graphene::Operation;
+use graphene::{layers::text_layer::FontCache, LayerId};
+
+use glam::{DAffine2, DVec2};
+use std::collections::VecDeque;
+
+#[derive(Clone, Debug)]
+pub struct Pivot {
+	/// Pivot between (0,0) and (1,1)
+	normalized_pivot: DVec2,
+	/// Transform to get from normalized pivot to viewspace
+	transform_from_normalized: DAffine2,
+	/// The viewspace pivot position (if applicable)
+	pivot: Option<DVec2>,
+	/// A reference to the previous overlays so we can destroy them
+	pivot_overlay_lines: Option<[Vec<LayerId>; 2]>,
+	/// The old pivot position in the gui, used to reduce refreshes of the document bar
+	old_pivot_position: PivotPosition,
+}
+
+impl Default for Pivot {
+	fn default() -> Self {
+		Self {
+			normalized_pivot: DVec2::splat(0.5),
+			transform_from_normalized: Default::default(),
+			pivot: Default::default(),
+			pivot_overlay_lines: Default::default(),
+			old_pivot_position: PivotPosition::Center,
+		}
+	}
+}
+
+impl Pivot {
+	/// Calculate the transform to get from normalized pivot to viewspace
+	fn get_layer_pivot_transform(layer_path: &[LayerId], layer: &graphene::layers::layer_info::Layer, document: &DocumentMessageHandler, font_cache: &FontCache) -> DAffine2 {
+		let [min, max] = layer.aabb_for_transform(DAffine2::IDENTITY, font_cache).unwrap_or([DVec2::ZERO, DVec2::ONE]);
+		let bounds_transform = DAffine2::from_translation(min) * DAffine2::from_scale(max - min);
+		let layer_transform = document.graphene_document.multiply_transforms(layer_path).unwrap_or(DAffine2::IDENTITY);
+		bounds_transform * layer_transform
+	}
+
+	/// Recomputes the pivot position and transform
+	fn recalculate_pivot(&mut self, document: &DocumentMessageHandler, font_cache: &FontCache) {
+		let mut layers = document.selected_visible_layers();
+		if let Some(first) = layers.next() {
+			let len = layers.count() + 1;
+			// If just one layer is selected we can use its inner transform
+			if len == 1 {
+				if let Ok(layer) = document.graphene_document.layer(first) {
+					self.normalized_pivot = layer.pivot;
+					self.transform_from_normalized = Self::get_layer_pivot_transform(first, layer, document, font_cache);
+					self.pivot = Some(self.transform_from_normalized.transform_point2(layer.pivot));
+				}
+			} else {
+				// If more than one layer is selected we use the AABB with the mean of the pivots
+				let xy_summation = document
+					.selected_visible_layers()
+					.filter_map(|path| document.graphene_document.pivot(path, font_cache))
+					.reduce(|a, b| a + b)
+					.unwrap_or_default();
+
+				let pivot = xy_summation / len as f64;
+				self.pivot = Some(pivot);
+				let [min, max] = document.selected_visible_layers_bounding_box(font_cache).unwrap_or([DVec2::ZERO, DVec2::ONE]);
+				self.normalized_pivot = (pivot - min) / (max - min);
+
+				self.transform_from_normalized = DAffine2::from_translation(min) * DAffine2::from_scale(max - min);
+			}
+		} else {
+			// If no layers are selected then we revert things back to default
+			self.normalized_pivot = DVec2::splat(0.5);
+			self.pivot = None;
+		}
+	}
+
+	pub fn clear_overlays(&mut self, responses: &mut VecDeque<Message>) {
+		if let Some(overlays) = self.pivot_overlay_lines.take() {
+			for path in overlays {
+				responses.push_back(DocumentMessage::Overlays(Operation::DeleteLayer { path }.into()).into());
+			}
+		}
+	}
+
+	fn redraw_pivot(&mut self, responses: &mut VecDeque<Message>) {
+		self.clear_overlays(responses);
+		let pivot = match self.pivot {
+			Some(pivot) => pivot,
+			None => {
+				return;
+			}
+		};
+
+		const PIVOT_WIDTH: f64 = 10.;
+		const PIVOT_SIZE: f64 = 40.;
+
+		let layer_paths = [vec![generate_uuid()], vec![generate_uuid()]];
+		for index in 0..=1 {
+			responses.push_back(
+				DocumentMessage::Overlays(
+					Operation::AddLine {
+						path: layer_paths[index].clone(),
+						transform: DAffine2::IDENTITY.to_cols_array(),
+						style: graphene::layers::style::PathStyle::new(Some(graphene::layers::style::Stroke::new(COLOR_ACCENT, PIVOT_WIDTH)), graphene::layers::style::Fill::None),
+						insert_index: -1,
+					}
+					.into(),
+				)
+				.into(),
+			);
+		}
+		self.pivot_overlay_lines = Some(layer_paths.clone());
+		let [vertical, horizontal] = layer_paths;
+
+		let transform = DAffine2::from_scale_angle_translation(DVec2::new(PIVOT_SIZE, 1.), std::f64::consts::FRAC_PI_2, pivot - DVec2::new(0., PIVOT_SIZE / 2.)).to_cols_array();
+		responses.push_back(DocumentMessage::Overlays(Operation::TransformLayerInViewport { path: vertical, transform }.into()).into());
+
+		let transform = DAffine2::from_scale_angle_translation(DVec2::new(PIVOT_SIZE, 1.), 0., pivot - DVec2::new(PIVOT_SIZE / 2., 0.)).to_cols_array();
+		responses.push_back(DocumentMessage::Overlays(Operation::TransformLayerInViewport { path: horizontal, transform }.into()).into());
+	}
+
+	pub fn update_pivot(&mut self, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
+		self.recalculate_pivot(document, font_cache);
+		self.redraw_pivot(responses);
+	}
+
+	pub fn should_refresh_pivot_position(&mut self) -> bool {
+		let new = self.to_pivot_position();
+		let should_refresh = new != self.old_pivot_position;
+		self.old_pivot_position = new;
+		should_refresh
+	}
+
+	pub fn to_pivot_position(&self) -> PivotPosition {
+		self.normalized_pivot.into()
+	}
+
+	pub fn set_viewport_position(&self, position: DVec2, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
+		for layer_path in document.selected_visible_layers() {
+			if let Ok(layer) = document.graphene_document.layer(layer_path) {
+				let transform = Self::get_layer_pivot_transform(layer_path, layer, document, font_cache);
+				let pivot = transform.inverse().transform_point2(position).into();
+				let layer_path = layer_path.to_owned();
+				responses.push_back(Operation::SetPivot { layer_path, pivot }.into());
+			}
+		}
+	}
+
+	pub fn set_normalised_position(&self, position: DVec2, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
+		self.set_viewport_position(self.transform_from_normalized.transform_point2(position), document, font_cache, responses);
+	}
+}

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -43,7 +43,7 @@ impl Pivot {
 		let [min, max] = layer.aabb_for_transform(DAffine2::IDENTITY, font_cache).unwrap_or([DVec2::ZERO, DVec2::ONE]);
 		let bounds_transform = DAffine2::from_translation(min) * DAffine2::from_scale(max - min);
 		let layer_transform = document.graphene_document.multiply_transforms(layer_path).unwrap_or(DAffine2::IDENTITY);
-		bounds_transform * layer_transform
+		layer_transform * bounds_transform
 	}
 
 	/// Recomputes the pivot position and transform

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -1,5 +1,7 @@
+//! Handler for the pivot visible on the selected layers whilst in the select tool which controls the centre of rotation
+
 use crate::application::generate_uuid;
-use crate::consts::COLOR_ACCENT;
+use crate::consts::{COLOR_ACCENT, PIVOT_SIZE, PIVOT_WIDTH};
 use crate::messages::layout::utility_types::widgets::assist_widgets::PivotPosition;
 use crate::messages::prelude::*;
 
@@ -8,9 +10,6 @@ use graphene::{layers::text_layer::FontCache, LayerId};
 
 use glam::{DAffine2, DVec2};
 use std::collections::VecDeque;
-
-const PIVOT_WIDTH: f64 = 10.;
-const PIVOT_SIZE: f64 = 40.;
 
 #[derive(Clone, Debug)]
 pub struct Pivot {
@@ -128,6 +127,7 @@ impl Pivot {
 		self.redraw_pivot(responses);
 	}
 
+	/// Has the pivot widget changed (so we should refresh the tool bar at the top of the canvas).
 	pub fn should_refresh_pivot_position(&mut self) -> bool {
 		let new = self.to_pivot_position();
 		let should_refresh = new != self.old_pivot_position;
@@ -139,6 +139,7 @@ impl Pivot {
 		self.normalized_pivot.into()
 	}
 
+	/// Sets the viewport position of the pivot for all selected layers.
 	pub fn set_viewport_position(&self, position: DVec2, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
 		for layer_path in document.selected_visible_layers() {
 			if let Ok(layer) = document.graphene_document.layer(layer_path) {
@@ -150,10 +151,12 @@ impl Pivot {
 		}
 	}
 
+	/// Set the pivot using the normalised transform that is set above.
 	pub fn set_normalised_position(&self, position: DVec2, document: &DocumentMessageHandler, font_cache: &FontCache, responses: &mut VecDeque<Message>) {
 		self.set_viewport_position(self.transform_from_normalized.transform_point2(position), document, font_cache, responses);
 	}
 
+	/// Is the mosue over the pivot?
 	pub fn is_over(&self, mouse: DVec2) -> bool {
 		self.pivot.filter(|&pivot| mouse.distance_squared(pivot) < (PIVOT_SIZE / 2.).powi(2)).is_some()
 	}

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -51,6 +51,7 @@ impl Pivot {
 	fn recalculate_pivot(&mut self, document: &DocumentMessageHandler, font_cache: &FontCache) {
 		let mut layers = document.selected_visible_layers();
 		if let Some(first) = layers.next() {
+			// Add one because the first item is consumed above.
 			let selected_layers_count = layers.count() + 1;
 
 			// If just one layer is selected we can use its inner transform

--- a/editor/src/messages/tool/common_functionality/transformation_cage.rs
+++ b/editor/src/messages/tool/common_functionality/transformation_cage.rs
@@ -81,19 +81,33 @@ impl SelectedEdges {
 
 		let mut pivot = self.pivot_from_bounds(min, max);
 		if center {
+			// Radio below is of (dragging edge / being centred)
+			// The is finite checks are in case the user is dragging the edge with the pivot on (in which case the centre is ignored).
 			if self.top {
-				max.y = center_around.y + ((center_around.y - min.y) / (center_around.y - self.bounds[0].y)) * (self.bounds[1].y - center_around.y);
-				pivot.y = center_around.y;
+				let ratio = (center_around.y - min.y) / (center_around.y - self.bounds[0].y);
+				if ratio.is_finite() {
+					max.y = center_around.y + ratio * (self.bounds[1].y - center_around.y);
+					pivot.y = center_around.y;
+				}
 			} else if self.bottom {
-				min.y = center_around.y - ((max.y - center_around.y) / (self.bounds[1].y - center_around.y)) * (center_around.y - self.bounds[0].y);
-				pivot.y = center_around.y;
+				let ratio = (max.y - center_around.y) / (self.bounds[1].y - center_around.y);
+				if ratio.is_finite() {
+					min.y = center_around.y - ratio * (center_around.y - self.bounds[0].y);
+					pivot.y = center_around.y;
+				}
 			}
 			if self.left {
-				max.x = center_around.x + ((center_around.x - min.x) / (center_around.x - self.bounds[0].x)) * (self.bounds[1].x - center_around.x);
-				pivot.x = center_around.x;
+				let ratio = (center_around.x - min.x) / (center_around.x - self.bounds[0].x);
+				if ratio.is_finite() {
+					max.x = center_around.x + ratio * (self.bounds[1].x - center_around.x);
+					pivot.x = center_around.x;
+				}
 			} else if self.right {
-				min.x = center_around.x - ((max.x - center_around.x) / (self.bounds[1].x - center_around.x)) * (center_around.x - self.bounds[0].x);
-				pivot.x = center_around.x;
+				let ratio = (max.x - center_around.x) / (self.bounds[1].x - center_around.x);
+				if ratio.is_finite() {
+					min.x = center_around.x - ratio * (center_around.x - self.bounds[0].x);
+					pivot.x = center_around.x;
+				}
 			}
 		}
 

--- a/editor/src/messages/tool/common_functionality/transformation_cage.rs
+++ b/editor/src/messages/tool/common_functionality/transformation_cage.rs
@@ -115,8 +115,16 @@ impl SelectedEdges {
 	}
 
 	/// Calculates the required scaling to resize the bounding box
-	pub fn bounds_to_scale_transform(&self, size: DVec2) -> DAffine2 {
-		DAffine2::from_scale(size / (self.bounds[1] - self.bounds[0]))
+	pub fn bounds_to_scale_transform(&self, position: DVec2, size: DVec2) -> (DAffine2, DVec2) {
+		let enlargement_factor = size / (self.bounds[1] - self.bounds[0]);
+		let mut pivot = (self.bounds[0] * enlargement_factor - position) / (enlargement_factor - DVec2::splat(1.));
+		if pivot.x.is_nan() {
+			pivot.x = 0.;
+		}
+		if pivot.y.is_nan() {
+			pivot.y = 0.;
+		}
+		(DAffine2::from_scale(enlargement_factor), pivot)
 	}
 }
 

--- a/editor/src/messages/tool/common_functionality/transformation_cage.rs
+++ b/editor/src/messages/tool/common_functionality/transformation_cage.rs
@@ -81,8 +81,8 @@ impl SelectedEdges {
 
 		let mut pivot = self.pivot_from_bounds(min, max);
 		if center {
-			// Radio below is of (dragging edge / being centred)
-			// The is finite checks are in case the user is dragging the edge with the pivot on (in which case the centre is ignored).
+			// The below ratio is: `dragging edge / being centred`.
+			// The `is_finite()` checks are in case the user is dragging the edge where the pivot is located (in which case the centering mode is ignored).
 			if self.top {
 				let ratio = (center_around.y - min.y) / (center_around.y - self.bounds[0].y);
 				if ratio.is_finite() {

--- a/editor/src/messages/tool/common_functionality/transformation_cage.rs
+++ b/editor/src/messages/tool/common_functionality/transformation_cage.rs
@@ -82,17 +82,17 @@ impl SelectedEdges {
 		let mut pivot = self.pivot_from_bounds(min, max);
 		if center {
 			if self.top {
-				max.y = center_around.y * 2. - min.y;
+				max.y = center_around.y + ((center_around.y - min.y) / (center_around.y - self.bounds[0].y)) * (self.bounds[1].y - center_around.y);
 				pivot.y = center_around.y;
 			} else if self.bottom {
-				min.y = center_around.y * 2. - max.y;
+				min.y = center_around.y - ((max.y - center_around.y) / (self.bounds[1].y - center_around.y)) * (center_around.y - self.bounds[0].y);
 				pivot.y = center_around.y;
 			}
 			if self.left {
-				max.x = center_around.x * 2. - min.x;
+				max.x = center_around.x + ((center_around.x - min.x) / (center_around.x - self.bounds[0].x)) * (self.bounds[1].x - center_around.x);
 				pivot.x = center_around.x;
 			} else if self.right {
-				min.x = center_around.x * 2. - max.x;
+				min.x = center_around.x - ((max.x - center_around.x) / (self.bounds[1].x - center_around.x)) * (center_around.x - self.bounds[0].x);
 				pivot.x = center_around.x;
 			}
 		}

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -282,7 +282,6 @@ impl<'a> MessageHandler<ToolMessage, ToolActionHandlerData<'a>> for SelectTool {
 		if self.tool_data.pivot.should_refresh_pivot_position() {
 			// Notify the frontend about the updated pivot position (a bit ugly to do it here not in the fsm but that doesn't have SelectTool)
 			self.register_properties(responses, LayoutTarget::ToolOptions);
-			log::info!("Updating pivot");
 		}
 
 		if self.fsm_state != new_state {

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -762,7 +762,7 @@ impl Fsm for SelectToolFsmState {
 				}
 				(_, SetPivot { position }) => {
 					let pos: Option<DVec2> = position.into();
-					tool_data.pivot.set_normalised_position(pos.unwrap(), document, font_cache, responses);
+					tool_data.pivot.set_normalized_position(pos.unwrap(), document, font_cache, responses);
 
 					self
 				}

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -641,7 +641,12 @@ impl Fsm for SelectToolFsmState {
 					DrawingBox
 				}
 				(Ready, PointerMove { .. }) => {
-					let cursor = tool_data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input, true));
+					let mut cursor = tool_data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input, true));
+					
+					// Dragging the pivot overrules the other operations
+					if tool_data.pivot.is_over(input.mouse.position) {
+						cursor = MouseCursorIcon::Default;
+					}
 
 					// Generate the select outline (but not if the user is going to use the bound overlays)
 					if cursor == MouseCursorIcon::Default {

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -644,7 +644,7 @@ impl Fsm for SelectToolFsmState {
 
 					// Dragging the pivot overrules the other operations
 					if tool_data.pivot.is_over(input.mouse.position) {
-						cursor = MouseCursorIcon::Default;
+						cursor = MouseCursorIcon::Move;
 					}
 
 					// Generate the select outline (but not if the user is going to use the bound overlays)

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -642,7 +642,7 @@ impl Fsm for SelectToolFsmState {
 				}
 				(Ready, PointerMove { .. }) => {
 					let mut cursor = tool_data.bounding_box_overlays.as_ref().map_or(MouseCursorIcon::Default, |bounds| bounds.get_cursor(input, true));
-					
+
 					// Dragging the pivot overrules the other operations
 					if tool_data.pivot.is_over(input.mouse.position) {
 						cursor = MouseCursorIcon::Default;

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -579,12 +579,11 @@ impl Fsm for SelectToolFsmState {
 
 							let snapped_mouse_position = tool_data.snap_manager.snap_position(responses, document, mouse_position);
 
-							let (_, size) = movement.new_size(snapped_mouse_position, bounds.transform, center, bounds.center_of_transformation, axis_align);
-							let delta = movement.bounds_to_scale_transform(size);
+							let (position, size) = movement.new_size(snapped_mouse_position, bounds.transform, center, bounds.center_of_transformation, axis_align);
+							let (delta, mut pivot) = movement.bounds_to_scale_transform(position, size);
 
 							let selected = &tool_data.layers_dragging.iter().collect::<Vec<_>>();
-							let pivot = if center { &mut bounds.center_of_transformation } else { &mut bounds.opposite_pivot };
-							let mut selected = Selected::new(&mut bounds.original_transforms, pivot, selected, responses, &document.graphene_document);
+							let mut selected = Selected::new(&mut bounds.original_transforms, &mut pivot, selected, responses, &document.graphene_document);
 
 							selected.update_transforms(delta);
 						}

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -195,6 +195,7 @@ const mouseCursorIconCSSNames = {
 	Grabbing: "grabbing",
 	Crosshair: "crosshair",
 	Text: "text",
+	Move: "move",
 	NSResize: "ns-resize",
 	EWResize: "ew-resize",
 	NESWResize: "nesw-resize",

--- a/graphene/src/document.rs
+++ b/graphene/src/document.rs
@@ -760,7 +760,12 @@ impl Document {
 				self.mark_as_dirty(&path)?;
 				Some([vec![DocumentChanged, LayerChanged { path: path.clone() }], update_thumbnails_upstream(&path)].concat())
 			}
-
+			Operation::SetPivot { layer_path, pivot } => {
+				let layer = self.layer_mut(&layer_path).expect("Setting pivot for invalid layer");
+				layer.pivot = pivot.into();
+				self.mark_as_dirty(&layer_path)?;
+				Some([vec![DocumentChanged, LayerChanged { path: layer_path.clone() }], update_thumbnails_upstream(&layer_path)].concat())
+			}
 			Operation::SetLayerTransformInViewport { path, transform } => {
 				let transform = DAffine2::from_cols_array(&transform);
 				self.set_transform_relative_to_viewport(&path, transform)?;

--- a/graphene/src/operation.rs
+++ b/graphene/src/operation.rs
@@ -56,6 +56,10 @@ pub enum Operation {
 		blob_url: String,
 		dimensions: (f64, f64),
 	},
+	SetPivot {
+		layer_path: Vec<LayerId>,
+		pivot: (f64, f64),
+	},
 	SetTextEditability {
 		path: Vec<LayerId>,
 		editable: bool,


### PR DESCRIPTION
Closes #525

Pivot is viewable and draggable in select tool and can be controlled with the tiny grid of squares. Functionality is roughly the same as in Inkscape (except I didn't add shift clicking the pivot to reset it as you can click the dot in the grid).