### PR TITLE
Remove additional boolean for mirroring distance

### DIFF
--- a/document-legacy/src/document.rs
+++ b/document-legacy/src/document.rs
@@ -1113,42 +1113,32 @@ impl Document {
 				}
 				Some(responses)
 			}
-			Operation::MoveSelectedManipulatorPoints { layer_path, delta } => {
+			Operation::MoveSelectedManipulatorPoints { layer_path, delta, mirror_distance } => {
 				if let Ok(viewspace) = self.generate_transform_relative_to_viewport(&layer_path) {
 					let objectspace = &viewspace.inverse();
 					let delta = objectspace.transform_vector2(DVec2::new(delta.0, delta.1));
 					let layer = self.layer_mut(&layer_path)?;
 					if let Some(shape) = layer.as_subpath_mut() {
-						shape.move_selected(delta);
+						shape.move_selected(delta, mirror_distance);
 					}
 				}
 				self.mark_as_dirty(&layer_path)?;
 				Some([vec![DocumentChanged, LayerChanged { path: layer_path.clone() }], update_thumbnails_upstream(&layer_path)].concat())
 			}
-			Operation::SetManipulatorHandleMirroring {
-				layer_path,
-				id,
-				mirror_distance,
-				mirror_angle,
-			} => {
+			Operation::SetManipulatorHandleMirroring { layer_path, id, mirror_angle } => {
 				if let Ok(Some(shape)) = self.layer_mut(&layer_path).map(|layer| layer.as_subpath_mut()) {
 					if let Some(manipulator_group) = shape.manipulator_groups_mut().by_id_mut(id) {
-						manipulator_group.editor_state.mirror_distance_between_handles = mirror_distance;
 						manipulator_group.editor_state.mirror_angle_between_handles = mirror_angle;
 						self.mark_as_dirty(&layer_path)?;
 					}
 				}
 				Some([update_thumbnails_upstream(&layer_path), vec![DocumentChanged, LayerChanged { path: layer_path }]].concat())
 			}
-			Operation::SetSelectedHandleMirroring {
-				layer_path,
-				toggle_distance,
-				toggle_angle,
-			} => {
+			Operation::SetSelectedHandleMirroring { layer_path, toggle_angle } => {
 				let layer = self.layer_mut(&layer_path)?;
 				if let Some(shape) = layer.as_subpath_mut() {
 					for manipulator_group in shape.selected_manipulator_groups_any_points_mut() {
-						manipulator_group.toggle_mirroring(toggle_distance, toggle_angle);
+						manipulator_group.toggle_mirroring(toggle_angle);
 					}
 				}
 				// This does nothing visually so we don't need to send any messages

--- a/document-legacy/src/operation.rs
+++ b/document-legacy/src/operation.rs
@@ -144,6 +144,7 @@ pub enum Operation {
 	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
+		mirror_distance: bool,
 	},
 	MoveManipulatorPoint {
 		layer_path: Vec<LayerId>,
@@ -272,12 +273,10 @@ pub enum Operation {
 	SetManipulatorHandleMirroring {
 		layer_path: Vec<LayerId>,
 		id: u64,
-		mirror_distance: bool,
 		mirror_angle: bool,
 	},
 	SetSelectedHandleMirroring {
 		layer_path: Vec<LayerId>,
-		toggle_distance: bool,
 		toggle_angle: bool,
 	},
 }

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -96,6 +96,7 @@ pub enum DocumentMessage {
 	MoveSelectedManipulatorPoints {
 		layer_path: Vec<LayerId>,
 		delta: (f64, f64),
+		mirror_distance: bool,
 	},
 	NodeGraphFrameGenerate,
 	NodeGraphFrameImaginate {
@@ -183,7 +184,6 @@ pub enum DocumentMessage {
 	},
 	ToggleSelectedHandleMirroring {
 		layer_path: Vec<LayerId>,
-		toggle_distance: bool,
 		toggle_angle: bool,
 	},
 	Undo,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -496,9 +496,9 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 					.into(),
 				);
 			}
-			MoveSelectedManipulatorPoints { layer_path, delta } => {
+			MoveSelectedManipulatorPoints { layer_path, delta, mirror_distance } => {
 				if let Ok(_layer) = self.document_legacy.layer(&layer_path) {
-					responses.push_back(DocumentOperation::MoveSelectedManipulatorPoints { layer_path, delta }.into());
+					responses.push_back(DocumentOperation::MoveSelectedManipulatorPoints { layer_path, delta, mirror_distance }.into());
 				}
 			}
 			NodeGraphFrameGenerate => {
@@ -826,19 +826,8 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 				responses.push_back(DocumentOperation::ToggleLayerVisibility { path: layer_path }.into());
 				responses.push_back(BroadcastEvent::DocumentIsDirty.into());
 			}
-			ToggleSelectedHandleMirroring {
-				layer_path,
-				toggle_distance,
-				toggle_angle,
-			} => {
-				responses.push_back(
-					DocumentOperation::SetSelectedHandleMirroring {
-						layer_path,
-						toggle_distance,
-						toggle_angle,
-					}
-					.into(),
-				);
+			ToggleSelectedHandleMirroring { layer_path, toggle_angle } => {
+				responses.push_back(DocumentOperation::SetSelectedHandleMirroring { layer_path, toggle_angle }.into());
 			}
 			Undo => {
 				self.undo_in_progress = true;

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -175,12 +175,13 @@ impl ShapeEditor {
 	}
 
 	/// Move the selected points by dragging the mouse.
-	pub fn move_selected_points(&self, delta: DVec2, responses: &mut VecDeque<Message>) {
+	pub fn move_selected_points(&self, delta: DVec2, mirror_distance: bool, responses: &mut VecDeque<Message>) {
 		for layer_path in &self.selected_layers {
 			responses.push_back(
 				DocumentMessage::MoveSelectedManipulatorPoints {
 					layer_path: layer_path.clone(),
 					delta: (delta.x, delta.y),
+					mirror_distance,
 				}
 				.into(),
 			);
@@ -193,13 +194,12 @@ impl ShapeEditor {
 	}
 
 	/// Toggle if the handles should mirror angle across the anchor position.
-	pub fn toggle_handle_mirroring_on_selected(&self, toggle_angle: bool, toggle_distance: bool, responses: &mut VecDeque<Message>) {
+	pub fn toggle_handle_mirroring_on_selected(&self, toggle_angle: bool, responses: &mut VecDeque<Message>) {
 		for layer_path in &self.selected_layers {
 			responses.push_back(
 				DocumentMessage::ToggleSelectedHandleMirroring {
 					layer_path: layer_path.clone(),
 					toggle_angle,
-					toggle_distance,
 				}
 				.into(),
 			);
@@ -391,7 +391,6 @@ impl ShapeEditor {
 					Operation::SetManipulatorHandleMirroring {
 						layer_path: layer_path.to_vec(),
 						id: bezier_id,
-						mirror_distance: false,
 						mirror_angle: true,
 					}
 					.into(),

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -131,7 +131,6 @@ struct PathToolData {
 
 	drag_start_pos: DVec2,
 	alt_debounce: bool,
-	shift_debounce: bool,
 }
 
 impl Fsm for PathToolFsmState {
@@ -248,20 +247,16 @@ impl Fsm for PathToolFsmState {
 						tool_data.alt_debounce = alt_pressed;
 						// Only on alt down
 						if alt_pressed {
-							tool_data.shape_editor.toggle_handle_mirroring_on_selected(true, false, responses);
+							tool_data.shape_editor.toggle_handle_mirroring_on_selected(true, responses);
 						}
 					}
 
 					// Determine when shift state changes
 					let shift_pressed = input.keyboard.get(shift_mirror_distance as usize);
-					if shift_pressed != tool_data.shift_debounce {
-						tool_data.shift_debounce = shift_pressed;
-						tool_data.shape_editor.toggle_handle_mirroring_on_selected(false, true, responses);
-					}
 
 					// Move the selected points by the mouse position
 					let snapped_position = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos, responses);
+					tool_data.shape_editor.move_selected_points(snapped_position - tool_data.drag_start_pos, shift_pressed, responses);
 					tool_data.drag_start_pos = snapped_position;
 					PathToolFsmState::Dragging
 				}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -234,7 +234,6 @@ impl Fsm for PenToolFsmState {
 							let op = Operation::SetManipulatorHandleMirroring {
 								layer_path: layer.to_vec(),
 								id,
-								mirror_distance: false,
 								mirror_angle: false,
 							};
 							responses.push_back(op.into());
@@ -328,7 +327,6 @@ impl Fsm for PenToolFsmState {
 								let op = Operation::SetManipulatorHandleMirroring {
 									layer_path: layer_path.clone(),
 									id: previous_id,
-									mirror_distance: false,
 									mirror_angle: false,
 								};
 								responses.push_back(op.into());
@@ -386,7 +384,6 @@ impl Fsm for PenToolFsmState {
 							let op = Operation::SetManipulatorHandleMirroring {
 								layer_path: layer_path.clone(),
 								id: first_id,
-								mirror_distance: false,
 								mirror_angle: false,
 							};
 							responses.push_back(op.into());
@@ -475,7 +472,6 @@ impl Fsm for PenToolFsmState {
 						let op = Operation::SetManipulatorHandleMirroring {
 							layer_path: layer_path.clone(),
 							id: last_id,
-							mirror_distance: should_mirror,
 							mirror_angle: should_mirror,
 						};
 						responses.push_back(op.into());

--- a/node-graph/gcore/src/vector/manipulator_group.rs
+++ b/node-graph/gcore/src/vector/manipulator_group.rs
@@ -105,9 +105,8 @@ impl ManipulatorGroup {
 	}
 
 	/// Move the selected points by the provided transform.
-	pub fn move_selected_points(&mut self, delta: DVec2) {
+	pub fn move_selected_points(&mut self, delta: DVec2, mirror_distance: bool) {
 		let mirror_angle = self.editor_state.mirror_angle_between_handles;
-		let mirror_distance = self.editor_state.mirror_distance_between_handles;
 
 		// Move the point absolutely or relatively depending on if the point is under the cursor (the last selected point)
 		let move_point = |point: &mut ManipulatorPoint, delta: DVec2| {
@@ -270,10 +269,7 @@ impl ManipulatorGroup {
 	}
 
 	/// Set the mirroring state
-	pub fn toggle_mirroring(&mut self, toggle_distance: bool, toggle_angle: bool) {
-		if toggle_distance {
-			self.editor_state.mirror_distance_between_handles = !self.editor_state.mirror_distance_between_handles;
-		}
+	pub fn toggle_mirroring(&mut self, toggle_angle: bool) {
 		if toggle_angle {
 			self.editor_state.mirror_angle_between_handles = !self.editor_state.mirror_angle_between_handles;
 		}
@@ -301,15 +297,10 @@ impl ManipulatorGroup {
 pub struct ManipulatorGroupEditorState {
 	// Whether the angle between the handles should be maintained
 	pub mirror_angle_between_handles: bool,
-	// Whether the distance between the handles should be equidistant to the anchor
-	pub mirror_distance_between_handles: bool,
 }
 
 impl Default for ManipulatorGroupEditorState {
 	fn default() -> Self {
-		Self {
-			mirror_angle_between_handles: true,
-			mirror_distance_between_handles: false,
-		}
+		Self { mirror_angle_between_handles: true }
 	}
 }

--- a/node-graph/gcore/src/vector/subpath.rs
+++ b/node-graph/gcore/src/vector/subpath.rs
@@ -182,9 +182,9 @@ impl Subpath {
 	}
 
 	/// Move the selected points by the delta vector
-	pub fn move_selected(&mut self, delta: DVec2) {
+	pub fn move_selected(&mut self, delta: DVec2, mirror_distance: bool) {
 		self.selected_manipulator_groups_any_points_mut()
-			.for_each(|manipulator_group| manipulator_group.move_selected_points(delta));
+			.for_each(|manipulator_group| manipulator_group.move_selected_points(delta, mirror_distance));
 	}
 
 	/// Delete the selected points from the [Subpath]


### PR DESCRIPTION
Removes additional bool from the ManipulatorGroup struct.

Closes #966
