### PR TITLE
Update UI when deleting last point of shape with Path tool

### DIFF
--- a/document-legacy/src/document.rs
+++ b/document-legacy/src/document.rs
@@ -1098,10 +1098,16 @@ impl Document {
 
 						// Delete the layer if there are no longer any manipulator groups
 						if (shape.manipulator_groups().len() - 1) == 0 {
-							self.delete(&layer_path)?;
-							responses.push(DocumentChanged);
-							responses.push(DocumentResponse::DeletedLayer { path: layer_path });
-							return Ok(Some(responses));
+							// delegate deletion to DeleteLayer to update Layer Tree in frontend
+							match self.handle_operation(Operation::DeleteLayer { path: layer_path.clone() }, font_cache) {
+								Ok(Some(delete_responses)) => {
+									responses.extend(delete_responses);
+									responses.push(DocumentResponse::DeletedSelectedManipulatorPoints);
+									return Ok(Some(responses));
+								}
+								Err(e) => error!("DocumentError: {:?}", e),
+								Ok(_) => {}
+							}
 						}
 
 						// If we still have manipulator groups, update the layer and thumbnails

--- a/document-legacy/src/document.rs
+++ b/document-legacy/src/document.rs
@@ -1098,7 +1098,7 @@ impl Document {
 
 						// Delete the layer if there are no longer any manipulator groups
 						if (shape.manipulator_groups().len() - 1) == 0 {
-							// delegate deletion to DeleteLayer to update Layer Tree in frontend
+							// Delegate deletion to DeleteLayer to update Layer Tree in frontend
 							match self.handle_operation(Operation::DeleteLayer { path: layer_path.clone() }, font_cache) {
 								Ok(Some(delete_responses)) => {
 									responses.extend(delete_responses);

--- a/document-legacy/src/response.rs
+++ b/document-legacy/src/response.rs
@@ -1,4 +1,4 @@
-use crate::LayerId;
+use crate::{document::Document, LayerId};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -32,6 +32,7 @@ impl fmt::Display for DocumentResponse {
 			DocumentResponse::CreatedLayer { .. } => write!(f, "CreatedLayer"),
 			DocumentResponse::LayerChanged { .. } => write!(f, "LayerChanged"),
 			DocumentResponse::DeletedLayer { .. } => write!(f, "DeleteLayer"),
+			DocumentResponse::DeletedSelectedManipulatorPoints { .. } => write!(f, "DeletedSelectedManipulatorPoints"),
 		}
 	}
 }

--- a/document-legacy/src/response.rs
+++ b/document-legacy/src/response.rs
@@ -1,4 +1,4 @@
-use crate::{document::Document, LayerId};
+use crate::LayerId;
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/document-legacy/src/response.rs
+++ b/document-legacy/src/response.rs
@@ -21,6 +21,7 @@ pub enum DocumentResponse {
 	LayerChanged {
 		path: Vec<LayerId>,
 	},
+	DeletedSelectedManipulatorPoints,
 }
 
 impl fmt::Display for DocumentResponse {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -143,7 +143,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 							}
 							DocumentResponse::DocumentChanged => responses.push_back(RenderDocument.into()),
 							DocumentResponse::DeletedSelectedManipulatorPoints => {
-								// clear Properties panel after deleting all points
+								// Clear Properties panel after deleting all points
 								responses.push_back(
 									FrontendMessage::UpdatePropertyPanelOptionsLayout {
 										layout_target: LayoutTarget::PropertiesOptions,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -5,7 +5,7 @@ use crate::consts::{ASYMPTOTIC_EFFECT, DEFAULT_DOCUMENT_NAME, FILE_SAVE_SUFFIX, 
 use crate::messages::frontend::utility_types::ExportBounds;
 use crate::messages::frontend::utility_types::{FileType, FrontendImageData};
 use crate::messages::input_mapper::utility_types::macros::action_keys;
-use crate::messages::layout::utility_types::layout_widget::{DiffUpdate, Layout, LayoutGroup, Widget, WidgetCallback, WidgetDiff, WidgetHolder, WidgetLayout};
+use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
 use crate::messages::layout::utility_types::misc::LayoutTarget;
 use crate::messages::layout::utility_types::widgets::button_widgets::{IconButton, PopoverButton};
 use crate::messages::layout::utility_types::widgets::input_widgets::{

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -5,7 +5,7 @@ use crate::consts::{ASYMPTOTIC_EFFECT, DEFAULT_DOCUMENT_NAME, FILE_SAVE_SUFFIX, 
 use crate::messages::frontend::utility_types::ExportBounds;
 use crate::messages::frontend::utility_types::{FileType, FrontendImageData};
 use crate::messages::input_mapper::utility_types::macros::action_keys;
-use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
+use crate::messages::layout::utility_types::layout_widget::{DiffUpdate, Layout, LayoutGroup, Widget, WidgetCallback, WidgetDiff, WidgetHolder, WidgetLayout};
 use crate::messages::layout::utility_types::misc::LayoutTarget;
 use crate::messages::layout::utility_types::widgets::button_widgets::{IconButton, PopoverButton};
 use crate::messages::layout::utility_types::widgets::input_widgets::{
@@ -146,7 +146,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 								// clear Properties panel after deleting all points
 								responses.push_back(
 									FrontendMessage::UpdatePropertyPanelOptionsLayout {
-										layout_target: PropertiesOptions,
+										layout_target: LayoutTarget::PropertiesOptions,
 										diff: vec![WidgetDiff {
 											widget_path: vec![],
 											new_value: DiffUpdate::SubLayout(vec![]),
@@ -156,7 +156,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 								);
 								responses.push_back(
 									FrontendMessage::UpdatePropertyPanelSectionsLayout {
-										layout_target: PropertiesSections,
+										layout_target: LayoutTarget::PropertiesSections,
 										diff: vec![WidgetDiff {
 											widget_path: vec![],
 											new_value: DiffUpdate::SubLayout(vec![]),

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -142,6 +142,29 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 								);
 							}
 							DocumentResponse::DocumentChanged => responses.push_back(RenderDocument.into()),
+							DocumentResponse::DeletedSelectedManipulatorPoints => {
+								// clear Properties panel after deleting all points
+								responses.push_back(
+									FrontendMessage::UpdatePropertyPanelOptionsLayout {
+										layout_target: PropertiesOptions,
+										diff: vec![WidgetDiff {
+											widget_path: vec![],
+											new_value: DiffUpdate::SubLayout(vec![]),
+										}],
+									}
+									.into(),
+								);
+								responses.push_back(
+									FrontendMessage::UpdatePropertyPanelSectionsLayout {
+										layout_target: PropertiesSections,
+										diff: vec![WidgetDiff {
+											widget_path: vec![],
+											new_value: DiffUpdate::SubLayout(vec![]),
+										}],
+									}
+									.into(),
+								);
+							}
 						};
 						responses.push_back(BroadcastEvent::DocumentIsDirty.into());
 					}

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -144,24 +144,18 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 							}
 							DocumentResponse::DocumentChanged => responses.push_back(RenderDocument.into()),
 							DocumentResponse::DeletedSelectedManipulatorPoints => {
-								// Clear Properties panel after deleting all points
+								// Clear Properties panel after deleting all points by updating backend widget state.
 								responses.push_back(
-									FrontendMessage::UpdatePropertyPanelOptionsLayout {
+									LayoutMessage::SendLayout {
+										layout: Layout::WidgetLayout(WidgetLayout::new(vec![])),
 										layout_target: LayoutTarget::PropertiesOptions,
-										diff: vec![WidgetDiff {
-											widget_path: vec![],
-											new_value: DiffUpdate::SubLayout(vec![]),
-										}],
 									}
 									.into(),
 								);
 								responses.push_back(
-									FrontendMessage::UpdatePropertyPanelSectionsLayout {
+									LayoutMessage::SendLayout {
+										layout: Layout::WidgetLayout(WidgetLayout::new(vec![])),
 										layout_target: LayoutTarget::PropertiesSections,
-										diff: vec![WidgetDiff {
-											widget_path: vec![],
-											new_value: DiffUpdate::SubLayout(vec![]),
-										}],
 									}
 									.into(),
 								);


### PR DESCRIPTION
The Operation::DeleteSelectedManipulatorPoints re-routes the deletion logic to Operation::DeleteLayer when you delete the last point in a shape, which updates the Layer Tree structure in the frontend. After it's done deleting it emits a new DocumentResponse, DeletedSelectedManipulatorPoints, and when handled by process_message() in document_message_handler.rs, clears the Properties panel.