### PR TITLE
Better downcast panics

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -685,11 +685,7 @@ impl PortfolioMessageHandler {
 						.0;
 				}
 				// If the input is just a value, return that value
-				NodeInput::Value { tagged_value, .. } => {
-					return dyn_any::downcast::<T>(tagged_value.clone().to_value().up_box())
-						.map(|v| *v)
-						.ok_or_else(|| "Incorrectly typed value".to_string())
-				}
+				NodeInput::Value { tagged_value, .. } => return dyn_any::downcast::<T>(tagged_value.clone().to_value().up_box()).map(|v| *v),
 				// If the input is from a node, set the node to be the output (so that is what is evaluated)
 				NodeInput::Node(n) => {
 					inner_network.output = *n;
@@ -717,7 +713,7 @@ impl PortfolioMessageHandler {
 
 		let boxed = unsafe { stack.get().last().unwrap().eval(image.into_owned().into_dyn()) };
 
-		dyn_any::downcast::<T>(boxed).map(|v| *v).ok_or_else(|| "Incorrectly typed output".to_string())
+		dyn_any::downcast::<T>(boxed).map(|v| *v)
 	}
 
 	/// Encodes an image into a format using the image crate

--- a/node-graph/graph-craft/src/imaginate_input.rs
+++ b/node-graph/graph-craft/src/imaginate_input.rs
@@ -18,7 +18,7 @@ pub enum ImaginateStatus {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImaginateBaseImage {
 	pub mime: String,
-	#[serde(rename = "imageData")]
+	#[cfg_attr(feature = "serde", serde(rename = "imageData"))]
 	pub image_data: Vec<u8>,
 	pub size: DVec2,
 }

--- a/node-graph/gstd/src/any.rs
+++ b/node-graph/gstd/src/any.rs
@@ -2,10 +2,6 @@ use dyn_any::{DynAny, StaticType, StaticTypeSized};
 pub use graphene_core::{generic, ops /*, structural*/, Node, RefNode};
 use std::marker::PhantomData;
 
-fn fmt_error<I>() -> String {
-	format!("DynAnyNode: input is not of correct type, expected {}", std::any::type_name::<I>())
-}
-
 pub struct DynAnyNode<N, I: StaticType, O: StaticType, ORef: StaticType>(pub N, pub PhantomData<(I, O, ORef)>);
 /*impl<'n, I: StaticType, N: RefNode<'n, &'n I, Output = O> + 'n, O: 'n + StaticType> Node<&'n dyn DynAny<'n>> for DynAnyNode<'n, N, I> {
 	type Output = Box<dyn dyn_any::DynAny<'n> + 'n>;
@@ -35,7 +31,7 @@ where
 {
 	type Output = Any<'n>;
 	fn eval(self, input: Any<'n>) -> Self::Output {
-		let input: Box<I> = dyn_any::downcast(input).unwrap_or_else(|| panic!("{}", fmt_error::<I>()));
+		let input: Box<I> = dyn_any::downcast(input).expect("DynAnyNode Input");
 		Box::new(self.0.eval(*input))
 	}
 }
@@ -45,7 +41,7 @@ where
 {
 	type Output = Any<'n>;
 	fn eval(self, input: Any<'n>) -> Self::Output {
-		let input: Box<I> = dyn_any::downcast(input).unwrap_or_else(|| panic!("{}", fmt_error::<I>()));
+		let input: Box<I> = dyn_any::downcast(input).expect("DynAnyNode Input");
 		Box::new((&self.0).eval_ref(*input))
 	}
 }
@@ -132,7 +128,7 @@ where
 	type Output = O;
 	fn eval(self, input: Any<'n>) -> Self::Output {
 		let output = self.0.eval(input);
-		*dyn_any::downcast(output).unwrap_or_else(|| panic!("DowncastNode: {}", fmt_error::<O>()))
+		*dyn_any::downcast(output).expect("DowncastNode Output")
 	}
 }
 impl<'n, N, I: StaticType> DowncastNode<N, I>
@@ -162,7 +158,7 @@ where
 	fn eval(self, input: I) -> Self::Output {
 		let input = Box::new(input) as Box<dyn DynAny>;
 		let output = self.0.eval(input);
-		*dyn_any::downcast(output).unwrap_or_else(|| panic!("DowncastBothNode Output: {}", fmt_error::<O>()))
+		*dyn_any::downcast(output).expect("DowncastBothNode Output")
 	}
 }
 impl<'n, N, I: StaticType, O: StaticType> DowncastBothNode<N, I, O>


### PR DESCRIPTION
Downcast panics now contain the actual type you failed to downcast as well as your target - meaning that debugging panics is easier. Embedding all the type names can be disabled by disabling the "log-bad-types" feature.