### PR TITLE
Fix incorrect wasm mime type

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.2", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2", features = ["api-all", "devtools"] }
+tauri = { version = "1.2", features = ["api-all", "devtools", "linux-protocol-headers", "wry"] }
 axum = "0.6.1"
 graphite-editor = { version = "0.0.0", path = "../../editor" }
 chrono = "^0.4.23"


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

This uses the the tauri wry runtime which allows us to serve the correct mime type when bundling the final image