### PR TITLE
Bezier-rs: Add bounding box, extrema, and inflection functions for subpath

### DIFF
--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -73,7 +73,7 @@ impl Subpath {
 			y_extremas.extend(extremas[1].iter().map(|t| ((index as f64) + t) / number_of_curves).collect::<Vec<f64>>());
 		}
 
-		// TODO: Consider the point between bezier curves.
+		// TODO: Consider the shared point between adjacent beziers.
 		[x_extremas, y_extremas]
 	}
 
@@ -85,14 +85,14 @@ impl Subpath {
 			// There is no bounding box for empty subpath.
 			None
 		} else {
-			let mut min_points = bounding_boxes[0][0];
-			let mut max_points = bounding_boxes[0][1];
+			let mut min_point = bounding_boxes[0][0];
+			let mut max_point = bounding_boxes[0][1];
 			for bounding_box in bounding_boxes {
 				// We take min of mins and max of maxes.
-				min_points = min_points.min(bounding_box[0]);
-				max_points = max_points.max(bounding_box[1]);
+				min_point = min_point.min(bounding_box[0]);
+				max_point = max_point.max(bounding_box[1]);
 			}
-			Some([min_points, max_points])
+			Some([min_point, max_point])
 		}
 	}
 
@@ -114,7 +114,7 @@ impl Subpath {
 			})
 			.collect();
 
-		// TODO: Consider the point between bezier curves.
+		// TODO: Consider the shared point between adjacent beziers.
 		inflection_t_values
 	}
 }

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -58,6 +58,25 @@ impl Subpath {
 		let (segment_index, t) = self.t_value_to_parametric(t);
 		self.get_segment(segment_index).unwrap().normal(TValue::Parametric(t))
 	}
+
+	/// Return the min and max corners that represent the bounding box of the subpath.
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/bounding-box/solo" title="Bounding Box Demo"></iframe>
+	pub fn bounding_box(&self) -> Option<[DVec2; 2]> {
+		let bounding_boxes = self.iter().map(|bezier| bezier.bounding_box()).collect::<Vec<[DVec2; 2]>>();
+		if bounding_boxes.is_empty() {
+			// There is no bounding box for empty subpath.
+			None
+		} else {
+			let mut min_points = bounding_boxes[0][0];
+			let mut max_points = bounding_boxes[0][1];
+			for bounding_box in bounding_boxes {
+				// We take min of mins and max of maxes.
+				min_points = min_points.min(bounding_box[0]);
+				max_points = max_points.max(bounding_box[1]);
+			}
+			Some([min_points, max_points])
+		}
+	}
 }
 
 #[cfg(test)]

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -59,6 +59,24 @@ impl Subpath {
 		self.get_segment(segment_index).unwrap().normal(TValue::Parametric(t))
 	}
 
+	/// Returns two lists of `t`-values representing the local extrema of the `x` and `y` parametric subpaths respectively.
+	/// The list of `t`-values returned are filtered such that they fall within the range `[0, 1]`.
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/local-extrema/solo" title="Local Extrema Demo"></iframe>
+	pub fn local_extrema(&self) -> [Vec<f64>; 2] {
+		let (mut x_extremas, mut y_extremas) = (Vec::new(), Vec::new());
+		let number_of_curves = self.len_segments() as f64;
+
+		for (index, bezier) in self.iter().enumerate() {
+			// Convert t-values of bezier curve to t-values of subpath
+			let extremas = bezier.local_extrema();
+			x_extremas.extend(extremas[0].iter().map(|t| ((index as f64) + t) / number_of_curves).collect::<Vec<f64>>());
+			y_extremas.extend(extremas[1].iter().map(|t| ((index as f64) + t) / number_of_curves).collect::<Vec<f64>>());
+		}
+
+		// TODO: Consider the point between bezier curves.
+		[x_extremas, y_extremas]
+	}
+
 	/// Return the min and max corners that represent the bounding box of the subpath.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/bounding-box/solo" title="Bounding Box Demo"></iframe>
 	pub fn bounding_box(&self) -> Option<[DVec2; 2]> {
@@ -76,6 +94,28 @@ impl Subpath {
 			}
 			Some([min_points, max_points])
 		}
+	}
+
+	/// Returns list of `t`-values representing the inflection points of the subpath.
+	/// The list of `t`-values returned are filtered such that they fall within the range `[0, 1]`.
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/inflections/solo" title="Inflections Demo"></iframe>
+	pub fn inflections(&self) -> Vec<f64> {
+		let number_of_curves = self.len_segments() as f64;
+		let inflection_t_values: Vec<f64> = self
+			.iter()
+			.enumerate()
+			.flat_map(|(index, bezier)| {
+				bezier
+					.inflections()
+					.into_iter()
+					// Convert t-values of bezier curve to t-values of subpath
+					.map(|t| ((index as f64) + t) / number_of_curves)
+					.collect::<Vec<f64>>()
+			})
+			.collect();
+
+		// TODO: Consider the point between bezier curves.
+		inflection_t_values
 	}
 }
 

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -40,6 +40,10 @@ const subpathFeatures = {
 		sliderOptions: [tSliderOptions],
 		chooseTVariant: true,
 	},
