### PR TITLE
Diff simple layout changes to avoid excessive DOM replacements

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -252,6 +252,7 @@ impl Dispatcher {
 #[cfg(test)]
 mod test {
 	use crate::application::Editor;
+	use crate::messages::layout::utility_types::layout_widget::DiffUpdate;
 	use crate::messages::portfolio::document::utility_types::clipboards::Clipboard;
 	use crate::messages::prelude::*;
 	use crate::test_utils::EditorTestUtils;
@@ -570,10 +571,12 @@ mod test {
 
 		for response in responses {
 			// Check for the existence of the file format incompatibility warning dialog after opening the test file
-			if let FrontendMessage::UpdateDialogDetails { layout_target: _, layout } = response {
-				if let LayoutGroup::Row { widgets } = &layout[0] {
-					if let Widget::TextLabel(TextLabel { value, .. }) = &widgets[0].widget {
-						print_problem_to_terminal_on_failure(value);
+			if let FrontendMessage::UpdateDialogDetails { layout_target: _, diff } = response {
+				if let DiffUpdate::SubLayout(sub_layout) = &diff[0].new_val {
+					if let LayoutGroup::Row { widgets } = &sub_layout[0] {
+						if let Widget::TextLabel(TextLabel { value, .. }) = &widgets[0].widget {
+							print_problem_to_terminal_on_failure(value);
+						}
 					}
 				}
 			}

--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -572,7 +572,7 @@ mod test {
 		for response in responses {
 			// Check for the existence of the file format incompatibility warning dialog after opening the test file
 			if let FrontendMessage::UpdateDialogDetails { layout_target: _, diff } = response {
-				if let DiffUpdate::SubLayout(sub_layout) = &diff[0].new_val {
+				if let DiffUpdate::SubLayout(sub_layout) = &diff[0].new_value {
 					if let LayoutGroup::Row { widgets } = &sub_layout[0] {
 						if let Widget::TextLabel(TextLabel { value, .. }) = &widgets[0].widget {
 							print_problem_to_terminal_on_failure(value);

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -1,5 +1,5 @@
 use super::utility_types::{FrontendDocumentDetails, FrontendImageData, MouseCursorIcon};
-use crate::messages::layout::utility_types::layout_widget::SubLayout;
+use crate::messages::layout::utility_types::layout_widget::WidgetDiff;
 use crate::messages::layout::utility_types::misc::LayoutTarget;
 use crate::messages::layout::utility_types::widgets::menu_widgets::MenuBarEntry;
 use crate::messages::portfolio::document::node_graph::{FrontendNode, FrontendNodeLink, FrontendNodeType};
@@ -143,7 +143,7 @@ pub enum FrontendMessage {
 	UpdateDialogDetails {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateDocumentArtboards {
 		svg: String,
@@ -154,7 +154,7 @@ pub enum FrontendMessage {
 	UpdateDocumentBarLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateDocumentLayerDetails {
 		data: LayerPanelEntry,
@@ -170,7 +170,7 @@ pub enum FrontendMessage {
 	UpdateDocumentModeLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateDocumentOverlays {
 		svg: String,
@@ -208,7 +208,7 @@ pub enum FrontendMessage {
 	UpdateLayerTreeOptionsLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateMenuBarLayout {
 		#[serde(rename = "layoutTarget")]
@@ -225,7 +225,7 @@ pub enum FrontendMessage {
 	UpdateNodeGraphBarLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateNodeGraphSelection {
 		selected: Vec<NodeId>,
@@ -244,26 +244,26 @@ pub enum FrontendMessage {
 	UpdatePropertyPanelOptionsLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdatePropertyPanelSectionsLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateToolOptionsLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateToolShelfLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 	UpdateWorkingColorsLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: SubLayout,
+		diff: Vec<WidgetDiff>,
 	},
 }

--- a/editor/src/messages/layout/layout_message.rs
+++ b/editor/src/messages/layout/layout_message.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[impl_message(Message, Layout)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum LayoutMessage {
-	RefreshLayout { layout_target: LayoutTarget },
+	RefreshLayout { layout_target: LayoutTarget, dirty_id: u64 },
 	SendLayout { layout: Layout, layout_target: LayoutTarget },
 	UpdateLayout { layout_target: LayoutTarget, widget_id: u64, value: serde_json::Value },
 }

--- a/editor/src/messages/layout/layout_message.rs
+++ b/editor/src/messages/layout/layout_message.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 #[impl_message(Message, Layout)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum LayoutMessage {
-	RefreshLayout { layout_target: LayoutTarget, dirty_id: u64 },
+	ResendActiveWidget { layout_target: LayoutTarget, dirty_id: u64 },
 	SendLayout { layout: Layout, layout_target: LayoutTarget },
 	UpdateLayout { layout_target: LayoutTarget, widget_id: u64, value: serde_json::Value },
 }

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -37,10 +37,9 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 									// Return if this is the correct ID
 									if widget.widget_id == id {
 										path.push(index);
-										return Some(WidgetDiff {
-											path,
-											new_val: DiffUpdate::Widget(widget.clone()),
-										});
+										let new_val = DiffUpdate::Widget(widget.clone());
+										let widget_path = path;
+										return Some(WidgetDiff { widget_path, new_val });
 									}
 								}
 							}

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -37,9 +37,9 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 									// Return if this is the correct ID
 									if widget.widget_id == id {
 										path.push(index);
-										let new_val = DiffUpdate::Widget(widget.clone());
+										let new_value = DiffUpdate::Widget(widget.clone());
 										let widget_path = path;
-										return Some(WidgetDiff { widget_path, new_val });
+										return Some(WidgetDiff { widget_path, new_value });
 									}
 								}
 							}
@@ -272,7 +272,7 @@ impl LayoutMessageHandler {
 	/// Send a diff to the frontend based on the layout target.
 	#[remain::check]
 	fn send_diff(&self, mut diff: Vec<WidgetDiff>, layout_target: LayoutTarget, responses: &mut VecDeque<Message>, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) {
-		diff.iter_mut().for_each(|diff| diff.new_val.apply_shortcut(action_input_mapping));
+		diff.iter_mut().for_each(|diff| diff.new_value.apply_shortcut(action_input_mapping));
 
 		info!("{layout_target:?} diff {diff:#?}");
 

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -279,7 +279,7 @@ impl LayoutMessageHandler {
 	fn send_diff(&self, mut diff: Vec<WidgetDiff>, layout_target: LayoutTarget, responses: &mut VecDeque<Message>, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) {
 		diff.iter_mut().for_each(|diff| diff.new_value.apply_shortcut(action_input_mapping));
 
-		info!("{layout_target:?} diff {diff:#?}");
+		trace!("{layout_target:?} diff {diff:#?}");
 
 		#[remain::sorted]
 		let message = match layout_target {

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -51,7 +51,7 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 		use LayoutMessage::*;
 		#[remain::sorted]
 		match message {
-			RefreshLayout { layout_target, dirty_id } => {
+			ResendActiveWidget { layout_target, dirty_id } => {
 				// Find the updated diff based on the specified layout target
 				let Some(diff) = (match &self.layouts[layout_target as usize] {
 					Layout::MenuLayout(_) => return,
@@ -232,7 +232,7 @@ impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage
 					}
 					Widget::TextLabel(_) => {}
 				};
-				responses.push_back(RefreshLayout { layout_target, dirty_id: widget_id }.into());
+				responses.push_back(ResendActiveWidget { layout_target, dirty_id: widget_id }.into());
 			}
 		}
 	}

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -246,7 +246,7 @@ impl LayoutMessageHandler {
 	/// Diff the update and send to the frontend where necessary
 	fn send_layout(&mut self, layout_target: LayoutTarget, new_layout: Layout, responses: &mut VecDeque<Message>, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) {
 		// We don't diff the menu bar layout yet.
-		if layout_target == LayoutTarget::MenuBar {
+		if matches!(new_layout, Layout::MenuLayout(_)) {
 			// Skip update if the same
 			if self.layouts[layout_target as usize] == new_layout {
 				return;

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -34,85 +34,103 @@ pub enum Layout {
 	MenuLayout(MenuLayout),
 }
 
-impl Layout {
-	pub fn unwrap_widget_layout(self, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) -> WidgetLayout {
-		if let Layout::WidgetLayout(mut widget_layout) = self {
-			// Function used multiple times later in this code block to convert `ActionKeys::Action` to `ActionKeys::Keys` and append its shortcut to the tooltip
-			let apply_shortcut_to_tooltip = |tooltip_shortcut: &mut ActionKeys, tooltip: &mut String| {
-				let shortcut_text = tooltip_shortcut.to_keys(action_input_mapping);
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub enum DiffUpdate {
+	#[serde(rename = "subLayout")]
+	SubLayout(SubLayout),
+	#[serde(rename = "layoutGroup")]
+	LayoutGroup(LayoutGroup),
+	#[serde(rename = "widget")]
+	Widget(WidgetHolder),
+}
 
-				if let ActionKeys::Keys(_keys) = tooltip_shortcut {
-					if !shortcut_text.is_empty() {
-						if !tooltip.is_empty() {
-							tooltip.push(' ');
-						}
-						tooltip.push('(');
-						tooltip.push_str(&shortcut_text);
-						tooltip.push(')');
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct WidgetDiff {
+	pub path: Vec<usize>,
+	#[serde(rename = "newVal")]
+	pub new_val: DiffUpdate,
+}
+
+impl DiffUpdate {
+	pub fn apply_shortcut(&mut self, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) {
+		// Function used multiple times later in this code block to convert `ActionKeys::Action` to `ActionKeys::Keys` and append its shortcut to the tooltip
+		let apply_shortcut_to_tooltip = |tooltip_shortcut: &mut ActionKeys, tooltip: &mut String| {
+			let shortcut_text = tooltip_shortcut.to_keys(action_input_mapping);
+
+			if let ActionKeys::Keys(_keys) = tooltip_shortcut {
+				if !shortcut_text.is_empty() {
+					if !tooltip.is_empty() {
+						tooltip.push(' ');
 					}
+					tooltip.push('(');
+					tooltip.push_str(&shortcut_text);
+					tooltip.push(')');
 				}
+			}
+		};
+
+		// Go through each widget to convert `ActionKeys::Action` to `ActionKeys::Keys` and append the key combination to the widget tooltip
+		let convert_tooltip = |widget_holder: &mut WidgetHolder| {
+			// Handle all the widgets that have tooltips
+			let mut tooltip_shortcut = match &mut widget_holder.widget {
+				Widget::BreadcrumbTrailButtons(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::CheckboxInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::ColorInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::DropdownInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::FontInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::IconButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::LayerReferenceInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::NumberInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::OptionalInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::ParameterExposeButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::PopoverButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::TextButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
+				Widget::IconLabel(_)
+				| Widget::InvisibleStandinInput(_)
+				| Widget::PivotAssist(_)
+				| Widget::RadioInput(_)
+				| Widget::Separator(_)
+				| Widget::SwatchPairInput(_)
+				| Widget::TextAreaInput(_)
+				| Widget::TextInput(_)
+				| Widget::TextLabel(_) => None,
 			};
+			if let Some((tooltip, Some(tooltip_shortcut))) = &mut tooltip_shortcut {
+				apply_shortcut_to_tooltip(tooltip_shortcut, tooltip);
+			}
 
-			// Go through each widget to convert `ActionKeys::Action` to `ActionKeys::Keys` and append the key combination to the widget tooltip
-			for widget_holder in &mut widget_layout.iter_mut() {
-				// Handle all the widgets that have tooltips
-				let mut tooltip_shortcut = match &mut widget_holder.widget {
-					Widget::BreadcrumbTrailButtons(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::CheckboxInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::ColorInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::DropdownInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::FontInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::IconButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::LayerReferenceInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::NumberInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::OptionalInput(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::ParameterExposeButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::PopoverButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::TextButton(widget) => Some((&mut widget.tooltip, &mut widget.tooltip_shortcut)),
-					Widget::IconLabel(_)
-					| Widget::InvisibleStandinInput(_)
-					| Widget::PivotAssist(_)
-					| Widget::RadioInput(_)
-					| Widget::Separator(_)
-					| Widget::SwatchPairInput(_)
-					| Widget::TextAreaInput(_)
-					| Widget::TextInput(_)
-					| Widget::TextLabel(_) => None,
-				};
-				if let Some((tooltip, Some(tooltip_shortcut))) = &mut tooltip_shortcut {
-					apply_shortcut_to_tooltip(tooltip_shortcut, tooltip);
-				}
-
-				// Handle RadioInput separately because its tooltips are children of the widget
-				if let Widget::RadioInput(radio_input) = &mut widget_holder.widget {
-					for radio_entry_data in &mut radio_input.entries {
-						if let RadioEntryData {
-							tooltip,
-							tooltip_shortcut: Some(tooltip_shortcut),
-							..
-						} = radio_entry_data
-						{
-							apply_shortcut_to_tooltip(tooltip_shortcut, tooltip);
-						}
+			// Handle RadioInput separately because its tooltips are children of the widget
+			if let Widget::RadioInput(radio_input) = &mut widget_holder.widget {
+				for radio_entry_data in &mut radio_input.entries {
+					if let RadioEntryData {
+						tooltip,
+						tooltip_shortcut: Some(tooltip_shortcut),
+						..
+					} = radio_entry_data
+					{
+						apply_shortcut_to_tooltip(tooltip_shortcut, tooltip);
 					}
 				}
 			}
+		};
 
-			widget_layout
-		} else {
-			panic!("Tried to unwrap layout as WidgetLayout. Got {:?}", self)
+		match self {
+			Self::SubLayout(sub_layout) => sub_layout.iter_mut().flat_map(|group| group.iter_mut()).for_each(convert_tooltip),
+			Self::LayoutGroup(layout_group) => layout_group.iter_mut().for_each(convert_tooltip),
+			Self::Widget(widget_holder) => convert_tooltip(widget_holder),
 		}
 	}
+}
 
+impl Layout {
 	pub fn unwrap_menu_layout(self, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) -> MenuLayout {
-		if let Layout::MenuLayout(mut menu_layout) = self {
-			for menu_column in &mut menu_layout.layout {
-				menu_column.children.fill_in_shortcut_actions_with_keys(action_input_mapping);
-			}
-
-			menu_layout
+		if let Self::MenuLayout(mut menu) = self {
+			menu.layout
+				.iter_mut()
+				.for_each(|menu_column| menu_column.children.fill_in_shortcut_actions_with_keys(action_input_mapping));
+			menu
 		} else {
-			panic!("Tried to unwrap layout as MenuLayout. Got {:?}", self)
+			panic!("Called unwrap_menu_layout on a widget layout");
 		}
 	}
 
@@ -127,6 +145,21 @@ impl Layout {
 		match self {
 			Layout::MenuLayout(menu_layout) => Box::new(menu_layout.iter_mut()),
 			Layout::WidgetLayout(widget_layout) => Box::new(widget_layout.iter_mut()),
+		}
+	}
+
+	/// Diffing updates self (where self is old) based on new, updating the list of modifications as it does so.
+	pub fn diff(&mut self, new: Self, path: &mut Vec<usize>, widget_diffs: &mut Vec<WidgetDiff>) {
+		match (self, new) {
+			(Self::WidgetLayout(s), Self::WidgetLayout(new)) => return s.diff(new, path, widget_diffs),
+			(current, new) => {
+				let new_val = match new.clone() {
+					Self::WidgetLayout(widget_layout) => DiffUpdate::SubLayout(widget_layout.layout),
+					Self::MenuLayout(_) => panic!("Cannot diff menu layout"),
+				};
+				widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val });
+				*current = new;
+			}
 		}
 	}
 }
@@ -158,6 +191,22 @@ impl WidgetLayout {
 		WidgetIterMut {
 			stack: self.layout.iter_mut().collect(),
 			current_slice: None,
+		}
+	}
+
+	/// Diffing updates self (where self is old) based on new, updating the list of modifications as it does so.
+	pub fn diff(&mut self, new: Self, path: &mut Vec<usize>, widget_diffs: &mut Vec<WidgetDiff>) {
+		// TODO: Diff insersion and deletion of items
+		if self.layout.len() != new.layout.len() {
+			self.layout = new.layout.clone();
+			let new = DiffUpdate::SubLayout(new.layout);
+			widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val: new });
+			return;
+		}
+		for (index, (s, new)) in self.layout.iter_mut().zip(new.layout.into_iter()).enumerate() {
+			path.push(index);
+			s.diff(new, path, widget_diffs);
+			path.pop();
 		}
 	}
 }
@@ -289,6 +338,58 @@ impl LayoutGroup {
 			Self::Row { widgets }
 		}
 	}
+
+	/// Diffing updates self (where self is old) based on new, updating the list of modifications as it does so.
+	pub fn diff(&mut self, new: Self, path: &mut Vec<usize>, widget_diffs: &mut Vec<WidgetDiff>) {
+		let is_column = matches!(new, Self::Column { .. });
+		match (self, new) {
+			(Self::Column { widgets: s }, Self::Column { widgets: new_widgets }) | (Self::Row { widgets: s }, Self::Row { widgets: new_widgets }) => {
+				// If the lengths are different then resend the entire panel
+				// TODO: Diff insersion and deletion of items
+				if s.len() != new_widgets.len() {
+					*s = new_widgets.clone();
+					let new_val = DiffUpdate::LayoutGroup(if is_column { Self::Column { widgets: new_widgets } } else { Self::Row { widgets: new_widgets } });
+					widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val });
+					return;
+				}
+				// Diff all of the children
+				for (index, (s, new)) in s.iter_mut().zip(new_widgets.into_iter()).enumerate() {
+					path.push(index);
+					s.diff(new, path, widget_diffs);
+					path.pop();
+				}
+			}
+			(Self::Section { name: s_name, layout: s_layout }, Self::Section { name: new_name, layout: new_layout }) => {
+				// If the lengths are different then resend the entire panel
+				// TODO: Diff insersion and deletion of items
+				if *s_name != new_name || s_layout.len() != new_layout.len() {
+					*s_name = new_name.clone();
+					*s_layout = new_layout.clone();
+					let new = DiffUpdate::LayoutGroup(Self::Section { name: new_name, layout: new_layout });
+					widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val: new });
+					return;
+				}
+				// Diff all of the children
+				for (index, (s, new)) in s_layout.iter_mut().zip(new_layout.into_iter()).enumerate() {
+					path.push(index);
+					s.diff(new, path, widget_diffs);
+					path.pop();
+				}
+			}
+			(current, new) => {
+				*current = new.clone();
+				let new = DiffUpdate::LayoutGroup(new);
+				widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val: new });
+			}
+		}
+	}
+
+	pub fn iter_mut(&mut self) -> WidgetIterMut<'_> {
+		WidgetIterMut {
+			stack: vec![self],
+			current_slice: None,
+		}
+	}
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -326,6 +427,17 @@ impl WidgetHolder {
 			bold: true,
 			..Default::default()
 		}))
+	}
+	/// Diffing updates self (where self is old) based on new, updating the list of modifications as it does so.
+	pub fn diff(&mut self, new: Self, path: &mut [usize], widget_diffs: &mut Vec<WidgetDiff>) {
+		if self.widget != new.widget {
+			*self = new.clone();
+			let new = DiffUpdate::Widget(new);
+			widget_diffs.push(WidgetDiff { path: path.to_vec(), new_val: new });
+		} else {
+			// Required to update the callback function, which the PartialEq check above skips
+			self.widget = new.widget;
+		}
 	}
 }
 

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -48,8 +48,8 @@ pub enum DiffUpdate {
 pub struct WidgetDiff {
 	#[serde(rename = "widgetPath")]
 	pub widget_path: Vec<usize>,
-	#[serde(rename = "newVal")]
-	pub new_val: DiffUpdate,
+	#[serde(rename = "newValue")]
+	pub new_value: DiffUpdate,
 }
 
 impl DiffUpdate {
@@ -154,12 +154,12 @@ impl Layout {
 		match (self, new) {
 			(Self::WidgetLayout(s), Self::WidgetLayout(new)) => s.diff(new, widget_path, widget_diffs),
 			(current, new) => {
-				let new_val = match new.clone() {
+				let new_value = match new.clone() {
 					Self::WidgetLayout(widget_layout) => DiffUpdate::SubLayout(widget_layout.layout),
 					Self::MenuLayout(_) => panic!("Cannot diff menu layout"),
 				};
 				let widget_path = widget_path.to_vec();
-				widget_diffs.push(WidgetDiff { widget_path, new_val });
+				widget_diffs.push(WidgetDiff { widget_path, new_value });
 				*current = new;
 			}
 		}
@@ -204,7 +204,7 @@ impl WidgetLayout {
 			let new = DiffUpdate::SubLayout(new.layout);
 			widget_diffs.push(WidgetDiff {
 				widget_path: widget_path.to_vec(),
-				new_val: new,
+				new_value: new,
 			});
 			return;
 		}
@@ -353,9 +353,9 @@ impl LayoutGroup {
 				// TODO: Diff insersion and deletion of items
 				if s.len() != new_widgets.len() {
 					*s = new_widgets.clone();
-					let new_val = DiffUpdate::LayoutGroup(if is_column { Self::Column { widgets: new_widgets } } else { Self::Row { widgets: new_widgets } });
+					let new_value = DiffUpdate::LayoutGroup(if is_column { Self::Column { widgets: new_widgets } } else { Self::Row { widgets: new_widgets } });
 					let widget_path = widget_path.to_vec();
-					widget_diffs.push(WidgetDiff { widget_path, new_val });
+					widget_diffs.push(WidgetDiff { widget_path, new_value });
 					return;
 				}
 				// Diff all of the children
@@ -371,9 +371,9 @@ impl LayoutGroup {
 				if *s_name != new_name || s_layout.len() != new_layout.len() {
 					*s_name = new_name.clone();
 					*s_layout = new_layout.clone();
-					let new_val = DiffUpdate::LayoutGroup(Self::Section { name: new_name, layout: new_layout });
+					let new_value = DiffUpdate::LayoutGroup(Self::Section { name: new_name, layout: new_layout });
 					let widget_path = widget_path.to_vec();
-					widget_diffs.push(WidgetDiff { widget_path, new_val });
+					widget_diffs.push(WidgetDiff { widget_path, new_value });
 					return;
 				}
 				// Diff all of the children
@@ -385,9 +385,9 @@ impl LayoutGroup {
 			}
 			(current, new) => {
 				*current = new.clone();
-				let new_val = DiffUpdate::LayoutGroup(new);
+				let new_value = DiffUpdate::LayoutGroup(new);
 				let widget_path = widget_path.to_vec();
-				widget_diffs.push(WidgetDiff { widget_path, new_val });
+				widget_diffs.push(WidgetDiff { widget_path, new_value });
 			}
 		}
 	}
@@ -440,9 +440,9 @@ impl WidgetHolder {
 	pub fn diff(&mut self, new: Self, widget_path: &mut [usize], widget_diffs: &mut Vec<WidgetDiff>) {
 		if self.widget != new.widget {
 			*self = new.clone();
-			let new_val = DiffUpdate::Widget(new);
+			let new_value = DiffUpdate::Widget(new);
 			let widget_path = widget_path.to_vec();
-			widget_diffs.push(WidgetDiff { widget_path, new_val });
+			widget_diffs.push(WidgetDiff { widget_path, new_value });
 		} else {
 			// Required to update the callback function, which the PartialEq check above skips
 			self.widget = new.widget;

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -151,7 +151,7 @@ impl Layout {
 	/// Diffing updates self (where self is old) based on new, updating the list of modifications as it does so.
 	pub fn diff(&mut self, new: Self, path: &mut Vec<usize>, widget_diffs: &mut Vec<WidgetDiff>) {
 		match (self, new) {
-			(Self::WidgetLayout(s), Self::WidgetLayout(new)) => return s.diff(new, path, widget_diffs),
+			(Self::WidgetLayout(s), Self::WidgetLayout(new)) => s.diff(new, path, widget_diffs),
 			(current, new) => {
 				let new_val = match new.clone() {
 					Self::WidgetLayout(widget_layout) => DiffUpdate::SubLayout(widget_layout.layout),

--- a/frontend/src/components/panels/Document.vue
+++ b/frontend/src/components/panels/Document.vue
@@ -231,6 +231,7 @@ import { textInputCleanup } from "@/utility-functions/keyboard-entry";
 import { rasterizeSVGCanvas } from "@/utility-functions/rasterization";
 import {
 	defaultWidgetLayout,
+	patchWidgetLayout,
 	type DisplayEditableTextbox,
 	type MouseCursorIcon,
 	type UpdateDocumentBarLayout,
@@ -505,19 +506,19 @@ export default defineComponent({
 		},
 		// Update layouts
 		updateDocumentModeLayout(updateDocumentModeLayout: UpdateDocumentModeLayout) {
-			this.documentModeLayout = updateDocumentModeLayout;
+			this.documentModeLayout = patchWidgetLayout(this.documentModeLayout, updateDocumentModeLayout);
 		},
 		updateToolOptionsLayout(updateToolOptionsLayout: UpdateToolOptionsLayout) {
-			this.toolOptionsLayout = updateToolOptionsLayout;
+			this.toolOptionsLayout = patchWidgetLayout(this.toolOptionsLayout, updateToolOptionsLayout);
 		},
 		updateDocumentBarLayout(updateDocumentBarLayout: UpdateDocumentBarLayout) {
-			this.documentBarLayout = updateDocumentBarLayout;
+			this.documentBarLayout = patchWidgetLayout(this.documentBarLayout, updateDocumentBarLayout);
 		},
 		updateToolShelfLayout(updateToolShelfLayout: UpdateToolShelfLayout) {
-			this.toolShelfLayout = updateToolShelfLayout;
+			this.toolShelfLayout = patchWidgetLayout(this.toolShelfLayout, updateToolShelfLayout);
 		},
 		updateWorkingColorsLayout(updateWorkingColorsLayout: UpdateWorkingColorsLayout) {
-			this.workingColorsLayout = updateWorkingColorsLayout;
+			this.workingColorsLayout = patchWidgetLayout(this.workingColorsLayout, updateWorkingColorsLayout);
 		},
 		// Resize elements to render the new viewport size
 		viewportResize() {

--- a/frontend/src/components/panels/Document.vue
+++ b/frontend/src/components/panels/Document.vue
@@ -506,19 +506,19 @@ export default defineComponent({
 		},
 		// Update layouts
 		updateDocumentModeLayout(updateDocumentModeLayout: UpdateDocumentModeLayout) {
-			this.documentModeLayout = patchWidgetLayout(this.documentModeLayout, updateDocumentModeLayout);
+			patchWidgetLayout(this.documentModeLayout, updateDocumentModeLayout);
 		},
 		updateToolOptionsLayout(updateToolOptionsLayout: UpdateToolOptionsLayout) {
-			this.toolOptionsLayout = patchWidgetLayout(this.toolOptionsLayout, updateToolOptionsLayout);
+			patchWidgetLayout(this.toolOptionsLayout, updateToolOptionsLayout);
 		},
 		updateDocumentBarLayout(updateDocumentBarLayout: UpdateDocumentBarLayout) {
-			this.documentBarLayout = patchWidgetLayout(this.documentBarLayout, updateDocumentBarLayout);
+			patchWidgetLayout(this.documentBarLayout, updateDocumentBarLayout);
 		},
 		updateToolShelfLayout(updateToolShelfLayout: UpdateToolShelfLayout) {
-			this.toolShelfLayout = patchWidgetLayout(this.toolShelfLayout, updateToolShelfLayout);
+			patchWidgetLayout(this.toolShelfLayout, updateToolShelfLayout);
 		},
 		updateWorkingColorsLayout(updateWorkingColorsLayout: UpdateWorkingColorsLayout) {
-			this.workingColorsLayout = patchWidgetLayout(this.workingColorsLayout, updateWorkingColorsLayout);
+			patchWidgetLayout(this.workingColorsLayout, updateWorkingColorsLayout);
 		},
 		// Resize elements to render the new viewport size
 		viewportResize() {

--- a/frontend/src/components/panels/LayerTree.vue
+++ b/frontend/src/components/panels/LayerTree.vue
@@ -524,7 +524,7 @@ export default defineComponent({
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdateLayerTreeOptionsLayout, (updateLayerTreeOptionsLayout) => {
-			this.layerTreeOptionsLayout = patchWidgetLayout(this.layerTreeOptionsLayout, updateLayerTreeOptionsLayout);
+			patchWidgetLayout(this.layerTreeOptionsLayout, updateLayerTreeOptionsLayout);
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdateDocumentLayerDetails, (updateDocumentLayerDetails) => {

--- a/frontend/src/components/panels/LayerTree.vue
+++ b/frontend/src/components/panels/LayerTree.vue
@@ -277,6 +277,7 @@ import {
 	type LayerTypeData,
 	type LayerPanelEntry,
 	defaultWidgetLayout,
+	patchWidgetLayout,
 	UpdateDocumentLayerDetails,
 	UpdateDocumentLayerTreeStructureJs,
 	UpdateLayerTreeOptionsLayout,
@@ -523,7 +524,7 @@ export default defineComponent({
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdateLayerTreeOptionsLayout, (updateLayerTreeOptionsLayout) => {
-			this.layerTreeOptionsLayout = updateLayerTreeOptionsLayout;
+			this.layerTreeOptionsLayout = patchWidgetLayout(this.layerTreeOptionsLayout, updateLayerTreeOptionsLayout);
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdateDocumentLayerDetails, (updateDocumentLayerDetails) => {

--- a/frontend/src/components/panels/Properties.vue
+++ b/frontend/src/components/panels/Properties.vue
@@ -32,7 +32,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 
-import { defaultWidgetLayout, UpdatePropertyPanelOptionsLayout, UpdatePropertyPanelSectionsLayout } from "@/wasm-communication/messages";
+import { defaultWidgetLayout, patchWidgetLayout, UpdatePropertyPanelOptionsLayout, UpdatePropertyPanelSectionsLayout } from "@/wasm-communication/messages";
 
 import LayoutCol from "@/components/layout/LayoutCol.vue";
 import LayoutRow from "@/components/layout/LayoutRow.vue";
@@ -48,11 +48,11 @@ export default defineComponent({
 	},
 	mounted() {
 		this.editor.subscriptions.subscribeJsMessage(UpdatePropertyPanelOptionsLayout, (updatePropertyPanelOptionsLayout) => {
-			this.propertiesOptionsLayout = updatePropertyPanelOptionsLayout;
+			this.propertiesOptionsLayout = patchWidgetLayout(this.propertiesOptionsLayout, updatePropertyPanelOptionsLayout);
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdatePropertyPanelSectionsLayout, (updatePropertyPanelSectionsLayout) => {
-			this.propertiesSectionsLayout = updatePropertyPanelSectionsLayout;
+			this.propertiesSectionsLayout = patchWidgetLayout(this.propertiesSectionsLayout, updatePropertyPanelSectionsLayout);
 		});
 	},
 	components: {

--- a/frontend/src/components/panels/Properties.vue
+++ b/frontend/src/components/panels/Properties.vue
@@ -48,11 +48,11 @@ export default defineComponent({
 	},
 	mounted() {
 		this.editor.subscriptions.subscribeJsMessage(UpdatePropertyPanelOptionsLayout, (updatePropertyPanelOptionsLayout) => {
-			this.propertiesOptionsLayout = patchWidgetLayout(this.propertiesOptionsLayout, updatePropertyPanelOptionsLayout);
+			patchWidgetLayout(this.propertiesOptionsLayout, updatePropertyPanelOptionsLayout);
 		});
 
 		this.editor.subscriptions.subscribeJsMessage(UpdatePropertyPanelSectionsLayout, (updatePropertyPanelSectionsLayout) => {
-			this.propertiesSectionsLayout = patchWidgetLayout(this.propertiesSectionsLayout, updatePropertyPanelSectionsLayout);
+			patchWidgetLayout(this.propertiesSectionsLayout, updatePropertyPanelSectionsLayout);
 		});
 	},
 	components: {

--- a/frontend/src/state-providers/dialog.ts
+++ b/frontend/src/state-providers/dialog.ts
@@ -37,7 +37,7 @@ export function createDialogState(editor: Editor) {
 		state.icon = displayDialog.icon;
 	});
 	editor.subscriptions.subscribeJsMessage(UpdateDialogDetails, (updateDialogDetails) => {
-		state.widgets = patchWidgetLayout(state.widgets, updateDialogDetails);
+		patchWidgetLayout(state.widgets, updateDialogDetails);
 		state.jsCallbackBasedButtons = undefined;
 	});
 	editor.subscriptions.subscribeJsMessage(DisplayDialogDismiss, dismissDialog);

--- a/frontend/src/state-providers/dialog.ts
+++ b/frontend/src/state-providers/dialog.ts
@@ -2,7 +2,7 @@ import { reactive, readonly } from "vue";
 
 import { type IconName } from "@/utility-functions/icons";
 import { type Editor } from "@/wasm-communication/editor";
-import { type TextButtonWidget, type WidgetLayout, defaultWidgetLayout, DisplayDialog, DisplayDialogDismiss, UpdateDialogDetails } from "@/wasm-communication/messages";
+import { type TextButtonWidget, type WidgetLayout, defaultWidgetLayout, DisplayDialog, DisplayDialogDismiss, UpdateDialogDetails, patchWidgetLayout } from "@/wasm-communication/messages";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createDialogState(editor: Editor) {
@@ -37,7 +37,7 @@ export function createDialogState(editor: Editor) {
 		state.icon = displayDialog.icon;
 	});
 	editor.subscriptions.subscribeJsMessage(UpdateDialogDetails, (updateDialogDetails) => {
-		state.widgets = updateDialogDetails;
+		state.widgets = patchWidgetLayout(state.widgets, updateDialogDetails);
 		state.jsCallbackBasedButtons = undefined;
 	});
 	editor.subscriptions.subscribeJsMessage(DisplayDialogDismiss, dismissDialog);

--- a/frontend/src/state-providers/node-graph.ts
+++ b/frontend/src/state-providers/node-graph.ts
@@ -1,7 +1,16 @@
 import { reactive, readonly } from "vue";
 
 import { type Editor } from "@/wasm-communication/editor";
-import { type FrontendNode, type FrontendNodeLink, type FrontendNodeType, UpdateNodeGraph, UpdateNodeTypes, UpdateNodeGraphBarLayout, defaultWidgetLayout } from "@/wasm-communication/messages";
+import {
+	type FrontendNode,
+	type FrontendNodeLink,
+	type FrontendNodeType,
+	UpdateNodeGraph,
+	UpdateNodeTypes,
+	UpdateNodeGraphBarLayout,
+	defaultWidgetLayout,
+	patchWidgetLayout,
+} from "@/wasm-communication/messages";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createNodeGraphState(editor: Editor) {
@@ -21,7 +30,7 @@ export function createNodeGraphState(editor: Editor) {
 		state.nodeTypes = updateNodeTypes.nodeTypes;
 	});
 	editor.subscriptions.subscribeJsMessage(UpdateNodeGraphBarLayout, (updateNodeGraphBarLayout) => {
-		state.nodeGraphBarLayout = updateNodeGraphBarLayout;
+		state.nodeGraphBarLayout = patchWidgetLayout(state.nodeGraphBarLayout, updateNodeGraphBarLayout);
 	});
 
 	return {

--- a/frontend/src/state-providers/node-graph.ts
+++ b/frontend/src/state-providers/node-graph.ts
@@ -30,7 +30,7 @@ export function createNodeGraphState(editor: Editor) {
 		state.nodeTypes = updateNodeTypes.nodeTypes;
 	});
 	editor.subscriptions.subscribeJsMessage(UpdateNodeGraphBarLayout, (updateNodeGraphBarLayout) => {
-		state.nodeGraphBarLayout = patchWidgetLayout(state.nodeGraphBarLayout, updateNodeGraphBarLayout);
+		patchWidgetLayout(state.nodeGraphBarLayout, updateNodeGraphBarLayout);
 	});
 
 	return {

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1195,7 +1195,8 @@ export type WidgetDiffUpdate = {
 	diff: WidgetDiff[];
 };
 
-type WidgetDiff = { widgetPath: number[]; new: LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] };
+type UIItem = LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] | MenuBarEntry | undefined;
+type WidgetDiff = { widgetPath: number[]; newValue: UIItem };
 
 export function defaultWidgetLayout(): WidgetLayout {
 	return {
@@ -1210,7 +1211,7 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 
 	updates.diff.forEach((update) => {
 		// Find the object where the diff applies to
-		let targetLayout = layout.layout as LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] | MenuBarEntry | undefined;
+		let targetLayout = layout.layout as UIItem;
 		update.widgetPath.forEach((index) => {
 			if (!targetLayout) return;
 			if ("columnWidgets" in targetLayout) targetLayout = targetLayout.columnWidgets[index];
@@ -1226,7 +1227,7 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 		if (targetLayout !== undefined && "length" in targetLayout) targetLayout.length = 0;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		if (targetLayout !== undefined) Object.keys(targetLayout).forEach((key) => delete (targetLayout as any)[key]);
-		if (targetLayout !== undefined) Object.assign(targetLayout, update.new);
+		if (targetLayout !== undefined) Object.assign(targetLayout, update.newValue);
 	});
 }
 
@@ -1251,15 +1252,15 @@ export function isWidgetSection(layoutRow: LayoutGroup): layoutRow is WidgetSect
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createWidgetDiff(diffs: any[]): WidgetDiff[] {
 	const diff = diffs.map((diff): WidgetDiff => {
-		const { widgetPath, newVal } = diff;
-		if (newVal.subLayout) {
-			return { widgetPath, new: newVal.subLayout.map(createLayoutGroup) };
+		const { widgetPath, newValue } = diff;
+		if (newValue.subLayout) {
+			return { widgetPath, newValue: newValue.subLayout.map(createLayoutGroup) };
 		}
-		if (newVal.layoutGroup) {
-			return { widgetPath, new: createLayoutGroup(newVal.layoutGroup) };
+		if (newValue.layoutGroup) {
+			return { widgetPath, newValue: createLayoutGroup(newValue.layoutGroup) };
 		}
-		if (newVal.widget) {
-			return { widgetPath, new: parseWidgetHolder(newVal.widget) };
+		if (newValue.widget) {
+			return { widgetPath, newValue: parseWidgetHolder(newValue.widget) };
 		}
 		throw new Error("DiffUpdate invalid");
 	});

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1223,10 +1223,14 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 			else targetLayout = targetLayout[index];
 		});
 
-		// Some odd code required to update the objects (assigning things doesn't work?)
+		// If this is a list with a length, then set the length to 0 to clear the list
 		if (targetLayout !== undefined && "length" in targetLayout) targetLayout.length = 0;
+		// Remove all of the keys from the old object
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		if (targetLayout !== undefined) Object.keys(targetLayout).forEach((key) => delete (targetLayout as any)[key]);
+		// Assign keys to the new object
+		// `Object.assign` works but `targetLayout = update.newValue;` doesn't.
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 		if (targetLayout !== undefined) Object.assign(targetLayout, update.newValue);
 	});
 }

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1195,7 +1195,7 @@ export type WidgetDiffUpdate = {
 	diff: WidgetDiff[];
 };
 
-type WidgetDiff = { path: number[]; new: LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] };
+type WidgetDiff = { widgetPath: number[]; new: LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] };
 
 export function defaultWidgetLayout(): WidgetLayout {
 	return {
@@ -1211,7 +1211,7 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 	updates.diff.forEach((update) => {
 		// Find the object where the diff applies to
 		let targetLayout = layout.layout as LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] | MenuBarEntry | undefined;
-		update.path.forEach((index) => {
+		update.widgetPath.forEach((index) => {
 			if (!targetLayout) return;
 			if ("columnWidgets" in targetLayout) targetLayout = targetLayout.columnWidgets[index];
 			else if ("rowWidgets" in targetLayout) targetLayout = targetLayout.rowWidgets[index];
@@ -1251,15 +1251,15 @@ export function isWidgetSection(layoutRow: LayoutGroup): layoutRow is WidgetSect
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createWidgetDiff(diffs: any[]): WidgetDiff[] {
 	const diff = diffs.map((diff): WidgetDiff => {
-		const { path, newVal } = diff;
+		const { widgetPath, newVal } = diff;
 		if (newVal.subLayout) {
-			return { path, new: newVal.subLayout.map(createLayoutGroup) };
+			return { widgetPath, new: newVal.subLayout.map(createLayoutGroup) };
 		}
 		if (newVal.layoutGroup) {
-			return { path, new: createLayoutGroup(newVal.layoutGroup) };
+			return { widgetPath, new: createLayoutGroup(newVal.layoutGroup) };
 		}
 		if (newVal.widget) {
-			return { path, new: parseWidgetHolder(newVal.widget) };
+			return { widgetPath, new: parseWidgetHolder(newVal.widget) };
 		}
 		throw new Error("DiffUpdate invalid");
 	});

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1205,7 +1205,7 @@ export function defaultWidgetLayout(): WidgetLayout {
 }
 
 // Updates a widget layout based on a list of updates, returning the new layout
-export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdate): WidgetLayout {
+export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdate) {
 	layout.layoutTarget = updates.layoutTarget;
 
 	updates.diff.forEach((update) => {
@@ -1213,11 +1213,11 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 		let targetLayout = layout.layout as LayoutGroup[] | LayoutGroup | Widget | MenuBarEntry[] | MenuBarEntry | undefined;
 		update.path.forEach((index) => {
 			if (!targetLayout) return;
-			if ("columnWidgets" in targetLayout) targetLayout = new Proxy(targetLayout.columnWidgets[index], {});
-			else if ("rowWidgets" in targetLayout) targetLayout = new Proxy(targetLayout.rowWidgets[index], {});
-			else if ("layout" in targetLayout) targetLayout = new Proxy(targetLayout.layout[index], {});
+			if ("columnWidgets" in targetLayout) targetLayout = targetLayout.columnWidgets[index];
+			else if ("rowWidgets" in targetLayout) targetLayout = targetLayout.rowWidgets[index];
+			else if ("layout" in targetLayout) targetLayout = targetLayout.layout[index];
 			else if (targetLayout instanceof Widget) console.error("Tried to index widget");
-			else if ("action" in targetLayout) targetLayout = targetLayout.children ? new Proxy(targetLayout.children[index], {}) : undefined;
+			else if ("action" in targetLayout) targetLayout = targetLayout.children ? targetLayout.children[index] : undefined;
 			else targetLayout = targetLayout[index];
 		});
 
@@ -1226,8 +1226,6 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 		if (targetLayout !== undefined) Object.keys(targetLayout).forEach((key) => delete (targetLayout as any)[key]);
 		if (targetLayout !== undefined) Object.assign(targetLayout, update.new);
 	});
-
-	return layout;
 }
 
 export type LayoutGroup = WidgetRow | WidgetColumn | WidgetSection;

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1269,21 +1269,21 @@ function createWidgetDiff(diffs: any[]): WidgetDiff[] {
 
 // Unpacking a layout group
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function createLayoutGroup(newVal: any): LayoutGroup {
-	if (newVal.column) {
-		const columnWidgets = hoistWidgetHolders(newVal.column.columnWidgets);
+function createLayoutGroup(layoutGroup: any): LayoutGroup {
+	if (layoutGroup.column) {
+		const columnWidgets = hoistWidgetHolders(layoutGroup.column.columnWidgets);
 
 		const result: WidgetColumn = { columnWidgets };
 		return result;
 	}
 
-	if (newVal.row) {
-		const result: WidgetRow = { rowWidgets: hoistWidgetHolders(newVal.row.rowWidgets) };
+	if (layoutGroup.row) {
+		const result: WidgetRow = { rowWidgets: hoistWidgetHolders(layoutGroup.row.rowWidgets) };
 		return result;
 	}
 
-	if (newVal.section) {
-		const result: WidgetSection = { name: newVal.section.name, layout: newVal.section.layout.map(createLayoutGroup) };
+	if (layoutGroup.section) {
+		const result: WidgetSection = { name: layoutGroup.section.name, layout: layoutGroup.section.layout.map(createLayoutGroup) };
 		return result;
 	}
 

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -1205,7 +1205,7 @@ export function defaultWidgetLayout(): WidgetLayout {
 }
 
 // Updates a widget layout based on a list of updates, returning the new layout
-export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdate) {
+export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdate): void {
 	layout.layoutTarget = updates.layoutTarget;
 
 	updates.diff.forEach((update) => {
@@ -1216,6 +1216,7 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 			if ("columnWidgets" in targetLayout) targetLayout = targetLayout.columnWidgets[index];
 			else if ("rowWidgets" in targetLayout) targetLayout = targetLayout.rowWidgets[index];
 			else if ("layout" in targetLayout) targetLayout = targetLayout.layout[index];
+			// eslint-disable-next-line no-console
 			else if (targetLayout instanceof Widget) console.error("Tried to index widget");
 			else if ("action" in targetLayout) targetLayout = targetLayout.children ? targetLayout.children[index] : undefined;
 			else targetLayout = targetLayout[index];
@@ -1223,6 +1224,7 @@ export function patchWidgetLayout(layout: WidgetLayout, updates: WidgetDiffUpdat
 
 		// Some odd code required to update the objects (assigning things doesn't work?)
 		if (targetLayout !== undefined && "length" in targetLayout) targetLayout.length = 0;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		if (targetLayout !== undefined) Object.keys(targetLayout).forEach((key) => delete (targetLayout as any)[key]);
 		if (targetLayout !== undefined) Object.assign(targetLayout, update.new);
 	});

--- a/frontend/wasm/.cargo/Config.toml
+++ b/frontend/wasm/.cargo/Config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+simd128,+atomics,+bulk-memory,+mutable-globals"]
+
+[unstable]
+build-std = ["panic_abort", "std"]


### PR DESCRIPTION
The Rust widgets are diffed and only the changed ones are updated. This probably won't speed things up that much but it reduces the amount of data put through serde each frame.