### PR TITLE
Fix boolean crash with self intersecting shape

### DIFF
--- a/document-legacy/src/boolean_ops.rs
+++ b/document-legacy/src/boolean_ops.rs
@@ -25,6 +25,7 @@ pub enum BooleanOperationError {
 	NoIntersections,
 	NothingDone, // Not necessarily an error
 	DirectionUndefined,
+	NoResult,
 	Unexpected, // For debugging, when complete nothing should be unexpected
 }
 
@@ -492,9 +493,13 @@ pub fn composite_boolean_operation(mut select: BooleanOperation, shapes: &mut Ve
 					match partial_union {
 						Ok(temp_union) => {
 							// The result of a successful union will be exactly one shape
-							shapes.push(RefCell::new(temp_union.into_iter().next().unwrap()));
-							shapes.swap_remove(subject_idx);
-							shapes.swap_remove(shape_idx);
+							if let Some(result) = temp_union.into_iter().next() {
+								shapes.push(RefCell::new(result));
+								shapes.swap_remove(subject_idx);
+								shapes.swap_remove(shape_idx);
+							} else {
+								return Err(BooleanOperationError::NoResult);
+							}
 						}
 						Err(BooleanOperationError::NothingDone) => shape_idx += 1,
 						Err(err) => return Err(err),


### PR DESCRIPTION
As discussed in discord, we now no longer panic and instead send a dialogue error.