### PR TITLE
Don't show the blue outline when bloburl is set

### DIFF
--- a/document-legacy/src/layers/nodegraph_layer.rs
+++ b/document-legacy/src/layers/nodegraph_layer.rs
@@ -65,14 +65,15 @@ impl LayerData for NodeGraphFrameLayer {
 				blob_url,
 				matrix
 			);
+		} else {
+			let _ = write!(
+				svg,
+				r#"<rect width="{}" height="{}" fill="none" stroke="var(--color-data-vector)" stroke-width="3" stroke-dasharray="8" transform="matrix({})" />"#,
+				width.abs(),
+				height.abs(),
+				matrix,
+			);
 		}
-		let _ = write!(
-			svg,
-			r#"<rect width="{}" height="{}" fill="none" stroke="var(--color-data-vector)" stroke-width="3" stroke-dasharray="8" transform="matrix({})" />"#,
-			width.abs(),
-			height.abs(),
-			matrix,
-		);
 
 		let _ = svg.write_str(r#"</g>"#);
 


### PR DESCRIPTION
Don't show the blue outline around node graph frames when the blob url is set. This can make the frame invisibe.