### PR TITLE
Update Imaginate to output bitmap data to the graph via Image Frame node

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -11,5 +11,6 @@ pub mod application;
 pub mod consts;
 pub mod dispatcher;
 pub mod messages;
+pub mod node_graph_executor;
 pub mod test_utils;
 pub mod utility_traits;

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -107,6 +107,7 @@ pub enum DocumentMessage {
 	},
 	NodeGraphFrameImaginateRandom {
 		imaginate_node: Vec<NodeId>,
+		then_generate: bool,
 	},
 	NodeGraphFrameImaginateTerminate {
 		layer_path: Vec<LayerId>,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -529,18 +529,22 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 					responses.push_back(message);
 				}
 			}
-			NodeGraphFrameImaginateRandom { imaginate_node } => {
+			NodeGraphFrameImaginateRandom { imaginate_node, then_generate } => {
 				// Set a random seed input
 				responses.push_back(
 					NodeGraphMessage::SetInputValue {
 						node_id: *imaginate_node.last().unwrap(),
-						input_index: 1,
+						// Needs to match the index of the seed parameter in `pub const IMAGINATE_NODE: DocumentNodeType` in `document_node_type.rs`
+						input_index: 2,
 						value: graph_craft::document::value::TaggedValue::F64((generate_uuid() >> 1) as f64),
 					}
 					.into(),
 				);
+
 				// Generate the image
-				responses.push_back(DocumentMessage::NodeGraphFrameImaginate { imaginate_node }.into());
+				if then_generate {
+					responses.push_back(DocumentMessage::NodeGraphFrameImaginate { imaginate_node }.into());
+				}
 			}
 			NodeGraphFrameImaginateTerminate { layer_path, node_path } => {
 				responses.push_back(

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -599,8 +599,8 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 				responses.push_back(DocumentMessage::StartTransaction.into());
 
 				let path = vec![generate_uuid()];
-				let image_node_id = 2;
-				let mut network = graph_craft::document::NodeNetwork::new_network(32, image_node_id);
+				let image_node_id = 100;
+				let mut network = crate::messages::portfolio::document::node_graph::new_image_network(32, image_node_id);
 
 				let Some(image_node_type) = crate::messages::portfolio::document::node_graph::resolve_document_node_type("Image") else {
 					warn!("Image node should be in registry");
@@ -609,12 +609,10 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 
 				network.nodes.insert(
 					image_node_id,
-					graph_craft::document::DocumentNode {
-						name: image_node_type.name.to_string(),
-						inputs: vec![graph_craft::document::NodeInput::value(graph_craft::document::value::TaggedValue::Image(image), false)],
-						implementation: image_node_type.generate_implementation(),
-						metadata: graph_craft::document::DocumentNodeMetadata { position: (20, 4).into() },
-					},
+					image_node_type.to_document_node(
+						[graph_craft::document::NodeInput::value(graph_craft::document::value::TaggedValue::Image(image), false)],
+						graph_craft::document::DocumentNodeMetadata::position((20, 4)),
+					),
 				);
 
 				responses.push_back(

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -21,6 +21,7 @@ use crate::messages::portfolio::document::utility_types::vectorize_layer_metadat
 use crate::messages::portfolio::utility_types::PersistentData;
 use crate::messages::prelude::*;
 use crate::messages::tool::utility_types::ToolType;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::boolean_ops::BooleanOperationError;
 use document_legacy::document::Document as DocumentLegacy;
@@ -104,13 +105,13 @@ impl Default for DocumentMessageHandler {
 	}
 }
 
-impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler)> for DocumentMessageHandler {
+impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler, &mut NodeGraphExecutor)> for DocumentMessageHandler {
 	#[remain::check]
 	fn process_message(
 		&mut self,
 		message: DocumentMessage,
 		responses: &mut VecDeque<Message>,
-		(document_id, ipp, persistent_data, preferences): (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler),
+		(document_id, ipp, persistent_data, preferences, executor): (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler, &mut NodeGraphExecutor),
 	) {
 		use DocumentMessage::*;
 
@@ -203,6 +204,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 					artboard_document: &self.artboard_message_handler.artboards_document,
 					selected_layers: &mut self.layer_metadata.iter().filter_map(|(path, data)| data.selected.then_some(path.as_slice())),
 					node_graph_message_handler: &self.node_graph_handler,
+					executor,
 				};
 				self.properties_panel_message_handler
 					.process_message(message, responses, (persistent_data, properties_panel_message_handler_data));

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -12,6 +12,7 @@ pub enum NodeGraphMessage {
 	CloseNodeGraph,
 	ConnectNodesByLink {
 		output_node: u64,
+		output_node_connector_index: usize,
 		input_node: u64,
 		input_node_connector_index: usize,
 	},

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -39,7 +39,7 @@ impl FrontendGraphDataType {
 	pub const fn with_tagged_value(value: &TaggedValue) -> Self {
 		match value {
 			TaggedValue::String(_) => Self::Text,
-			TaggedValue::F32(_) | TaggedValue::F64(_) | TaggedValue::U32(_) => Self::Number,
+			TaggedValue::F32(_) | TaggedValue::F64(_) | TaggedValue::U32(_) | TaggedValue::DAffine2(_) => Self::Number,
 			TaggedValue::Bool(_) => Self::Boolean,
 			TaggedValue::DVec2(_) => Self::Vector,
 			TaggedValue::Image(_) => Self::Raster,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -58,6 +58,13 @@ pub struct NodeGraphInput {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct NodeGraphOutput {
+	#[serde(rename = "dataType")]
+	data_type: FrontendGraphDataType,
+	name: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
 pub struct FrontendNode {
 	pub id: graph_craft::document::NodeId,
 	#[serde(rename = "displayName")]
@@ -66,10 +73,10 @@ pub struct FrontendNode {
 	pub primary_input: Option<FrontendGraphDataType>,
 	#[serde(rename = "exposedInputs")]
 	pub exposed_inputs: Vec<NodeGraphInput>,
-	pub outputs: Vec<FrontendGraphDataType>,
+	pub outputs: Vec<NodeGraphOutput>, // TODO: Break this apart into `primary_output` and `exposed_outputs`
 	pub position: (i32, i32),
 	pub disabled: bool,
-	pub output: bool,
+	pub previewed: bool,
 }
 
 // (link_start, link_end, link_end_input_index)
@@ -310,9 +317,16 @@ impl NodeGraphMessageHandler {
 						name: input_type.name.to_string(),
 					})
 					.collect(),
-				outputs: node_type.outputs.to_vec(),
+				outputs: node_type
+					.outputs
+					.iter()
+					.map(|output_type| NodeGraphOutput {
+						data_type: output_type.data_type,
+						name: output_type.name.to_string(),
+					})
+					.collect(),
 				position: node.metadata.position.into(),
-				output: network.outputs_contains(*id),
+				previewed: network.outputs_contains(*id),
 				disabled: network.disabled.contains(id),
 			})
 		}

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -214,7 +214,7 @@ impl NodeGraphMessageHandler {
 				if !(is_output && network.previous_outputs_contains(node_id).unwrap_or(true)) {
 					let output_button = WidgetHolder::new(Widget::TextButton(TextButton {
 						label: if is_output { "End Preview" } else { "Preview" }.to_string(),
-						tooltip: if is_output { "Restore preview to Output node" } else { "Preview node" }.to_string() + " (shortcut: Alt+click node)",
+						tooltip: if is_output { "Restore preview to Output node" } else { "Preview node" }.to_string() + " (Shortcut: Alt-click node)",
 						on_update: WidgetCallback::new(move |_| NodeGraphMessage::TogglePreview { node_id }.into()),
 						..Default::default()
 					}));

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -204,7 +204,7 @@ impl NodeGraphMessageHandler {
 				let is_output = network.outputs_contains(node_id);
 
 				// Don't show stop previewing button on the original output node
-				if !(is_output && !network.previous_outputs_contains(node_id)) {
+				if !(is_output && network.previous_outputs_contains(node_id).unwrap_or(true)) {
 					let output_button = WidgetHolder::new(Widget::TextButton(TextButton {
 						label: if is_output { "End Preview" } else { "Preview" }.to_string(),
 						tooltip: if is_output { "Restore preview to Output node" } else { "Preview node" }.to_string() + " (shortcut: Alt+click node)",
@@ -842,8 +842,8 @@ impl MessageHandler<NodeGraphMessage, (&mut Document, &mut dyn Iterator<Item = &
 			}
 			NodeGraphMessage::TogglePreviewImpl { node_id } => {
 				if let Some(network) = self.get_active_network_mut(document) {
-					// Check if the node is already being previewed and so the output should return to default
-					if network.outputs_contains(node_id) {
+					// Check if the node is not already being previewed
+					if !network.outputs_contains(node_id) {
 						network.previous_outputs = Some(network.previous_outputs.to_owned().unwrap_or_else(|| network.outputs.clone()));
 						network.outputs[0] = NodeOutput::new(node_id, 0);
 					} else if let Some(outputs) = network.previous_outputs.take() {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -77,8 +77,8 @@ pub struct FrontendNode {
 pub struct FrontendNodeLink {
 	#[serde(rename = "linkStart")]
 	pub link_start: u64,
-	#[serde(rename = "linkStartIndex")]
-	pub link_start_index: usize,
+	#[serde(rename = "linkStartOutputIndex")]
+	pub link_start_output_index: usize,
 	#[serde(rename = "linkEnd")]
 	pub link_end: u64,
 	#[serde(rename = "linkEndInputIndex")]
@@ -274,7 +274,7 @@ impl NodeGraphMessageHandler {
 				{
 					Some(FrontendNodeLink {
 						link_start,
-						link_start_index,
+						link_start_output_index: link_start_index,
 						link_end,
 						link_end_input_index: link_end_input_index as u64,
 					})
@@ -412,6 +412,7 @@ impl MessageHandler<NodeGraphMessage, (&mut Document, &mut dyn Iterator<Item = &
 			}
 			NodeGraphMessage::ConnectNodesByLink {
 				output_node,
+				output_node_connector_index,
 				input_node,
 				input_node_connector_index,
 			} => {
@@ -432,7 +433,7 @@ impl MessageHandler<NodeGraphMessage, (&mut Document, &mut dyn Iterator<Item = &
 
 				responses.push_back(DocumentMessage::StartTransaction.into());
 
-				let input = NodeInput::node(output_node, 0);
+				let input = NodeInput::node(output_node, output_node_connector_index);
 				responses.push_back(NodeGraphMessage::SetNodeInput { node_id, input_index, input }.into());
 
 				let should_rerender = network.connected_to_output(node_id);

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -452,12 +452,10 @@ impl MessageHandler<NodeGraphMessage, (&mut Document, &mut dyn Iterator<Item = &
 
 				responses.push_back(DocumentMessage::StartTransaction.into());
 
-				let document_node = DocumentNode {
-					name: node_type.clone(),
-					inputs: document_node_type.inputs.iter().map(|input| input.default.clone()).collect(),
-					implementation: document_node_type.generate_implementation(),
-					metadata: graph_craft::document::DocumentNodeMetadata { position: (x, y).into() },
-				};
+				let document_node = document_node_type.to_document_node(
+					document_node_type.inputs.iter().map(|input| input.default.clone()),
+					graph_craft::document::DocumentNodeMetadata::position((x, y)),
+				);
 				responses.push_back(NodeGraphMessage::InsertNode { node_id, document_node }.into());
 
 				responses.push_back(NodeGraphMessage::SendGraph { should_rerender: false }.into());

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -185,7 +185,7 @@ impl NodeGraphMessageHandler {
 			let mut widgets = Vec::new();
 
 			// Don't allow disabling input or output nodes
-			let mut selected_nodes = self.selected_nodes.iter().filter(|&&id| !network.inputs.contains(&id) && !network.origional_outputs_contains(id));
+			let mut selected_nodes = self.selected_nodes.iter().filter(|&&id| !network.inputs.contains(&id) && !network.original_outputs_contain(id));
 
 			// If there is at least one other selected node then show the hide or show button
 			if selected_nodes.next().is_some() {
@@ -208,10 +208,10 @@ impl NodeGraphMessageHandler {
 			if self.selected_nodes.len() == 1 {
 				let node_id = self.selected_nodes[0];
 				// Is this node the current output
-				let is_output = network.outputs_contains(node_id);
+				let is_output = network.outputs_contain(node_id);
 
 				// Don't show stop previewing button on the original output node
-				if !(is_output && network.previous_outputs_contains(node_id).unwrap_or(true)) {
+				if !(is_output && network.previous_outputs_contain(node_id).unwrap_or(true)) {
 					let output_button = WidgetHolder::new(Widget::TextButton(TextButton {
 						label: if is_output { "End Preview" } else { "Preview" }.to_string(),
 						tooltip: if is_output { "Restore preview to Output node" } else { "Preview node" }.to_string() + " (Shortcut: Alt-click node)",
@@ -326,7 +326,7 @@ impl NodeGraphMessageHandler {
 					})
 					.collect(),
 				position: node.metadata.position.into(),
-				previewed: network.outputs_contains(*id),
+				previewed: network.outputs_contain(*id),
 				disabled: network.disabled.contains(id),
 			})
 		}
@@ -349,7 +349,7 @@ impl NodeGraphMessageHandler {
 			warn!("Deleting input node");
 			return false;
 		}
-		if network.outputs_contains(deleting_node_id) {
+		if network.outputs_contain(deleting_node_id) {
 			warn!("Deleting the output node!");
 			return false;
 		}
@@ -358,7 +358,7 @@ impl NodeGraphMessageHandler {
 				continue;
 			}
 			for (input_index, input) in node.inputs.iter_mut().enumerate() {
-				let NodeInput::Node{node_id,..}= input else {
+				let NodeInput::Node{ node_id, .. } = input else {
 					continue;
 				};
 				if *node_id != deleting_node_id {
@@ -402,7 +402,7 @@ impl NodeGraphMessageHandler {
 	fn copy_nodes<'a>(network: &'a NodeNetwork, new_ids: &'a HashMap<NodeId, NodeId>) -> impl Iterator<Item = (NodeId, DocumentNode)> + 'a {
 		new_ids
 			.iter()
-			.filter(|&(&id, _)| !network.outputs_contains(id) && !network.inputs.contains(&id))
+			.filter(|&(&id, _)| !network.outputs_contain(id) && !network.inputs.contains(&id))
 			.filter_map(|(&id, &new)| network.nodes.get(&id).map(|node| (new, node.clone())))
 			.map(move |(new, node)| (new, node.map_ids(Self::default_node_input, new_ids)))
 	}
@@ -857,7 +857,7 @@ impl MessageHandler<NodeGraphMessage, (&mut Document, &mut dyn Iterator<Item = &
 			NodeGraphMessage::TogglePreviewImpl { node_id } => {
 				if let Some(network) = self.get_active_network_mut(document) {
 					// Check if the node is not already being previewed
-					if !network.outputs_contains(node_id) {
+					if !network.outputs_contain(node_id) {
 						network.previous_outputs = Some(network.previous_outputs.to_owned().unwrap_or_else(|| network.outputs.clone()));
 						network.outputs[0] = NodeOutput::new(node_id, 0);
 					} else if let Some(outputs) = network.previous_outputs.take() {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -247,6 +247,7 @@ impl NodeGraphMessageHandler {
 					document_node
 						.inputs
 						.iter()
+						.take(1) // Only show the primary input
 						.filter_map(|input| if let NodeInput::Node { node_id: ref_id, .. } = input { Some(*ref_id) } else { None }),
 				);
 				nodes.push((document_node, node_id));

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -123,13 +123,13 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 				DocumentNode {
 					name: "Identity".to_string(),
 					inputs: vec![NodeInput::Network],
-					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[concrete!("Any<'_>")])),
+					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
 					metadata: Default::default(),
 				},
 				DocumentNode {
 					name: "Identity".to_string(),
 					inputs: vec![NodeInput::Network],
-					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[concrete!("Any<'_>")])),
+					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
 					metadata: Default::default(),
 				},
 			]
@@ -201,7 +201,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 	DocumentNodeType {
 		name: "Image Frame",
 		category: "General",
-		identifier: NodeImplementation::proto("graphene_std::raster::ImageFrameNode", &[concrete!("Image"), concrete!("DAffine2")]),
+		identifier: NodeImplementation::proto("graphene_std::raster::ImageFrameNode<_>", &[concrete!("Image"), concrete!("DAffine2")]),
 		inputs: &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -527,11 +527,11 @@ pub const IMAGINATE_NODE: DocumentNodeType = DocumentNodeType {
 	inputs: &[
 		DocumentInputType::new("Input Image", TaggedValue::Image(Image::empty()), true),
 		DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),
-		DocumentInputType::new("Seed", TaggedValue::F64(0.), false),
+		DocumentInputType::new("Seed", TaggedValue::F64(0.), false), // Remember to keep index used in `NodeGraphFrameImaginateRandom` updated with this entry's index
 		DocumentInputType::new("Resolution", TaggedValue::OptionalDVec2(None), false),
 		DocumentInputType::new("Samples", TaggedValue::F64(30.), false),
 		DocumentInputType::new("Sampling Method", TaggedValue::ImaginateSamplingMethod(ImaginateSamplingMethod::EulerA), false),
-		DocumentInputType::new("Prompt Guidance", TaggedValue::F64(10.), false),
+		DocumentInputType::new("Prompt Guidance", TaggedValue::F64(7.5), false),
 		DocumentInputType::new("Prompt", TaggedValue::String(String::new()), false),
 		DocumentInputType::new("Negative Prompt", TaggedValue::String(String::new()), false),
 		DocumentInputType::new("Adapt Input Image", TaggedValue::Bool(false), false),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -141,7 +141,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		}),
 		inputs: INPUT_MULTIPLE_INPUTS,
 		outputs: &[FrontendGraphDataType::Raster, FrontendGraphDataType::Number],
-		properties: node_properties::no_properties,
+		properties: node_properties::input_properties,
 	};
 	vec.push(input_multiple);
 	vec.push(blur);
@@ -184,14 +184,6 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			default: NodeInput::Network,
 		}],
 		outputs: &[FrontendGraphDataType::Raster],
-		properties: node_properties::input_properties,
-	},
-	DocumentNodeType {
-		name: "Input Multiple",
-		category: "Ignore",
-		identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[concrete!("Any<'_>")]),
-		inputs: &[],
-		outputs: &[FrontendGraphDataType::Raster, FrontendGraphDataType::General],
 		properties: node_properties::input_properties,
 	},
 	DocumentNodeType {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -79,12 +79,11 @@ pub struct DocumentNodeType {
 fn document_node_types() -> Vec<DocumentNodeType> {
 	let mut vec: Vec<_> = STATIC_NODES.to_vec();
 
-	const INPUTS: &[DocumentInputType] = &[
+	const GAUSSIAN_BLUR_NODE_INPUTS: &[DocumentInputType] = &[
 		DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 		DocumentInputType::new("Radius", TaggedValue::U32(3), false),
 		DocumentInputType::new("Sigma", TaggedValue::F64(1.), false),
 	];
-
 	let blur = DocumentNodeType {
 		name: "Gaussian Blur",
 		category: "Image Filters",
@@ -115,14 +114,16 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 			.collect(),
 			..Default::default()
 		}),
-		inputs: INPUTS,
+		inputs: GAUSSIAN_BLUR_NODE_INPUTS,
 		outputs: &[DocumentOutputType {
 			name: "Image",
 			data_type: FrontendGraphDataType::Raster,
 		}],
 		properties: node_properties::blur_image_properties,
 	};
-	const INPUT_MULTIPLE_INPUTS: &[DocumentInputType] = &[
+	vec.push(blur);
+
+	const INPUT_NODE_INPUTS: &[DocumentInputType] = &[
 		DocumentInputType {
 			name: "In",
 			data_type: FrontendGraphDataType::General,
@@ -130,8 +131,8 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		},
 		DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), false),
 	];
-	let input_multiple = DocumentNodeType {
-		name: "Input Multiple",
+	let input = DocumentNodeType {
+		name: "Input",
 		category: "Ignore",
 		identifier: NodeImplementation::DocumentNode(NodeNetwork {
 			inputs: vec![0, 1],
@@ -156,7 +157,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 			.collect(),
 			..Default::default()
 		}),
-		inputs: INPUT_MULTIPLE_INPUTS,
+		inputs: INPUT_NODE_INPUTS,
 		outputs: &[
 			DocumentOutputType {
 				name: "Image",
@@ -169,8 +170,8 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		],
 		properties: node_properties::input_properties,
 	};
-	vec.push(input_multiple);
-	vec.push(blur);
+	vec.push(input);
+
 	vec
 }
 
@@ -200,18 +201,18 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: |_document_node, _node_id, _context| node_properties::string_properties("A bitmap image embedded in this node"),
 	},
-	DocumentNodeType {
-		name: "Input",
-		category: "Ignore",
-		identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[generic!("T")]),
-		inputs: &[DocumentInputType {
-			name: "In",
-			data_type: FrontendGraphDataType::Raster,
-			default: NodeInput::Network,
-		}],
-		outputs: &[DocumentOutputType::new("Out", FrontendGraphDataType::Raster)],
-		properties: node_properties::input_properties,
-	},
+	// DocumentNodeType {
+	// 	name: "Input",
+	// 	category: "Ignore",
+	// 	identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[generic!("T")]),
+	// 	inputs: &[DocumentInputType {
+	// 		name: "In",
+	// 		data_type: FrontendGraphDataType::Raster,
+	// 		default: NodeInput::Network,
+	// 	}],
+	// 	outputs: &[DocumentOutputType::new("Out", FrontendGraphDataType::Raster)],
+	// 	properties: node_properties::input_properties,
+	// },
 	DocumentNodeType {
 		name: "Output",
 		category: "Ignore",
@@ -608,7 +609,7 @@ pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetw
 		inputs: vec![0],
 		outputs: vec![NodeOutput::new(1, 0)],
 		nodes: [
-			resolve_document_node_type("Input Multiple").expect("Input multiple node does not exist").to_document_node(
+			resolve_document_node_type("Input").expect("Input node does not exist").to_document_node(
 				[NodeInput::Network, NodeInput::value(TaggedValue::DAffine2(DAffine2::IDENTITY), false)],
 				DocumentNodeMetadata::position((8, 4)),
 			),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -33,6 +33,17 @@ impl DocumentInputType {
 	}
 }
 
+pub struct DocumentOutputType {
+	pub name: &'static str,
+	pub data_type: FrontendGraphDataType,
+}
+
+impl DocumentOutputType {
+	pub const fn new(name: &'static str, data_type: FrontendGraphDataType) -> Self {
+		Self { name, data_type }
+	}
+}
+
 pub struct NodePropertiesContext<'a> {
 	pub persistent_data: &'a crate::messages::portfolio::utility_types::PersistentData,
 	pub document: &'a document_legacy::document::Document,
@@ -61,7 +72,7 @@ pub struct DocumentNodeType {
 	pub category: &'static str,
 	pub identifier: NodeImplementation,
 	pub inputs: &'static [DocumentInputType],
-	pub outputs: &'static [FrontendGraphDataType],
+	pub outputs: &'static [DocumentOutputType],
 	pub properties: fn(&DocumentNode, NodeId, &mut NodePropertiesContext) -> Vec<LayoutGroup>,
 }
 
@@ -105,7 +116,10 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 			..Default::default()
 		}),
 		inputs: INPUTS,
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType {
+			name: "Image",
+			data_type: FrontendGraphDataType::Raster,
+		}],
 		properties: node_properties::blur_image_properties,
 	};
 	const INPUT_MULTIPLE_INPUTS: &[DocumentInputType] = &[
@@ -143,7 +157,16 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 			..Default::default()
 		}),
 		inputs: INPUT_MULTIPLE_INPUTS,
-		outputs: &[FrontendGraphDataType::Raster, FrontendGraphDataType::Number],
+		outputs: &[
+			DocumentOutputType {
+				name: "Image",
+				data_type: FrontendGraphDataType::Raster,
+			},
+			DocumentOutputType {
+				name: "Transform",
+				data_type: FrontendGraphDataType::Number,
+			},
+		],
 		properties: node_properties::input_properties,
 	};
 	vec.push(input_multiple);
@@ -166,7 +189,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			data_type: FrontendGraphDataType::General,
 			default: NodeInput::node(0, 0),
 		}],
-		outputs: &[FrontendGraphDataType::General],
+		outputs: &[DocumentOutputType::new("Out", FrontendGraphDataType::General)],
 		properties: |_document_node, _node_id, _context| node_properties::string_properties("The identity node simply returns the input"),
 	},
 	DocumentNodeType {
@@ -174,7 +197,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		category: "Ignore",
 		identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[generic!("T")]),
 		inputs: &[DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), false)],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: |_document_node, _node_id, _context| node_properties::string_properties("A bitmap image embedded in this node"),
 	},
 	DocumentNodeType {
@@ -186,7 +209,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			data_type: FrontendGraphDataType::Raster,
 			default: NodeInput::Network,
 		}],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Out", FrontendGraphDataType::Raster)],
 		properties: node_properties::input_properties,
 	},
 	DocumentNodeType {
@@ -209,7 +232,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: |_document_node, _node_id, _context| node_properties::string_properties("Creates an embedded image with the given transform"),
 	},
 	DocumentNodeType {
@@ -270,7 +293,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 				default: NodeInput::value(TaggedValue::F64(50.), false),
 			},
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::grayscale_properties,
 	},
 	DocumentNodeType {
@@ -281,7 +304,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Luma Calculation", TaggedValue::LuminanceCalculation(LuminanceCalculation::SRGB), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::luminance_properties,
 	},
 	#[cfg(feature = "gpu")]
@@ -297,7 +320,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 				default: NodeInput::value(TaggedValue::String(String::new()), false),
 			},
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::gpu_map_properties,
 	},
 	#[cfg(feature = "quantization")]
@@ -322,7 +345,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 				default: NodeInput::value(TaggedValue::U32(0), false),
 			},
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::quantize_properties,
 	},
 	DocumentNodeType {
@@ -330,7 +353,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		category: "Structural",
 		identifier: NodeImplementation::proto("graphene_std::memo::CacheNode", &[concrete!("Image")]),
 		inputs: &[DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true)],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::no_properties,
 	},
 	DocumentNodeType {
@@ -338,7 +361,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		category: "Image Adjustments",
 		identifier: NodeImplementation::proto("graphene_core::raster::InvertRGBNode", &[concrete!("Image")]),
 		inputs: &[DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true)],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::no_properties,
 	},
 	DocumentNodeType {
@@ -354,7 +377,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Saturation Shift", TaggedValue::F64(0.), false),
 			DocumentInputType::new("Lightness Shift", TaggedValue::F64(0.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::adjust_hsl_properties,
 	},
 	DocumentNodeType {
@@ -366,7 +389,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Brightness", TaggedValue::F64(0.), false),
 			DocumentInputType::new("Contrast", TaggedValue::F64(0.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::brighten_image_properties,
 	},
 	DocumentNodeType {
@@ -378,7 +401,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Luma Calculation", TaggedValue::LuminanceCalculation(LuminanceCalculation::SRGB), false),
 			DocumentInputType::new("Threshold", TaggedValue::F64(50.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::adjust_threshold_properties,
 	},
 	DocumentNodeType {
@@ -389,7 +412,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Vibrance", TaggedValue::F64(0.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::adjust_vibrance_properties,
 	},
 	DocumentNodeType {
@@ -400,7 +423,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Factor", TaggedValue::F64(100.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::multiply_opacity,
 	},
 	DocumentNodeType {
@@ -411,7 +434,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Value", TaggedValue::F64(4.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::posterize_properties,
 	},
 	DocumentNodeType {
@@ -427,7 +450,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Offset", TaggedValue::F64(0.), false),
 			DocumentInputType::new("Gamma Correction", TaggedValue::F64(1.), false),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 		properties: node_properties::exposure_properties,
 	},
 	IMAGINATE_NODE,
@@ -439,7 +462,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Input", TaggedValue::F64(0.), true),
 			DocumentInputType::new("Addend", TaggedValue::F64(0.), true),
 		],
-		outputs: &[FrontendGraphDataType::Number],
+		outputs: &[DocumentOutputType::new("Output", FrontendGraphDataType::Number)],
 		properties: node_properties::add_properties,
 	},
 	/*DocumentNodeType {
@@ -447,7 +470,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		category: "Vector",
 		identifier: NodeImplementation::proto("graphene_std::vector::generator_nodes::UnitCircleGenerator", &[]),
 		inputs: &[DocumentInputType::none()],
-		outputs: &[FrontendGraphDataType::Subpath],
+		outputs: &[DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
 		properties: node_properties::no_properties,
 	},
 	DocumentNodeType {
@@ -455,7 +478,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		category: "Vector",
 		identifier: NodeImplementation::proto("graphene_std::vector::generator_nodes::UnitSquareGenerator", &[]),
 		inputs: &[DocumentInputType::none()],
-		outputs: &[FrontendGraphDataType::Subpath],
+		outputs: &[DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
 		properties: node_properties::no_properties,
 	},
 	DocumentNodeType {
@@ -467,7 +490,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			data_type: FrontendGraphDataType::Subpath,
 			default: NodeInput::value(TaggedValue::Subpath(Subpath::new()), false),
 		}],
-		outputs: &[FrontendGraphDataType::Subpath],
+		outputs: &[DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
 		properties: node_properties::no_properties,
 	},
 	DocumentNodeType {
@@ -481,7 +504,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Scale", TaggedValue::DVec2(DVec2::ONE), false),
 			DocumentInputType::new("Skew", TaggedValue::DVec2(DVec2::ZERO), false),
 		],
-		outputs: &[FrontendGraphDataType::Subpath],
+		outputs: &[DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
 		properties: node_properties::transform_properties,
 	},
 	DocumentNodeType {
@@ -492,7 +515,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
 			DocumentInputType::new("Subpath", TaggedValue::Subpath(Subpath::empty()), true),
 		],
-		outputs: &[FrontendGraphDataType::Raster],
+		outputs: &[DocumentOutputType::new("Vector", FrontendGraphDataType::Raster)],
 		properties: node_properties::no_properties,
 	},*/
 ];
@@ -524,7 +547,7 @@ pub const IMAGINATE_NODE: DocumentNodeType = DocumentNodeType {
 		DocumentInputType::new("Percent Complete", TaggedValue::F64(0.), false),
 		DocumentInputType::new("Status", TaggedValue::ImaginateStatus(ImaginateStatus::Idle), false),
 	],
-	outputs: &[FrontendGraphDataType::Raster],
+	outputs: &[DocumentOutputType::new("Image", FrontendGraphDataType::Raster)],
 	properties: node_properties::imaginate_properties,
 };
 

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -76,7 +76,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		category: "Image Filters",
 		identifier: NodeImplementation::DocumentNode(NodeNetwork {
 			inputs: vec![0, 1, 1],
-			output: 1,
+			outputs: vec![1],
 			nodes: vec![
 				(
 					0,
@@ -495,7 +495,7 @@ impl DocumentNodeType {
 			NodeImplementation::ProtoNode(ident) => {
 				NodeNetwork {
 					inputs: (0..num_inputs).map(|_| 0).collect(),
-					output: 0,
+					outputs: vec![0],
 					nodes: [(
 						0,
 						DocumentNode {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -76,7 +76,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		category: "Image Filters",
 		identifier: NodeImplementation::DocumentNode(NodeNetwork {
 			inputs: vec![0, 1, 1],
-			outputs: vec![1],
+			outputs: vec![NodeOutput::new(1, 0)],
 			nodes: vec![
 				(
 					0,
@@ -91,7 +91,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 					1,
 					DocumentNode {
 						name: "BlurNode".to_string(),
-						inputs: vec![NodeInput::Node(0), NodeInput::Network, NodeInput::Network, NodeInput::Node(0)],
+						inputs: vec![NodeInput::node(0, 0), NodeInput::Network, NodeInput::Network, NodeInput::node(0, 0)],
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::raster::BlurNode", &[concrete!("Image")])),
 						metadata: Default::default(),
 					},
@@ -118,7 +118,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		category: "Image Filters",
 		identifier: NodeImplementation::DocumentNode(NodeNetwork {
 			inputs: vec![0, 1],
-			outputs: vec![0, 1],
+			outputs: vec![NodeOutput::new(0, 0), NodeOutput::new(1, 0)],
 			nodes: [
 				DocumentNode {
 					name: "Identity".to_string(),
@@ -161,7 +161,7 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		inputs: &[DocumentInputType {
 			name: "In",
 			data_type: FrontendGraphDataType::General,
-			default: NodeInput::Node(0),
+			default: NodeInput::node(0, 0),
 		}],
 		outputs: &[FrontendGraphDataType::General],
 		properties: |_document_node, _node_id, _context| node_properties::string_properties("The identity node simply returns the input"),
@@ -553,7 +553,7 @@ impl DocumentNodeType {
 			NodeImplementation::ProtoNode(ident) => {
 				NodeNetwork {
 					inputs: (0..num_inputs).map(|_| 0).collect(),
-					outputs: vec![0],
+					outputs: vec![NodeOutput::new(0, 0)],
 					nodes: [(
 						0,
 						DocumentNode {
@@ -587,7 +587,7 @@ impl DocumentNodeType {
 pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetwork {
 	NodeNetwork {
 		inputs: vec![0],
-		outputs: vec![1],
+		outputs: vec![NodeOutput::new(1, 0)],
 		nodes: [
 			resolve_document_node_type("Input Multiple").expect("Input mutliple node does not exist").to_document_node(
 				[NodeInput::Network, NodeInput::value(TaggedValue::DAffine2(DAffine2::IDENTITY), false)],
@@ -595,10 +595,10 @@ pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetw
 			),
 			resolve_document_node_type("Output")
 				.expect("Output node does not exist")
-				.to_document_node([NodeInput::Node(2)], DocumentNodeMetadata::position((output_offset + 8, 4))),
+				.to_document_node([NodeInput::node(2, 0)], DocumentNodeMetadata::position((output_offset + 8, 4))),
 			resolve_document_node_type("Image Frame")
 				.expect("Image frame node does not exist")
-				.to_document_node([NodeInput::Node(output_node_id), NodeInput::Node(0)], DocumentNodeMetadata::position((output_offset, 4))),
+				.to_document_node([NodeInput::node(output_node_id, 0), NodeInput::node(0, 1)], DocumentNodeMetadata::position((output_offset, 4))),
 		]
 		.into_iter()
 		.enumerate()

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -105,6 +105,45 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 		outputs: &[FrontendGraphDataType::Raster],
 		properties: node_properties::blur_image_properties,
 	};
+	const INPUT_MULTIPLE_INPUTS: &[DocumentInputType] = &[
+		DocumentInputType {
+			name: "In",
+			data_type: FrontendGraphDataType::General,
+			default: NodeInput::Network,
+		},
+		DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), false),
+	];
+	let input_multiple = DocumentNodeType {
+		name: "Input Multiple",
+		category: "Image Filters",
+		identifier: NodeImplementation::DocumentNode(NodeNetwork {
+			inputs: vec![0, 1],
+			outputs: vec![0, 1],
+			nodes: [
+				DocumentNode {
+					name: "Identity".to_string(),
+					inputs: vec![NodeInput::Network],
+					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[concrete!("Any<'_>")])),
+					metadata: Default::default(),
+				},
+				DocumentNode {
+					name: "Identity".to_string(),
+					inputs: vec![NodeInput::Network],
+					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[concrete!("Any<'_>")])),
+					metadata: Default::default(),
+				},
+			]
+			.into_iter()
+			.enumerate()
+			.map(|(id, node)| (id as NodeId, node))
+			.collect(),
+			..Default::default()
+		}),
+		inputs: INPUT_MULTIPLE_INPUTS,
+		outputs: &[FrontendGraphDataType::Raster, FrontendGraphDataType::Number],
+		properties: node_properties::no_properties,
+	};
+	vec.push(input_multiple);
 	vec.push(blur);
 	vec
 }
@@ -148,6 +187,14 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 		properties: node_properties::input_properties,
 	},
 	DocumentNodeType {
+		name: "Input Multiple",
+		category: "Ignore",
+		identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[concrete!("Any<'_>")]),
+		inputs: &[],
+		outputs: &[FrontendGraphDataType::Raster, FrontendGraphDataType::General],
+		properties: node_properties::input_properties,
+	},
+	DocumentNodeType {
 		name: "Output",
 		category: "Ignore",
 		identifier: NodeImplementation::proto("graphene_core::ops::IdNode", &[generic!("T")]),
@@ -157,7 +204,18 @@ static STATIC_NODES: &[DocumentNodeType] = &[
 			default: NodeInput::value(TaggedValue::Image(Image::empty()), true),
 		}],
 		outputs: &[],
-		properties: |_document_node, _node_id, _context| node_properties::string_properties("The graph's output is rendered into the frame".to_string()),
+		properties: |_document_node, _node_id, _context| node_properties::string_properties("The graph's output is rendered into the frame"),
+	},
+	DocumentNodeType {
+		name: "Image Frame",
+		category: "General",
+		identifier: NodeImplementation::proto("graphene_std::raster::ImageFrameNode", &[concrete!("Image"), concrete!("DAffine2")]),
+		inputs: &[
+			DocumentInputType::new("Image", TaggedValue::Image(Image::empty()), true),
+			DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),
+		],
+		outputs: &[FrontendGraphDataType::Raster],
+		properties: |_document_node, _node_id, _context| node_properties::string_properties("Creates an embedded image with the given transform"),
 	},
 	DocumentNodeType {
 		name: "Grayscale",
@@ -514,5 +572,38 @@ impl DocumentNodeType {
 			NodeImplementation::DocumentNode(network) => network.clone(),
 		};
 		DocumentNodeImplementation::Network(inner_network)
+	}
+
+	pub fn to_document_node(&self, inputs: impl IntoIterator<Item = NodeInput>, metadata: graph_craft::document::DocumentNodeMetadata) -> DocumentNode {
+		DocumentNode {
+			name: self.name.to_string(),
+			inputs: inputs.into_iter().collect(),
+			implementation: self.generate_implementation(),
+			metadata,
+		}
+	}
+}
+
+pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetwork {
+	NodeNetwork {
+		inputs: vec![0],
+		outputs: vec![1],
+		nodes: [
+			resolve_document_node_type("Input Multiple").expect("Input mutliple node does not exist").to_document_node(
+				[NodeInput::Network, NodeInput::value(TaggedValue::DAffine2(DAffine2::IDENTITY), false)],
+				DocumentNodeMetadata::position((8, 4)),
+			),
+			resolve_document_node_type("Output")
+				.expect("Output node does not exist")
+				.to_document_node([NodeInput::Node(2)], DocumentNodeMetadata::position((output_offset + 8, 4))),
+			resolve_document_node_type("Image Frame")
+				.expect("Image frame node does not exist")
+				.to_document_node([NodeInput::Node(output_node_id), NodeInput::Node(0)], DocumentNodeMetadata::position((output_offset, 4))),
+		]
+		.into_iter()
+		.enumerate()
+		.map(|(id, node)| (id as NodeId, node))
+		.collect(),
+		..Default::default()
 	}
 }

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -1,5 +1,6 @@
 use super::{node_properties, FrontendGraphDataType, FrontendNodeType};
 use crate::messages::layout::utility_types::layout_widget::LayoutGroup;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use graph_craft::document::value::*;
 use graph_craft::document::*;
@@ -38,6 +39,8 @@ pub struct NodePropertiesContext<'a> {
 	pub responses: &'a mut VecDeque<crate::messages::prelude::Message>,
 	pub layer_path: &'a [document_legacy::LayerId],
 	pub nested_path: &'a [NodeId],
+	pub executor: &'a mut NodeGraphExecutor,
+	pub network: &'a NodeNetwork,
 }
 
 #[derive(Clone)]
@@ -500,6 +503,7 @@ pub const IMAGINATE_NODE: DocumentNodeType = DocumentNodeType {
 	identifier: NodeImplementation::proto("graphene_std::raster::ImaginateNode<_>", &[concrete!("Image"), concrete!("Option<std::sync::Arc<Image>>")]),
 	inputs: &[
 		DocumentInputType::new("Input Image", TaggedValue::Image(Image::empty()), true),
+		DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),
 		DocumentInputType::new("Seed", TaggedValue::F64(0.), false),
 		DocumentInputType::new("Resolution", TaggedValue::OptionalDVec2(None), false),
 		DocumentInputType::new("Samples", TaggedValue::F64(30.), false),
@@ -581,7 +585,7 @@ pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetw
 		inputs: vec![0],
 		outputs: vec![NodeOutput::new(1, 0)],
 		nodes: [
-			resolve_document_node_type("Input Multiple").expect("Input mutliple node does not exist").to_document_node(
+			resolve_document_node_type("Input Multiple").expect("Input multiple node does not exist").to_document_node(
 				[NodeInput::Network, NodeInput::value(TaggedValue::DAffine2(DAffine2::IDENTITY), false)],
 				DocumentNodeMetadata::position((8, 4)),
 			),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -115,7 +115,7 @@ fn document_node_types() -> Vec<DocumentNodeType> {
 	];
 	let input_multiple = DocumentNodeType {
 		name: "Input Multiple",
-		category: "Image Filters",
+		category: "Ignore",
 		identifier: NodeImplementation::DocumentNode(NodeNetwork {
 			inputs: vec![0, 1],
 			outputs: vec![NodeOutput::new(0, 0), NodeOutput::new(1, 0)],

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -633,7 +633,7 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 		image: graphene_core::raster::Image::empty(),
 		transform,
 	});
-	// Comput the transform input to the node graph frame
+	// Compute the transform input to the node graph frame
 	let transform: glam::DAffine2 = context.executor.compute_input(context.network, &imaginate_node, 1, image_frame).unwrap_or_default();
 
 	let resolution = {

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
@@ -28,6 +28,7 @@ impl<'a> MessageHandler<PropertiesPanelMessage, (&PersistentData, PropertiesPane
 			artboard_document,
 			selected_layers,
 			node_graph_message_handler,
+			executor,
 		} = data;
 		let get_document = |document_selector: TargetDocument| match document_selector {
 			TargetDocument::Artboard => artboard_document,
@@ -166,7 +167,7 @@ impl<'a> MessageHandler<PropertiesPanelMessage, (&PersistentData, PropertiesPane
 					let layer = document.layer(&path).unwrap();
 					match target_document {
 						TargetDocument::Artboard => register_artboard_layer_properties(layer, responses, persistent_data),
-						TargetDocument::Artwork => register_artwork_layer_properties(document, path, layer, responses, persistent_data, node_graph_message_handler),
+						TargetDocument::Artwork => register_artwork_layer_properties(document, path, layer, responses, persistent_data, node_graph_message_handler, executor),
 					}
 				}
 			}

--- a/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
@@ -8,6 +8,7 @@ use crate::messages::layout::utility_types::widgets::input_widgets::{CheckboxInp
 use crate::messages::layout::utility_types::widgets::label_widgets::{IconLabel, TextLabel};
 use crate::messages::portfolio::utility_types::PersistentData;
 use crate::messages::prelude::*;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::document::Document;
 use document_legacy::layers::layer_info::{Layer, LayerDataType, LayerDataTypeDiscriminant};
@@ -246,6 +247,7 @@ pub fn register_artwork_layer_properties(
 	responses: &mut VecDeque<Message>,
 	persistent_data: &PersistentData,
 	node_graph_message_handler: &NodeGraphMessageHandler,
+	executor: &mut NodeGraphExecutor,
 ) {
 	let options_bar = vec![LayoutGroup::Row {
 		widgets: vec![
@@ -323,6 +325,8 @@ pub fn register_artwork_layer_properties(
 				responses,
 				nested_path: &node_graph_message_handler.nested_path,
 				layer_path: &layer_path,
+				executor,
+				network: &node_graph_frame.network,
 			};
 			node_graph_message_handler.collate_properties(node_graph_frame, &mut context, &mut properties_sections);
 

--- a/editor/src/messages/portfolio/document/properties_panel/utility_types.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_types.rs
@@ -3,13 +3,14 @@ use document_legacy::LayerId;
 
 use serde::{Deserialize, Serialize};
 
-use crate::messages::prelude::NodeGraphMessageHandler;
+use crate::{messages::prelude::NodeGraphMessageHandler, node_graph_executor::NodeGraphExecutor};
 
 pub struct PropertiesPanelMessageHandlerData<'a> {
 	pub artwork_document: &'a DocumentLegacy,
 	pub artboard_document: &'a DocumentLegacy,
 	pub selected_layers: &'a mut dyn Iterator<Item = &'a [LayerId]>,
 	pub node_graph_message_handler: &'a NodeGraphMessageHandler,
+	pub executor: &'a mut NodeGraphExecutor,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, specta::Type)]

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -685,6 +685,8 @@ impl PortfolioMessageHandler {
 	/// Execute the network by flattening it and creating a borrow stack. Casts the output to the generic `T`.
 	fn execute_network<T: dyn_any::StaticType>(executor: &mut DynamicExecutor, mut network: NodeNetwork, image: Image) -> Result<T, String> {
 		network.duplicate_outputs(&mut generate_uuid);
+		network.remove_dead_nodes();
+
 		// We assume only one output
 		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
 		let c = Compiler {};

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -124,12 +124,13 @@ impl Fsm for ImaginateToolFsmState {
 
 					let mut imaginate_inputs: Vec<NodeInput> = imaginate_node_type.inputs.iter().map(|input| input.default.clone()).collect();
 					imaginate_inputs[0] = NodeInput::node(0, 0);
+					imaginate_inputs[1] = NodeInput::node(0, 1);
 
 					let imaginate_node_id = 100;
 					let mut network = node_graph::new_image_network(32, imaginate_node_id);
 					network.nodes.insert(
 						imaginate_node_id,
-						imaginate_node_type.to_document_node(imaginate_inputs, graph_craft::document::DocumentNodeMetadata::position((20, 4))),
+						imaginate_node_type.to_document_node(imaginate_inputs, graph_craft::document::DocumentNodeMetadata::position((20, 3))),
 					);
 
 					responses.push_back(

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -1,7 +1,7 @@
 use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::input_mapper::utility_types::input_keyboard::{Key, MouseMotion};
 use crate::messages::layout::utility_types::layout_widget::PropertyHolder;
-use crate::messages::portfolio::document::node_graph::IMAGINATE_NODE;
+use crate::messages::portfolio::document::node_graph::{self, IMAGINATE_NODE};
 use crate::messages::prelude::*;
 use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::utility_types::{EventToMessageMap, Fsm, ToolActionHandlerData, ToolMetadata, ToolTransition, ToolType};
@@ -125,16 +125,11 @@ impl Fsm for ImaginateToolFsmState {
 					let mut imaginate_inputs: Vec<NodeInput> = imaginate_node_type.inputs.iter().map(|input| input.default.clone()).collect();
 					imaginate_inputs[0] = NodeInput::Node(0);
 
-					let imaginate_node_id = 2;
-					let mut network = NodeNetwork::new_network(32, imaginate_node_id);
+					let imaginate_node_id = 100;
+					let mut network = node_graph::new_image_network(32, imaginate_node_id);
 					network.nodes.insert(
 						imaginate_node_id,
-						DocumentNode {
-							name: imaginate_node_type.name.to_string(),
-							inputs: imaginate_inputs,
-							implementation: imaginate_node_type.generate_implementation(),
-							metadata: graph_craft::document::DocumentNodeMetadata { position: (20, 4).into() },
-						},
+						imaginate_node_type.to_document_node(imaginate_inputs, graph_craft::document::DocumentNodeMetadata::position((20, 4))),
 					);
 
 					responses.push_back(

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -123,7 +123,7 @@ impl Fsm for ImaginateToolFsmState {
 					let imaginate_node_type = IMAGINATE_NODE;
 
 					let mut imaginate_inputs: Vec<NodeInput> = imaginate_node_type.inputs.iter().map(|input| input.default.clone()).collect();
-					imaginate_inputs[0] = NodeInput::Node(0);
+					imaginate_inputs[0] = NodeInput::node(0, 0);
 
 					let imaginate_node_id = 100;
 					let mut network = node_graph::new_image_network(32, imaginate_node_id);

--- a/editor/src/messages/tool/tool_messages/node_graph_frame_tool.rs
+++ b/editor/src/messages/tool/tool_messages/node_graph_frame_tool.rs
@@ -1,6 +1,7 @@
 use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::input_mapper::utility_types::input_keyboard::{Key, MouseMotion};
 use crate::messages::layout::utility_types::layout_widget::PropertyHolder;
+use crate::messages::portfolio::document::node_graph;
 use crate::messages::prelude::*;
 use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::utility_types::{EventToMessageMap, Fsm, ToolActionHandlerData, ToolMetadata, ToolTransition, ToolType};
@@ -117,7 +118,7 @@ impl Fsm for NodeGraphToolFsmState {
 					shape_data.path = Some(document.get_path_for_new_layer());
 					responses.push_back(DocumentMessage::DeselectAllLayers.into());
 
-					let network = graph_craft::document::NodeNetwork::new_network(20, 0);
+					let network = node_graph::new_image_network(20, 0);
 
 					responses.push_back(
 						Operation::AddNodeGraphFrame {

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -1,0 +1,280 @@
+use crate::messages::frontend::utility_types::FrontendImageData;
+use crate::messages::portfolio::document::utility_types::misc::DocumentRenderMode;
+use crate::messages::portfolio::utility_types::PersistentData;
+use crate::messages::prelude::*;
+
+use document_legacy::{document::pick_safe_imaginate_resolution, layers::layer_info::LayerDataType};
+use document_legacy::{LayerId, Operation};
+use graph_craft::document::{generate_uuid, value::TaggedValue, NodeId, NodeInput, NodeNetwork, NodeOutput};
+use graph_craft::executor::Compiler;
+use graphene_core::raster::{Image, ImageFrame};
+use interpreted_executor::executor::DynamicExecutor;
+
+use glam::{DAffine2, DVec2};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, Default)]
+pub struct NodeGraphExecutor {
+	executor: DynamicExecutor,
+}
+
+impl NodeGraphExecutor {
+	/// Sets the transform property on the input node
+	fn set_input_transform(network: &mut NodeNetwork, transform: DAffine2) {
+		let Some(input_node) = network.nodes.get_mut(&network.inputs[0]) else {
+			return;
+		};
+		input_node.inputs[1] = NodeInput::value(TaggedValue::DAffine2(transform), false);
+	}
+
+	/// Execute the network by flattening it and creating a borrow stack. Casts the output to the generic `T`.
+	fn execute_network<T: dyn_any::StaticType>(&mut self, mut network: NodeNetwork, image_frame: ImageFrame) -> Result<T, String> {
+		Self::set_input_transform(&mut network, image_frame.transform);
+		network.duplicate_outputs(&mut generate_uuid);
+		network.remove_dead_nodes();
+
+		// We assume only one output
+		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
+		let c = Compiler {};
+		let proto_network = c.compile_single(network, true)?;
+
+		assert_ne!(proto_network.nodes.len(), 0, "No protonodes exist?");
+		self.executor.update(proto_network);
+
+		use dyn_any::IntoDynAny;
+		use graph_craft::executor::Executor;
+
+		let boxed = self.executor.execute(image_frame.image.into_dyn()).map_err(|e| e.to_string())?;
+
+		dyn_any::downcast::<T>(boxed).map(|v| *v)
+	}
+
+	/// Computes an input for a node in the graph
+	pub fn compute_input<T: dyn_any::StaticType>(&mut self, old_network: &NodeNetwork, node_path: &[NodeId], mut input_index: usize, image_frame: Cow<ImageFrame>) -> Result<T, String> {
+		let mut network = old_network.clone();
+		// Adjust the output of the graph so we find the relevant output
+		'outer: for end in (0..node_path.len()).rev() {
+			let mut inner_network = &mut network;
+			for &node_id in &node_path[..end] {
+				inner_network.outputs[0] = NodeOutput::new(node_id, 0);
+
+				let Some(new_inner) = inner_network.nodes.get_mut(&node_id).and_then(|node| node.implementation.get_network_mut()) else {
+					return Err("Failed to find network".to_string());
+				};
+				inner_network = new_inner;
+			}
+			match &inner_network.nodes.get(&node_path[end]).unwrap().inputs[input_index] {
+				// If the input is from a parent network then adjust the input index and continue iteration
+				NodeInput::Network => {
+					input_index = inner_network
+						.inputs
+						.iter()
+						.enumerate()
+						.filter(|&(_index, &id)| id == node_path[end])
+						.nth(input_index)
+						.ok_or_else(|| "Invalid network input".to_string())?
+						.0;
+				}
+				// If the input is just a value, return that value
+				NodeInput::Value { tagged_value, .. } => return dyn_any::downcast::<T>(tagged_value.clone().to_any()).map(|v| *v),
+				// If the input is from a node, set the node to be the output (so that is what is evaluated)
+				NodeInput::Node { node_id, output_index } => {
+					inner_network.outputs[0] = NodeOutput::new(*node_id, *output_index);
+					break 'outer;
+				}
+			}
+		}
+
+		self.execute_network(network, image_frame.into_owned())
+	}
+
+	/// Encodes an image into a format using the image crate
+	fn encode_img(image: Image, resize: Option<DVec2>, format: image::ImageOutputFormat) -> Result<(Vec<u8>, (u32, u32)), String> {
+		use image::{ImageBuffer, Rgba};
+		use std::io::Cursor;
+
+		let (result_bytes, width, height) = image.as_flat_u8();
+
+		let mut output: ImageBuffer<Rgba<u8>, _> = image::ImageBuffer::from_raw(width, height, result_bytes).ok_or_else(|| "Invalid image size".to_string())?;
+		if let Some(size) = resize {
+			let size = size.as_uvec2();
+			if size.x > 0 && size.y > 0 {
+				output = image::imageops::resize(&output, size.x, size.y, image::imageops::Triangle);
+			}
+		}
+		let size = output.dimensions();
+		let mut image_data: Vec<u8> = Vec::new();
+		output.write_to(&mut Cursor::new(&mut image_data), format).map_err(|e| e.to_string())?;
+		debug!("Returning from encode image");
+		Ok::<_, String>((image_data, size))
+	}
+
+	fn generate_imaginate(
+		&mut self,
+		network: NodeNetwork,
+		imaginate_node: Vec<NodeId>,
+		(document, document_id): (&mut DocumentMessageHandler, u64),
+		layer_path: Vec<LayerId>,
+		image_frame: ImageFrame,
+		(preferences, persistent_data): (&PreferencesMessageHandler, &PersistentData),
+	) -> Result<Message, String> {
+		use crate::messages::portfolio::document::node_graph::IMAGINATE_NODE;
+		use graph_craft::imaginate_input::*;
+
+		let get = |name: &str| IMAGINATE_NODE.inputs.iter().position(|input| input.name == name).unwrap_or_else(|| panic!("Input {name} not found"));
+
+		let transform: DAffine2 = self.compute_input(&network, &imaginate_node, get("Transform"), Cow::Borrowed(&image_frame))?;
+
+		let resolution: Option<glam::DVec2> = self.compute_input(&network, &imaginate_node, get("Resolution"), Cow::Borrowed(&image_frame))?;
+		let resolution = resolution.unwrap_or_else(|| {
+			let (x, y) = pick_safe_imaginate_resolution((transform.transform_vector2(DVec2::new(1., 0.)).length(), transform.transform_vector2(DVec2::new(0., 1.)).length()));
+			DVec2::new(x as f64, y as f64)
+		});
+
+		let parameters = ImaginateGenerationParameters {
+			seed: self.compute_input::<f64>(&network, &imaginate_node, get("Seed"), Cow::Borrowed(&image_frame))? as u64,
+			resolution: resolution.as_uvec2().into(),
+			samples: self.compute_input::<f64>(&network, &imaginate_node, get("Samples"), Cow::Borrowed(&image_frame))? as u32,
+			sampling_method: self
+				.compute_input::<ImaginateSamplingMethod>(&network, &imaginate_node, get("Sampling Method"), Cow::Borrowed(&image_frame))?
+				.api_value()
+				.to_string(),
+			text_guidance: self.compute_input(&network, &imaginate_node, get("Prompt Guidance"), Cow::Borrowed(&image_frame))?,
+			text_prompt: self.compute_input(&network, &imaginate_node, get("Prompt"), Cow::Borrowed(&image_frame))?,
+			negative_prompt: self.compute_input(&network, &imaginate_node, get("Negative Prompt"), Cow::Borrowed(&image_frame))?,
+			image_creativity: Some(self.compute_input::<f64>(&network, &imaginate_node, get("Image Creativity"), Cow::Borrowed(&image_frame))? / 100.),
+			restore_faces: self.compute_input(&network, &imaginate_node, get("Improve Faces"), Cow::Borrowed(&image_frame))?,
+			tiling: self.compute_input(&network, &imaginate_node, get("Tiling"), Cow::Borrowed(&image_frame))?,
+		};
+		let use_base_image = self.compute_input::<bool>(&network, &imaginate_node, get("Adapt Input Image"), Cow::Borrowed(&image_frame))?;
+
+		let base_image = if use_base_image {
+			let image: Image = self.compute_input(&network, &imaginate_node, get("Input Image"), Cow::Borrowed(&image_frame))?;
+			// Only use if has size
+			if image.width > 0 && image.height > 0 {
+				debug!("Start image encode");
+				let (image_data, size) = Self::encode_img(image, Some(resolution), image::ImageOutputFormat::Png)?;
+				debug!("End image encode");
+				let size = DVec2::new(size.0 as f64, size.1 as f64);
+				let mime = "image/png".to_string();
+				Some(ImaginateBaseImage { image_data, size, mime })
+			} else {
+				None
+			}
+		} else {
+			None
+		};
+
+		let mask_image = if base_image.is_some() {
+			let mask_path: Option<Vec<LayerId>> = self.compute_input(&network, &imaginate_node, get("Masking Layer"), Cow::Borrowed(&image_frame))?;
+
+			// Calculate the size of the node graph frame
+			let size = DVec2::new(transform.transform_vector2(DVec2::new(1., 0.)).length(), transform.transform_vector2(DVec2::new(0., 1.)).length());
+
+			// Render the masking layer within the node graph frame
+			let old_transforms = document.remove_document_transform();
+			let mask_is_some = mask_path.is_some();
+			let mask_image = mask_path.filter(|mask_layer_path| document.document_legacy.layer(mask_layer_path).is_ok()).map(|mask_layer_path| {
+				let render_mode = DocumentRenderMode::LayerCutout(&mask_layer_path, graphene_core::raster::color::Color::WHITE);
+				let svg = document.render_document(size, transform.inverse(), persistent_data, render_mode);
+
+				ImaginateMaskImage { svg, size }
+			});
+
+			if mask_is_some && mask_image.is_none() {
+				return Err(
+					"Imagination masking layer is missing.\nIt may have been deleted or moved. Please drag a new layer reference\ninto the 'Masking Layer' parameter input, then generate again."
+						.to_string(),
+				);
+			}
+
+			document.restore_document_transform(old_transforms);
+			mask_image
+		} else {
+			None
+		};
+
+		Ok(FrontendMessage::TriggerImaginateGenerate {
+			parameters: Box::new(parameters),
+			base_image: base_image.map(Box::new),
+			mask_image: mask_image.map(Box::new),
+			mask_paint_mode: if self.compute_input::<bool>(&network, &imaginate_node, get("Inpaint"), Cow::Borrowed(&image_frame))? {
+				ImaginateMaskPaintMode::Inpaint
+			} else {
+				ImaginateMaskPaintMode::Outpaint
+			},
+			mask_blur_px: self.compute_input::<f64>(&network, &imaginate_node, get("Mask Blur"), Cow::Borrowed(&image_frame))? as u32,
+			imaginate_mask_starting_fill: self.compute_input(&network, &imaginate_node, get("Mask Starting Fill"), Cow::Borrowed(&image_frame))?,
+			hostname: preferences.imaginate_server_hostname.clone(),
+			refresh_frequency: preferences.imaginate_refresh_frequency,
+			document_id,
+			layer_path,
+			node_path: imaginate_node,
+		}
+		.into())
+	}
+
+	/// Evaluates a node graph, computing either the imaginate node or the entire graph
+	pub fn evaluate_node_graph(
+		&mut self,
+		(document_id, documents): (u64, &mut HashMap<u64, DocumentMessageHandler>),
+		layer_path: Vec<LayerId>,
+		(image_data, (width, height)): (Vec<u8>, (u32, u32)),
+		imaginate_node: Option<Vec<NodeId>>,
+		persistent_data: (&PreferencesMessageHandler, &PersistentData),
+		responses: &mut VecDeque<Message>,
+	) -> Result<(), String> {
+		// Reformat the input image data into an f32 image
+		let image = graphene_core::raster::Image::from_image_data(&image_data, width, height);
+
+		// Get the node graph layer
+		let document = documents.get_mut(&document_id).ok_or_else(|| "Invalid document".to_string())?;
+		let layer = document.document_legacy.layer(&layer_path).map_err(|e| format!("No layer: {e:?}"))?;
+
+		// Construct the input image frame
+		let transform = layer.transform;
+		let image_frame = ImageFrame { image, transform };
+
+		let node_graph_frame = match &layer.data {
+			LayerDataType::NodeGraphFrame(frame) => Ok(frame),
+			_ => Err("Invalid layer type".to_string()),
+		}?;
+		let network = node_graph_frame.network.clone();
+
+		// Execute the node graph
+		if let Some(imaginate_node) = imaginate_node {
+			responses.push_back(self.generate_imaginate(network, imaginate_node, (document, document_id), layer_path, image_frame, persistent_data)?);
+		} else {
+			let ImageFrame { mut image, transform } = self.execute_network(network, image_frame)?;
+
+			// If no image was generated, use the input image
+			if image.width == 0 || image.height == 0 {
+				image = graphene_core::raster::Image::from_image_data(&image_data, width, height);
+			}
+
+			let (image_data, _size) = Self::encode_img(image, None, image::ImageOutputFormat::Bmp)?;
+
+			responses.push_back(
+				Operation::SetNodeGraphFrameImageData {
+					layer_path: layer_path.clone(),
+					image_data: image_data.clone(),
+				}
+				.into(),
+			);
+			let mime = "image/bmp".to_string();
+			let image_data = std::sync::Arc::new(image_data);
+			let image_data = vec![FrontendImageData {
+				path: layer_path.clone(),
+				image_data,
+				mime,
+			}];
+			responses.push_back(FrontendMessage::UpdateImageData { document_id, image_data }.into());
+
+			// Update the transform based on the graph output
+			let transform = transform.to_cols_array();
+			responses.push_back(Operation::SetLayerTransform { path: layer_path, transform }.into());
+		}
+
+		Ok(())
+	}
+}

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -105,7 +105,6 @@ impl NodeGraphExecutor {
 		let size = output.dimensions();
 		let mut image_data: Vec<u8> = Vec::new();
 		output.write_to(&mut Cursor::new(&mut image_data), format).map_err(|e| e.to_string())?;
-		debug!("Returning from encode image");
 		Ok::<_, String>((image_data, size))
 	}
 
@@ -152,9 +151,7 @@ impl NodeGraphExecutor {
 			let image: Image = self.compute_input(&network, &imaginate_node, get("Input Image"), Cow::Borrowed(&image_frame))?;
 			// Only use if has size
 			if image.width > 0 && image.height > 0 {
-				debug!("Start image encode");
 				let (image_data, size) = Self::encode_img(image, Some(resolution), image::ImageOutputFormat::Png)?;
-				debug!("End image encode");
 				let size = DVec2::new(size.0 as f64, size.1 as f64);
 				let mime = "image/png".to_string();
 				Some(ImaginateBaseImage { image_data, size, mime })

--- a/frontend-svelte/src/wasm-communication/messages.ts
+++ b/frontend-svelte/src/wasm-communication/messages.ts
@@ -83,6 +83,12 @@ export class NodeGraphInput {
 	readonly name!: string;
 }
 
+export class NodeGraphOutput {
+	readonly dataType!: FrontendGraphDataType;
+
+	readonly name!: string;
+}
+
 export class FrontendNode {
 	readonly id!: bigint;
 
@@ -92,18 +98,20 @@ export class FrontendNode {
 
 	readonly exposedInputs!: NodeGraphInput[];
 
-	readonly outputs!: FrontendGraphDataType[];
+	readonly outputs!: NodeGraphOutput[];
 
 	@TupleToVec2
 	readonly position!: XY | undefined;
 
-	readonly output!: boolean;
+	readonly previewed!: boolean;
 
 	readonly disabled!: boolean;
 }
 
 export class FrontendNodeLink {
 	readonly linkStart!: bigint;
+
+	readonly linkStartOutputIndex!: bigint;
 
 	readonly linkEnd!: bigint;
 

--- a/frontend-svelte/wasm/src/editor_api.rs
+++ b/frontend-svelte/wasm/src/editor_api.rs
@@ -578,9 +578,10 @@ impl JsEditorHandle {
 
 	/// Notifies the backend that the user connected a node's primary output to one of another node's inputs
 	#[wasm_bindgen(js_name = connectNodesByLink)]
-	pub fn connect_nodes_by_link(&self, output_node: u64, input_node: u64, input_node_connector_index: usize) {
+	pub fn connect_nodes_by_link(&self, output_node: u64, output_node_connector_index: usize, input_node: u64, input_node_connector_index: usize) {
 		let message = NodeGraphMessage::ConnectNodesByLink {
 			output_node,
+			output_node_connector_index,
 			input_node,
 			input_node_connector_index,
 		};

--- a/frontend/src/components/panels/NodeGraph.vue
+++ b/frontend/src/components/panels/NodeGraph.vue
@@ -67,19 +67,33 @@
 						<IconLabel :icon="nodeIcon(node.displayName)" />
 						<TextLabel>{{ node.displayName }}</TextLabel>
 					</div>
-					<div v-if="node.exposedInputs.length > 0" class="arguments">
-						<div v-for="(argument, index) in node.exposedInputs" :key="index" class="argument">
+					<div v-if="node.exposedInputs.length > 0 || node.outputs.length > 1" class="arguments">
+						<!-- Note here index is inclusive and starts with an initial value of 1 instead of 0. (probably just to be inconsistant with the rest of the world) -->
+						<div v-for="index in Math.max(node.exposedInputs.length, node.outputs.length - 1)" :key="index" class="argument">
 							<div class="ports">
 								<div
+									v-if="node.exposedInputs.length >= index"
 									class="input port"
 									data-port="input"
-									:data-datatype="argument.dataType"
-									:style="{ '--data-color': `var(--color-data-${argument.dataType})`, '--data-color-dim': `var(--color-data-${argument.dataType}-dim)` }"
+									:data-datatype="node.exposedInputs[index - 1].dataType"
+									:style="{
+										'--data-color': `var(--color-data-${node.exposedInputs[index - 1].dataType})`,
+										'--data-color-dim': `var(--color-data-${node.exposedInputs[index - 1].dataType}-dim)`,
+									}"
+								>
+									<div></div>
+								</div>
+								<div
+									v-if="node.outputs.length >= index + 1"
+									class="output port"
+									data-port="output"
+									:data-datatype="node.outputs[index]"
+									:style="{ '--data-color': `var(--color-data-${node.outputs[index]})`, '--data-color-dim': `var(--color-data-${node.outputs[index]}-dim)` }"
 								>
 									<div></div>
 								</div>
 							</div>
-							<TextLabel>{{ argument.name }}</TextLabel>
+							<TextLabel v-if="node.exposedInputs.length >= index">{{ node.exposedInputs[index - 1].name }}</TextLabel>
 						</div>
 					</div>
 				</div>

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -83,6 +83,12 @@ export class NodeGraphInput {
 	readonly name!: string;
 }
 
+export class NodeGraphOutput {
+	readonly dataType!: FrontendGraphDataType;
+
+	readonly name!: string;
+}
+
 export class FrontendNode {
 	readonly id!: bigint;
 
@@ -92,12 +98,12 @@ export class FrontendNode {
 
 	readonly exposedInputs!: NodeGraphInput[];
 
-	readonly outputs!: FrontendGraphDataType[];
+	readonly outputs!: NodeGraphOutput[];
 
 	@TupleToVec2
 	readonly position!: XY | undefined;
 
-	readonly output!: boolean;
+	readonly previewed!: boolean;
 
 	readonly disabled!: boolean;
 }

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -105,6 +105,8 @@ export class FrontendNode {
 export class FrontendNodeLink {
 	readonly linkStart!: bigint;
 
+	readonly linkStartOutputIndex!: bigint;
+
 	readonly linkEnd!: bigint;
 
 	readonly linkEndInputIndex!: bigint;

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -578,9 +578,10 @@ impl JsEditorHandle {
 
 	/// Notifies the backend that the user connected a node's primary output to one of another node's inputs
 	#[wasm_bindgen(js_name = connectNodesByLink)]
-	pub fn connect_nodes_by_link(&self, output_node: u64, input_node: u64, input_node_connector_index: usize) {
+	pub fn connect_nodes_by_link(&self, output_node: u64, output_node_connector_index: usize, input_node: u64, input_node_connector_index: usize) {
 		let message = NodeGraphMessage::ConnectNodesByLink {
 			output_node,
+			output_node_connector_index,
 			input_node,
 			input_node_connector_index,
 		};

--- a/node-graph/compilation-client/src/main.rs
+++ b/node-graph/compilation-client/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
 
 	let network = NodeNetwork {
 		inputs: vec![0],
-		outputs: vec![0],
+		outputs: vec![NodeOutput::new(0, 0)],
 		disabled: vec![],
 		previous_outputs: None,
 		nodes: [(
@@ -39,7 +39,7 @@ fn main() {
 fn add_network() -> NodeNetwork {
 	NodeNetwork {
 		inputs: vec![0, 0],
-		outputs: vec![1],
+		outputs: vec![NodeOutput::new(1, 0)],
 		disabled: vec![],
 		previous_outputs: None,
 		nodes: [
@@ -56,7 +56,7 @@ fn add_network() -> NodeNetwork {
 				1,
 				DocumentNode {
 					name: "Add".into(),
-					inputs: vec![NodeInput::Node(0)],
+					inputs: vec![NodeInput::node(0, 0)],
 					metadata: DocumentNodeMetadata::default(),
 					implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::AddNode", &[generic!("T"), generic!("U")])),
 				},

--- a/node-graph/compilation-client/src/main.rs
+++ b/node-graph/compilation-client/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
 
 	let network = NodeNetwork {
 		inputs: vec![0],
-		output: 0,
+		outputs: vec![0],
 		disabled: vec![],
-		previous_output: None,
+		previous_outputs: None,
 		nodes: [(
 			0,
 			DocumentNode {
@@ -39,9 +39,9 @@ fn main() {
 fn add_network() -> NodeNetwork {
 	NodeNetwork {
 		inputs: vec![0, 0],
-		output: 1,
+		outputs: vec![1],
 		disabled: vec![],
-		previous_output: None,
+		previous_outputs: None,
 		nodes: [
 			(
 				0,

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 std = ["dyn-any", "dyn-any/std"]
-default = ["async", "serde", "kurbo", "log"]
+default = ["async", "serde", "kurbo", "log", "std"]
 log = ["dep:log"]
 serde = ["dep:serde", "glam/serde"]
 gpu = ["spirv-std", "bytemuck", "glam/bytemuck", "dyn-any"]

--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -275,7 +275,6 @@ mod test {
 	pub fn map_result() {
 		let value: ClonedNode<Result<&u32, ()>> = ClonedNode(Ok(&4u32));
 		assert_eq!(value.eval(()), Ok(&4u32));
-		static clone: &CloneNode<u32> = &CloneNode::new();
 		//let type_erased_clone = clone as &dyn for<'a> Node<'a, &'a u32, Output = u32>;
 		let map_result = MapResultNode::new(ValueNode::new(FnNode::new(|x: &u32| x.clone())));
 		//et type_erased = &map_result as &dyn for<'a> Node<'a, Result<&'a u32, ()>, Output = Result<u32, ()>>;

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -364,6 +364,8 @@ mod image {
 			data,
 		}
 	}
+
+	#[derive(Clone, Debug, PartialEq, DynAny, Default)]
 	pub struct ImageFrame {
 		pub image: Image,
 		pub transform: DAffine2,

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -323,7 +323,7 @@ mod image {
 			Image { width, height, data }
 		}
 
-		/// Flattens each channel casted to a u8
+		/// Flattens each channel cast to a u8
 		pub fn as_flat_u8(self) -> (Vec<u8>, u32, u32) {
 			let Image { width, height, data } = self;
 

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -327,9 +327,7 @@ mod image {
 		pub fn as_flat_u8(self) -> (Vec<u8>, u32, u32) {
 			let Image { width, height, data } = self;
 
-			info!("Data {data:?}");
 			let result_bytes = data.into_iter().flat_map(|color| color.to_rgba8()).collect();
-			info!("result_bytes {result_bytes:?}");
 
 			(result_bytes, width, height)
 		}

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -285,13 +285,14 @@ fn dimensions_node(input: ImageSlice<'input>) -> (u32, u32) {
 }
 
 #[cfg(feature = "alloc")]
-pub use image::{CollectNode, Image, ImageRefNode, MapImageSliceNode};
+pub use image::{CollectNode, Image, ImageFrame, ImageRefNode, MapImageSliceNode};
 #[cfg(feature = "alloc")]
 mod image {
 	use super::{Color, ImageSlice};
 	use crate::Node;
 	use alloc::vec::Vec;
 	use dyn_any::{DynAny, StaticType};
+	use glam::DAffine2;
 
 	#[derive(Clone, Debug, PartialEq, DynAny, Default, specta::Type, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -362,6 +363,10 @@ mod image {
 			height: input.1,
 			data,
 		}
+	}
+	pub struct ImageFrame {
+		pub image: Image,
+		pub transform: DAffine2,
 	}
 }
 

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -322,6 +322,17 @@ mod image {
 			let data = image_data.chunks_exact(4).map(|v| Color::from_rgba8(v[0], v[1], v[2], v[3])).collect();
 			Image { width, height, data }
 		}
+
+		/// Flattens each channel casted to a u8
+		pub fn as_flat_u8(self) -> (Vec<u8>, u32, u32) {
+			let Image { width, height, data } = self;
+
+			info!("Data {data:?}");
+			let result_bytes = data.into_iter().flat_map(|color| color.to_rgba8()).collect();
+			info!("result_bytes {result_bytes:?}");
+
+			(result_bytes, width, height)
+		}
 	}
 
 	impl IntoIterator for Image {

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -9,6 +9,7 @@ use rand_chacha::{
 	ChaCha20Rng,
 };
 use std::collections::{HashMap, HashSet};
+use std::net;
 use std::sync::Mutex;
 
 pub mod value;
@@ -54,7 +55,7 @@ pub struct DocumentNode {
 }
 
 impl DocumentNode {
-	pub fn populate_first_network_input(&mut self, node: NodeId, offset: usize) {
+	pub fn populate_first_network_input(&mut self, node_id: NodeId, output_index: usize, offset: usize) {
 		let input = self
 			.inputs
 			.iter()
@@ -64,7 +65,7 @@ impl DocumentNode {
 			.expect("no network input");
 
 		let index = input.0;
-		self.inputs[index] = NodeInput::Node(node);
+		self.inputs[index] = NodeInput::Node { node_id, output_index };
 	}
 
 	fn resolve_proto_node(mut self) -> ProtoNode {
@@ -76,7 +77,10 @@ impl DocumentNode {
 					assert_eq!(self.inputs.len(), 0);
 					(ProtoNodeInput::None, ConstructionArgs::Value(tagged_value))
 				}
-				NodeInput::Node(id) => (ProtoNodeInput::Node(id), ConstructionArgs::Nodes(vec![])),
+				NodeInput::Node { node_id, output_index } => {
+					assert_eq!(output_index, 0, "Outputs should be flattened before converting to protonode.");
+					(ProtoNodeInput::Node(node_id), ConstructionArgs::Nodes(vec![]))
+				}
 				NodeInput::Network => (ProtoNodeInput::Network, ConstructionArgs::Nodes(vec![])),
 			};
 			assert!(!self.inputs.iter().any(|input| matches!(input, NodeInput::Network)), "recieved non resolved parameter");
@@ -89,7 +93,7 @@ impl DocumentNode {
 
 			if let ConstructionArgs::Nodes(nodes) = &mut args {
 				nodes.extend(self.inputs.iter().map(|input| match input {
-					NodeInput::Node(id) => *id,
+					NodeInput::Node { node_id, .. } => *node_id,
 					_ => unreachable!(),
 				}));
 			}
@@ -111,11 +115,11 @@ impl DocumentNode {
 		P: Fn(String, usize) -> Option<NodeInput>,
 	{
 		for (index, input) in self.inputs.iter_mut().enumerate() {
-			let &mut NodeInput::Node(id) = input else {
+			let &mut NodeInput::Node{node_id: id, output_index} = input else {
 				continue;
 			};
 			if let Some(&new_id) = new_ids.get(&id) {
-				*input = NodeInput::Node(new_id);
+				*input = NodeInput::Node { node_id: new_id, output_index };
 			} else if let Some(new_input) = default_input(self.name.clone(), index) {
 				*input = new_input;
 			} else {
@@ -129,23 +133,26 @@ impl DocumentNode {
 #[derive(Clone, Debug, specta::Type)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NodeInput {
-	Node(NodeId),
+	Node { node_id: NodeId, output_index: usize },
 	Value { tagged_value: value::TaggedValue, exposed: bool },
 	Network,
 }
 
 impl NodeInput {
+	pub const fn node(node_id: NodeId, output_index: usize) -> Self {
+		Self::Node { node_id, output_index }
+	}
 	pub const fn value(tagged_value: value::TaggedValue, exposed: bool) -> Self {
 		Self::Value { tagged_value, exposed }
 	}
 	fn map_ids(&mut self, f: impl Fn(NodeId) -> NodeId) {
-		if let NodeInput::Node(id) = self {
-			*self = NodeInput::Node(f(*id))
+		if let &mut NodeInput::Node { node_id, output_index } = self {
+			*self = NodeInput::Node { node_id: f(node_id), output_index }
 		}
 	}
 	pub fn is_exposed(&self) -> bool {
 		match self {
-			NodeInput::Node(_) => true,
+			NodeInput::Node { .. } => true,
 			NodeInput::Value { exposed, .. } => *exposed,
 			NodeInput::Network => false,
 		}
@@ -155,7 +162,7 @@ impl NodeInput {
 impl PartialEq for NodeInput {
 	fn eq(&self, other: &Self) -> bool {
 		match (&self, &other) {
-			(Self::Node(n1), Self::Node(n2)) => n1 == n2,
+			(Self::Node { node_id: n0, output_index: o0 }, Self::Node { node_id: n1, output_index: o1 }) => n0 == n1 && o0 == o1,
 			(Self::Value { tagged_value: v1, .. }, Self::Value { tagged_value: v2, .. }) => v1 == v2,
 			_ => core::mem::discriminant(self) == core::mem::discriminant(other),
 		}
@@ -187,24 +194,38 @@ impl DocumentNodeImplementation {
 	}
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, DynAny, specta::Type)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NodeOutput {
+	pub node_id: NodeId,
+	pub node_output_index: usize,
+}
+impl NodeOutput {
+	pub fn new(node_id: NodeId, node_output_index: usize) -> Self {
+		Self { node_id, node_output_index }
+	}
+}
+
 #[derive(Clone, Debug, Default, PartialEq, DynAny, specta::Type)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeNetwork {
 	pub inputs: Vec<NodeId>,
-	pub outputs: Vec<NodeId>,
+	pub outputs: Vec<NodeOutput>,
 	pub nodes: HashMap<NodeId, DocumentNode>,
 	/// These nodes are replaced with identity nodes when flattening
 	pub disabled: Vec<NodeId>,
 	/// In the case where a new node is chosen as output - what was the origional
-	pub previous_outputs: Option<Vec<NodeId>>,
+	pub previous_outputs: Option<Vec<NodeOutput>>,
 }
 
 impl NodeNetwork {
 	pub fn map_ids(&mut self, f: impl Fn(NodeId) -> NodeId + Copy) {
 		self.inputs.iter_mut().for_each(|id| *id = f(*id));
-		self.outputs.iter_mut().for_each(|id| *id = f(*id));
+		self.outputs.iter_mut().for_each(|output| output.node_id = f(output.node_id));
 		self.disabled.iter_mut().for_each(|id| *id = f(*id));
-		self.previous_outputs.iter_mut().for_each(|nodes| nodes.iter_mut().for_each(|id| *id = f(*id)));
+		self.previous_outputs
+			.iter_mut()
+			.for_each(|nodes| nodes.iter_mut().for_each(|output| output.node_id = f(output.node_id)));
 		let mut empty = HashMap::new();
 		std::mem::swap(&mut self.nodes, &mut empty);
 		self.nodes = empty
@@ -221,12 +242,102 @@ impl NodeNetwork {
 		let mut outwards_links: HashMap<u64, Vec<u64>> = HashMap::new();
 		for (node_id, node) in &self.nodes {
 			for input in &node.inputs {
-				if let NodeInput::Node(ref_id) = input {
+				if let NodeInput::Node { node_id: ref_id, .. } = input {
 					outwards_links.entry(*ref_id).or_default().push(*node_id)
 				}
 			}
 		}
 		outwards_links
+	}
+
+	/// When a node has multiple outputs, we actually just duplicate the node and evaluate each output seperatly
+	pub fn duplicate_outputs(&mut self, mut gen_id: &mut impl FnMut() -> NodeId) {
+		let mut duplicating_nodes = HashMap::new();
+		// Find the nodes where the inputs require duplicating
+		for node in &mut self.nodes.values_mut() {
+			// Recursivly duplicate children
+			if let DocumentNodeImplementation::Network(network) = &mut node.implementation {
+				network.duplicate_outputs(gen_id);
+			}
+
+			for input in &mut node.inputs {
+				let &mut NodeInput::Node { node_id, output_index}= input else {
+					continue;
+				};
+				// Use the initial node when getting the first output
+				if output_index == 0 {
+					continue;
+				}
+				// Get the existing duplicated node id (or create a new one)
+				let duplicated_node_id = *duplicating_nodes.entry((node_id, output_index)).or_insert_with(&mut gen_id);
+				// Use the first output from the duplicated node
+				*input = NodeInput::node(duplicated_node_id, 0);
+			}
+		}
+		// Find the network outputs that require duplicating
+		for network_output in &mut self.outputs {
+			// Use the initial node when getting the first output
+			if network_output.node_output_index == 0 {
+				continue;
+			}
+			// Get the existing duplicated node id (or create a new one)
+			let duplicated_node_id = *duplicating_nodes.entry((network_output.node_id, network_output.node_output_index)).or_insert_with(&mut gen_id);
+			// Use the first output from the duplicated node
+			*network_output = NodeOutput::new(duplicated_node_id, 0);
+		}
+		// Duplicate the nodes
+		for ((origional_node_id, output_index), new_node_id) in duplicating_nodes {
+			let Some(origional_node) = self.nodes.get(&origional_node_id) else {
+				continue;
+			};
+			let mut new_node = origional_node.clone();
+			// Update the required outputs from a nested network to be just the relevant output
+			if let DocumentNodeImplementation::Network(network) = &mut new_node.implementation {
+				network.outputs = vec![network.outputs[output_index]];
+			}
+			self.nodes.insert(new_node_id, new_node);
+		}
+
+		// Ensure all nodes only have one output
+		for node in self.nodes.values_mut() {
+			if let DocumentNodeImplementation::Network(network) = &mut node.implementation {
+				network.outputs = vec![network.outputs[0]];
+			}
+		}
+	}
+
+	/// Removes unused nodes from the graph. Returns a list of bools which represent if each of the inputs have been retained
+	pub fn remove_dead_nodes(&mut self) -> Vec<bool> {
+		// Take all the nodes out of the nodes list
+		let mut old_nodes = std::mem::take(&mut self.nodes);
+		let mut stack = self.outputs.iter().map(|output| output.node_id).collect::<Vec<_>>();
+		while let Some(node_id) = stack.pop() {
+			let Some((node_id, mut document_node)) = old_nodes.remove_entry(&node_id) else {
+				continue;
+			};
+			// Remove dead nodes from child networks
+			if let DocumentNodeImplementation::Network(network) = &mut document_node.implementation {
+				// Remove inputs to the parent node if they have been removed from the child
+				let mut retain_inputs = network.remove_dead_nodes().into_iter();
+				document_node.inputs.retain(|_| retain_inputs.next().unwrap())
+			}
+			// Visit all nodes that this node references
+			stack.extend(
+				document_node
+					.inputs
+					.iter()
+					.filter_map(|input| if let NodeInput::Node { node_id, .. } = input { Some(node_id) } else { None }),
+			);
+			// Add the node back to the list of nodes
+			self.nodes.insert(node_id, document_node);
+		}
+
+		// Check if inputs are used and store for return value
+		let are_inputs_used = self.inputs.iter().map(|input| self.nodes.contains_key(input)).collect();
+		// Remove unused inputs from graph
+		self.inputs.retain(|input| self.nodes.contains_key(input));
+
+		are_inputs_used
 	}
 
 	pub fn flatten(&mut self, node: NodeId) {
@@ -260,9 +371,9 @@ impl NodeNetwork {
 				for (document_input, network_input) in node.inputs.into_iter().zip(inner_network.inputs.iter()) {
 					let offset = network_offsets.entry(network_input).or_insert(0);
 					match document_input {
-						NodeInput::Node(node) => {
+						NodeInput::Node { node_id, output_index } => {
 							let network_input = self.nodes.get_mut(network_input).unwrap();
-							network_input.populate_first_network_input(node, *offset);
+							network_input.populate_first_network_input(node_id, output_index, *offset);
 						}
 						NodeInput::Value { tagged_value, exposed } => {
 							// Skip formatting very large values for seconds in performance speedup
@@ -284,7 +395,7 @@ impl NodeNetwork {
 							assert!(!self.nodes.contains_key(&new_id));
 							self.nodes.insert(new_id, value_node);
 							let network_input = self.nodes.get_mut(network_input).unwrap();
-							network_input.populate_first_network_input(new_id, *offset);
+							network_input.populate_first_network_input(new_id, 0, *offset);
 						}
 						NodeInput::Network => {
 							*network_offsets.get_mut(network_input).unwrap() += 1;
@@ -295,7 +406,14 @@ impl NodeNetwork {
 					}
 				}
 				node.implementation = DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")]));
-				node.inputs = inner_network.outputs.iter().map(|&id| NodeInput::Node(id)).collect();
+				node.inputs = inner_network
+					.outputs
+					.iter()
+					.map(|&NodeOutput { node_id, node_output_index }| NodeInput::Node {
+						node_id,
+						output_index: node_output_index,
+					})
+					.collect();
 				for node_id in new_nodes {
 					self.flatten_with_fns(node_id, map_ids, gen_id);
 				}
@@ -311,15 +429,15 @@ impl NodeNetwork {
 		nodes.sort_unstable_by_key(|(i, _)| *i);
 
 		// Create a network to evaluate each output
-		self.outputs.into_iter().map(move |output_id| ProtoNetwork {
+		self.outputs.into_iter().map(move |output| ProtoNetwork {
 			inputs: self.inputs.clone(),
-			output: output_id,
+			output: output.node_id,
 			nodes: nodes.clone(),
 		})
 	}
 
 	/// Get the original output nodes of this network, ignoring any preview node
-	pub fn original_outputs(&self) -> &Vec<NodeId> {
+	pub fn original_outputs(&self) -> &Vec<NodeOutput> {
 		self.previous_outputs.as_ref().unwrap_or(&self.outputs)
 	}
 
@@ -327,7 +445,7 @@ impl NodeNetwork {
 	pub fn new_network(output_offset: i32, output_node_id: NodeId) -> Self {
 		Self {
 			inputs: vec![0],
-			outputs: vec![1],
+			outputs: vec![NodeOutput::new(1, 0)],
 			nodes: [
 				(
 					0,
@@ -342,7 +460,7 @@ impl NodeNetwork {
 					1,
 					DocumentNode {
 						name: "Output".into(),
-						inputs: vec![NodeInput::Node(output_node_id)],
+						inputs: vec![NodeInput::node(output_node_id, 0)],
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
 						metadata: DocumentNodeMetadata { position: (output_offset, 4).into() },
 					},
@@ -375,27 +493,27 @@ impl NodeNetwork {
 	}
 
 	/// Check if the specified node id is connected to the output
-	pub fn connected_to_output(&self, node_id: NodeId) -> bool {
+	pub fn connected_to_output(&self, target_node_id: NodeId) -> bool {
 		// If the node is the output then return true
-		if self.outputs.contains(&node_id) {
+		if self.outputs.iter().any(|&NodeOutput { node_id, .. }| node_id == target_node_id) {
 			return true;
 		}
 		// Get the outputs
-		let Some(mut stack) = self.outputs.iter().map(|&output| self.nodes.get(&output)).collect::<Option<Vec<_>>>() else {
+		let Some(mut stack) = self.outputs.iter().map(|&output| self.nodes.get(&output.node_id)).collect::<Option<Vec<_>>>() else {
 			return false;
 		};
 		let mut already_visited = HashSet::new();
-		already_visited.extend(self.outputs.iter());
+		already_visited.extend(self.outputs.iter().map(|output| output.node_id));
 
 		while let Some(node) = stack.pop() {
 			for input in &node.inputs {
-				if let &NodeInput::Node(ref_id) = input {
+				if let &NodeInput::Node { node_id: ref_id, .. } = input {
 					// Skip if already viewed
 					if already_visited.contains(&ref_id) {
 						continue;
 					}
 					// If the target node is used as input then return true
-					if ref_id == node_id {
+					if ref_id == target_node_id {
 						return true;
 					}
 					// Add the referenced node to the stack
@@ -409,6 +527,21 @@ impl NodeNetwork {
 		}
 
 		false
+	}
+
+	/// Is the node being used directly as an output?
+	pub fn outputs_contains(&self, node_id: NodeId) -> bool {
+		self.outputs.iter().any(|output| output.node_id == node_id)
+	}
+
+	/// Is the node being used directly as an origional output?
+	pub fn origional_outputs_contains(&self, node_id: NodeId) -> bool {
+		self.original_outputs().iter().any(|output| output.node_id == node_id)
+	}
+
+	/// Is the node being used directly as a previous output?
+	pub fn previous_outputs_contains(&self, node_id: NodeId) -> bool {
+		self.previous_outputs.as_ref().map_or(false, |outputs| outputs.iter().any(|output| output.node_id == node_id))
 	}
 }
 
@@ -428,7 +561,7 @@ mod test {
 	fn add_network() -> NodeNetwork {
 		NodeNetwork {
 			inputs: vec![0, 0],
-			outputs: vec![1],
+			outputs: vec![NodeOutput::new(1, 0)],
 			nodes: [
 				(
 					0,
@@ -443,7 +576,7 @@ mod test {
 					1,
 					DocumentNode {
 						name: "Add".into(),
-						inputs: vec![NodeInput::Node(0)],
+						inputs: vec![NodeInput::node(0, 0)],
 						metadata: DocumentNodeMetadata::default(),
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::AddNode", &[generic!("T"), generic!("U")])),
 					},
@@ -461,7 +594,7 @@ mod test {
 		network.map_ids(|id| id + 1);
 		let maped_add = NodeNetwork {
 			inputs: vec![1, 1],
-			outputs: vec![2],
+			outputs: vec![NodeOutput::new(2, 0)],
 			nodes: [
 				(
 					1,
@@ -476,7 +609,7 @@ mod test {
 					2,
 					DocumentNode {
 						name: "Add".into(),
-						inputs: vec![NodeInput::Node(1)],
+						inputs: vec![NodeInput::node(1, 0)],
 						metadata: DocumentNodeMetadata::default(),
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::AddNode", &[generic!("T"), generic!("U")])),
 					},
@@ -493,7 +626,7 @@ mod test {
 	fn flatten_add() {
 		let mut network = NodeNetwork {
 			inputs: vec![1],
-			outputs: vec![1],
+			outputs: vec![NodeOutput::new(1, 0)],
 			nodes: [(
 				1,
 				DocumentNode {
@@ -525,7 +658,7 @@ mod test {
 	fn resolve_proto_node_add() {
 		let document_node = DocumentNode {
 			name: "Cons".into(),
-			inputs: vec![NodeInput::Network, NodeInput::Node(0)],
+			inputs: vec![NodeInput::Network, NodeInput::node(0, 0)],
 			metadata: DocumentNodeMetadata::default(),
 			implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::structural::ConsNode", &[generic!("T"), generic!("U")])),
 		};
@@ -585,13 +718,13 @@ mod test {
 	fn flat_network() -> NodeNetwork {
 		NodeNetwork {
 			inputs: vec![10],
-			outputs: vec![1],
+			outputs: vec![NodeOutput::new(1, 0)],
 			nodes: [
 				(
 					1,
 					DocumentNode {
 						name: "Inc".into(),
-						inputs: vec![NodeInput::Node(11)],
+						inputs: vec![NodeInput::node(11, 0)],
 						metadata: DocumentNodeMetadata::default(),
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
 					},
@@ -600,7 +733,7 @@ mod test {
 					10,
 					DocumentNode {
 						name: "Cons".into(),
-						inputs: vec![NodeInput::Network, NodeInput::Node(14)],
+						inputs: vec![NodeInput::Network, NodeInput::node(14, 0)],
 						metadata: DocumentNodeMetadata::default(),
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::structural::ConsNode", &[generic!("T"), generic!("U")])),
 					},
@@ -621,7 +754,7 @@ mod test {
 					11,
 					DocumentNode {
 						name: "Add".into(),
-						inputs: vec![NodeInput::Node(10)],
+						inputs: vec![NodeInput::node(10, 0)],
 						metadata: DocumentNodeMetadata::default(),
 						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::AddNode", &[generic!("T"), generic!("U")])),
 					},
@@ -631,5 +764,122 @@ mod test {
 			.collect(),
 			..Default::default()
 		}
+	}
+
+	fn two_node_identity() -> NodeNetwork {
+		NodeNetwork {
+			inputs: vec![1, 2],
+			outputs: vec![NodeOutput::new(1, 0), NodeOutput::new(2, 0)],
+			nodes: [
+				(
+					1,
+					DocumentNode {
+						name: "Identity 1".into(),
+						inputs: vec![NodeInput::Network],
+						metadata: DocumentNodeMetadata::default(),
+						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
+					},
+				),
+				(
+					2,
+					DocumentNode {
+						name: "Identity 2".into(),
+						inputs: vec![NodeInput::Network],
+						metadata: DocumentNodeMetadata::default(),
+						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
+					},
+				),
+			]
+			.into_iter()
+			.collect(),
+			..Default::default()
+		}
+	}
+
+	fn output_duplicate(network_outputs: Vec<NodeOutput>, result_node_input: NodeInput) -> NodeNetwork {
+		let mut network = NodeNetwork {
+			inputs: Vec::new(),
+			outputs: network_outputs,
+			nodes: [
+				(
+					10,
+					DocumentNode {
+						name: "Nested network".into(),
+						inputs: vec![NodeInput::value(TaggedValue::F32(1.), false), NodeInput::value(TaggedValue::F32(2.), false)],
+						metadata: DocumentNodeMetadata::default(),
+						implementation: DocumentNodeImplementation::Network(two_node_identity()),
+					},
+				),
+				(
+					11,
+					DocumentNode {
+						name: "Result".into(),
+						inputs: vec![result_node_input],
+						metadata: DocumentNodeMetadata::default(),
+						implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::IdNode", &[generic!("T")])),
+					},
+				),
+			]
+			.into_iter()
+			.collect(),
+			..Default::default()
+		};
+		let mut new_ids = 101..;
+		network.duplicate_outputs(&mut || new_ids.next().unwrap());
+		network.remove_dead_nodes();
+		network
+	}
+
+	#[test]
+	fn simple_duplicate() {
+		let result = output_duplicate(vec![NodeOutput::new(10, 1)], NodeInput::node(10, 0));
+		assert_eq!(result.outputs.len(), 1, "The number of outputs should remain as 1");
+		assert_eq!(result.outputs[0], NodeOutput::new(101, 0), "The outer network output should be from a duplicated inner network");
+		assert_eq!(result.nodes.keys().copied().collect::<Vec<_>>(), vec![101], "Should just call nested network");
+		let nested_network_node = result.nodes.get(&101).unwrap();
+		assert_eq!(nested_network_node.name, "Nested network".to_string(), "Name should not change");
+		assert_eq!(nested_network_node.inputs, vec![NodeInput::value(TaggedValue::F32(2.), false)], "Input should be 2");
+		let inner_network = nested_network_node.implementation.get_network().expect("Implementation should be network");
+		assert_eq!(inner_network.inputs, vec![2], "The input should be sent to the second node");
+		assert_eq!(inner_network.outputs, vec![NodeOutput::new(2, 0)], "The output should be node id 2");
+		assert_eq!(inner_network.nodes.get(&2).unwrap().name, "Identity 2", "The node should be identity 2");
+	}
+
+	#[test]
+	fn out_of_order_duplicate() {
+		let result = output_duplicate(vec![NodeOutput::new(10, 1), NodeOutput::new(10, 0)], NodeInput::node(10, 0));
+		assert_eq!(result.outputs[0], NodeOutput::new(101, 0), "The first network output should be from a duplicated nested network");
+		assert_eq!(result.outputs[1], NodeOutput::new(10, 0), "The second network output should be from the origional nested network");
+		assert!(
+			result.nodes.contains_key(&10) && result.nodes.contains_key(&101) && result.nodes.len() == 2,
+			"Network should contain two duplicated nodes"
+		);
+		for (node_id, input_value, inner_id) in [(10, 1., 1), (101, 2., 2)] {
+			let nested_network_node = result.nodes.get(&node_id).unwrap();
+			assert_eq!(nested_network_node.name, "Nested network".to_string(), "Name should not change");
+			assert_eq!(nested_network_node.inputs, vec![NodeInput::value(TaggedValue::F32(input_value), false)], "Input should be stable");
+			let inner_network = nested_network_node.implementation.get_network().expect("Implementation should be network");
+			assert_eq!(inner_network.inputs, vec![inner_id], "The input should be sent to the second node");
+			assert_eq!(inner_network.outputs, vec![NodeOutput::new(inner_id, 0)], "The output should be node id");
+			assert_eq!(inner_network.nodes.get(&inner_id).unwrap().name, format!("Identity {inner_id}"), "The node should be identity");
+		}
+	}
+	#[test]
+	fn using_other_node_duplicate() {
+		let result = output_duplicate(vec![NodeOutput::new(11, 0)], NodeInput::node(10, 1));
+		assert_eq!(result.outputs, vec![NodeOutput::new(11, 0)], "The network output should be the result node");
+		assert!(
+			result.nodes.contains_key(&11) && result.nodes.contains_key(&101) && result.nodes.len() == 2,
+			"Network should contain a duplicated node and a result node"
+		);
+		let result_node = result.nodes.get(&11).unwrap();
+		assert_eq!(result_node.inputs, vec![NodeInput::node(101, 0)], "Result node should refer to duplicate node as input");
+		let nested_network_node = result.nodes.get(&101).unwrap();
+		assert_eq!(nested_network_node.name, "Nested network".to_string(), "Name should not change");
+		assert_eq!(nested_network_node.inputs, vec![NodeInput::value(TaggedValue::F32(2.), false)], "Input should be 2");
+		let inner_network = nested_network_node.implementation.get_network().expect("Implementation should be network");
+		assert_eq!(inner_network.inputs, vec![2], "The input should be sent to the second node");
+		assert_eq!(inner_network.outputs, vec![NodeOutput::new(2, 0)], "The output should be node id 2");
+		assert_eq!(inner_network.nodes.get(&2).unwrap().name, "Identity 2", "The node should be identity 2");
 	}
 }

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -213,7 +213,7 @@ pub struct NodeNetwork {
 	pub nodes: HashMap<NodeId, DocumentNode>,
 	/// These nodes are replaced with identity nodes when flattening
 	pub disabled: Vec<NodeId>,
-	/// In the case where a new node is chosen as output - what was the origional
+	/// In the case where a new node is chosen as output - what was the original
 	pub previous_outputs: Option<Vec<NodeOutput>>,
 }
 
@@ -249,7 +249,7 @@ impl NodeNetwork {
 		outwards_links
 	}
 
-	/// When a node has multiple outputs, we actually just duplicate the node and evaluate each output seperatly
+	/// When a node has multiple outputs, we actually just duplicate the node and evaluate each output separately
 	pub fn duplicate_outputs(&mut self, mut gen_id: &mut impl FnMut() -> NodeId) {
 		let mut duplicating_nodes = HashMap::new();
 		// Find the nodes where the inputs require duplicating
@@ -260,7 +260,7 @@ impl NodeNetwork {
 			}
 
 			for input in &mut node.inputs {
-				let &mut NodeInput::Node { node_id, output_index}= input else {
+				let &mut NodeInput::Node { node_id, output_index} = input else {
 					continue;
 				};
 				// Use the initial node when getting the first output
@@ -285,11 +285,11 @@ impl NodeNetwork {
 			*network_output = NodeOutput::new(duplicated_node_id, 0);
 		}
 		// Duplicate the nodes
-		for ((origional_node_id, output_index), new_node_id) in duplicating_nodes {
-			let Some(origional_node) = self.nodes.get(&origional_node_id) else {
+		for ((original_node_id, output_index), new_node_id) in duplicating_nodes {
+			let Some(original_node) = self.nodes.get(&original_node_id) else {
 				continue;
 			};
-			let mut new_node = origional_node.clone();
+			let mut new_node = original_node.clone();
 			// Update the required outputs from a nested network to be just the relevant output
 			if let DocumentNodeImplementation::Network(network) = &mut new_node.implementation {
 				if network.outputs.is_empty() {
@@ -535,17 +535,17 @@ impl NodeNetwork {
 	}
 
 	/// Is the node being used directly as an output?
-	pub fn outputs_contains(&self, node_id: NodeId) -> bool {
+	pub fn outputs_contain(&self, node_id: NodeId) -> bool {
 		self.outputs.iter().any(|output| output.node_id == node_id)
 	}
 
-	/// Is the node being used directly as an origional output?
-	pub fn origional_outputs_contains(&self, node_id: NodeId) -> bool {
+	/// Is the node being used directly as an original output?
+	pub fn original_outputs_contain(&self, node_id: NodeId) -> bool {
 		self.original_outputs().iter().any(|output| output.node_id == node_id)
 	}
 
 	/// Is the node being used directly as a previous output?
-	pub fn previous_outputs_contains(&self, node_id: NodeId) -> Option<bool> {
+	pub fn previous_outputs_contain(&self, node_id: NodeId) -> Option<bool> {
 		self.previous_outputs.as_ref().map(|outputs| outputs.iter().any(|output| output.node_id == node_id))
 	}
 }
@@ -854,7 +854,7 @@ mod test {
 	fn out_of_order_duplicate() {
 		let result = output_duplicate(vec![NodeOutput::new(10, 1), NodeOutput::new(10, 0)], NodeInput::node(10, 0));
 		assert_eq!(result.outputs[0], NodeOutput::new(101, 0), "The first network output should be from a duplicated nested network");
-		assert_eq!(result.outputs[1], NodeOutput::new(10, 0), "The second network output should be from the origional nested network");
+		assert_eq!(result.outputs[1], NodeOutput::new(10, 0), "The second network output should be from the original nested network");
 		assert!(
 			result.nodes.contains_key(&10) && result.nodes.contains_key(&101) && result.nodes.len() == 2,
 			"Network should contain two duplicated nodes"

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -293,6 +293,9 @@ impl NodeNetwork {
 			let mut new_node = origional_node.clone();
 			// Update the required outputs from a nested network to be just the relevant output
 			if let DocumentNodeImplementation::Network(network) = &mut new_node.implementation {
+				if network.outputs.is_empty() {
+					continue;
+				}
 				network.outputs = vec![network.outputs[output_index]];
 			}
 			self.nodes.insert(new_node_id, new_node);
@@ -301,6 +304,9 @@ impl NodeNetwork {
 		// Ensure all nodes only have one output
 		for node in self.nodes.values_mut() {
 			if let DocumentNodeImplementation::Network(network) = &mut node.implementation {
+				if network.outputs.is_empty() {
+					continue;
+				}
 				network.outputs = vec![network.outputs[0]];
 			}
 		}
@@ -319,7 +325,7 @@ impl NodeNetwork {
 			if let DocumentNodeImplementation::Network(network) = &mut document_node.implementation {
 				// Remove inputs to the parent node if they have been removed from the child
 				let mut retain_inputs = network.remove_dead_nodes().into_iter();
-				document_node.inputs.retain(|_| retain_inputs.next().unwrap())
+				document_node.inputs.retain(|_| retain_inputs.next().unwrap_or(true))
 			}
 			// Visit all nodes that this node references
 			stack.extend(

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -38,6 +38,12 @@ pub struct DocumentNodeMetadata {
 	pub position: IVec2,
 }
 
+impl DocumentNodeMetadata {
+	pub fn position(position: impl Into<IVec2>) -> Self {
+		Self { position: position.into() }
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, specta::Type)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DocumentNode {

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -9,7 +9,6 @@ use rand_chacha::{
 	ChaCha20Rng,
 };
 use std::collections::{HashMap, HashSet};
-use std::net;
 use std::sync::Mutex;
 
 pub mod value;

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -546,8 +546,8 @@ impl NodeNetwork {
 	}
 
 	/// Is the node being used directly as a previous output?
-	pub fn previous_outputs_contains(&self, node_id: NodeId) -> bool {
-		self.previous_outputs.as_ref().map_or(false, |outputs| outputs.iter().any(|output| output.node_id == node_id))
+	pub fn previous_outputs_contains(&self, node_id: NodeId) -> Option<bool> {
+		self.previous_outputs.as_ref().map(|outputs| outputs.iter().any(|output| output.node_id == node_id))
 	}
 }
 

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -1,7 +1,7 @@
 pub use dyn_any::StaticType;
 use dyn_any::{DynAny, Upcast};
 use dyn_clone::DynClone;
-pub use glam::DVec2;
+pub use glam::{DAffine2, DVec2};
 use graphene_core::raster::LuminanceCalculation;
 use graphene_core::Node;
 use std::hash::Hash;
@@ -22,6 +22,7 @@ pub enum TaggedValue {
 	Bool(bool),
 	DVec2(DVec2),
 	OptionalDVec2(Option<DVec2>),
+	DAffine2(DAffine2),
 	Image(graphene_core::raster::Image),
 	RcImage(Option<Arc<graphene_core::raster::Image>>),
 	Color(graphene_core::raster::color::Color),
@@ -67,6 +68,10 @@ impl Hash for TaggedValue {
 			Self::OptionalDVec2(Some(v)) => {
 				8.hash(state);
 				Self::DVec2(*v).hash(state)
+			}
+			Self::DAffine2(m) => {
+				9.hash(state);
+				m.to_cols_array().iter().for_each(|x| x.to_bits().hash(state))
 			}
 			Self::Image(i) => {
 				9.hash(state);
@@ -124,6 +129,7 @@ impl<'a> TaggedValue {
 			TaggedValue::Bool(x) => Box::new(x),
 			TaggedValue::DVec2(x) => Box::new(x),
 			TaggedValue::OptionalDVec2(x) => Box::new(x),
+			TaggedValue::DAffine2(x) => Box::new(x),
 			TaggedValue::Image(x) => Box::new(x),
 			TaggedValue::RcImage(x) => Box::new(x),
 			TaggedValue::Color(x) => Box::new(x),

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -74,43 +74,43 @@ impl Hash for TaggedValue {
 				m.to_cols_array().iter().for_each(|x| x.to_bits().hash(state))
 			}
 			Self::Image(i) => {
-				9.hash(state);
-				i.hash(state)
-			}
-			Self::RcImage(i) => {
 				10.hash(state);
 				i.hash(state)
 			}
-			Self::Color(c) => {
+			Self::RcImage(i) => {
 				11.hash(state);
+				i.hash(state)
+			}
+			Self::Color(c) => {
+				12.hash(state);
 				c.hash(state)
 			}
 			Self::Subpath(s) => {
-				12.hash(state);
-				s.hash(state)
-			}
-			Self::RcSubpath(s) => {
 				13.hash(state);
 				s.hash(state)
 			}
-			Self::LuminanceCalculation(l) => {
+			Self::RcSubpath(s) => {
 				14.hash(state);
+				s.hash(state)
+			}
+			Self::LuminanceCalculation(l) => {
+				15.hash(state);
 				l.hash(state)
 			}
 			Self::ImaginateSamplingMethod(m) => {
-				15.hash(state);
+				16.hash(state);
 				m.hash(state)
 			}
 			Self::ImaginateMaskStartingFill(f) => {
-				16.hash(state);
+				17.hash(state);
 				f.hash(state)
 			}
 			Self::ImaginateStatus(s) => {
-				17.hash(state);
+				18.hash(state);
 				s.hash(state)
 			}
 			Self::LayerPath(p) => {
-				18.hash(state);
+				19.hash(state);
 				p.hash(state)
 			}
 		}

--- a/node-graph/graph-craft/src/executor.rs
+++ b/node-graph/graph-craft/src/executor.rs
@@ -27,7 +27,7 @@ impl Compiler {
 	}
 	pub fn compile_single(&self, network: NodeNetwork, resolve_inputs: bool) -> Result<ProtoNetwork, String> {
 		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
-		let Some(proto_network) = self.compile(network, resolve_inputs).into_iter().next() else {
+		let Some(proto_network) = self.compile(network, resolve_inputs).next() else {
 			return Err("Failed to convert graph into proto graph".to_string());
 		};
 		Ok(proto_network)

--- a/node-graph/graph-craft/src/executor.rs
+++ b/node-graph/graph-craft/src/executor.rs
@@ -8,21 +8,29 @@ use crate::proto::ProtoNetwork;
 pub struct Compiler {}
 
 impl Compiler {
-	pub fn compile(&self, mut network: NodeNetwork, resolve_inputs: bool) -> ProtoNetwork {
+	pub fn compile(&self, mut network: NodeNetwork, resolve_inputs: bool) -> impl Iterator<Item = ProtoNetwork> {
 		let node_ids = network.nodes.keys().copied().collect::<Vec<_>>();
 		println!("flattening");
 		for id in node_ids {
 			network.flatten(id);
 		}
-		let mut proto_network = network.into_proto_network();
-		if resolve_inputs {
-			println!("resolving inputs");
-			proto_network.resolve_inputs();
-		}
-		println!("reordering ids");
-		proto_network.reorder_ids();
-		proto_network.generate_stable_node_ids();
-		proto_network
+		let proto_networks = network.into_proto_networks();
+		proto_networks.map(move |mut proto_network| {
+			if resolve_inputs {
+				println!("resolving inputs");
+				proto_network.resolve_inputs();
+			}
+			proto_network.reorder_ids();
+			proto_network.generate_stable_node_ids();
+			proto_network
+		})
+	}
+	pub fn compile_single(&self, network: NodeNetwork, resolve_inputs: bool) -> Result<ProtoNetwork, String> {
+		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
+		let Some(proto_network) = self.compile(network, resolve_inputs).into_iter().next() else {
+			return Err("Failed to convert graph into proto graph".to_string());
+		};
+		Ok(proto_network)
 	}
 }
 pub type Any<'a> = Box<dyn DynAny<'a> + 'a>;

--- a/node-graph/graph-craft/src/proto.rs
+++ b/node-graph/graph-craft/src/proto.rs
@@ -94,7 +94,7 @@ pub struct ProtoNetwork {
 	pub nodes: Vec<(NodeId, ProtoNode)>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ConstructionArgs {
 	Value(value::TaggedValue),
 	Nodes(Vec<NodeId>),
@@ -133,7 +133,7 @@ impl ConstructionArgs {
 	}
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ProtoNode {
 	pub construction_args: ConstructionArgs,
 	pub input: ProtoNodeInput,

--- a/node-graph/gstd/src/any.rs
+++ b/node-graph/gstd/src/any.rs
@@ -73,7 +73,7 @@ where
 	N: Node<'input, Any<'input>, Output = Any<'input>>,
 {
 	let node_name = core::any::type_name::<N>();
-	let out = dyn_any::downcast(node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e} in:\n{node_name}"));
+	let out = dyn_any::downcast(node.eval(input)).unwrap_or_else(|e| panic!("DowncastNode Input {e} in:\n{node_name}"));
 	*out
 }
 
@@ -91,7 +91,7 @@ impl<'n: 'input, 'input, O: 'input + StaticType, I: 'input + StaticType> Node<'i
 	fn eval<'node: 'input>(&'node self, input: I) -> Self::Output {
 		{
 			let input = Box::new(input);
-			let out = dyn_any::downcast(self.node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e}"));
+			let out = dyn_any::downcast(self.node.eval(input)).unwrap_or_else(|e| panic!("DowncastBothNode Input {e}"));
 			*out
 		}
 	}
@@ -118,7 +118,7 @@ impl<'n: 'input, 'input, O: 'input + StaticType, I: 'input + StaticType> Node<'i
 	fn eval<'node: 'input>(&'node self, input: I) -> Self::Output {
 		{
 			let input = Box::new(input);
-			let out: Box<&_> = dyn_any::downcast::<&O>(self.node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e}"));
+			let out: Box<&_> = dyn_any::downcast::<&O>(self.node.eval(input)).unwrap_or_else(|e| panic!("DowncastBothRefNode Input {e}"));
 			*out
 		}
 	}

--- a/node-graph/gstd/src/raster.rs
+++ b/node-graph/gstd/src/raster.rs
@@ -118,6 +118,7 @@ fn imaginate(image: Image, cached: Option<std::sync::Arc<graphene_core::raster::
 	cached.map(|mut x| std::sync::Arc::make_mut(&mut x).clone()).unwrap_or(image)
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct ImageFrameNode<Transform> {
 	transform: Transform,
 }

--- a/node-graph/gstd/src/raster.rs
+++ b/node-graph/gstd/src/raster.rs
@@ -1,5 +1,6 @@
 use dyn_any::{DynAny, StaticType};
 
+use glam::DAffine2;
 use graphene_core::raster::{Color, Image};
 use graphene_core::Node;
 
@@ -117,6 +118,13 @@ fn imaginate(image: Image, cached: Option<std::sync::Arc<graphene_core::raster::
 	cached.map(|mut x| std::sync::Arc::make_mut(&mut x).clone()).unwrap_or(image)
 }
 
+pub struct ImageFrameNode<Transform> {
+	transform: Transform,
+}
+#[node_macro::node_fn(ImageFrameNode)]
+fn image_frame(image: Image, transform: DAffine2) -> graphene_core::raster::ImageFrame {
+	graphene_core::raster::ImageFrame { image, transform }
+}
 #[cfg(test)]
 mod test {
 

--- a/node-graph/interpreted-executor/Cargo.toml
+++ b/node-graph/interpreted-executor/Cargo.toml
@@ -16,7 +16,7 @@ quantization = ["graphene-std/quantization"]
 graphene-core = { path = "../gcore", features = ["async", "std" ] }
 graphene-std = { path = "../gstd" }
 graph-craft = { path = "../graph-craft" }
-dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types"] }
+dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "glam"] }
 num-traits = "0.2"
 borrow_stack = { path = "../borrow_stack" }
 dyn-clone = "1.0"

--- a/node-graph/interpreted-executor/src/executor.rs
+++ b/node-graph/interpreted-executor/src/executor.rs
@@ -26,7 +26,7 @@ impl DynamicExecutor {
 
 	pub fn update(&mut self, proto_network: ProtoNetwork) {
 		self.output = proto_network.output;
-		info!("setting output to {}", self.output);
+		trace!("setting output to {}", self.output);
 		self.tree.update(proto_network);
 	}
 }

--- a/node-graph/interpreted-executor/src/lib.rs
+++ b/node-graph/interpreted-executor/src/lib.rs
@@ -52,7 +52,7 @@ mod tests {
 		fn add_network() -> NodeNetwork {
 			NodeNetwork {
 				inputs: vec![0, 0],
-				output: 1,
+				outputs: vec![1],
 				nodes: [
 					(
 						0,
@@ -81,7 +81,7 @@ mod tests {
 
 		let network = NodeNetwork {
 			inputs: vec![0],
-			output: 0,
+			outputs: vec![0],
 			nodes: [(
 				0,
 				DocumentNode {
@@ -106,7 +106,7 @@ mod tests {
 		use graph_craft::executor::{Compiler, Executor};
 
 		let compiler = Compiler {};
-		let protograph = compiler.compile(network, true);
+		let protograph = compiler.compile_single(network, true).unwrap();
 
 		let exec = DynamicExecutor::new(protograph);
 

--- a/node-graph/interpreted-executor/src/lib.rs
+++ b/node-graph/interpreted-executor/src/lib.rs
@@ -52,7 +52,7 @@ mod tests {
 		fn add_network() -> NodeNetwork {
 			NodeNetwork {
 				inputs: vec![0, 0],
-				outputs: vec![1],
+				outputs: vec![NodeOutput::new(1, 0)],
 				nodes: [
 					(
 						0,
@@ -67,7 +67,7 @@ mod tests {
 						1,
 						DocumentNode {
 							name: "Add".into(),
-							inputs: vec![NodeInput::Node(0)],
+							inputs: vec![NodeInput::node(0, 0)],
 							implementation: DocumentNodeImplementation::Unresolved(NodeIdentifier::new("graphene_core::ops::AddNode", &[concrete!("(u32, u32)")])),
 							metadata: DocumentNodeMetadata::default(),
 						},
@@ -81,7 +81,7 @@ mod tests {
 
 		let network = NodeNetwork {
 			inputs: vec![0],
-			outputs: vec![0],
+			outputs: vec![NodeOutput::new(0, 0)],
 			nodes: [(
 				0,
 				DocumentNode {
@@ -106,7 +106,7 @@ mod tests {
 		use graph_craft::executor::{Compiler, Executor};
 
 		let compiler = Compiler {};
-		let protograph = compiler.compile_single(network, true).unwrap();
+		let protograph = compiler.compile_single(network, true).expect("Graph should be generated");
 
 		let exec = DynamicExecutor::new(protograph);
 

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -1,3 +1,4 @@
+use glam::{DAffine2, DVec2};
 use graphene_core::ops::{CloneNode, IdNode, TypeNode};
 use graphene_core::raster::color::Color;
 use graphene_core::raster::*;
@@ -126,6 +127,7 @@ static NODE_REGISTRY: &[(NodeIdentifier, NodeConstructor)] = &[
 		any.into_type_erased()
 	}),
 	register_node!(graphene_core::structural::ConsNode<_, _>, input: Image, params: [&str]),
+	register_node!(graphene_std::raster::ImageFrameNode<_>, input: Image, params: [DAffine2]),
 	/*
 		(NodeIdentifier::new("graphene_std::raster::ImageNode", &[concrete!("&str")]), |_proto_node, stack| {
 			stack.push_fn(|_nodes| {

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -1,4 +1,4 @@
-use glam::{DAffine2, DVec2};
+use glam::DAffine2;
 use graphene_core::ops::{CloneNode, IdNode, TypeNode};
 use graphene_core::raster::color::Color;
 use graphene_core::raster::*;
@@ -84,7 +84,7 @@ static NODE_REGISTRY: &[(NodeIdentifier, NodeConstructor)] = &[
 	(
 		NodeIdentifier::new("graphene_std::raster::ImaginateNode<_>", &[concrete!("Image"), concrete!("Option<std::sync::Arc<Image>>")]),
 		|args| {
-			let cached = graphene_std::any::input_node::<Option<std::sync::Arc<Image>>>(args[15]);
+			let cached = graphene_std::any::input_node::<Option<std::sync::Arc<Image>>>(args[16]);
 			let node = graphene_std::raster::ImaginateNode::new(cached);
 			let any = DynAnyNode::new(ValueNode::new(node));
 			any.into_type_erased()

--- a/proc-macros/src/widget_builder.rs
+++ b/proc-macros/src/widget_builder.rs
@@ -13,7 +13,7 @@ fn has_attribute(attrs: &[Attribute], target: &str) -> bool {
 
 /// Make setting strings easier by allowing all types that `impl Into<String>`
 ///
-/// Returns the new input type and a conversion to the origional.
+/// Returns the new input type and a conversion to the original.
 fn easier_string_assignment(field_ty: &Type, field_ident: &Ident) -> (TokenStream2, TokenStream2) {
 	if let Type::Path(type_path) = field_ty {
 		if let Some(last_segment) = type_path.path.segments.last() {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #992

The bulk of this PR involves allowing nodes to have multiple outputs. This required some frontend Vue modifications as well as some work with the backend, ensuring all node inputs and network outputs have an index. A document graph rewriting step called `duplicate_outputs` was added to flatten the multiple outputs.

The node graph now outputs an ImageFrame struct that contains the image data and a transform. Further information can be easily added.  The transform is the local transform of the layer, and the resulting transform is applied to the layer. This means that if you disconnect the transform, the layer will resize to have an identity transform.

Modifications to the imaginate tool have not yet been added.