### PR TITLE
#[macro_use] the log crate

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -161,7 +161,7 @@ impl Dispatcher {
 							&mut queue,
 						);
 					} else {
-						log::warn!("Called ToolMessage without an active document.\nGot {:?}", message);
+						warn!("Called ToolMessage without an active document.\nGot {:?}", message);
 					}
 				}
 				Workspace(message) => {
@@ -218,11 +218,11 @@ impl Dispatcher {
 			match message_logging_verbosity {
 				MessageLoggingVerbosity::Off => {}
 				MessageLoggingVerbosity::Names => {
-					log::info!("{}{:?}", Self::create_indents(queues), message.to_discriminant());
+					info!("{}{:?}", Self::create_indents(queues), message.to_discriminant());
 				}
 				MessageLoggingVerbosity::Contents => {
 					if !(matches!(message, Message::InputPreprocessor(_))) {
-						log::info!("Message: {}{:?}", Self::create_indents(queues), message);
+						info!("Message: {}{:?}", Self::create_indents(queues), message);
 					}
 				}
 			}
@@ -232,7 +232,7 @@ impl Dispatcher {
 	/// Logs into the tree that the message is in the side effect free messages and its execution will be deferred
 	fn log_deferred_message(&self, message: &Message, queues: &[VecDeque<Message>], message_logging_verbosity: MessageLoggingVerbosity) {
 		if let MessageLoggingVerbosity::Names = message_logging_verbosity {
-			log::info!("{}Deferred \"{:?}\" because it's a SIDE_EFFECT_FREE_MESSAGE", Self::create_indents(queues), message.to_discriminant());
+			info!("{}Deferred \"{:?}\" because it's a SIDE_EFFECT_FREE_MESSAGE", Self::create_indents(queues), message.to_discriminant());
 		}
 	}
 }

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -4,6 +4,10 @@ extern crate graphite_proc_macros;
 #[macro_use]
 mod macros;
 
+// `macro_use` puts the log macros (`error!`, `warn!`, `debug!`, `info!` and `trace!`) in scope for the crate
+#[macro_use]
+extern crate log;
+
 pub mod application;
 pub mod consts;
 pub mod dispatcher;

--- a/editor/src/messages/input_mapper/utility_types/misc.rs
+++ b/editor/src/messages/input_mapper/utility_types/misc.rs
@@ -98,7 +98,7 @@ impl ActionKeys {
 				}
 			}
 			ActionKeys::Keys(keys) => {
-				log::warn!("Calling `.to_keys()` on a `ActionKeys::Keys` is a mistake/bug. Keys are: {:?}.", keys);
+				warn!("Calling `.to_keys()` on a `ActionKeys::Keys` is a mistake/bug. Keys are: {:?}.", keys);
 			}
 		}
 	}

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -34,10 +34,9 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 				let layout = if let Some(layout) = self.layouts.get_mut(layout_target as usize) {
 					layout
 				} else {
-					log::warn!(
+					warn!(
 						"UpdateLayout was called referencing an invalid layout. `widget_id: {}`, `layout_target: {:?}`",
-						widget_id,
-						layout_target
+						widget_id, layout_target
 					);
 					return;
 				};
@@ -45,10 +44,9 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 				let widget_holder = if let Some(widget_holder) = layout.iter_mut().find(|widget| widget.widget_id == widget_id) {
 					widget_holder
 				} else {
-					log::warn!(
+					warn!(
 						"UpdateLayout was called referencing an invalid widget ID, although the layout target was valid. `widget_id: {}`, `layout_target: {:?}`",
-						widget_id,
-						layout_target
+						widget_id, layout_target
 					);
 					return;
 				};

--- a/editor/src/messages/portfolio/document/artboard/artboard_message_handler.rs
+++ b/editor/src/messages/portfolio/document/artboard/artboard_message_handler.rs
@@ -40,7 +40,7 @@ impl MessageHandler<ArtboardMessage, &FontCache> for ArtboardMessageHandler {
 					}
 				}
 				Ok(None) => {}
-				Err(e) => log::error!("Artboard Error: {:?}", e),
+				Err(e) => error!("Artboard Error: {:?}", e),
 			},
 
 			// Messages

