### PR TITLE
Pen tool redraw overlays on selection change

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -203,6 +203,11 @@ impl Fsm for PenToolFsmState {
 					for layer_path in document.all_layers() {
 						tool_data.overlay_renderer.layer_overlay_visibility(&document.document_legacy, layer_path.to_vec(), false, responses);
 					}
+
+					// Redraw the overlays of the newly selected layers
+					for layer_path in document.selected_visible_layers() {
+						tool_data.overlay_renderer.render_subpath_overlays(&document.document_legacy, layer_path.to_vec(), responses);
+					}
 					self
 				}
 				(PenToolFsmState::Ready, PenToolMessage::DragStart) => {


### PR DESCRIPTION
Fix with Pen tool selected, starting with no selected layer and using the Layer panel to select doesn't result in that layer showing its blue curve overlays. (Panning by a pixel refreshes it.) 