### PR TITLE
Gradient tool improvements

### DIFF
--- a/document-legacy/src/color.rs
+++ b/document-legacy/src/color.rs
@@ -205,4 +205,17 @@ impl Color {
 
 		Some(Color::from_rgb8(r, g, b))
 	}
+
+	/// Linearly interpolates between two colors based on t.
+	///
+	/// T must be between 0 and 1.
+	pub fn lerp(self, other: Color, t: f32) -> Option<Self> {
+		assert!((0. ..=1.).contains(&t));
+		Color::from_rgbaf32(
+			self.red + ((other.red - self.red) * t),
+			self.green + ((other.green - self.green) * t),
+			self.blue + ((other.blue - self.blue) * t),
+			self.alpha + ((other.alpha - self.alpha) * t),
+		)
+	}
 }

--- a/document-legacy/src/document.rs
+++ b/document-legacy/src/document.rs
@@ -32,6 +32,12 @@ pub struct Document {
 	pub state_identifier: DefaultHasher,
 }
 
+impl PartialEq for Document {
+	fn eq(&self, other: &Self) -> bool {
+		self.state_identifier.finish() == other.state_identifier.finish()
+	}
+}
+
 impl Default for Document {
 	fn default() -> Self {
 		Self {

--- a/document-legacy/src/layers/style/mod.rs
+++ b/document-legacy/src/layers/style/mod.rs
@@ -138,6 +138,42 @@ impl Gradient {
 			}
 		}
 	}
+
+	/// Insert a stop into the gradient, the index if successful
+	pub fn insert_stop(&mut self, mouse: DVec2) -> Option<usize> {
+		// Calculate the new position by finding the closest point on the line
+		let new_position = ((self.end - self.start).angle_between(mouse - self.start)).cos() * self.start.distance(mouse) / self.start.distance(self.end);
+
+		// Don't insert point past end of line
+		if !(0. ..=1.).contains(&new_position) {
+			return None;
+		}
+
+		// Compute the color of the inserted stop
+		let get_color = |index: usize, time: f64| match (self.positions[index].1, self.positions.get(index + 1).and_then(|x| x.1)) {
+			// Lerp between the nearest colours if applicable
+			(Some(a), Some(b)) => a.lerp(
+				b,
+				((time - self.positions[index].0) / self.positions.get(index + 1).map(|end| end.0 - self.positions[index].0).unwrap_or_default()) as f32,
+			),
+			// Use the start or the end colour if applicable
+			(Some(v), _) | (_, Some(v)) => Some(v),
+			_ => Some(Color::WHITE),
+		};
+
+		// Compute the correct index to keep the positions in order
+		let mut index = 0;
+		while self.positions.len() > index && self.positions[index].0 <= new_position {
+			index += 1;
+		}
+
+		let new_color = get_color(index - 1, new_position);
+
+		// Insert the new stop
+		self.positions.insert(index, (new_position, new_color));
+
+		Some(index)
+	}
 }
 
 /// Describes the fill of a layer.

--- a/document-legacy/src/layers/style/mod.rs
+++ b/document-legacy/src/layers/style/mod.rs
@@ -189,6 +189,15 @@ impl Fill {
 	pub fn is_some(&self) -> bool {
 		*self != Self::None
 	}
+
+	/// Extract a gradient from the fill
+	pub fn as_gradient(&self) -> Option<&Gradient> {
+		if let Self::Gradient(gradient) = self {
+			Some(gradient)
+		} else {
+			None
+		}
+	}
 }
 
 /// The stroke (outline) style of an SVG element.

--- a/document-legacy/src/layers/style/mod.rs
+++ b/document-legacy/src/layers/style/mod.rs
@@ -140,9 +140,12 @@ impl Gradient {
 	}
 
 	/// Insert a stop into the gradient, the index if successful
