### PR TITLE
Bezier-rs: Add hash URLs for individual API examples

### DIFF
--- a/website/other/bezier-rs-demos/.eslintrc.js
+++ b/website/other/bezier-rs-demos/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
 	rules: {
 		// Standard ESLint config
 		indent: "off",
-		quotes: ["error", "double"],
+		quotes: ["error", "double", { allowTemplateLiterals: true }],
 		camelcase: ["error", { properties: "always" }],
 		"linebreak-style": ["error", "unix"],
 		"eol-last": ["error", "always"],

--- a/website/other/bezier-rs-demos/src/components/BezierDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemo.ts
@@ -1,5 +1,5 @@
 import { WasmBezier } from "@/../wasm/pkg";
-import bezierFeatures, { BezierFeatureName } from "@/features/bezier-features";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
 import { renderDemo } from "@/utils/render";
 import { getConstructorKey, getCurveType, BezierCallback, BezierCurveType, SliderOption, WasmBezierManipulatorKey, ComputeType, Demo } from "@/utils/types";
 
@@ -18,7 +18,7 @@ class BezierDemo extends HTMLElement implements Demo {
 
 	points!: number[][];
 
-	name!: BezierFeatureName;
+	key!: BezierFeatureKey;
 
 	sliderOptions!: SliderOption[];
 
@@ -54,12 +54,12 @@ class BezierDemo extends HTMLElement implements Demo {
 	connectedCallback(): void {
 		this.title = this.getAttribute("title") || "";
 		this.points = JSON.parse(this.getAttribute("points") || "[]");
-		this.name = this.getAttribute("name") as BezierFeatureName;
+		this.key = this.getAttribute("key") as BezierFeatureKey;
 		this.sliderOptions = JSON.parse(this.getAttribute("sliderOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";
 		this.computeType = (this.getAttribute("computetype") || "Parametric") as ComputeType;
 
-		this.callback = bezierFeatures[this.name].callback as BezierCallback;
+		this.callback = bezierFeatures[this.key].callback as BezierCallback;
 		const curveType = getCurveType(this.points.length);
 
 		this.manipulatorKeys = MANIPULATOR_KEYS_FROM_BEZIER_TYPE[curveType];

--- a/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
@@ -46,10 +46,10 @@ class BezierDemoPane extends HTMLElement implements DemoPane {
 	computeType!: ComputeType;
 
 	connectedCallback(): void {
-		this.id = `${Math.random()}`.substring(2);
 		this.computeType = "Parametric";
 
 		this.key = (this.getAttribute("name") || "") as BezierFeatureKey;
+		this.id = `bezier_${this.key}`;
 		this.name = bezierFeatures[this.key].name;
 		this.demoOptions = JSON.parse(this.getAttribute("demoOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";

--- a/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
@@ -1,4 +1,4 @@
-import { BezierFeatureName } from "@/features/bezier-features";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
 import { renderDemoPane } from "@/utils/render";
 import { BezierCurveType, BEZIER_CURVE_TYPE, ComputeType, BezierDemoOptions, SliderOption, Demo, DemoPane, BezierDemoArgs } from "@/utils/types";
 
@@ -28,7 +28,9 @@ const demoDefaults = {
 
 class BezierDemoPane extends HTMLElement implements DemoPane {
 	// Props
-	name!: BezierFeatureName;
+	key!: BezierFeatureKey;
+
+	name!: string;
 
 	demoOptions!: BezierDemoOptions;
 
@@ -47,7 +49,8 @@ class BezierDemoPane extends HTMLElement implements DemoPane {
 		this.id = `${Math.random()}`.substring(2);
 		this.computeType = "Parametric";
 
-		this.name = (this.getAttribute("name") || "") as BezierFeatureName;
+		this.key = (this.getAttribute("name") || "") as BezierFeatureKey;
+		this.name = bezierFeatures[this.key].name;
 		this.demoOptions = JSON.parse(this.getAttribute("demoOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";
 		this.chooseComputeType = this.getAttribute("chooseComputeType") === "true";
@@ -74,7 +77,7 @@ class BezierDemoPane extends HTMLElement implements DemoPane {
 		const bezierDemo = document.createElement("bezier-demo");
 		bezierDemo.setAttribute("title", demo.title);
 		bezierDemo.setAttribute("points", JSON.stringify(demo.points));
-		bezierDemo.setAttribute("name", this.name);
+		bezierDemo.setAttribute("key", this.key);
 		bezierDemo.setAttribute("sliderOptions", JSON.stringify(demo.sliderOptions));
 		bezierDemo.setAttribute("triggerOnMouseMove", String(this.triggerOnMouseMove));
 		bezierDemo.setAttribute("computetype", this.computeType);

--- a/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
@@ -49,7 +49,7 @@ class BezierDemoPane extends HTMLElement implements DemoPane {
 		this.computeType = "Parametric";
 
 		this.key = (this.getAttribute("name") || "") as BezierFeatureKey;
-		this.id = `bezier_${this.key}`;
+		this.id = `bezier/${this.key}`;
 		this.name = bezierFeatures[this.key].name;
 		this.demoOptions = JSON.parse(this.getAttribute("demoOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";

--- a/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
@@ -1,5 +1,5 @@
 import { WasmSubpath } from "@/../wasm/pkg";
-import subpathFeatures, { SubpathFeatureName } from "@/features/subpath-features";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
 import { renderDemo } from "@/utils/render";
 
 import { SubpathCallback, WasmSubpathInstance, WasmSubpathManipulatorKey, SliderOption, ComputeType } from "@/utils/types";
@@ -13,7 +13,7 @@ class SubpathDemo extends HTMLElement {
 
 	triples!: (number[] | undefined)[][];
 
-	name!: SubpathFeatureName;
+	key!: SubpathFeatureKey;
 
 	closed!: boolean;
 
@@ -51,13 +51,13 @@ class SubpathDemo extends HTMLElement {
 	connectedCallback(): void {
 		this.title = this.getAttribute("title") || "";
 		this.triples = JSON.parse(this.getAttribute("triples") || "[]");
-		this.name = this.getAttribute("name") as SubpathFeatureName;
+		this.key = this.getAttribute("key") as SubpathFeatureKey;
 		this.sliderOptions = JSON.parse(this.getAttribute("sliderOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";
 		this.closed = this.getAttribute("closed") === "true";
 		this.computeType = (this.getAttribute("computetype") || "Parametric") as ComputeType;
 
-		this.callback = subpathFeatures[this.name].callback as SubpathCallback;
+		this.callback = subpathFeatures[this.key].callback as SubpathCallback;
 		this.subpath = WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));

--- a/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
@@ -50,7 +50,7 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 		this.computeType = "Parametric";
 
 		this.key = (this.getAttribute("name") || "") as SubpathFeatureKey;
-		this.id = `subpath_${this.key}`;
+		this.id = `subpath/${this.key}`;
 		this.name = subpathFeatures[this.key].name;
 		this.sliderOptions = JSON.parse(this.getAttribute("sliderOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";

--- a/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
@@ -1,10 +1,12 @@
-import { SubpathFeatureName } from "@/features/subpath-features";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
 import { renderDemoPane } from "@/utils/render";
 import { ComputeType, Demo, DemoPane, SliderOption, SubpathDemoArgs } from "@/utils/types";
 
 class SubpathDemoPane extends HTMLElement implements DemoPane {
 	// Props
-	name!: SubpathFeatureName;
+	key!: SubpathFeatureKey;
+
+	name!: string;
 
 	sliderOptions!: SliderOption[];
 
@@ -48,7 +50,8 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 		this.id = `${Math.random()}`.substring(2);
 		this.computeType = "Parametric";
 
-		this.name = (this.getAttribute("name") || "") as SubpathFeatureName;
+		this.key = (this.getAttribute("name") || "") as SubpathFeatureKey;
+		this.name = subpathFeatures[this.key].name;
 		this.sliderOptions = JSON.parse(this.getAttribute("sliderOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";
 		this.chooseComputeType = this.getAttribute("chooseComputeType") === "true";
@@ -65,7 +68,7 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 		subpathDemo.setAttribute("title", demo.title);
 		subpathDemo.setAttribute("triples", JSON.stringify(demo.triples));
 		subpathDemo.setAttribute("closed", String(demo.closed));
-		subpathDemo.setAttribute("name", this.name);
+		subpathDemo.setAttribute("key", this.key);
 		subpathDemo.setAttribute("sliderOptions", JSON.stringify(this.sliderOptions));
 		subpathDemo.setAttribute("triggerOnMouseMove", String(this.triggerOnMouseMove));
 		subpathDemo.setAttribute("computetype", this.computeType);

--- a/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
@@ -47,10 +47,10 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 				closed: true,
 			},
 		];
-		this.id = `${Math.random()}`.substring(2);
 		this.computeType = "Parametric";
 
 		this.key = (this.getAttribute("name") || "") as SubpathFeatureKey;
+		this.id = `subpath_${this.key}`;
 		this.name = subpathFeatures[this.key].name;
 		this.sliderOptions = JSON.parse(this.getAttribute("sliderOptions") || "[]");
 		this.triggerOnMouseMove = this.getAttribute("triggerOnMouseMove") === "true";

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -3,10 +3,12 @@ import { tSliderOptions, tErrorOptions, tMinimumSeperationOptions } from "@/util
 import { ComputeType, BezierDemoOptions, WasmBezierInstance, BezierCallback } from "@/utils/types";
 
 const bezierFeatures = {
-	Constructor: {
+	constructor: {
+		name: "Constructor",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.to_svg(),
 	},
-	"Bezier Through Points": {
+	bezierThroughPoints: {
+		name: "Bezier Through Points",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const points = JSON.parse(bezier.get_points());
 			if (Object.values(options).length === 1) {
@@ -59,10 +61,12 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Length: {
+	length: {
+		name: "Length",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.length(),
 	},
-	Evaluate: {
+	evaluate: {
+		name: "Evaluate",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>, _: undefined, computeType: ComputeType): string => bezier.evaluate(options.computeArgument, computeType),
 		demoOptions: {
 			Quadratic: {
@@ -71,7 +75,8 @@ const bezierFeatures = {
 		},
 		chooseComputeType: true,
 	},
-	"Lookup Table": {
+	lookupTable: {
+		name: "Lookup Table",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.compute_lookup_table(options.steps),
 		demoOptions: {
 			Quadratic: {
@@ -87,7 +92,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Derivative: {
+	derivative: {
+		name: "Derivative",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.derivative(),
 		demoOptions: {
 			Linear: {
@@ -110,7 +116,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Tangent: {
+	tangent: {
+		name: "Tangent",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.tangent(options.t),
 		demoOptions: {
 			Quadratic: {
@@ -118,7 +125,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Normal: {
+	normal: {
+		name: "Normal",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.normal(options.t),
 		demoOptions: {
 			Quadratic: {
@@ -126,7 +134,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Curvature: {
+	curvature: {
+		name: "Curvature",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.curvature(options.t),
 		demoOptions: {
 			Linear: {
@@ -137,7 +146,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Split: {
+	split: {
+		name: "Split",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.split(options.t),
 		demoOptions: {
 			Quadratic: {
@@ -145,7 +155,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Trim: {
+	trim: {
+		name: "Trim",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.trim(options.t1, options.t2),
 		demoOptions: {
 			Quadratic: {
@@ -168,12 +179,14 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Project: {
+	project: {
+		name: "Project",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>, mouseLocation?: [number, number]): string =>
 			mouseLocation ? bezier.project(mouseLocation[0], mouseLocation[1]) : bezier.to_svg(),
 		triggerOnMouseMove: true,
 	},
-	"Local Extrema": {
+	localExtrema: {
+		name: "Local Extrema",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.local_extrema(),
 		demoOptions: {
 			Quadratic: {
@@ -193,10 +206,12 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"Bounding Box": {
+	boundingBox: {
+		name: "Bounding Box",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.bounding_box(),
 	},
-	Inflections: {
+	inflections: {
+		name: "Inflections",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.inflections(),
 		demoOptions: {
 			Linear: {
@@ -207,10 +222,12 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Reduce: {
+	reduce: {
+		name: "Reduce",
 		callback: (bezier: WasmBezierInstance): string => bezier.reduce(),
 	},
-	Offset: {
+	offset: {
+		name: "Offset",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.offset(options.distance),
 		demoOptions: {
 			Quadratic: {
@@ -226,7 +243,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Outline: {
+	outline: {
+		name: "Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.outline(options.distance),
 		demoOptions: {
 			Quadratic: {
@@ -242,7 +260,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"Graduated Outline": {
+	graduatedOutline: {
+		name: "Graduated Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance),
 		demoOptions: {
 			Quadratic: {
@@ -273,7 +292,8 @@ const bezierFeatures = {
 			],
 		},
 	},
-	"Skewed Outline": {
+	skewedOutline: {
+		name: "Skewed Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4),
 		demoOptions: {
 			Quadratic: {
@@ -310,7 +330,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	Arcs: {
+	arcs: {
+		name: "Arcs",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.arcs(options.error, options.max_iterations, options.strategy),
 		demoOptions: ((): Omit<BezierDemoOptions, "Linear"> => {
 			const sliderOptions = [
@@ -361,7 +382,8 @@ const bezierFeatures = {
 			};
 		})(),
 	},
-	"Intersect (Line Segment)": {
+	intersectLinear: {
+		name: "Intersect (Line Segment)",
 		callback: (bezier: WasmBezierInstance): string => {
 			const line = [
 				[150, 150],
@@ -370,7 +392,8 @@ const bezierFeatures = {
 			return bezier.intersect_line_segment(line);
 		},
 	},
-	"Intersect (Quadratic)": {
+	intersectQuadratic: {
+		name: "Intersect (Quadratic)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const quadratic = [
 				[20, 80],
@@ -385,7 +408,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"Intersect (Cubic)": {
+	intersectCubic: {
+		name: "Intersect (Cubic)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const cubic = [
 				[40, 20],
@@ -401,7 +425,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"Intersect (Self)": {
+	intersectSelf: {
+		name: "Intersect (Self)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.intersect_self(options.error),
 		demoOptions: {
 			Quadratic: {
@@ -417,14 +442,16 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"Intersect (Rectangle)": {
+	intersectRectangle: {
+		name: "Intersect (Rectangle)",
 		callback: (bezier: WasmBezierInstance): string =>
 			bezier.intersect_rectangle([
 				[50, 50],
 				[150, 150],
 			]),
 	},
-	Rotate: {
+	rotate: {
+		name: "Rotate",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.rotate(options.angle * Math.PI, 100, 100),
 		demoOptions: {
 			Quadratic: {
@@ -441,7 +468,8 @@ const bezierFeatures = {
 			},
 		},
 	},
-	"De Casteljau Points": {
+	deCasteljauPoints: {
+		name: "De Casteljau Points",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.de_casteljau_points(options.t),
 		demoOptions: {
 			Quadratic: {
@@ -451,11 +479,12 @@ const bezierFeatures = {
 	},
 };
 
-export type BezierFeatureName = keyof typeof bezierFeatures;
+export type BezierFeatureKey = keyof typeof bezierFeatures;
 export type BezierFeatureOptions = {
+	name: string;
 	callback: BezierCallback;
 	demoOptions?: Partial<BezierDemoOptions>;
 	triggerOnMouseMove?: boolean;
 	chooseComputeType?: boolean;
 };
-export default bezierFeatures as Record<BezierFeatureName, BezierFeatureOptions>;
+export default bezierFeatures as Record<BezierFeatureKey, BezierFeatureOptions>;

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -7,7 +7,7 @@ const bezierFeatures = {
 		name: "Constructor",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.to_svg(),
 	},
-	bezierThroughPoints: {
+	"bezier-through-points": {
 		name: "Bezier Through Points",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const points = JSON.parse(bezier.get_points());
@@ -75,7 +75,7 @@ const bezierFeatures = {
 		},
 		chooseComputeType: true,
 	},
-	lookupTable: {
+	"lookup-table": {
 		name: "Lookup Table",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.compute_lookup_table(options.steps),
 		demoOptions: {
@@ -185,7 +185,7 @@ const bezierFeatures = {
 			mouseLocation ? bezier.project(mouseLocation[0], mouseLocation[1]) : bezier.to_svg(),
 		triggerOnMouseMove: true,
 	},
-	localExtrema: {
+	"local-extrema": {
 		name: "Local Extrema",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.local_extrema(),
 		demoOptions: {
@@ -206,7 +206,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	boundingBox: {
+	"bounding-box": {
 		name: "Bounding Box",
 		callback: (bezier: WasmBezierInstance, _: Record<string, number>): string => bezier.bounding_box(),
 	},
@@ -260,7 +260,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	graduatedOutline: {
+	"graduated-outline": {
 		name: "Graduated Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance),
 		demoOptions: {
@@ -292,7 +292,7 @@ const bezierFeatures = {
 			],
 		},
 	},
-	skewedOutline: {
+	"skewed-outline": {
 		name: "Skewed Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4),
 		demoOptions: {
@@ -382,7 +382,7 @@ const bezierFeatures = {
 			};
 		})(),
 	},
-	intersectLinear: {
+	"intersect-linear": {
 		name: "Intersect (Line Segment)",
 		callback: (bezier: WasmBezierInstance): string => {
 			const line = [
@@ -392,7 +392,7 @@ const bezierFeatures = {
 			return bezier.intersect_line_segment(line);
 		},
 	},
-	intersectQuadratic: {
+	"intersect-quadratic": {
 		name: "Intersect (Quadratic)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const quadratic = [
@@ -408,7 +408,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	intersectCubic: {
+	"intersect-cubic": {
 		name: "Intersect (Cubic)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => {
 			const cubic = [
@@ -425,7 +425,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	intersectSelf: {
+	"intersect-self": {
 		name: "Intersect (Self)",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.intersect_self(options.error),
 		demoOptions: {
@@ -442,7 +442,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	intersectRectangle: {
+	"intersect-rectangle": {
 		name: "Intersect (Rectangle)",
 		callback: (bezier: WasmBezierInstance): string =>
 			bezier.intersect_rectangle([
@@ -468,7 +468,7 @@ const bezierFeatures = {
 			},
 		},
 	},
-	deCasteljauPoints: {
+	"de-casteljau-points": {
 		name: "De Casteljau Points",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.de_casteljau_points(options.t),
 		demoOptions: {

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -2,44 +2,53 @@ import { tSliderOptions } from "@/utils/options";
 import { ComputeType, SliderOption, SubpathCallback, WasmSubpathInstance } from "@/utils/types";
 
 const subpathFeatures = {
-	Constructor: {
+	constructor: {
+		name: "Constructor",
 		callback: (subpath: WasmSubpathInstance): string => subpath.to_svg(),
 	},
-	Insert: {
+	insert: {
+		name: "Insert",
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined, computeType: ComputeType): string => subpath.insert(options.computeArgument, computeType),
 		sliderOptions: [{ ...tSliderOptions, variable: "computeArgument" }],
 		// TODO: Uncomment this after implementing the Euclidean version
 		// chooseComputeType: true,
 	},
-	Length: {
+	length: {
+		name: "Length",
 		callback: (subpath: WasmSubpathInstance): string => subpath.length(),
 	},
-	Evaluate: {
+	evaluate: {
+		name: "Evaluate",
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined, computeType: ComputeType): string => subpath.evaluate(options.computeArgument, computeType),
 		sliderOptions: [{ ...tSliderOptions, variable: "computeArgument" }],
 		chooseComputeType: true,
 	},
-	Project: {
+	project: {
+		name: "Project",
 		callback: (subpath: WasmSubpathInstance, _: Record<string, number>, mouseLocation?: [number, number]): string =>
 			mouseLocation ? subpath.project(mouseLocation[0], mouseLocation[1]) : subpath.to_svg(),
 		triggerOnMouseMove: true,
 	},
-	Tangent: {
+	tangent: {
+		name: "Tangent",
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.tangent(options.t),
 		sliderOptions: [tSliderOptions],
 	},
-	Normal: {
+	normal: {
+		name: "Normal",
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.normal(options.t),
 		sliderOptions: [tSliderOptions],
 	},
-	"Intersect (Line Segment)": {
+	intersectLinear: {
+		name: "Intersect (Line Segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_line_segment([
 				[150, 150],
 				[20, 20],
 			]),
 	},
-	"Intersect (Quadratic segment)": {
+	intersectQuadratic: {
+		name: "Intersect (Quadratic segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_quadratic_segment([
 				[20, 80],
@@ -47,7 +56,8 @@ const subpathFeatures = {
 				[90, 120],
 			]),
 	},
-	"Intersect (Cubic segment)": {
+	intersectCubic: {
+		name: "Intersect (Cubic segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_cubic_segment([
 				[40, 20],
@@ -56,7 +66,8 @@ const subpathFeatures = {
 				[175, 140],
 			]),
 	},
-	Split: {
+	split: {
+		name: "Split",
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined, computeType: ComputeType): string => subpath.split(options.computeArgument, computeType),
 		sliderOptions: [{ ...tSliderOptions, variable: "computeArgument" }],
 		// TODO: Uncomment this after implementing the Euclidean version
@@ -64,11 +75,12 @@ const subpathFeatures = {
 	},
 };
 
-export type SubpathFeatureName = keyof typeof subpathFeatures;
+export type SubpathFeatureKey = keyof typeof subpathFeatures;
 export type SubpathFeatureOptions = {
+	name: string;
 	callback: SubpathCallback;
 	sliderOptions?: SliderOption[];
 	triggerOnMouseMove?: boolean;
 	chooseComputeType?: boolean;
 };
-export default subpathFeatures as Record<SubpathFeatureName, SubpathFeatureOptions>;
+export default subpathFeatures as Record<SubpathFeatureKey, SubpathFeatureOptions>;

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -39,7 +39,7 @@ const subpathFeatures = {
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.normal(options.t),
 		sliderOptions: [tSliderOptions],
 	},
-	intersectLinear: {
+	"intersect-linear": {
 		name: "Intersect (Line Segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_line_segment([
@@ -47,7 +47,7 @@ const subpathFeatures = {
 				[20, 20],
 			]),
 	},
-	intersectQuadratic: {
+	"intersect-quadratic": {
 		name: "Intersect (Quadratic segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_quadratic_segment([
@@ -56,7 +56,7 @@ const subpathFeatures = {
 				[90, 120],
 			]),
 	},
-	intersectCubic: {
+	"intersect-cubic": {
 		name: "Intersect (Cubic segment)",
 		callback: (subpath: WasmSubpathInstance): string =>
 			subpath.intersect_cubic_segment([

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -48,7 +48,7 @@ function renderSubpathPane(featureName: SubpathFeatureKey, container: HTMLElemen
 
 function isUrlSolo(url: string): boolean {
 	const hash = url.split("#")?.[1];
-	const splitHash = hash?.split("_");
+	const splitHash = hash?.split("/");
 	return splitHash?.length === 3 && splitHash?.[2] === "solo";
 }
 
@@ -56,7 +56,7 @@ window.addEventListener("hashchange", (e: Event): void => {
 	const hashChangeEvent = e as HashChangeEvent;
 	const isOldHashSolo = isUrlSolo(hashChangeEvent.oldURL);
 	const isNewHashSolo = isUrlSolo(hashChangeEvent.newURL);
-	const target = document.querySelector(window.location.hash);
+	const target = document.getElementById(window.location.hash.substring(1));
 	// Determine whether the page needs to recompute which examples to show
 	if (!target || isOldHashSolo !== isNewHashSolo) {
 		renderExamples();
@@ -65,7 +65,7 @@ window.addEventListener("hashchange", (e: Event): void => {
 
 function renderExamples(): void {
 	const hash = window.location.hash;
-	const splitHash = hash.split("_");
+	const splitHash = hash.split("/");
 
 	// Determine which examples to render based on hash
 	if (splitHash[0] === "#bezier" && splitHash[1] in bezierFeatures && splitHash[2] === "solo") {
@@ -98,7 +98,7 @@ function renderExamples(): void {
 
 	// Scroll to specified hash if it exists
 	if (hash) {
-		const target = document.querySelector(hash);
+		const target = document.getElementById(hash.substring(1));
 		if (target) {
 			target.scrollIntoView();
 		}

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -49,7 +49,7 @@ function renderSubpathPane(featureName: SubpathFeatureKey, container: HTMLElemen
 const pathname = window.location.pathname;
 const splitPathName = pathname.split("/");
 
-// Render based on pathname
+// Determine which examples to render based on pathname
 if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
 	window.document.body.innerHTML = `<div id="bezier-demos"></div>`;
 	renderBezierPane(splitPathName[2] as BezierFeatureKey, document.getElementById("bezier-demos"));
@@ -76,4 +76,11 @@ if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
 
 	(Object.keys(bezierFeatures) as BezierFeatureKey[]).forEach((feature) => renderBezierPane(feature, bezierDemos));
 	(Object.keys(subpathFeatures) as SubpathFeatureKey[]).forEach((feature) => renderSubpathPane(feature, subpathDemos));
+}
+
+// Scroll to specified hash if it exists
+const hash = window.location.hash;
+const target = document.querySelector(hash);
+if (target) {
+	target.scrollIntoView();
 }

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -60,8 +60,6 @@ if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
   <div id="subpath-demos"></div>
   `.trim();
 	renderSubpathPane(splitPathName[2] as SubpathFeatureKey, document.getElementById("subpath-demos"));
-} else if (pathname !== "/") {
-	window.location.pathname = "/";
 } else {
 	window.document.body.innerHTML = `
   <h1>Bezier-rs Interactive Documentation</h1>

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -46,41 +46,63 @@ function renderSubpathPane(featureName: SubpathFeatureKey, container: HTMLElemen
 	container?.append(demo);
 }
 
-const pathname = window.location.pathname;
-const splitPathName = pathname.split("/");
-
-// Determine which examples to render based on pathname
-if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
-	window.document.body.innerHTML = `<div id="bezier-demos"></div>`;
-	renderBezierPane(splitPathName[2] as BezierFeatureKey, document.getElementById("bezier-demos"));
-} else if (splitPathName[1] === "subpath" && splitPathName[2] in subpathFeatures) {
-	window.document.body.innerHTML = `<div id="subpath-demos"></div>`;
-	renderSubpathPane(splitPathName[2] as SubpathFeatureKey, document.getElementById("subpath-demos"));
-} else {
-	window.document.body.innerHTML = `
-  <h1>Bezier-rs Interactive Documentation</h1>
-  <p>
-    This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
-    <a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
-    for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
-  </p>
-  
-  <h2>Beziers</h2>
-  <div id="bezier-demos"></div>
-  <h2>Subpaths</h2>
-  <div id="subpath-demos"></div>
-  `.trim();
-
-	const bezierDemos = document.getElementById("bezier-demos");
-	const subpathDemos = document.getElementById("subpath-demos");
-
-	(Object.keys(bezierFeatures) as BezierFeatureKey[]).forEach((feature) => renderBezierPane(feature, bezierDemos));
-	(Object.keys(subpathFeatures) as SubpathFeatureKey[]).forEach((feature) => renderSubpathPane(feature, subpathDemos));
+function isUrlSolo(url: string): boolean {
+	const hash = url.split("#")?.[1];
+	const splitHash = hash?.split("_");
+	return splitHash?.length === 3 && splitHash?.[2] === "solo";
 }
 
-// Scroll to specified hash if it exists
-const hash = window.location.hash;
-const target = document.querySelector(hash);
-if (target) {
-	target.scrollIntoView();
+window.addEventListener("hashchange", (e: Event): void => {
+	const hashChangeEvent = e as HashChangeEvent;
+	const isOldHashSolo = isUrlSolo(hashChangeEvent.oldURL);
+	const isNewHashSolo = isUrlSolo(hashChangeEvent.newURL);
+	const target = document.querySelector(window.location.hash);
+	// Determine whether the page needs to recompute which examples to show
+	if (!target || isOldHashSolo !== isNewHashSolo) {
+		renderExamples();
+	}
+});
+
+function renderExamples(): void {
+	const hash = window.location.hash;
+	const splitHash = hash.split("_");
+
+	// Determine which examples to render based on hash
+	if (splitHash[0] === "#bezier" && splitHash[1] in bezierFeatures && splitHash[2] === "solo") {
+		window.document.body.innerHTML = `<div id="bezier-demos"></div>`;
+		renderBezierPane(splitHash[1] as BezierFeatureKey, document.getElementById("bezier-demos"));
+	} else if (splitHash[0] === "#subpath" && splitHash[1] in subpathFeatures && splitHash[2] === "solo") {
+		window.document.body.innerHTML = `<div id="subpath-demos"></div>`;
+		renderSubpathPane(splitHash[1] as SubpathFeatureKey, document.getElementById("subpath-demos"));
+	} else {
+		window.document.body.innerHTML = `
+    <h1>Bezier-rs Interactive Documentation</h1>
+    <p>
+      This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
+      <a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
+      for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
+    </p>
+    
+    <h2>Beziers</h2>
+    <div id="bezier-demos"></div>
+    <h2>Subpaths</h2>
+    <div id="subpath-demos"></div>
+    `.trim();
+
+		const bezierDemos = document.getElementById("bezier-demos");
+		const subpathDemos = document.getElementById("subpath-demos");
+
+		(Object.keys(bezierFeatures) as BezierFeatureKey[]).forEach((feature) => renderBezierPane(feature, bezierDemos));
+		(Object.keys(subpathFeatures) as SubpathFeatureKey[]).forEach((feature) => renderSubpathPane(feature, subpathDemos));
+	}
+
+	// Scroll to specified hash if it exists
+	if (hash) {
+		const target = document.querySelector(hash);
+		if (target) {
+			target.scrollIntoView();
+		}
+	}
 }
+
+renderExamples();

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -3,25 +3,10 @@ import BezierDemoPane from "@/components/BezierDemoPane";
 import SubpathDemo from "@/components/SubpathDemo";
 import SubpathDemoPane from "@/components/SubpathDemoPane";
 
-import bezierFeatures, { BezierFeatureName } from "@/features/bezier-features";
-import subpathFeatures, { SubpathFeatureName } from "@/features/subpath-features";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
 
 import "@/style.css";
-
-window.document.title = "Bezier-rs Interactive Documentation";
-window.document.body.innerHTML = `
-<h1>Bezier-rs Interactive Documentation</h1>
-<p>
-	This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
-	<a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
-	for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
-</p>
-
-<h2>Beziers</h2>
-<div id="bezier-demos"></div>
-<h2>Subpaths</h2>
-<div id="subpath-demos"></div>
-`.trim();
 
 declare global {
 	interface HTMLElementTagNameMap {
@@ -32,13 +17,14 @@ declare global {
 	}
 }
 
+window.document.title = "Bezier-rs Interactive Documentation";
+
 window.customElements.define("bezier-demo", BezierDemo);
 window.customElements.define("bezier-demo-pane", BezierDemoPane);
 window.customElements.define("subpath-demo", SubpathDemo);
 window.customElements.define("subpath-demo-pane", SubpathDemoPane);
 
-const bezierDemos = document.getElementById("bezier-demos");
-(Object.keys(bezierFeatures) as BezierFeatureName[]).forEach((featureName) => {
+function renderBezierPane(featureName: BezierFeatureKey, container: HTMLElement | null): void {
 	const feature = bezierFeatures[featureName];
 	const demo = document.createElement("bezier-demo-pane");
 
@@ -46,11 +32,10 @@ const bezierDemos = document.getElementById("bezier-demos");
 	demo.setAttribute("demoOptions", JSON.stringify(feature.demoOptions || {}));
 	demo.setAttribute("triggerOnMouseMove", String(feature.triggerOnMouseMove));
 	demo.setAttribute("chooseComputeType", String(feature.chooseComputeType));
-	bezierDemos?.append(demo);
-});
+	container?.append(demo);
+}
 
-const subpathDemos = document.getElementById("subpath-demos");
-(Object.keys(subpathFeatures) as SubpathFeatureName[]).forEach((featureName) => {
+function renderSubpathPane(featureName: SubpathFeatureKey, container: HTMLElement | null): void {
 	const feature = subpathFeatures[featureName];
 	const demo = document.createElement("subpath-demo-pane");
 
@@ -58,5 +43,43 @@ const subpathDemos = document.getElementById("subpath-demos");
 	demo.setAttribute("sliderOptions", JSON.stringify(feature.sliderOptions || []));
 	demo.setAttribute("triggerOnMouseMove", String(feature.triggerOnMouseMove));
 	demo.setAttribute("chooseComputeType", String(feature.chooseComputeType));
-	subpathDemos?.append(demo);
-});
+	container?.append(demo);
+}
+
+const pathname = window.location.pathname;
+const splitPathName = pathname.split("/");
+
+// Render based on pathname
+if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
+	window.document.body.innerHTML = `
+  <div id="bezier-demos"></div>
+  `.trim();
+	renderBezierPane(splitPathName[2] as BezierFeatureKey, document.getElementById("bezier-demos"));
+} else if (splitPathName[1] === "subpath" && splitPathName[2] in subpathFeatures) {
+	window.document.body.innerHTML = `
+  <div id="subpath-demos"></div>
+  `.trim();
+	renderSubpathPane(splitPathName[2] as SubpathFeatureKey, document.getElementById("subpath-demos"));
+} else if (pathname !== "/") {
+	window.location.pathname = "/";
+} else {
+	window.document.body.innerHTML = `
+  <h1>Bezier-rs Interactive Documentation</h1>
+  <p>
+    This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
+    <a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
+    for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
+  </p>
+  
+  <h2>Beziers</h2>
+  <div id="bezier-demos"></div>
+  <h2>Subpaths</h2>
+  <div id="subpath-demos"></div>
+  `.trim();
+
+	const bezierDemos = document.getElementById("bezier-demos");
+	const subpathDemos = document.getElementById("subpath-demos");
+
+	(Object.keys(bezierFeatures) as BezierFeatureKey[]).forEach((feature) => renderBezierPane(feature, bezierDemos));
+	(Object.keys(subpathFeatures) as SubpathFeatureKey[]).forEach((feature) => renderSubpathPane(feature, subpathDemos));
+}

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -51,14 +51,10 @@ const splitPathName = pathname.split("/");
 
 // Render based on pathname
 if (splitPathName[1] === "bezier" && splitPathName[2] in bezierFeatures) {
-	window.document.body.innerHTML = `
-  <div id="bezier-demos"></div>
-  `.trim();
+	window.document.body.innerHTML = `<div id="bezier-demos"></div>`;
 	renderBezierPane(splitPathName[2] as BezierFeatureKey, document.getElementById("bezier-demos"));
 } else if (splitPathName[1] === "subpath" && splitPathName[2] in subpathFeatures) {
-	window.document.body.innerHTML = `
-  <div id="subpath-demos"></div>
-  `.trim();
+	window.document.body.innerHTML = `<div id="subpath-demos"></div>`;
 	renderSubpathPane(splitPathName[2] as SubpathFeatureKey, document.getElementById("subpath-demos"));
 } else {
 	window.document.body.innerHTML = `

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -76,18 +76,18 @@ function renderExamples(): void {
 		renderSubpathPane(splitHash[1] as SubpathFeatureKey, document.getElementById("subpath-demos"));
 	} else {
 		window.document.body.innerHTML = `
-    <h1>Bezier-rs Interactive Documentation</h1>
-    <p>
-      This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
-      <a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
-      for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
-    </p>
-    
-    <h2>Beziers</h2>
-    <div id="bezier-demos"></div>
-    <h2>Subpaths</h2>
-    <div id="subpath-demos"></div>
-    `.trim();
+		<h1>Bezier-rs Interactive Documentation</h1>
+		<p>
+			This is the interactive documentation for the <a href="https://crates.io/crates/bezier-rs"><b>Bezier-rs</b></a> library. View the
+			<a href="https://docs.rs/bezier-rs/latest/bezier_rs">crate documentation</a>
+			for detailed function descriptions and API usage. Click and drag on the endpoints of the demo curves to visualize the various Bezier utilities and functions.
+		</p>
+		
+		<h2>Beziers</h2>
+		<div id="bezier-demos"></div>
+		<h2>Subpaths</h2>
+		<div id="subpath-demos"></div>
+		`.trim();
 
 		const bezierDemos = document.getElementById("bezier-demos");
 		const subpathDemos = document.getElementById("subpath-demos");

--- a/website/other/bezier-rs-demos/src/style.css
+++ b/website/other/bezier-rs-demos/src/style.css
@@ -1,6 +1,6 @@
 html,
 body {
-	height: 100%;
+	height: auto;
 	font-family: Arial, sans-serif;
 	text-align: center;
 }

--- a/website/other/bezier-rs-demos/src/style.css
+++ b/website/other/bezier-rs-demos/src/style.css
@@ -3,6 +3,9 @@ body {
 	height: 100%;
 	font-family: Arial, sans-serif;
 	text-align: center;
+}
+
+body > h1 {
 	margin: 40px 0;
 }
 

--- a/website/other/bezier-rs-demos/src/style.css
+++ b/website/other/bezier-rs-demos/src/style.css
@@ -8,6 +8,10 @@ body > h1 {
 	margin: 40px 0;
 }
 
+body > h1 ~ :last-child {
+	margin-bottom: 40px;
+}
+
 body > h1 + p {
 	max-width: 768px;
 	line-height: 1.4;
@@ -31,8 +35,24 @@ body > h2 {
 }
 
 .demo-pane-header {
+	display: inline-block;
+	position: relative;
 	margin-top: 2em;
 	margin-bottom: 0;
+	padding: 0 1em;
+}
+
+.demo-pane-header a {
+	display: none;
+	position: absolute;
+	left: 0;
+	text-decoration: none;
+	color: inherit;
+	opacity: 0.5;
+}
+
+.demo-pane-header:hover a {
+	display: inline-block;
 }
 
 .demo-pane-container {

--- a/website/other/bezier-rs-demos/src/style.css
+++ b/website/other/bezier-rs-demos/src/style.css
@@ -1,6 +1,5 @@
 html,
 body {
-	height: auto;
 	font-family: Arial, sans-serif;
 	text-align: center;
 }

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -45,7 +45,7 @@ export function renderDemoPane(demoPane: DemoPane): void {
 	const header = document.createElement("h3");
 	const headerHref = document.createElement("a");
 	headerHref.innerText = demoPane.name;
-	const currentHash = window.location.hash.split("_");
+	const currentHash = window.location.hash.split("/");
 	// Add href anchor if not on a solo example page
 	if (currentHash.length !== 3 && currentHash[2] !== "solo") {
 		headerHref.href = `#${demoPane.id}`;

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -45,7 +45,11 @@ export function renderDemoPane(demoPane: DemoPane): void {
 	const header = document.createElement("h3");
 	const headerHref = document.createElement("a");
 	headerHref.innerText = demoPane.name;
-	headerHref.href = `#${demoPane.id}`;
+	const currentHash = window.location.hash.split("_");
+	// Add href anchor if not on a solo example page
+	if (currentHash.length !== 3 && currentHash[2] !== "solo") {
+		headerHref.href = `#${demoPane.id}`;
+	}
 	header.className = "demo-pane-header";
 	header.append(headerHref);
 

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -42,16 +42,16 @@ export function renderDemoPane(demoPane: DemoPane): void {
 	const container = document.createElement("div");
 	container.className = "demo-pane-container";
 
-	const header = document.createElement("h3");
-	const headerHref = document.createElement("a");
-	headerHref.innerText = demoPane.name;
+	const headerAnchorLink = document.createElement("a");
+	headerAnchorLink.innerText = "#";
 	const currentHash = window.location.hash.split("/");
 	// Add href anchor if not on a solo example page
-	if (currentHash.length !== 3 && currentHash[2] !== "solo") {
-		headerHref.href = `#${demoPane.id}`;
-	}
+	if (currentHash.length !== 3 && currentHash[2] !== "solo") headerAnchorLink.href = `#${demoPane.id}`;
+
+	const header = document.createElement("h3");
+	header.innerText = demoPane.name;
 	header.className = "demo-pane-header";
-	header.append(headerHref);
+	header.append(headerAnchorLink);
 
 	const computeTypeContainer = document.createElement("div");
 	computeTypeContainer.className = "compute-type-choice";

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -43,8 +43,11 @@ export function renderDemoPane(demoPane: DemoPane): void {
 	container.className = "demo-pane-container";
 
 	const header = document.createElement("h3");
-	header.innerText = demoPane.name;
+	const headerHref = document.createElement("a");
+	headerHref.innerText = demoPane.name;
+	headerHref.href = `#${demoPane.id}`;
 	header.className = "demo-pane-header";
+	header.append(headerHref);
 
 	const computeTypeContainer = document.createElement("div");
 	computeTypeContainer.className = "compute-type-choice";

--- a/website/other/bezier-rs-demos/vue.config.js
+++ b/website/other/bezier-rs-demos/vue.config.js
@@ -5,6 +5,7 @@ const { defineConfig } = require("@vue/cli-service");
 const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 
 module.exports = defineConfig({
+	publicPath: ".",
 	transpileDependencies: true,
 	// https://cli.vuejs.org/guide/webpack.html
 	chainWebpack: (config) => {

--- a/website/other/bezier-rs-demos/vue.config.js
+++ b/website/other/bezier-rs-demos/vue.config.js
@@ -5,7 +5,6 @@ const { defineConfig } = require("@vue/cli-service");
 const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 
 module.exports = defineConfig({
-	publicPath: ".",
 	transpileDependencies: true,
 	// https://cli.vuejs.org/guide/webpack.html
 	chainWebpack: (config) => {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Handle displaying a single demo at a time using `hash`

Ex. `#bezier_intersectQuadratic_solo` will render only the example pane showing the "Intersect (Quadratic)" example for beziers