+	"bounding-box": {
+		name: "Bounding Box",
+		callback: (subpath: WasmSubpathInstance): string => subpath.bounding_box(),
+	},
 	"intersect-linear": {
 		name: "Intersect (Line Segment)",
 		callback: (subpath: WasmSubpathInstance): string =>

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -40,9 +40,17 @@ const subpathFeatures = {
 		sliderOptions: [tSliderOptions],
 		chooseTVariant: true,
 	},
+	"local-extrema": {
+		name: "Local Extrema",
+		callback: (subpath: WasmSubpathInstance): string => subpath.local_extrema(),
+	},
 	"bounding-box": {
 		name: "Bounding Box",
 		callback: (subpath: WasmSubpathInstance): string => subpath.bounding_box(),
+	},
+	inflections: {
+		name: "Inflections",
+		callback: (subpath: WasmSubpathInstance): string => subpath.inflections(),
 	},
 	"intersect-linear": {
 		name: "Intersect (Line Segment)",

--- a/website/other/bezier-rs-demos/src/style.css
+++ b/website/other/bezier-rs-demos/src/style.css
@@ -73,3 +73,8 @@ body > h2 {
 	margin-bottom: 20px;
 	border: solid 1px black;
 }
+
+svg text {
+	pointer-events: none;
+	user-select: none;
+}

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -210,6 +210,24 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
 	}
 
+	pub fn bounding_box(&self) -> String {
+		let subpath_svg = self.0.to_svg(ToSVGOptions::default());
+		let bounding_box = self.0.bounding_box();
+		match bounding_box {
+			None => wrap_svg_tag(subpath_svg),
+			Some(bounding_box) => {
+				let content = format!(
+					"{subpath_svg}<rect x={} y ={} width=\"{}\" height=\"{}\" style=\"fill:{NONE};stroke:{RED};stroke-width:1\" />",
+					bounding_box[0].x,
+					bounding_box[0].y,
+					bounding_box[1].x - bounding_box[0].x,
+					bounding_box[1].y - bounding_box[0].y,
+				);
+				wrap_svg_tag(content)
+			}
+		}
+	}
+
 	pub fn split(&self, t: f64, t_variant: String) -> String {
 		let t = parse_t_variant(&t_variant, t);
 		let (main_subpath, optional_subpath) = self.0.split(t);

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -114,6 +114,62 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{}{}{}", self.to_default_svg(), point_text, line_text, normal_end_point))
 	}
 
+	pub fn local_extrema(&self) -> String {
+		let local_extrema: [Vec<f64>; 2] = self.0.local_extrema();
+
+		let bezier = self.to_default_svg();
+		let circles: String = local_extrema
+			.iter()
+			.zip([RED, GREEN])
+			.flat_map(|(t_value_list, color)| {
+				t_value_list.iter().map(|&t_value| {
+					let point = self.0.evaluate(SubpathTValue::GlobalParametric(t_value));
+					draw_circle(point, 3., color, 1.5, WHITE)
+				})
+			})
+			.fold("".to_string(), |acc, circle| acc + &circle);
+
+		let content = format!(
+			"{bezier}{circles}{}{}",
+			draw_text("X extrema".to_string(), TEXT_OFFSET_X, TEXT_OFFSET_Y - 20., RED),
+			draw_text("Y extrema".to_string(), TEXT_OFFSET_X, TEXT_OFFSET_Y, GREEN),
+		);
+		wrap_svg_tag(content)
+	}
+
+	pub fn bounding_box(&self) -> String {
+		let subpath_svg = self.to_default_svg();
+		let bounding_box = self.0.bounding_box();
+		match bounding_box {
+			None => wrap_svg_tag(subpath_svg),
+			Some(bounding_box) => {
+				let content = format!(
+					"{subpath_svg}<rect x={} y ={} width=\"{}\" height=\"{}\" style=\"fill:{NONE};stroke:{RED};stroke-width:1\" />",
+					bounding_box[0].x,
+					bounding_box[0].y,
+					bounding_box[1].x - bounding_box[0].x,
+					bounding_box[1].y - bounding_box[0].y,
+				);
+				wrap_svg_tag(content)
+			}
+		}
+	}
+
+	pub fn inflections(&self) -> String {
+		let inflections: Vec<f64> = self.0.inflections();
+
+		let bezier = self.to_default_svg();
+		let circles: String = inflections
+			.iter()
+			.map(|&t_value| {
+				let point = self.0.evaluate(SubpathTValue::GlobalParametric(t_value));
+				draw_circle(point, 3., RED, 1.5, WHITE)
+			})
+			.fold("".to_string(), |acc, circle| acc + &circle);
+		let content = format!("{bezier}{circles}");
+		wrap_svg_tag(content)
+	}
+
 	pub fn project(&self, x: f64, y: f64) -> String {
 		let (segment_index, projected_t) = self.0.project(DVec2::new(x, y), ProjectionOptions::default()).unwrap();
 		let projected_point = self.0.evaluate(SubpathTValue::Parametric { segment_index, t: projected_t });
@@ -208,24 +264,6 @@ impl WasmSubpath {
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));
 
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
-	}
-
-	pub fn bounding_box(&self) -> String {
-		let subpath_svg = self.0.to_svg(ToSVGOptions::default());
-		let bounding_box = self.0.bounding_box();
-		match bounding_box {
-			None => wrap_svg_tag(subpath_svg),
-			Some(bounding_box) => {
-				let content = format!(
-					"{subpath_svg}<rect x={} y ={} width=\"{}\" height=\"{}\" style=\"fill:{NONE};stroke:{RED};stroke-width:1\" />",
-					bounding_box[0].x,
-					bounding_box[0].y,
-					bounding_box[1].x - bounding_box[0].x,
-					bounding_box[1].y - bounding_box[0].y,
-				);
-				wrap_svg_tag(content)
-			}
-		}
 	}
 
 	pub fn split(&self, t: f64, t_variant: String) -> String {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Added `bounding_box`, `local_extrema` and `inflections` functions for the subpath class in bezier-rs.
Note, the current functions do not consider the points in between two bezier curves. We may want to consider these points for local extrema and inflection.