-	pub fn insert_stop(&mut self, mouse: DVec2) -> Option<usize> {
+	pub fn insert_stop(&mut self, mouse: DVec2, transform: DAffine2) -> Option<usize> {
+		// Transform the start and end positions to the same coordinate space as the mouse.
+		let (start, end) = (transform.transform_point2(self.start), transform.transform_point2(self.end));
+
 		// Calculate the new position by finding the closest point on the line
-		let new_position = ((self.end - self.start).angle_between(mouse - self.start)).cos() * self.start.distance(mouse) / self.start.distance(self.end);
+		let new_position = ((end - start).angle_between(mouse - start)).cos() * start.distance(mouse) / start.distance(end);
 
 		// Don't insert point past end of line
 		if !(0. ..=1.).contains(&new_position) {

--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -116,6 +116,8 @@ pub fn default_mapping() -> Mapping {
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
 		entry!(KeyUp(Lmb); action_dispatch=GradientToolMessage::PointerUp),
 		entry!(DoubleClick; action_dispatch=GradientToolMessage::InsertStop),
+		entry!(KeyDown(Delete); action_dispatch=GradientToolMessage::DeleteStop),
+		entry!(KeyDown(Backspace); action_dispatch=GradientToolMessage::DeleteStop),
 		//
 		// RectangleToolMessage
 		entry!(KeyDown(Lmb); action_dispatch=RectangleToolMessage::DragStart),

--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -115,6 +115,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=GradientToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
 		entry!(KeyUp(Lmb); action_dispatch=GradientToolMessage::PointerUp),
+		entry!(DoubleClick; action_dispatch=GradientToolMessage::InsertStop),
 		//
 		// RectangleToolMessage
 		entry!(KeyDown(Lmb); action_dispatch=RectangleToolMessage::DragStart),

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -4,6 +4,7 @@ use crate::messages::portfolio::document::utility_types::misc::{AlignAggregate, 
 use crate::messages::prelude::*;
 
 use document_legacy::boolean_ops::BooleanOperation as BooleanOperationType;
+use document_legacy::document::Document as DocumentLegacy;
 use document_legacy::layers::blend_mode::BlendMode;
 use document_legacy::layers::style::ViewMode;
 use document_legacy::LayerId;
@@ -45,6 +46,10 @@ pub enum DocumentMessage {
 	AlignSelectedLayers {
 		axis: AlignAxis,
 		aggregate: AlignAggregate,
+	},
+	BackupDocument {
+		document: DocumentLegacy,
+		layer_metadata: HashMap<Vec<LayerId>, LayerMetadata>,
 	},
 	BooleanOperation(BooleanOperationType),
 	ClearLayerTree,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -231,6 +231,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 					responses.push_back(BroadcastEvent::DocumentIsDirty.into());
 				}
 			}
+			BackupDocument { document, layer_metadata } => self.backup_with_document(document, layer_metadata, responses),
 			BooleanOperation(op) => {
 				// Convert Vec<&[LayerId]> to Vec<Vec<&LayerId>> because Vec<&[LayerId]> does not implement several traits (Debug, Serialize, Deserialize, ...) required by DocumentOperation enum
 				responses.push_back(StartTransaction.into());
@@ -1273,15 +1274,32 @@ impl DocumentMessageHandler {
 			.unwrap_or_else(|| panic!("Layer data cannot be found because the path {:?} does not exist", path))
 	}
 
-	pub fn backup(&mut self, responses: &mut VecDeque<Message>) {
+	/// Places a document into the history system
+	fn backup_with_document(&mut self, document: DocumentLegacy, layer_metadata: HashMap<Vec<LayerId>, LayerMetadata>, responses: &mut VecDeque<Message>) {
 		self.document_redo_history.clear();
-		self.document_undo_history.push_back((self.document_legacy.clone(), self.layer_metadata.clone()));
+		self.document_undo_history.push_back((document, layer_metadata));
 		if self.document_undo_history.len() > crate::consts::MAX_UNDO_HISTORY_LEN {
 			self.document_undo_history.pop_front();
 		}
 
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.push_back(PortfolioMessage::UpdateOpenDocumentsList.into());
+	}
+
+	/// Copies the entire document into the history system
+	pub fn backup(&mut self, responses: &mut VecDeque<Message>) {
+		self.backup_with_document(self.document_legacy.clone(), self.layer_metadata.clone(), responses);
+	}
+
+	/// Push a message backing up the document in its current state
+	pub fn backup_nonmut(&self, responses: &mut VecDeque<Message>) {
+		responses.push_back(
+			DocumentMessage::BackupDocument {
+				document: self.document_legacy.clone(),
+				layer_metadata: self.layer_metadata.clone(),
+			}
+			.into(),
+		);
 	}
 
 	pub fn rollback(&mut self, responses: &mut VecDeque<Message>) -> Result<(), EditorError> {

--- a/editor/src/messages/tool/tool_message.rs
+++ b/editor/src/messages/tool/tool_message.rs
@@ -125,6 +125,7 @@ pub enum ToolMessage {
 	},
 	DeactivateTools,
 	InitTools,
+	RefreshToolOptions,
 	ResetColors,
 	SelectPrimaryColor {
 		color: Color,

--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -136,6 +136,10 @@ impl MessageHandler<ToolMessage, (&DocumentMessageHandler, u64, &InputPreprocess
 					.active_tool_mut()
 					.process_message(ToolMessage::UpdateCursor, (document, document_id, document_data, input, &persistent_data.font_cache), responses);
 			}
+			ToolMessage::RefreshToolOptions => {
+				let tool_data = &mut self.tool_state.tool_data;
+				tool_data.tools.get(&tool_data.active_tool_type).unwrap().register_properties(responses, LayoutTarget::ToolOptions);
+			}
 			ToolMessage::ResetColors => {
 				let document_data = &mut self.tool_state.document_tool_data;
 

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -1,5 +1,5 @@
 use crate::application::generate_uuid;
-use crate::consts::{COLOR_ACCENT, DRAG_THRESHOLD, LINE_ROTATE_SNAP_ANGLE, MANIPULATOR_GROUP_MARKER_SIZE, SELECTION_TOLERANCE};
+use crate::consts::{COLOR_ACCENT, DRAG_THRESHOLD, LINE_ROTATE_SNAP_ANGLE, MANIPULATOR_GROUP_MARKER_SIZE, SELECTION_THRESHOLD, SELECTION_TOLERANCE};
 use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::input_mapper::utility_types::input_keyboard::{Key, KeysGroup, MouseMotion};
 use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup, PropertyHolder, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
@@ -516,7 +516,7 @@ impl Fsm for GradientToolFsmState {
 						let distance = (end - start).angle_between(mouse - start).sin() * (mouse - start).length();
 
 						// If click is on the line then insert point
-						if distance < SELECTION_TOLERANCE {
+						if distance < SELECTION_THRESHOLD {
 							let mut gradient = overlay.gradient.clone();
 
 							// Try and insert the new stop

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -456,17 +456,22 @@ impl Fsm for GradientToolFsmState {
 
 							let layer = document.document_legacy.layer(&intersection).unwrap();
 
-							let gradient = Gradient::new(
-								DVec2::ZERO,
-								global_tool_data.secondary_color,
-								DVec2::ONE,
-								global_tool_data.primary_color,
-								DAffine2::IDENTITY,
-								generate_uuid(),
-								tool_options.gradient_type,
-							);
-							let mut selected_gradient = SelectedGradient::new(gradient, &intersection, layer, document, font_cache).with_gradient_start(input.mouse.position);
-							selected_gradient.update_gradient(input.mouse.position, responses, false, tool_options.gradient_type);
+							// Use the already existing gradient if it exists
+							let gradient = if let Some(gradient) = layer.style().ok().map(|style| style.fill()).and_then(|fill| fill.as_gradient()) {
+								gradient.clone()
+							} else {
+								// Generate a new gradient
+								Gradient::new(
+									DVec2::ZERO,
+									global_tool_data.secondary_color,
+									DVec2::ONE,
+									global_tool_data.primary_color,
+									DAffine2::IDENTITY,
+									generate_uuid(),
+									tool_options.gradient_type,
+								)
+							};
+							let selected_gradient = SelectedGradient::new(gradient, &intersection, layer, document, font_cache).with_gradient_start(input.mouse.position);
 
 							tool_data.selected_gradient = Some(selected_gradient);
 


### PR DESCRIPTION
- Existing gradient stop points are reused (from discord todo list)
- Undo works on gradient tool modifications (not properties panel yet)
- Double click on the line to insert a stop (like inkscape)
