### PR TITLE
Add preview and disable buttons for nodes

### DIFF
--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -250,6 +250,13 @@ pub enum LayoutGroup {
 	#[serde(rename = "section")]
 	Section { name: String, layout: SubLayout },
 }
+
+impl Default for LayoutGroup {
+	fn default() -> Self {
+		Self::Row { widgets: Vec::new() }
+	}
+}
+
 impl LayoutGroup {
 	/// Applies a tooltip to all widgets in this row or column without a tooltip.
 	pub fn with_tooltip(self, tooltip: impl Into<String>) -> Self {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -67,6 +67,12 @@ pub enum NodeGraphMessage {
 		input_index: usize,
 		value: TaggedValue,
 	},
+	SetSelectedEnabled {
+		enabled: bool,
+	},
+	SetSelectedOutput {
+		output: bool,
+	},
 	ShiftNode {
 		node_id: NodeId,
 	},

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -158,6 +158,7 @@ impl Fsm for ImaginateToolFsmState {
 						)]
 						.into_iter()
 						.collect(),
+						..Default::default()
 					};
 					let mut imaginate_inputs: Vec<NodeInput> = imaginate_node_type.inputs.iter().map(|input| input.default.clone()).collect();
 					imaginate_inputs[0] = NodeInput::Node(0);
@@ -197,6 +198,7 @@ impl Fsm for ImaginateToolFsmState {
 						]
 						.into_iter()
 						.collect(),
+						..Default::default()
 					};
 
 					responses.push_back(

--- a/editor/src/messages/tool/tool_messages/node_graph_frame_tool.rs
+++ b/editor/src/messages/tool/tool_messages/node_graph_frame_tool.rs
@@ -163,6 +163,7 @@ impl Fsm for NodeGraphToolFsmState {
 						]
 						.into_iter()
 						.collect(),
+						..Default::default()
 					};
 
 					responses.push_back(

--- a/frontend/src/components/panels/NodeGraph.vue
+++ b/frontend/src/components/panels/NodeGraph.vue
@@ -36,7 +36,7 @@
 					v-for="node in nodes"
 					:key="String(node.id)"
 					class="node"
-					:class="{ selected: selected.includes(node.id) }"
+					:class="{ selected: selected.includes(node.id), output: node.output, disabled: node.disabled }"
 					:style="{
 						'--offset-left': (node.position?.x || 0) + (selected.includes(node.id) ? draggingNodes?.roundX || 0 : 0),
 						'--offset-top': (node.position?.y || 0) + (selected.includes(node.id) ? draggingNodes?.roundY || 0 : 0),
@@ -127,6 +127,12 @@
 		margin: 0 4px;
 		flex: 0 0 auto;
 		align-items: center;
+
+		.widget-layout {
+			flex-direction: row;
+			flex-grow: 1;
+			justify-content: space-between;
+		}
 	}
 
 	.graph {
@@ -191,6 +197,19 @@
 				&.selected {
 					border: 1px solid var(--color-e-nearwhite);
 					margin: -1px;
+				}
+
+				&.disabled {
+					background: var(--color-3-darkgray);
+					color: var(--color-a-softgray);
+
+					.icon-label {
+						fill: var(--color-a-softgray);
+					}
+				}
+
+				&.output {
+					outline: 3px solid var(--color-data-vector);
 				}
 
 				.primary {
@@ -385,6 +404,7 @@ export default defineComponent({
 		nodes: {
 			immediate: true,
 			async handler() {
+				this.selected = this.selected.filter((id) => this.nodeGraph.state.nodes.find((node) => node.id === id));
 				await this.refreshLinks();
 			},
 		},

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -96,6 +96,10 @@ export class FrontendNode {
 
 	@TupleToVec2
 	readonly position!: XY | undefined;
+
+	readonly output!: boolean;
+
+	readonly disabled!: boolean;
 }
 
 export class FrontendNodeLink {

--- a/node-graph/interpreted-executor/src/lib.rs
+++ b/node-graph/interpreted-executor/src/lib.rs
@@ -87,6 +87,7 @@ mod tests {
 				]
 				.into_iter()
 				.collect(),
+				..Default::default()
 			}
 		}
 
@@ -110,6 +111,7 @@ mod tests {
 			)]
 			.into_iter()
 			.collect(),
+			..Default::default()
 		};
 
 		use crate::executor::DynamicExecutor;


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #881

The preview and disable buttons show in the right of the bar above the node graph. They hide if no nodes are selected.

Disabling a node converts it to an identity node and setting a preview will set it as output. The output is shown with a blue outline and disabled nodes are greyed out.