### PR TITLE
Fix viewport culling with nested layers

### DIFF
--- a/document-legacy/src/layers/folder_layer.rs
+++ b/document-legacy/src/layers/folder_layer.rs
@@ -22,13 +22,13 @@ pub struct FolderLayer {
 
 impl LayerData for FolderLayer {
 	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<glam::DAffine2>, render_data: RenderData) -> bool {
-		let mut failed = false;
+		let mut any_child_requires_refresh = false;
 		for layer in &mut self.layers {
-			let (svg_value, success) = layer.render(transforms, svg_defs, render_data);
+			let (svg_value, requires_refresh) = layer.render(transforms, svg_defs, render_data);
 			*svg += svg_value;
-			failed = failed || (!success);
+			any_child_requires_refresh = any_child_requires_refresh || requires_refresh;
 		}
-		!failed
+		!any_child_requires_refresh
 	}
 
 	fn intersects_quad(&self, quad: Quad, path: &mut Vec<LayerId>, intersections: &mut Vec<Vec<LayerId>>, font_cache: &FontCache) {

--- a/document-legacy/src/layers/folder_layer.rs
+++ b/document-legacy/src/layers/folder_layer.rs
@@ -6,7 +6,6 @@ use crate::{DocumentError, LayerId};
 
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
-use std::fmt::Write;
 
 /// A layer that encapsulates other layers, including potentially more folders.
 /// The contained layers are rendered in the same order they are
@@ -22,10 +21,14 @@ pub struct FolderLayer {
 }
 
 impl LayerData for FolderLayer {
-	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<glam::DAffine2>, render_data: RenderData) {
+	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<glam::DAffine2>, render_data: RenderData) -> bool {
+		let mut failed = false;
 		for layer in &mut self.layers {
-			let _ = writeln!(svg, "{}", layer.render(transforms, svg_defs, render_data));
+			let (svg_value, success) = layer.render(transforms, svg_defs, render_data);
+			*svg += svg_value;
+			failed = failed || (!success);
 		}
+		!failed
 	}
 
 	fn intersects_quad(&self, quad: Quad, path: &mut Vec<LayerId>, intersections: &mut Vec<Vec<LayerId>>, font_cache: &FontCache) {

--- a/document-legacy/src/layers/image_layer.rs
+++ b/document-legacy/src/layers/image_layer.rs
@@ -23,13 +23,13 @@ pub struct ImageLayer {
 }
 
 impl LayerData for ImageLayer {
-	fn render(&mut self, svg: &mut String, _svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) {
+	fn render(&mut self, svg: &mut String, _svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) -> bool {
 		let transform = self.transform(transforms, render_data.view_mode);
 		let inverse = transform.inverse();
 
 		if !inverse.is_finite() {
 			let _ = write!(svg, "<!-- SVG shape has an invalid transform -->");
-			return;
+			return false;
 		}
 
 		let _ = writeln!(svg, r#"<g transform="matrix("#);
@@ -53,6 +53,8 @@ impl LayerData for ImageLayer {
 			self.blob_url.as_ref().unwrap_or(&String::new())
 		);
 		let _ = svg.write_str("</g>");
+
+		true
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/image_layer.rs
+++ b/document-legacy/src/layers/image_layer.rs
@@ -54,7 +54,7 @@ impl LayerData for ImageLayer {
 		);
 		let _ = svg.write_str("</g>");
 
-		true
+		false
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/nodegraph_layer.rs
+++ b/document-legacy/src/layers/nodegraph_layer.rs
@@ -76,7 +76,7 @@ impl LayerData for NodeGraphFrameLayer {
 
 		let _ = svg.write_str(r#"</g>"#);
 
-		true
+		false
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/nodegraph_layer.rs
+++ b/document-legacy/src/layers/nodegraph_layer.rs
@@ -33,7 +33,7 @@ pub struct ImageData {
 }
 
 impl LayerData for NodeGraphFrameLayer {
-	fn render(&mut self, svg: &mut String, _svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) {
+	fn render(&mut self, svg: &mut String, _svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) -> bool {
 		let transform = self.transform(transforms, render_data.view_mode);
 		let inverse = transform.inverse();
 
@@ -41,7 +41,7 @@ impl LayerData for NodeGraphFrameLayer {
 
 		if !inverse.is_finite() {
 			let _ = write!(svg, "<!-- SVG shape has an invalid transform -->");
-			return;
+			return false;
 		}
 
 		let _ = writeln!(svg, r#"<g transform="matrix("#);
@@ -75,6 +75,8 @@ impl LayerData for NodeGraphFrameLayer {
 		);
 
 		let _ = svg.write_str(r#"</g>"#);
+
+		true
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/shape_layer.rs
+++ b/document-legacy/src/layers/shape_layer.rs
@@ -55,7 +55,7 @@ impl LayerData for ShapeLayer {
 		);
 		let _ = svg.write_str("</g>");
 
-		true
+		false
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/shape_layer.rs
+++ b/document-legacy/src/layers/shape_layer.rs
@@ -27,7 +27,7 @@ pub struct ShapeLayer {
 }
 
 impl LayerData for ShapeLayer {
-	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) {
+	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) -> bool {
 		let mut subpath = self.shape.clone();
 
 		let layer_bounds = subpath.bounding_box().unwrap_or_default();
@@ -36,7 +36,7 @@ impl LayerData for ShapeLayer {
 		let inverse = transform.inverse();
 		if !inverse.is_finite() {
 			let _ = write!(svg, "<!-- SVG shape has an invalid transform -->");
-			return;
+			return false;
 		}
 		subpath.apply_affine(transform);
 
@@ -54,6 +54,8 @@ impl LayerData for ShapeLayer {
 			self.style.render(render_data.view_mode, svg_defs, transform, layer_bounds, transformed_bounds)
 		);
 		let _ = svg.write_str("</g>");
+
+		true
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, _font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/text_layer.rs
+++ b/document-legacy/src/layers/text_layer.rs
@@ -86,7 +86,7 @@ impl LayerData for TextLayer {
 		}
 		let _ = svg.write_str("</g>");
 
-		true
+		false
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, font_cache: &FontCache) -> Option<[DVec2; 2]> {

--- a/document-legacy/src/layers/text_layer.rs
+++ b/document-legacy/src/layers/text_layer.rs
@@ -34,13 +34,13 @@ pub struct TextLayer {
 }
 
 impl LayerData for TextLayer {
-	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) {
+	fn render(&mut self, svg: &mut String, svg_defs: &mut String, transforms: &mut Vec<DAffine2>, render_data: RenderData) -> bool {
 		let transform = self.transform(transforms, render_data.view_mode);
 		let inverse = transform.inverse();
 
 		if !inverse.is_finite() {
 			let _ = write!(svg, "<!-- SVG shape has an invalid transform -->");
-			return;
+			return false;
 		}
 
 		let _ = writeln!(svg, r#"<g transform="matrix("#);
@@ -85,6 +85,8 @@ impl LayerData for TextLayer {
 			);
 		}
 		let _ = svg.write_str("</g>");
+
+		true
 	}
 
 	fn bounding_box(&self, transform: glam::DAffine2, font_cache: &FontCache) -> Option<[DVec2; 2]> {


### PR DESCRIPTION
If the layer is outside of the viewport then we don't render it and mark the cache as dirty, however if a child of a folder is not rendered then the parent folder may not be marked as dirty, meaning that we do not check again if the layer is inside the viewport.

Steps to reproduce:
- Draw two rectangles next to each other
- Place them in a folder
- Move the folder off the screen
- Move the document so you can see the folder again, noticing that one of the rectangles has disappeared

This is because the folder is using a cached value where one of the rectangles has been culled, and it has not been marked as dirty.