### PR TITLE
Fix disappearing path when it is closed with the Pen tool by drawing from its start point

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -394,7 +394,7 @@ impl Fsm for PenToolFsmState {
 							responses.push_back(op.into());
 
 							// Push a close path node
-							responses.push_back(add_manipulator_group(&tool_data.path, tool_data.from_start, ManipulatorGroup::closed()));
+							responses.push_back(add_manipulator_group(&tool_data.path, false, ManipulatorGroup::closed()));
 
 							responses.push_back(DocumentMessage::CommitTransaction.into());
 


### PR DESCRIPTION
When extending the path from the start (as it is rendered into svg), the close path Z is inserted at the front of the svg path to make something like "Z M 100 350 l 150 -300 l 150 300" which is invalid so skipped by your browser causing the shape to disappear.