### PR TITLE
Fix a derivative causing NaNs in boolean ops

### DIFF
--- a/document-legacy/src/boolean_ops.rs
+++ b/document-legacy/src/boolean_ops.rs
@@ -18,7 +18,7 @@ pub enum BooleanOperation {
 	SubtractBack,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub enum BooleanOperationError {
 	InvalidSelection,
 	InvalidIntersections,

--- a/document-legacy/src/error.rs
+++ b/document-legacy/src/error.rs
@@ -14,11 +14,11 @@ pub enum DocumentError {
 	NotAnImage,
 	NotAnImaginate,
 	InvalidFile(String),
+	BooleanOperationError(BooleanOperationError),
 }
 
-// TODO: change how BooleanOperationErrors are handled
 impl From<BooleanOperationError> for DocumentError {
 	fn from(err: BooleanOperationError) -> Self {
-		DocumentError::InvalidFile(format!("{:?}", err))
+		DocumentError::BooleanOperationError(err)
 	}
 }

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -145,8 +145,8 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 				// Display boolean operation error to the user (except if it is a nothing done error).
 				Err(DocumentError::BooleanOperationError(boolean_operation_error)) if boolean_operation_error != BooleanOperationError::NothingDone => responses.push_back(
 					DialogMessage::DisplayDialogError {
-						title: "Error processing boolean operation".into(),
-						description: format!("Boolean operations can unfortunatley be somewhat unreliable.\nError: {boolean_operation_error:?}"),
+						title: "Failed to calculate boolean operation".into(),
+						description: format!("Unfortunately, this feature not that robust yet.\n\nError: {boolean_operation_error:?}"),
 					}
 					.into(),
 				),


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #931

The handles on top of control points caused the derivative to be zero, which led to NaNs.