### PR TITLE
Bezier-rs: Convert from canvas to svg for constructors

### DIFF
--- a/libraries/bezier-rs/src/svg.rs
+++ b/libraries/bezier-rs/src/svg.rs
@@ -28,12 +28,12 @@ pub struct ToSVGOptions {
 
 impl ToSVGOptions {
 	/// Combine and format curve styling options for an SVG path.
-	pub(crate) fn formatted_curve_arguments(&self) -> String {
+	pub fn formatted_curve_arguments(&self) -> String {
 		format!(r#"stroke="{}" stroke-width="{}" fill="none""#, self.curve_stroke_color, self.curve_stroke_width)
 	}
 
 	/// Combine and format anchor styling options an SVG circle.
-	pub(crate) fn formatted_anchor_arguments(&self) -> String {
+	pub fn formatted_anchor_arguments(&self) -> String {
 		format!(
 			r#"r="{}", stroke="{}" stroke-width="{}" fill="{}""#,
 			self.anchor_radius, self.anchor_stroke_color, self.anchor_stroke_width, self.anchor_fill
@@ -41,7 +41,7 @@ impl ToSVGOptions {
 	}
 
 	/// Combine and format handle point styling options for an SVG circle.
-	pub(crate) fn formatted_handle_point_arguments(&self) -> String {
+	pub fn formatted_handle_point_arguments(&self) -> String {
 		format!(
 			r#"r="{}", stroke="{}" stroke-width="{}" fill="{}""#,
 			self.handle_point_radius, self.handle_point_stroke_color, self.handle_point_stroke_width, self.handle_point_fill
@@ -49,7 +49,7 @@ impl ToSVGOptions {
 	}
 
 	/// Combine and format handle line styling options an SVG path.
-	pub(crate) fn formatted_handle_line_arguments(&self) -> String {
+	pub fn formatted_handle_line_arguments(&self) -> String {
 		format!(r#"stroke="{}" stroke-width="{}" fill="none""#, self.handle_line_stroke_color, self.handle_line_stroke_width)
 	}
 }

--- a/website/other/bezier-rs-demos/src/App.vue
+++ b/website/other/bezier-rs-demos/src/App.vue
@@ -4,6 +4,9 @@
 		<p>This is the interactive documentation for the <b>bezier-rs</b> library. Click and drag on the endpoints of the example curves to visualize the various Bezier utilities and functions.</p>
 		<h2>Beziers</h2>
 		<div v-for="(feature, index) in bezierFeatures" :key="index">
+			<BezierExamplePane :name="feature.name" :callback="feature.callback" />
+		</div>
+		<div v-for="(feature, index) in features" :key="index">
 			<ExamplePane
 				:template="feature.template"
 				:templateOptions="feature.templateOptions"
@@ -28,6 +31,7 @@ import { defineComponent, markRaw } from "vue";
 import { drawBezier, drawBezierHelper, drawCircle, drawCircleSector, drawCurve, drawLine, drawPoint, drawText, getContextFromCanvas, COLORS } from "@/utils/drawing";
 import { BezierCurveType, CircleSector, Point, WasmBezierInstance, WasmSubpathInstance } from "@/utils/types";
 
+import BezierExamplePane from "@/components/BezierExamplePane.vue";
 import ExamplePane from "@/components/ExamplePane.vue";
 import SliderExample from "@/components/SliderExample.vue";
 import SubpathExamplePane from "@/components/SubpathExamplePane.vue";
@@ -48,9 +52,10 @@ export default defineComponent({
 			bezierFeatures: [
 				{
 					name: "Constructor",
-					// eslint-disable-next-line
-					callback: (): void => {},
+					callback: (bezier: WasmBezierInstance): string => bezier.to_svg(),
 				},
+			],
+			features: [
 				{
 					name: "Bezier Through Points",
 					// eslint-disable-next-line
@@ -586,6 +591,7 @@ export default defineComponent({
 		};
 	},
 	components: {
+		BezierExamplePane,
 		ExamplePane,
 		SubpathExamplePane,
 	},

--- a/website/other/bezier-rs-demos/src/App.vue
+++ b/website/other/bezier-rs-demos/src/App.vue
@@ -4,7 +4,7 @@
 		<p>This is the interactive documentation for the <b>bezier-rs</b> library. Click and drag on the endpoints of the example curves to visualize the various Bezier utilities and functions.</p>
 		<h2>Beziers</h2>
 		<div v-for="(feature, index) in bezierFeatures" :key="index">
-			<BezierExamplePane :name="feature.name" :callback="feature.callback" />
+			<BezierExamplePane :name="feature.name" :callback="feature.callback" :exampleOptions="feature.exampleOptions" />
 		</div>
 		<div v-for="(feature, index) in features" :key="index">
 			<ExamplePane
@@ -12,10 +12,8 @@
 				:templateOptions="feature.templateOptions"
 				:name="feature.name"
 				:callback="feature.callback"
-				:createThroughPoints="feature.createThroughPoints"
 				:curveDegrees="feature.curveDegrees"
 				:customPoints="feature.customPoints"
-				:customOptions="feature.customOptions"
 			/>
 		</div>
 		<h2>Subpaths</h2>
@@ -28,6 +26,7 @@
 <script lang="ts">
 import { defineComponent, markRaw } from "vue";
 
+import { WasmBezier } from "@/../wasm/pkg";
 import { drawBezier, drawBezierHelper, drawCircle, drawCircleSector, drawCurve, drawLine, drawPoint, drawText, getContextFromCanvas, COLORS } from "@/utils/drawing";
 import { BezierCurveType, CircleSector, Point, WasmBezierInstance, WasmSubpathInstance } from "@/utils/types";
 
@@ -52,31 +51,45 @@ export default defineComponent({
 			bezierFeatures: [
 				{
 					name: "Constructor",
-					callback: (bezier: WasmBezierInstance): string => bezier.to_svg(),
+					callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.to_svg(),
 				},
-			],
-			features: [
 				{
 					name: "Bezier Through Points",
-					// eslint-disable-next-line
-					callback: (): void => {},
-					curveDegrees: new Set([BezierCurveType.Quadratic, BezierCurveType.Cubic]),
-					createThroughPoints: true,
-					template: markRaw(SliderExample),
-					templateOptions: {
-						sliders: [
-							{
-								min: 0.01,
-								max: 0.99,
-								step: 0.01,
-								default: 0.5,
-								variable: "t",
-							},
-						],
+					callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
+						const points: Point[] = JSON.parse(bezier.get_points());
+						const formattedPoints: number[][] = points.map((p) => [p.x, p.y]);
+						if (Object.values(options).length === 1) {
+							return WasmBezier.quadratic_through_points(formattedPoints, options.t);
+						}
+						return WasmBezier.cubic_through_points(formattedPoints, options.t, options["midpoint separation"]);
 					},
-					customOptions: {
+					exampleOptions: {
+						[BezierCurveType.Linear]: {
+							disabled: true,
+						},
+						[BezierCurveType.Quadratic]: {
+							customPoints: [
+								[30, 50],
+								[120, 70],
+								[160, 170],
+							],
+							sliderOptions: [
+								{
+									min: 0.01,
+									max: 0.99,
+									step: 0.01,
+									default: 0.5,
+									variable: "t",
+								},
+							],
+						},
 						[BezierCurveType.Cubic]: {
-							sliders: [
+							customPoints: [
+								[30, 50],
+								[120, 70],
+								[160, 170],
+							],
+							sliderOptions: [
 								{
 									min: 0.01,
 									max: 0.99,
@@ -94,14 +107,9 @@ export default defineComponent({
 							],
 						},
 					},
-					customPoints: {
-						[BezierCurveType.Quadratic]: [
-							[30, 50],
-							[120, 70],
-							[160, 170],
-						],
-					},
 				},
+			],
+			features: [
 				{
 					name: "Length",
 					callback: (canvas: HTMLCanvasElement, bezier: WasmBezierInstance): void => {

--- a/website/other/bezier-rs-demos/src/components/BezierDrawing.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDrawing.ts
@@ -1,5 +1,3 @@
-import { WasmBezier } from "@/../wasm/pkg";
-
 import { COLORS, drawBezier, drawPoint, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
 import { Callback, BezierPoint, BezierStyleConfig, Point, WasmBezierManipulatorKey, WasmBezierInstance } from "@/utils/types";
 
@@ -120,22 +118,13 @@ class BezierDrawing {
 
 		// For the create through points cases, we store a bezier where the handle is actually the point that the curve should pass through
 		// This is so that we can re-use the drag and drop logic, while simply drawing the desired bezier instead
-		const actualBezierPointLength = JSON.parse(this.bezier.get_points()).length;
-		let pointsToDraw = this.points;
+		const pointsToDraw = this.points;
 
 		let styleConfig: Partial<BezierStyleConfig> = {
 			handleLineStrokeColor: COLORS.INTERACTIVE.STROKE_2,
 		};
 		let dragIndex = this.dragIndex;
 		if (this.createThroughPoints) {
-			let bezierThroughPoints;
-			const pointList = this.points.map((p) => [p.x, p.y]);
-			if (actualBezierPointLength === 3) {
-				bezierThroughPoints = WasmBezier.quadratic_through_points(pointList, this.options.t);
-			} else {
-				bezierThroughPoints = WasmBezier.cubic_through_points(pointList, this.options.t, this.options["midpoint separation"]);
-			}
-			pointsToDraw = JSON.parse(bezierThroughPoints.get_points());
 			if (this.dragIndex === 1) {
 				// Do not propagate dragIndex when the the non-endpoint is moved
 				dragIndex = null;

--- a/website/other/bezier-rs-demos/src/components/BezierDrawing.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDrawing.ts
@@ -1,7 +1,7 @@
 import { WasmBezier } from "@/../wasm/pkg";
 
 import { COLORS, drawBezier, drawPoint, getContextFromCanvas, getPointSizeByIndex } from "@/utils/drawing";
-import { BezierCallback, BezierPoint, BezierStyleConfig, Point, WasmBezierManipulatorKey, WasmBezierInstance } from "@/utils/types";
+import { Callback, BezierPoint, BezierStyleConfig, Point, WasmBezierManipulatorKey, WasmBezierInstance } from "@/utils/types";
 
 // Offset to increase selectable range, used to make points easier to grab
 const FUDGE_FACTOR = 3;
@@ -24,13 +24,13 @@ class BezierDrawing {
 
 	bezier: WasmBezierInstance;
 
-	callback: BezierCallback;
+	callback: Callback;
 
 	options: Record<string, number>;
 
 	createThroughPoints: boolean;
 
-	constructor(bezier: WasmBezierInstance, callback: BezierCallback, options: Record<string, number>, createThroughPoints = false) {
+	constructor(bezier: WasmBezierInstance, callback: Callback, options: Record<string, number>, createThroughPoints = false) {
 		this.bezier = bezier;
 		this.callback = callback;
 		this.options = options;

--- a/website/other/bezier-rs-demos/src/components/BezierExample.vue
+++ b/website/other/bezier-rs-demos/src/components/BezierExample.vue
@@ -2,6 +2,10 @@
 	<div>
 		<h4 class="example-header">{{ title }}</h4>
 		<figure @mousedown="onMouseDown" @mouseup="onMouseUp" @mousemove="onMouseMove" class="example-figure" v-html="bezierSVG"></figure>
+		<div v-for="(slider, index) in sliderOptions" :key="index">
+			<div class="slider-label">{{ slider.variable }} = {{ sliderData[slider.variable] }}{{ getSliderValue(sliderData[slider.variable], sliderUnits[slider.variable]) }}</div>
+			<input class="slider" v-model.number="sliderData[slider.variable]" type="range" :step="slider.step" :min="slider.min" :max="slider.max" />
+		</div>
 	</div>
 </template>
 
@@ -10,7 +14,7 @@ import { defineComponent, PropType } from "vue";
 
 import { WasmBezier } from "@/../wasm/pkg";
 import { getConstructorKey, getCurveType } from "@/utils/helpers";
-import { BezierCallback, BezierCurveType, WasmBezierManipulatorKey } from "@/utils/types";
+import { BezierCallback, BezierCurveType, WasmBezierManipulatorKey, SliderOption } from "@/utils/types";
 
 const SELECTABLE_RANGE = 10;
 
@@ -33,17 +37,26 @@ export default defineComponent({
 			type: Function as PropType<BezierCallback>,
 			required: true,
 		},
+		sliderOptions: {
+			type: Object as PropType<Array<SliderOption>>,
+			default: () => ({}),
+		},
 	},
 	data() {
 		const curveType = getCurveType(this.points.length);
 		const manipulatorKeys = MANIPULATOR_KEYS_FROM_BEZIER_TYPE[curveType];
+
 		const bezier = WasmBezier[getConstructorKey(curveType)](this.points);
+		const sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
+
 		return {
 			bezier,
-			bezierSVG: this.callback(bezier),
+			bezierSVG: this.callback(bezier, sliderData),
 			manipulatorKeys,
 			activeIndex: undefined as number | undefined,
 			mutablePoints: JSON.parse(JSON.stringify(this.points)),
+			sliderData,
+			sliderUnits: Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit }))),
 		};
 	},
 	methods: {
@@ -67,8 +80,17 @@ export default defineComponent({
 			if (this.activeIndex !== undefined) {
 				this.bezier[this.manipulatorKeys[this.activeIndex]](mx, my);
 				this.mutablePoints[this.activeIndex] = [mx, my];
-				this.bezierSVG = this.callback(this.bezier);
+				this.bezierSVG = this.callback(this.bezier, this.sliderData);
 			}
+		},
+		getSliderValue: (sliderValue: number, sliderUnit?: string | string[]) => (Array.isArray(sliderUnit) ? sliderUnit[sliderValue] : sliderUnit),
+	},
+	watch: {
+		sliderData: {
+			handler() {
+				this.bezierSVG = this.callback(this.bezier, this.sliderData);
+			},
+			deep: true,
 		},
 	},
 });

--- a/website/other/bezier-rs-demos/src/components/BezierExample.vue
+++ b/website/other/bezier-rs-demos/src/components/BezierExample.vue
@@ -1,0 +1,83 @@
+<template>
+	<div>
+		<h4 class="example-header">{{ title }}</h4>
+		<figure @mousedown="onMouseDown" @mouseup="onMouseUp" @mousemove="onMouseMove" class="example-figure" v-html="bezierSVG"></figure>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+
+import { WasmBezier } from "@/../wasm/pkg";
+import { getConstructorKey, getCurveType } from "@/utils/helpers";
+import { BezierCallback, BezierCurveType, WasmBezierManipulatorKey } from "@/utils/types";
+
+const SELECTABLE_RANGE = 10;
+
+// Given the number of points in the curve, map the index of a point to the correct manipulator key
+const MANIPULATOR_KEYS_FROM_BEZIER_TYPE: { [key in BezierCurveType]: WasmBezierManipulatorKey[] } = {
+	[BezierCurveType.Linear]: ["set_start", "set_end"],
+	[BezierCurveType.Quadratic]: ["set_start", "set_handle_start", "set_end"],
+	[BezierCurveType.Cubic]: ["set_start", "set_handle_start", "set_handle_end", "set_end"],
+};
+
+export default defineComponent({
+	props: {
+		title: String,
+		points: {
+			type: Array as PropType<Array<Array<number>>>,
+			required: true,
+			mutable: true,
+		},
+		callback: {
+			type: Function as PropType<BezierCallback>,
+			required: true,
+		},
+	},
+	data() {
+		const curveType = getCurveType(this.points.length);
+		const manipulatorKeys = MANIPULATOR_KEYS_FROM_BEZIER_TYPE[curveType];
+		const bezier = WasmBezier[getConstructorKey(curveType)](this.points);
+		return {
+			bezier,
+			bezierSVG: this.callback(bezier),
+			manipulatorKeys,
+			activeIndex: undefined as number | undefined,
+			mutablePoints: JSON.parse(JSON.stringify(this.points)),
+		};
+	},
+	methods: {
+		onMouseDown(event: MouseEvent) {
+			const mx = event.offsetX;
+			const my = event.offsetY;
+			for (let pointIndex = 0; pointIndex < this.points.length; pointIndex += 1) {
+				const point = this.mutablePoints[pointIndex];
+				if (point && Math.abs(mx - point[0]) < SELECTABLE_RANGE && Math.abs(my - point[1]) < SELECTABLE_RANGE) {
+					this.activeIndex = pointIndex;
+					return;
+				}
+			}
+		},
+		onMouseUp() {
+			this.activeIndex = undefined;
+		},
+		onMouseMove(event: MouseEvent) {
+			const mx = event.offsetX;
+			const my = event.offsetY;
+			if (this.activeIndex !== undefined) {
+				this.bezier[this.manipulatorKeys[this.activeIndex]](mx, my);
+				this.mutablePoints[this.activeIndex] = [mx, my];
+				this.bezierSVG = this.callback(this.bezier);
+			}
+		},
+	},
+});
+</script>
+
+<style scoped>
+.example-figure {
+	border: solid 1px black;
+	width: 200px;
+	height: 200px;
+}
+</style>

--- a/website/other/bezier-rs-demos/src/components/BezierExamplePane.vue
+++ b/website/other/bezier-rs-demos/src/components/BezierExamplePane.vue
@@ -1,0 +1,73 @@
+<template>
+	<div>
+		<h3 class="example-pane-header">{{ name }}</h3>
+		<div class="example-row">
+			<div v-for="(example, index) in examples" :key="index">
+				<BezierExample :title="example.title" :points="example.points" :callback="callback" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+
+import { BezierCallback } from "@/utils/types";
+
+import BezierExample from "@/components/BezierExample.vue";
+
+export default defineComponent({
+	props: {
+		name: String,
+		callback: {
+			type: Function as PropType<BezierCallback>,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			examples: [
+				{
+					title: "Linear",
+					points: [
+						[30, 60],
+						[140, 120],
+					],
+				},
+				{
+					title: "Quadratic",
+					points: [
+						[30, 50],
+						[140, 30],
+						[160, 170],
+					],
+				},
+				{
+					title: "Quadratic",
+					points: [
+						[30, 30],
+						[60, 140],
+						[150, 30],
+						[160, 160],
+					],
+				},
+			],
+		};
+	},
+	components: {
+		BezierExample,
+	},
+});
+</script>
+
+<style scoped>
+.example-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+}
+
+.example-pane-header {
+	margin-bottom: 0;
+}
+</style>

--- a/website/other/bezier-rs-demos/src/components/BezierExamplePane.vue
+++ b/website/other/bezier-rs-demos/src/components/BezierExamplePane.vue
@@ -3,7 +3,7 @@
 		<h3 class="example-pane-header">{{ name }}</h3>
 		<div class="example-row">
 			<div v-for="(example, index) in examples" :key="index">
-				<BezierExample :title="example.title" :points="example.points" :callback="callback" />
+				<BezierExample v-if="!example.disabled" :title="example.title" :points="example.points" :callback="callback" :sliderOptions="example.sliderOptions" />
 			</div>
 		</div>
 	</div>
@@ -12,7 +12,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
 
-import { BezierCallback } from "@/utils/types";
+import { BezierCallback, BezierCurveType, ExampleOptions } from "@/utils/types";
 
 import BezierExample from "@/components/BezierExample.vue";
 
@@ -23,35 +23,47 @@ export default defineComponent({
 			type: Function as PropType<BezierCallback>,
 			required: true,
 		},
+		exampleOptions: {
+			type: Object as PropType<ExampleOptions>,
+			default: () => ({}),
+		},
 	},
 	data() {
+		const exampleDefaults = {
+			[BezierCurveType.Linear]: {
+				points: [
+					[30, 60],
+					[140, 120],
+				],
+			},
+			[BezierCurveType.Quadratic]: {
+				points: [
+					[30, 50],
+					[140, 30],
+					[160, 170],
+				],
+			},
+			[BezierCurveType.Cubic]: {
+				points: [
+					[30, 30],
+					[60, 140],
+					[150, 30],
+					[160, 160],
+				],
+			},
+		};
+
 		return {
-			examples: [
-				{
-					title: "Linear",
-					points: [
-						[30, 60],
-						[140, 120],
-					],
-				},
-				{
-					title: "Quadratic",
-					points: [
-						[30, 50],
-						[140, 30],
-						[160, 170],
-					],
-				},
-				{
-					title: "Quadratic",
-					points: [
-						[30, 30],
-						[60, 140],
-						[150, 30],
-						[160, 160],
-					],
-				},
-			],
+			examples: Object.values(BezierCurveType).map((curveType) => {
+				const givenData = this.exampleOptions[curveType];
+				const defaultData = exampleDefaults[curveType];
+				return {
+					title: curveType,
+					disabled: givenData?.disabled || false,
+					points: givenData?.customPoints || defaultData.points,
+					sliderOptions: givenData?.sliderOptions || [],
+				};
+			}),
 		};
 	},
 	components: {

--- a/website/other/bezier-rs-demos/src/components/Example.vue
+++ b/website/other/bezier-rs-demos/src/components/Example.vue
@@ -9,7 +9,7 @@
 import { defineComponent, PropType } from "vue";
 
 import BezierDrawing from "@/components/BezierDrawing";
-import { BezierCallback, WasmBezierInstance } from "@/utils/types";
+import { Callback, WasmBezierInstance } from "@/utils/types";
 
 export default defineComponent({
 	props: {
@@ -19,7 +19,7 @@ export default defineComponent({
 			required: true,
 		},
 		callback: {
-			type: Function as PropType<BezierCallback>,
+			type: Function as PropType<Callback>,
 			required: true,
 		},
 		options: {

--- a/website/other/bezier-rs-demos/src/utils/helpers.ts
+++ b/website/other/bezier-rs-demos/src/utils/helpers.ts
@@ -1,0 +1,29 @@
+import { BezierCurveType, WasmBezierConstructorKey } from "@/utils/types";
+
+export const getCurveType = (numPoints: number): BezierCurveType => {
+	switch (numPoints) {
+		case 2:
+			return BezierCurveType.Linear;
+		case 3:
+			return BezierCurveType.Quadratic;
+		case 4:
+			return BezierCurveType.Cubic;
+		default:
+			// Not possible
+			return BezierCurveType.Linear;
+	}
+};
+
+export const getConstructorKey = (bezierCurveType: BezierCurveType): WasmBezierConstructorKey => {
+	switch (bezierCurveType) {
+		case BezierCurveType.Linear:
+			return "new_linear";
+		case BezierCurveType.Quadratic:
+			return "new_quadratic";
+		case BezierCurveType.Cubic:
+			return "new_cubic";
+		default:
+			// Not possible
+			return "new_linear";
+	}
+};

--- a/website/other/bezier-rs-demos/src/utils/helpers.ts
+++ b/website/other/bezier-rs-demos/src/utils/helpers.ts
@@ -9,8 +9,7 @@ export const getCurveType = (numPoints: number): BezierCurveType => {
 		case 4:
 			return BezierCurveType.Cubic;
 		default:
-			// Not possible
-			return BezierCurveType.Linear;
+			throw new Error("Invalid number of points for a bezier");
 	}
 };
 
@@ -23,7 +22,6 @@ export const getConstructorKey = (bezierCurveType: BezierCurveType): WasmBezierC
 		case BezierCurveType.Cubic:
 			return "new_cubic";
 		default:
-			// Not possible
-			return "new_linear";
+			throw new Error("Invalid value for a BezierCurveType");
 	}
 };

--- a/website/other/bezier-rs-demos/src/utils/types.ts
+++ b/website/other/bezier-rs-demos/src/utils/types.ts
@@ -15,8 +15,16 @@ export enum BezierCurveType {
 }
 
 export type Callback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point) => void;
-export type BezierCallback = (bezier: WasmBezierInstance) => string;
+export type BezierCallback = (bezier: WasmBezierInstance, options: Record<string, number>) => string;
 export type SubpathCallback = (subpath: WasmSubpathInstance) => string;
+
+export type ExampleOptions = {
+	[key in BezierCurveType]: {
+		disabled: boolean;
+		sliderOptions: SliderOption[];
+		customPoints: number[][];
+	};
+};
 
 export type SliderOption = {
 	min: number;

--- a/website/other/bezier-rs-demos/src/utils/types.ts
+++ b/website/other/bezier-rs-demos/src/utils/types.ts
@@ -14,7 +14,8 @@ export enum BezierCurveType {
 	Cubic = "Cubic",
 }
 
-export type BezierCallback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point) => void;
+export type Callback = (canvas: HTMLCanvasElement, bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: Point) => void;
+export type BezierCallback = (bezier: WasmBezierInstance) => string;
 export type SubpathCallback = (subpath: WasmSubpathInstance) => string;
 
 export type SliderOption = {

--- a/website/other/bezier-rs-demos/wasm/src/svg_drawing.rs
+++ b/website/other/bezier-rs-demos/wasm/src/svg_drawing.rs
@@ -4,6 +4,8 @@ pub const SVG_CLOSE_TAG: &str = "</svg>";
 
 // Stylistic constants
 pub const BLACK: &str = "black";
+pub const GRAY: &str = "gray";
+pub const RED: &str = "red";
 
 // Default attributes
 pub const CURVE_ATTRIBUTES: &str = "stroke=\"black\" stroke-width=\"2\" fill=\"none\"";


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Replace usage of HTML canvas with `rust` generated SVGs.
- Added `BezierExample` and `BezierExamplePane` to replace `Example`, `BezierDrawing` and `ExamplePane`
- Changed the related functions in the `wasm` code to return a `String` containing the corresponding SVG

Changes made for the following demos:
- Constructor
- Bezier Through Points
