### PR TITLE
Avoid deprecated into_serde()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,8 +4715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/website/other/bezier-rs-demos/wasm/Cargo.toml
+++ b/website/other/bezier-rs-demos/wasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 bezier-rs = { path = "../../../../libraries/bezier-rs", package = "bezier-rs" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.73" }
 serde_json = "*"
 serde-wasm-bindgen = "0.4.1"
 js-sys = "0.3.55"

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -30,7 +30,7 @@ pub struct WasmBezier(Bezier);
 
 /// Serialize some data and then convert it to a JsValue.
 fn to_js_value<T: Serialize>(data: T) -> JsValue {
-	JsValue::from_serde(&serde_json::to_string(&data).unwrap()).unwrap()
+	serde_wasm_bindgen::to_value(&serde_json::to_string(&data).unwrap()).unwrap()
 }
 
 fn convert_wasm_maximize_arcs(wasm_enum_value: WasmMaximizeArcs) -> ArcStrategy {
@@ -44,20 +44,20 @@ fn convert_wasm_maximize_arcs(wasm_enum_value: WasmMaximizeArcs) -> ArcStrategy 
 #[wasm_bindgen]
 impl WasmBezier {
 	/// Expect js_points to be a list of 2 pairs.
-	pub fn new_linear(js_points: &JsValue) -> WasmBezier {
-		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+	pub fn new_linear(js_points: JsValue) -> WasmBezier {
+		let points: [DVec2; 2] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		WasmBezier(Bezier::from_linear_dvec2(points[0], points[1]))
 	}
 
 	/// Expect js_points to be a list of 3 pairs.
-	pub fn new_quadratic(js_points: &JsValue) -> WasmBezier {
-		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+	pub fn new_quadratic(js_points: JsValue) -> WasmBezier {
+		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		WasmBezier(Bezier::from_quadratic_dvec2(points[0], points[1], points[2]))
 	}
 
 	/// Expect js_points to be a list of 4 pairs.
-	pub fn new_cubic(js_points: &JsValue) -> WasmBezier {
-		let points: [DVec2; 4] = js_points.into_serde().unwrap();
+	pub fn new_cubic(js_points: JsValue) -> WasmBezier {
+		let points: [DVec2; 4] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		WasmBezier(Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]))
 	}
 
@@ -75,14 +75,14 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_string}{through_point_circle}"))
 	}
 
-	pub fn quadratic_through_points(js_points: &JsValue, t: f64) -> String {
-		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+	pub fn quadratic_through_points(js_points: JsValue, t: f64) -> String {
+		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let bezier = Bezier::quadratic_through_points(points[0], points[1], points[2], Some(t));
 		WasmBezier::draw_bezier_through_points(bezier, points[1])
 	}
 
-	pub fn cubic_through_points(js_points: &JsValue, t: f64, midpoint_separation: f64) -> String {
-		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+	pub fn cubic_through_points(js_points: JsValue, t: f64, midpoint_separation: f64) -> String {
+		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let bezier = Bezier::cubic_through_points(points[0], points[1], points[2], Some(t), Some(midpoint_separation));
 		WasmBezier::draw_bezier_through_points(bezier, points[1])
 	}
@@ -400,8 +400,8 @@ impl WasmBezier {
 		self.0.intersections(curve, error, minimum_separation)
 	}
 
-	pub fn intersect_line_segment(&self, js_points: &JsValue) -> String {
-		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+	pub fn intersect_line_segment(&self, js_points: JsValue) -> String {
+		let points: [DVec2; 2] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_linear_dvec2(points[0], points[1]);
 
 		let bezier_curve_svg = self.get_bezier_path();
@@ -420,8 +420,8 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_curve_svg}{line_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_quadratic_segment(&self, js_points: &JsValue, error: f64, minimum_separation: f64) -> String {
-		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+	pub fn intersect_quadratic_segment(&self, js_points: JsValue, error: f64, minimum_separation: f64) -> String {
+		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let quadratic = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
 
 		let bezier_curve_svg = self.get_bezier_path();
@@ -440,8 +440,8 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_curve_svg}{quadratic_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_cubic_segment(&self, js_points: &JsValue, error: f64, minimum_separation: f64) -> String {
-		let points: [DVec2; 4] = js_points.into_serde().unwrap();
+	pub fn intersect_cubic_segment(&self, js_points: JsValue, error: f64, minimum_separation: f64) -> String {
+		let points: [DVec2; 4] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let cubic = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
 
 		let bezier_curve_svg = self.get_bezier_path();
@@ -477,8 +477,8 @@ impl WasmBezier {
 		wrap_svg_tag(intersect_self_svg)
 	}
 
-	pub fn intersect_rectangle(&self, js_points: &JsValue) -> String {
-		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+	pub fn intersect_rectangle(&self, js_points: JsValue) -> String {
+		let points: [DVec2; 2] = serde_wasm_bindgen::from_value(js_points).unwrap();
 
 		let bezier_curve_svg = self.get_bezier_path();
 

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -12,8 +12,8 @@ pub struct WasmSubpath(Subpath);
 #[wasm_bindgen]
 impl WasmSubpath {
 	/// Expects js_points to be an unbounded list of triples, where each item is a tuple of floats.
-	pub fn from_triples(js_points: &JsValue, closed: bool) -> WasmSubpath {
-		let point_triples: Vec<[Option<DVec2>; 3]> = js_points.into_serde().unwrap();
+	pub fn from_triples(js_points: JsValue, closed: bool) -> WasmSubpath {
+		let point_triples: Vec<[Option<DVec2>; 3]> = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let manipulator_groups = point_triples
 			.into_iter()
 			.map(|point_triple| ManipulatorGroup {
@@ -68,8 +68,8 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{}", self.to_default_svg(), point_text))
 	}
 
-	pub fn intersect_line_segment(&self, js_points: &JsValue) -> String {
-		let points: [DVec2; 2] = js_points.into_serde().unwrap();
+	pub fn intersect_line_segment(&self, js_points: JsValue) -> String {
+		let points: [DVec2; 2] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_linear_dvec2(points[0], points[1]);
 
 		let subpath_svg = self.to_default_svg();
@@ -97,8 +97,8 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_quadratic_segment(&self, js_points: &JsValue) -> String {
-		let points: [DVec2; 3] = js_points.into_serde().unwrap();
+	pub fn intersect_quadratic_segment(&self, js_points: JsValue) -> String {
+		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
 
 		let subpath_svg = self.to_default_svg();
@@ -126,8 +126,8 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_cubic_segment(&self, js_points: &JsValue) -> String {
-		let points: [DVec2; 4] = js_points.into_serde().unwrap();
+	pub fn intersect_cubic_segment(&self, js_points: JsValue) -> String {
+		let points: [DVec2; 4] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
 
 		let subpath_svg = self.to_default_svg();


### PR DESCRIPTION
Avoids the warning about `.into_serde()` being deprecated.