### PR TITLE
Round document alignment in viewport to avoid AA induced by a shift after zooming in and panning

### DIFF
--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -21,11 +21,11 @@ impl ViewportBounds {
 	}
 
 	pub fn size(&self) -> DVec2 {
-		self.bottom_right - self.top_left
+		(self.bottom_right - self.top_left).ceil()
 	}
 
 	pub fn center(&self) -> DVec2 {
-		self.bottom_right.lerp(self.top_left, 0.5)
+		(self.bottom_right - self.top_left).ceil() / 2.
 	}
 
 	pub fn in_bounds(&self, position: ViewportPosition) -> bool {

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -29,7 +29,7 @@ impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputP
 					let new_size = bounds.size();
 					let existing_size = self.viewport_bounds.size();
 
-					let translation = (new_size - existing_size) / 2.;
+					let translation = ((new_size - existing_size) / 2.).round();
 
 					// TODO: Extend this to multiple viewports instead of setting it to the value of this last loop iteration
 					self.viewport_bounds = bounds;

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -307,11 +307,15 @@ impl NavigationMessageHandler {
 	}
 
 	pub fn calculate_offset_transform(&self, offset: DVec2) -> DAffine2 {
+		// Try to avoid fractional coordinates to reduce anti aliasing.
+		let scale = self.snapped_scale();
+		let rounded_pan = ((self.pan + offset) * scale).round() / scale - offset;
+
 		// TODO: replace with DAffine2::from_scale_angle_translation and fix the errors
 		let offset_transform = DAffine2::from_translation(offset);
-		let scale_transform = DAffine2::from_scale(DVec2::splat(self.snapped_scale()));
+		let scale_transform = DAffine2::from_scale(DVec2::splat(scale));
 		let angle_transform = DAffine2::from_angle(self.snapped_angle());
-		let translation_transform = DAffine2::from_translation(self.pan);
+		let translation_transform = DAffine2::from_translation(rounded_pan);
 		scale_transform * offset_transform * angle_transform * translation_transform
 	}
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #309

Perhaps it works?