--- a/editor/src/messages/portfolio/document/overlays/overlays_message_handler.rs
+++ b/editor/src/messages/portfolio/document/overlays/overlays_message_handler.rs
@@ -20,7 +20,7 @@ impl MessageHandler<OverlaysMessage, (bool, &FontCache, &InputPreprocessorMessag
 			#[remain::unsorted]
 			DispatchOperation(operation) => match self.overlays_graphene_document.handle_operation(*operation, font_cache) {
 				Ok(_) => responses.push_back(OverlaysMessage::Rerender.into()),
-				Err(e) => log::error!("OverlaysError: {:?}", e),
+				Err(e) => error!("OverlaysError: {:?}", e),
 			},
 
 			// Messages

--- a/editor/src/messages/portfolio/document/utility_types/misc.rs
+++ b/editor/src/messages/portfolio/document/utility_types/misc.rs
@@ -77,7 +77,7 @@ impl Platform {
 		match self {
 			Platform::Mac => KeyboardPlatformLayout::Mac,
 			Platform::Unknown => {
-				log::warn!("The platform has not been set, remember to send `GlobalsMessage::SetPlatform` during editor initialization.");
+				warn!("The platform has not been set, remember to send `GlobalsMessage::SetPlatform` during editor initialization.");
 				KeyboardPlatformLayout::Standard
 			}
 			_ => KeyboardPlatformLayout::Standard,

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -203,7 +203,7 @@ impl<'a> Selected<'a> {
 				if let Ok(layer) = document.layer(path) {
 					original_transforms.insert(path.to_vec(), layer.transform);
 				} else {
-					log::warn!("Didn't find a layer for {:?}", path);
+					warn!("Didn't find a layer for {:?}", path);
 				}
 			}
 		}

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -11,8 +11,6 @@ use graphene::layers::layer_info::LayerDataTypeDiscriminant;
 use graphene::layers::text_layer::{Font, FontCache};
 use graphene::Operation as DocumentOperation;
 
-use log::warn;
-
 #[derive(Debug, Clone, Default)]
 pub struct PortfolioMessageHandler {
 	menu_bar_message_handler: MenuBarMessageHandler,
@@ -292,7 +290,7 @@ impl MessageHandler<PortfolioMessage, &InputPreprocessorMessageHandler> for Port
 			} => {
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>| {
 					if let Some(document) = self.active_document() {
-						log::trace!("Pasting into folder {:?} as index: {}", &path, insert_index);
+						trace!("Pasting into folder {:?} as index: {}", &path, insert_index);
 						let destination_path = [path.to_vec(), vec![generate_uuid()]].concat();
 
 						responses.push_front(

--- a/editor/src/messages/tool/common_functionality/overlay_renderer.rs
+++ b/editor/src/messages/tool/common_functionality/overlay_renderer.rs
@@ -42,16 +42,16 @@ impl OverlayRenderer {
 
 			if let Some(shape) = layer.as_subpath() {
 				let outline_cache = self.shape_overlay_cache.get(layer_id);
-				log::trace!("Overlay: Outline cache {:?}", &outline_cache);
+				trace!("Overlay: Outline cache {:?}", &outline_cache);
 
 				// Create an outline if we do not have a cached one
 				if outline_cache == None {
 					let outline_path = self.create_shape_outline_overlay(shape.clone(), responses);
 					self.shape_overlay_cache.insert(*layer_id, outline_path.clone());
 					Self::place_outline_overlays(outline_path.clone(), &transform, responses);
-					log::trace!("Overlay: Creating new outline {:?}", &outline_path);
+					trace!("Overlay: Creating new outline {:?}", &outline_path);
 				} else if let Some(outline_path) = outline_cache {
-					log::trace!("Overlay: Updating overlays for {:?} owning layer: {:?}", outline_path, layer_id);
+					trace!("Overlay: Updating overlays for {:?} owning layer: {:?}", outline_path, layer_id);
 					Self::modify_outline_overlays(outline_path.clone(), shape.clone(), responses);
 					Self::place_outline_overlays(outline_path.clone(), &transform, responses);
 				}
@@ -62,7 +62,7 @@ impl OverlayRenderer {
 
 					// If cached update placement and style
 					if let Some(manipulator_group_overlays) = manipulator_group_cache {
-						log::trace!("Overlay: Updating detail overlays for {:?}", manipulator_group_overlays);
+						trace!("Overlay: Updating detail overlays for {:?}", manipulator_group_overlays);
 						Self::place_manipulator_group_overlays(manipulator_group, manipulator_group_overlays, &transform, responses);
 						Self::style_overlays(manipulator_group, manipulator_group_overlays, responses);
 					} else {
@@ -251,7 +251,7 @@ impl OverlayRenderer {
 	/// Removes the manipulator overlays from the overlay document.
 	fn remove_manipulator_group_overlays(overlay_paths: &ManipulatorGroupOverlays, responses: &mut VecDeque<Message>) {
 		overlay_paths.iter().flatten().for_each(|layer_id| {
-			log::trace!("Overlay: Sending delete message for: {:?}", layer_id);
+			trace!("Overlay: Sending delete message for: {:?}", layer_id);
 			responses.push_back(DocumentMessage::Overlays(Operation::DeleteLayer { path: layer_id.clone() }.into()).into());
 		});
 	}

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -45,7 +45,7 @@ impl ShapeEditor {
 		}
 
 		if let Some((shape_layer_path, manipulator_group_id, manipulator_point_index)) = self.find_nearest_point_indices(document, mouse_position, select_threshold) {
-			log::trace!("Selecting... manipulator group ID: {}, manipulator point index: {}", manipulator_group_id, manipulator_point_index);
+			trace!("Selecting... manipulator group ID: {}, manipulator point index: {}", manipulator_group_id, manipulator_point_index);
 
 			// If the point we're selecting has already been selected
 			// we can assume this point exists.. since we did just click on it hence the unwrap
@@ -225,7 +225,7 @@ impl ShapeEditor {
 			if let Some((manipulator_id, manipulator_point_index, distance_squared)) = self.closest_point_in_layer(document, layer, mouse_position) {
 				// Choose the first point under the threshold
 				if distance_squared < select_threshold_squared {
-					log::trace!("Selecting... manipulator ID: {}, manipulator point index: {}", manipulator_id, manipulator_point_index);
+					trace!("Selecting... manipulator ID: {}, manipulator point index: {}", manipulator_id, manipulator_point_index);
 					return Some((layer, manipulator_id, manipulator_point_index));
 				}
 			}

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -941,7 +941,7 @@ impl SelectToolData {
 			let layer = match document.graphene_document.layer(layer_path) {
 				Ok(layer) => layer.clone(),
 				Err(e) => {
-					log::warn!("Could not access selected layer {:?}: {:?}", layer_path, e);
+					warn!("Could not access selected layer {:?}: {:?}", layer_path, e);
 					continue;
 				}
 			};

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -98,7 +98,7 @@ impl JsEditorHandle {
 		let js_return_value = self.frontend_message_handler_callback.call2(&JsValue::null(), &JsValue::from(message_type), &message_data);
 
 		if let Err(error) = js_return_value {
-			log::error!(
+			error!(
 				"While handling FrontendMessage \"{:?}\", JavaScript threw an error: {:?}",
 				message.to_discriminant().local_name(),
 				error,
@@ -295,7 +295,7 @@ impl JsEditorHandle {
 		let key = translate_key(&name);
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
-		log::trace!("Key down {:?}, name: {}, modifiers: {:?}", key, name, modifiers);
+		trace!("Key down {:?}, name: {}, modifiers: {:?}", key, name, modifiers);
 
 		let message = InputPreprocessorMessage::KeyDown { key, modifier_keys };
 		self.dispatch(message);
@@ -307,7 +307,7 @@ impl JsEditorHandle {
 		let key = translate_key(&name);
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
-		log::trace!("Key up {:?}, name: {}, modifiers: {:?}", key, name, modifier_keys);
+		trace!("Key up {:?}, name: {}, modifiers: {:?}", key, name, modifier_keys);
 
 		let message = InputPreprocessorMessage::KeyUp { key, modifier_keys };
 		self.dispatch(message);

--- a/frontend/wasm/src/helpers.rs
+++ b/frontend/wasm/src/helpers.rs
@@ -11,7 +11,7 @@ pub fn panic_hook(info: &panic::PanicInfo) {
 	let header = "The editor crashed — sorry about that";
 	let description = "An internal error occurred. Reload the editor to continue. Please report this by filing an issue on GitHub.";
 
-	log::error!("{}", info);
+	error!("{}", info);
 
 	JS_EDITOR_HANDLES.with(|instances| {
 		instances.borrow_mut().values_mut().for_each(|instance| {
@@ -74,7 +74,7 @@ impl log::Log for WasmLog {
 pub fn translate_key(name: &str) -> Key {
 	use Key::*;
 
-	log::trace!("Key event received: {}", name);
+	trace!("Key event received: {}", name);
 
 	match name {
 		// Writing system keys

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+// `macro_use` puts the log macros (`error!`, `warn!`, `debug!`, `info!` and `trace!`) in scope for the crate
+#[macro_use]
+extern crate log;
+
 pub mod editor_api;
 pub mod helpers;
 

--- a/graphene/src/intersection.rs
+++ b/graphene/src/intersection.rs
@@ -335,7 +335,7 @@ fn path_intersections(a: &SubCurve, b: &SubCurve, intersections: &mut Vec<Inters
 				// Return the best estimate of intersection regardless of quality
 				// Also provides a base case and prevents infinite recursion
 				if a.available_precision() <= F64PRECISE || b.available_precision() <= F64PRECISE {
-					log::trace!("Precision reached");
+					trace!("Precision reached");
 					intersections.push(cross);
 					return;
 				}
@@ -343,7 +343,7 @@ fn path_intersections(a: &SubCurve, b: &SubCurve, intersections: &mut Vec<Inters
 			// Alternate base case
 			// Note: may occur for the less forgiving side of a `PathSeg` endpoint intersect
 			if a.available_precision() <= F64PRECISE || b.available_precision() <= F64PRECISE {
-				log::trace!("Precision reached without finding intersect");
+				trace!("Precision reached without finding intersect");
 				return;
 			}
 		}

--- a/graphene/src/lib.rs
+++ b/graphene/src/lib.rs
@@ -1,3 +1,7 @@
+// `macro_use` puts the log macros (`error!`, `warn!`, `debug!`, `info!` and `trace!`) in scope for the crate
+#[macro_use]
+extern crate log;
+
 pub mod boolean_ops;
 /// Contains the [Color](color::Color) type.
 pub mod color;


### PR DESCRIPTION
We no longer need to prefix log statements with `log::` so `log::warn!("...")` can be replaced with `warn!("...")`