### PR TITLE
Add transform input to Imaginate node

### DIFF
--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -11,5 +11,6 @@ pub mod application;
 pub mod consts;
 pub mod dispatcher;
 pub mod messages;
+pub mod node_graph_executor;
 pub mod test_utils;
 pub mod utility_traits;

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -21,6 +21,7 @@ use crate::messages::portfolio::document::utility_types::vectorize_layer_metadat
 use crate::messages::portfolio::utility_types::PersistentData;
 use crate::messages::prelude::*;
 use crate::messages::tool::utility_types::ToolType;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::boolean_ops::BooleanOperationError;
 use document_legacy::document::Document as DocumentLegacy;
@@ -104,13 +105,13 @@ impl Default for DocumentMessageHandler {
 	}
 }
 
-impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler)> for DocumentMessageHandler {
+impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler, &mut NodeGraphExecutor)> for DocumentMessageHandler {
 	#[remain::check]
 	fn process_message(
 		&mut self,
 		message: DocumentMessage,
 		responses: &mut VecDeque<Message>,
-		(document_id, ipp, persistent_data, preferences): (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler),
+		(document_id, ipp, persistent_data, preferences, executor): (u64, &InputPreprocessorMessageHandler, &PersistentData, &PreferencesMessageHandler, &mut NodeGraphExecutor),
 	) {
 		use DocumentMessage::*;
 
@@ -203,6 +204,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 					artboard_document: &self.artboard_message_handler.artboards_document,
 					selected_layers: &mut self.layer_metadata.iter().filter_map(|(path, data)| data.selected.then_some(path.as_slice())),
 					node_graph_message_handler: &self.node_graph_handler,
+					executor,
 				};
 				self.properties_panel_message_handler
 					.process_message(message, responses, (persistent_data, properties_panel_message_handler_data));

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -520,7 +520,7 @@ pub fn new_image_network(output_offset: i32, output_node_id: NodeId) -> NodeNetw
 		inputs: vec![0],
 		outputs: vec![NodeOutput::new(1, 0)],
 		nodes: [
-			resolve_document_node_type("Input Multiple").expect("Input mutliple node does not exist").to_document_node(
+			resolve_document_node_type("Input Multiple").expect("Input multiple node does not exist").to_document_node(
 				[NodeInput::Network, NodeInput::value(TaggedValue::DAffine2(DAffine2::IDENTITY), false)],
 				DocumentNodeMetadata::position((8, 4)),
 			),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -1,5 +1,6 @@
 use super::{node_properties, FrontendGraphDataType, FrontendNodeType};
 use crate::messages::layout::utility_types::layout_widget::LayoutGroup;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use graph_craft::document::value::*;
 use graph_craft::document::*;
@@ -38,6 +39,8 @@ pub struct NodePropertiesContext<'a> {
 	pub responses: &'a mut VecDeque<crate::messages::prelude::Message>,
 	pub layer_path: &'a [document_legacy::LayerId],
 	pub nested_path: &'a [NodeId],
+	pub executor: &'a mut NodeGraphExecutor,
+	pub network: &'a NodeNetwork,
 }
 
 #[derive(Clone)]
@@ -435,6 +438,7 @@ pub const IMAGINATE_NODE: DocumentNodeType = DocumentNodeType {
 	identifier: NodeImplementation::proto("graphene_std::raster::ImaginateNode<_>", &[concrete!("Image"), concrete!("Option<std::sync::Arc<Image>>")]),
 	inputs: &[
 		DocumentInputType::new("Input Image", TaggedValue::Image(Image::empty()), true),
+		DocumentInputType::new("Transform", TaggedValue::DAffine2(DAffine2::IDENTITY), true),
 		DocumentInputType::new("Seed", TaggedValue::F64(0.), false),
 		DocumentInputType::new("Resolution", TaggedValue::OptionalDVec2(None), false),
 		DocumentInputType::new("Samples", TaggedValue::F64(30.), false),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -338,6 +338,7 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 	let layer_path = context.layer_path.to_vec();
 
 	let resolve_input = |name: &str| IMAGINATE_NODE.inputs.iter().position(|input| input.name == name).unwrap_or_else(|| panic!("Input {name} not found"));
+	let transform_index = resolve_input("Transform");
 	let seed_index = resolve_input("Seed");
 	let resolution_index = resolve_input("Resolution");
 	let samples_index = resolve_input("Samples");
@@ -405,6 +406,9 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 	} else {
 		true
 	};
+
+	let transform_not_connected = matches!(document_node.inputs[transform_index], NodeInput::Value { .. });
+
 	let progress = {
 		// Since we don't serialize the status, we need to derive from other state whether the Idle state is actually supposed to be the Terminated state
 		let mut interpreted_status = imaginate_status;
@@ -589,9 +593,10 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 					})
 					.widget_holder(),
 				WidgetHolder::unrelated_separator(),
-				CheckboxInput::new(!dimensions_is_auto)
+				CheckboxInput::new(!dimensions_is_auto || transform_not_connected)
 					.icon("Edit")
 					.tooltip("Set a custom resolution instead of using the frame's rounded dimensions")
+					.disabled(transform_not_connected)
 					.on_update(update_value(
 						move |checkbox_input: &CheckboxInput| {
 							if checkbox_input.checked {
@@ -608,7 +613,7 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 				NumberInput::new(Some(vec2.x))
 					.label("W")
 					.unit(" px")
-					.disabled(dimensions_is_auto)
+					.disabled(dimensions_is_auto && !transform_not_connected)
 					.on_update(update_value(
 						move |number_input: &NumberInput| TaggedValue::OptionalDVec2(round(DVec2::new(number_input.value.unwrap(), vec2.y))),
 						node_id,
@@ -619,7 +624,7 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 				NumberInput::new(Some(vec2.y))
 					.label("H")
 					.unit(" px")
-					.disabled(dimensions_is_auto)
+					.disabled(dimensions_is_auto && !transform_not_connected)
 					.on_update(update_value(
 						move |number_input: &NumberInput| TaggedValue::OptionalDVec2(round(DVec2::new(vec2.x, number_input.value.unwrap()))),
 						node_id,

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
@@ -28,6 +28,7 @@ impl<'a> MessageHandler<PropertiesPanelMessage, (&PersistentData, PropertiesPane
 			artboard_document,
 			selected_layers,
 			node_graph_message_handler,
+			executor,
 		} = data;
 		let get_document = |document_selector: TargetDocument| match document_selector {
 			TargetDocument::Artboard => artboard_document,
@@ -166,7 +167,7 @@ impl<'a> MessageHandler<PropertiesPanelMessage, (&PersistentData, PropertiesPane
 					let layer = document.layer(&path).unwrap();
 					match target_document {
 						TargetDocument::Artboard => register_artboard_layer_properties(layer, responses, persistent_data),
-						TargetDocument::Artwork => register_artwork_layer_properties(document, path, layer, responses, persistent_data, node_graph_message_handler),
+						TargetDocument::Artwork => register_artwork_layer_properties(document, path, layer, responses, persistent_data, node_graph_message_handler, executor),
 					}
 				}
 			}

--- a/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
@@ -8,6 +8,7 @@ use crate::messages::layout::utility_types::widgets::input_widgets::{CheckboxInp
 use crate::messages::layout::utility_types::widgets::label_widgets::{IconLabel, TextLabel};
 use crate::messages::portfolio::utility_types::PersistentData;
 use crate::messages::prelude::*;
+use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::document::Document;
 use document_legacy::layers::layer_info::{Layer, LayerDataType, LayerDataTypeDiscriminant};
@@ -246,6 +247,7 @@ pub fn register_artwork_layer_properties(
 	responses: &mut VecDeque<Message>,
 	persistent_data: &PersistentData,
 	node_graph_message_handler: &NodeGraphMessageHandler,
+	executor: &mut NodeGraphExecutor,
 ) {
 	let options_bar = vec![LayoutGroup::Row {
 		widgets: vec![
@@ -323,6 +325,8 @@ pub fn register_artwork_layer_properties(
 				responses,
 				nested_path: &node_graph_message_handler.nested_path,
 				layer_path: &layer_path,
+				executor,
+				network: &node_graph_frame.network,
 			};
 			node_graph_message_handler.collate_properties(node_graph_frame, &mut context, &mut properties_sections);
 

--- a/editor/src/messages/portfolio/document/properties_panel/utility_types.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_types.rs
@@ -3,13 +3,14 @@ use document_legacy::LayerId;
 
 use serde::{Deserialize, Serialize};
 
-use crate::messages::prelude::NodeGraphMessageHandler;
+use crate::{messages::prelude::NodeGraphMessageHandler, node_graph_executor::NodeGraphExecutor};
 
 pub struct PropertiesPanelMessageHandlerData<'a> {
 	pub artwork_document: &'a DocumentLegacy,
 	pub artboard_document: &'a DocumentLegacy,
 	pub selected_layers: &'a mut dyn Iterator<Item = &'a [LayerId]>,
 	pub node_graph_message_handler: &'a NodeGraphMessageHandler,
+	pub executor: &'a mut NodeGraphExecutor,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, specta::Type)]

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -124,12 +124,13 @@ impl Fsm for ImaginateToolFsmState {
 
 					let mut imaginate_inputs: Vec<NodeInput> = imaginate_node_type.inputs.iter().map(|input| input.default.clone()).collect();
 					imaginate_inputs[0] = NodeInput::node(0, 0);
+					imaginate_inputs[1] = NodeInput::node(0, 1);
 
 					let imaginate_node_id = 100;
 					let mut network = node_graph::new_image_network(32, imaginate_node_id);
 					network.nodes.insert(
 						imaginate_node_id,
-						imaginate_node_type.to_document_node(imaginate_inputs, graph_craft::document::DocumentNodeMetadata::position((20, 4))),
+						imaginate_node_type.to_document_node(imaginate_inputs, graph_craft::document::DocumentNodeMetadata::position((20, 3))),
 					);
 
 					responses.push_back(

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -124,7 +124,6 @@ impl NodeGraphExecutor {
 		let get = |name: &str| IMAGINATE_NODE.inputs.iter().position(|input| input.name == name).unwrap_or_else(|| panic!("Input {name} not found"));
 
 		let transform: DAffine2 = self.compute_input(&network, &imaginate_node, get("Transform"), Cow::Borrowed(&image_frame))?;
-		debug!("Transform {transform} x {x} y {y}");
 
 		let resolution: Option<glam::DVec2> = self.compute_input(&network, &imaginate_node, get("Resolution"), Cow::Borrowed(&image_frame))?;
 		let resolution = resolution.unwrap_or_else(|| {

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -1,0 +1,280 @@
+use crate::messages::frontend::utility_types::FrontendImageData;
+use crate::messages::portfolio::document::utility_types::misc::DocumentRenderMode;
+use crate::messages::portfolio::utility_types::PersistentData;
+use crate::messages::prelude::*;
+
+use document_legacy::{document::pick_safe_imaginate_resolution, layers::layer_info::LayerDataType};
+use document_legacy::{LayerId, Operation};
+use graph_craft::document::{generate_uuid, value::TaggedValue, NodeId, NodeInput, NodeNetwork, NodeOutput};
+use graph_craft::executor::Compiler;
+use graphene_core::raster::{Image, ImageFrame};
+use interpreted_executor::executor::DynamicExecutor;
+
+use glam::{DAffine2, DVec2};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, Default)]
+pub struct NodeGraphExecutor {
+	executor: DynamicExecutor,
+}
+
+impl NodeGraphExecutor {
+	/// Sets the transform property on the input node
+	fn set_input_transform(network: &mut NodeNetwork, transform: DAffine2) {
+		let Some(input_node) = network.nodes.get_mut(&network.inputs[0]) else {
+			return;
+		};
+		input_node.inputs[1] = NodeInput::value(TaggedValue::DAffine2(transform), false);
+	}
+
+	/// Execute the network by flattening it and creating a borrow stack. Casts the output to the generic `T`.
+	fn execute_network<T: dyn_any::StaticType>(&mut self, mut network: NodeNetwork, image_frame: ImageFrame) -> Result<T, String> {
+		Self::set_input_transform(&mut network, image_frame.transform);
+		network.duplicate_outputs(&mut generate_uuid);
+		network.remove_dead_nodes();
+
+		// We assume only one output
+		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
+		let c = Compiler {};
+		let proto_network = c.compile_single(network, true)?;
+
+		assert_ne!(proto_network.nodes.len(), 0, "No protonodes exist?");
+		self.executor.update(proto_network);
+
+		use dyn_any::IntoDynAny;
+		use graph_craft::executor::Executor;
+
+		let boxed = self.executor.execute(image_frame.image.into_dyn()).map_err(|e| e.to_string())?;
+
+		dyn_any::downcast::<T>(boxed).map(|v| *v)
+	}
+
+	/// Computes an input for a node in the graph
+	pub fn compute_input<T: dyn_any::StaticType>(&mut self, old_network: &NodeNetwork, node_path: &[NodeId], mut input_index: usize, image_frame: Cow<ImageFrame>) -> Result<T, String> {
+		let mut network = old_network.clone();
+		// Adjust the output of the graph so we find the relevant output
+		'outer: for end in (0..node_path.len()).rev() {
+			let mut inner_network = &mut network;
+			for &node_id in &node_path[..end] {
+				inner_network.outputs[0] = NodeOutput::new(node_id, 0);
+
+				let Some(new_inner) = inner_network.nodes.get_mut(&node_id).and_then(|node| node.implementation.get_network_mut()) else {
+					return Err("Failed to find network".to_string());
+				};
+				inner_network = new_inner;
+			}
+			match &inner_network.nodes.get(&node_path[end]).unwrap().inputs[input_index] {
+				// If the input is from a parent network then adjust the input index and continue iteration
+				NodeInput::Network => {
+					input_index = inner_network
+						.inputs
+						.iter()
+						.enumerate()
+						.filter(|&(_index, &id)| id == node_path[end])
+						.nth(input_index)
+						.ok_or_else(|| "Invalid network input".to_string())?
+						.0;
+				}
+				// If the input is just a value, return that value
+				NodeInput::Value { tagged_value, .. } => return dyn_any::downcast::<T>(tagged_value.clone().to_any()).map(|v| *v),
+				// If the input is from a node, set the node to be the output (so that is what is evaluated)
+				NodeInput::Node { node_id, output_index } => {
+					inner_network.outputs[0] = NodeOutput::new(*node_id, *output_index);
+					break 'outer;
+				}
+			}
+		}
+
+		self.execute_network(network, image_frame.into_owned())
+	}
+
+	/// Encodes an image into a format using the image crate
+	fn encode_img(image: Image, resize: Option<DVec2>, format: image::ImageOutputFormat) -> Result<(Vec<u8>, (u32, u32)), String> {
+		use image::{ImageBuffer, Rgba};
+		use std::io::Cursor;
+
+		let (result_bytes, width, height) = image.as_flat_u8();
+
+		let mut output: ImageBuffer<Rgba<u8>, _> = image::ImageBuffer::from_raw(width, height, result_bytes).ok_or_else(|| "Invalid image size".to_string())?;
+		if let Some(size) = resize {
+			let size = size.as_uvec2();
+			if size.x > 0 && size.y > 0 {
+				output = image::imageops::resize(&output, size.x, size.y, image::imageops::Triangle);
+			}
+		}
+		let size = output.dimensions();
+		let mut image_data: Vec<u8> = Vec::new();
+		output.write_to(&mut Cursor::new(&mut image_data), format).map_err(|e| e.to_string())?;
+		debug!("Returning from encode image");
+		Ok::<_, String>((image_data, size))
+	}
+
+	fn generate_imaginate(
+		&mut self,
+		network: NodeNetwork,
+		imaginate_node: Vec<NodeId>,
+		(document, document_id): (&mut DocumentMessageHandler, u64),
+		layer_path: Vec<LayerId>,
+		image_frame: ImageFrame,
+		(preferences, persistent_data): (&PreferencesMessageHandler, &PersistentData),
+	) -> Result<Message, String> {
+		use crate::messages::portfolio::document::node_graph::IMAGINATE_NODE;
+		use graph_craft::imaginate_input::*;
+
+		let get = |name: &str| IMAGINATE_NODE.inputs.iter().position(|input| input.name == name).unwrap_or_else(|| panic!("Input {name} not found"));
+
+		let resolution: Option<glam::DVec2> = self.compute_input(&network, &imaginate_node, get("Resolution"), Cow::Borrowed(&image_frame))?;
+		let resolution = resolution.unwrap_or_else(|| {
+			let transform = document.document_legacy.root.transform.inverse() * document.document_legacy.multiply_transforms(&layer_path).unwrap();
+			let (x, y) = pick_safe_imaginate_resolution((transform.transform_vector2(DVec2::new(1., 0.)).length(), transform.transform_vector2(DVec2::new(0., 1.)).length()));
+			DVec2::new(x as f64, y as f64)
+		});
+
+		let transform = document.document_legacy.root.transform.inverse() * document.document_legacy.multiply_transforms(&layer_path).unwrap();
+		let parameters = ImaginateGenerationParameters {
+			seed: self.compute_input::<f64>(&network, &imaginate_node, get("Seed"), Cow::Borrowed(&image_frame))? as u64,
+			resolution: resolution.as_uvec2().into(),
+			samples: self.compute_input::<f64>(&network, &imaginate_node, get("Samples"), Cow::Borrowed(&image_frame))? as u32,
+			sampling_method: self
+				.compute_input::<ImaginateSamplingMethod>(&network, &imaginate_node, get("Sampling Method"), Cow::Borrowed(&image_frame))?
+				.api_value()
+				.to_string(),
+			text_guidance: self.compute_input(&network, &imaginate_node, get("Prompt Guidance"), Cow::Borrowed(&image_frame))?,
+			text_prompt: self.compute_input(&network, &imaginate_node, get("Prompt"), Cow::Borrowed(&image_frame))?,
+			negative_prompt: self.compute_input(&network, &imaginate_node, get("Negative Prompt"), Cow::Borrowed(&image_frame))?,
+			image_creativity: Some(self.compute_input::<f64>(&network, &imaginate_node, get("Image Creativity"), Cow::Borrowed(&image_frame))? / 100.),
+			restore_faces: self.compute_input(&network, &imaginate_node, get("Improve Faces"), Cow::Borrowed(&image_frame))?,
+			tiling: self.compute_input(&network, &imaginate_node, get("Tiling"), Cow::Borrowed(&image_frame))?,
+		};
+		let use_base_image = self.compute_input::<bool>(&network, &imaginate_node, get("Adapt Input Image"), Cow::Borrowed(&image_frame))?;
+
+		let base_image = if use_base_image {
+			let image: Image = self.compute_input(&network, &imaginate_node, get("Input Image"), Cow::Borrowed(&image_frame))?;
+			// Only use if has size
+			if image.width > 0 && image.height > 0 {
+				debug!("Start image encode");
+				let (image_data, size) = Self::encode_img(image, Some(resolution), image::ImageOutputFormat::Png)?;
+				debug!("End image encode");
+				let size = DVec2::new(size.0 as f64, size.1 as f64);
+				let mime = "image/png".to_string();
+				Some(ImaginateBaseImage { image_data, size, mime })
+			} else {
+				None
+			}
+		} else {
+			None
+		};
+
+		let mask_image = if base_image.is_some() {
+			let mask_path: Option<Vec<LayerId>> = self.compute_input(&network, &imaginate_node, get("Masking Layer"), Cow::Borrowed(&image_frame))?;
+
+			// Calculate the size of the node graph frame
+			let size = DVec2::new(transform.transform_vector2(DVec2::new(1., 0.)).length(), transform.transform_vector2(DVec2::new(0., 1.)).length());
+
+			// Render the masking layer within the node graph frame
+			let old_transforms = document.remove_document_transform();
+			let mask_is_some = mask_path.is_some();
+			let mask_image = mask_path.filter(|mask_layer_path| document.document_legacy.layer(mask_layer_path).is_ok()).map(|mask_layer_path| {
+				let render_mode = DocumentRenderMode::LayerCutout(&mask_layer_path, graphene_core::raster::color::Color::WHITE);
+				let svg = document.render_document(size, transform.inverse(), persistent_data, render_mode);
+
+				ImaginateMaskImage { svg, size }
+			});
+
+			if mask_is_some && mask_image.is_none() {
+				return Err(
+					"Imagination masking layer is missing.\nIt may have been deleted or moved. Please drag a new layer reference\ninto the 'Masking Layer' parameter input, then generate again."
+						.to_string(),
+				);
+			}
+
+			document.restore_document_transform(old_transforms);
+			mask_image
+		} else {
+			None
+		};
+
+		Ok(FrontendMessage::TriggerImaginateGenerate {
+			parameters: Box::new(parameters),
+			base_image: base_image.map(Box::new),
+			mask_image: mask_image.map(Box::new),
+			mask_paint_mode: if self.compute_input::<bool>(&network, &imaginate_node, get("Inpaint"), Cow::Borrowed(&image_frame))? {
+				ImaginateMaskPaintMode::Inpaint
+			} else {
+				ImaginateMaskPaintMode::Outpaint
+			},
+			mask_blur_px: self.compute_input::<f64>(&network, &imaginate_node, get("Mask Blur"), Cow::Borrowed(&image_frame))? as u32,
+			imaginate_mask_starting_fill: self.compute_input(&network, &imaginate_node, get("Mask Starting Fill"), Cow::Borrowed(&image_frame))?,
+			hostname: preferences.imaginate_server_hostname.clone(),
+			refresh_frequency: preferences.imaginate_refresh_frequency,
+			document_id,
+			layer_path,
+			node_path: imaginate_node,
+		}
+		.into())
+	}
+
+	/// Evaluates a node graph, computing either the imaginate node or the entire graph
+	pub fn evaluate_node_graph(
+		&mut self,
+		(document_id, documents): (u64, &mut HashMap<u64, DocumentMessageHandler>),
+		layer_path: Vec<LayerId>,
+		(image_data, (width, height)): (Vec<u8>, (u32, u32)),
+		imaginate_node: Option<Vec<NodeId>>,
+		persistent_data: (&PreferencesMessageHandler, &PersistentData),
+		responses: &mut VecDeque<Message>,
+	) -> Result<(), String> {
+		// Reformat the input image data into an f32 image
+		let image = graphene_core::raster::Image::from_image_data(&image_data, width, height);
+
+		// Get the node graph layer
+		let document = documents.get_mut(&document_id).ok_or_else(|| "Invalid document".to_string())?;
+		let layer = document.document_legacy.layer(&layer_path).map_err(|e| format!("No layer: {e:?}"))?;
+
+		// Construct the input image frame
+		let transform = layer.transform;
+		let image_frame = ImageFrame { image, transform };
+
+		let node_graph_frame = match &layer.data {
+			LayerDataType::NodeGraphFrame(frame) => Ok(frame),
+			_ => Err("Invalid layer type".to_string()),
+		}?;
+		let network = node_graph_frame.network.clone();
+
+		// Execute the node graph
+		if let Some(imaginate_node) = imaginate_node {
+			responses.push_back(self.generate_imaginate(network, imaginate_node, (document, document_id), layer_path, image_frame, persistent_data)?);
+		} else {
+			let ImageFrame { mut image, transform } = self.execute_network(network, image_frame)?;
+
+			// If no image was generated, use the input image
+			if image.width == 0 || image.height == 0 {
+				image = graphene_core::raster::Image::from_image_data(&image_data, width, height);
+			}
+
+			let (image_data, _size) = Self::encode_img(image, None, image::ImageOutputFormat::Bmp)?;
+
+			responses.push_back(
+				Operation::SetNodeGraphFrameImageData {
+					layer_path: layer_path.clone(),
+					image_data: image_data.clone(),
+				}
+				.into(),
+			);
+			let mime = "image/bmp".to_string();
+			let image_data = std::sync::Arc::new(image_data);
+			let image_data = vec![FrontendImageData {
+				path: layer_path.clone(),
+				image_data,
+				mime,
+			}];
+			responses.push_back(FrontendMessage::UpdateImageData { document_id, image_data }.into());
+
+			// Update the transform based on the graph output
+			let transform = transform.to_cols_array();
+			responses.push_back(Operation::SetLayerTransform { path: layer_path, transform }.into());
+		}
+
+		Ok(())
+	}
+}

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -123,14 +123,15 @@ impl NodeGraphExecutor {
 
 		let get = |name: &str| IMAGINATE_NODE.inputs.iter().position(|input| input.name == name).unwrap_or_else(|| panic!("Input {name} not found"));
 
+		let transform: DAffine2 = self.compute_input(&network, &imaginate_node, get("Transform"), Cow::Borrowed(&image_frame))?;
+		debug!("Transform {transform} x {x} y {y}");
+
 		let resolution: Option<glam::DVec2> = self.compute_input(&network, &imaginate_node, get("Resolution"), Cow::Borrowed(&image_frame))?;
 		let resolution = resolution.unwrap_or_else(|| {
-			let transform = document.document_legacy.root.transform.inverse() * document.document_legacy.multiply_transforms(&layer_path).unwrap();
 			let (x, y) = pick_safe_imaginate_resolution((transform.transform_vector2(DVec2::new(1., 0.)).length(), transform.transform_vector2(DVec2::new(0., 1.)).length()));
 			DVec2::new(x as f64, y as f64)
 		});
 
-		let transform = document.document_legacy.root.transform.inverse() * document.document_legacy.multiply_transforms(&layer_path).unwrap();
 		let parameters = ImaginateGenerationParameters {
 			seed: self.compute_input::<f64>(&network, &imaginate_node, get("Seed"), Cow::Borrowed(&image_frame))? as u64,
 			resolution: resolution.as_uvec2().into(),

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -9,7 +9,6 @@ use rand_chacha::{
 	ChaCha20Rng,
 };
 use std::collections::{HashMap, HashSet};
-use std::net;
 use std::sync::Mutex;
 
 pub mod value;

--- a/node-graph/graph-craft/src/executor.rs
+++ b/node-graph/graph-craft/src/executor.rs
@@ -27,7 +27,7 @@ impl Compiler {
 	}
 	pub fn compile_single(&self, network: NodeNetwork, resolve_inputs: bool) -> Result<ProtoNetwork, String> {
 		assert_eq!(network.outputs.len(), 1, "Graph with multiple outputs not yet handled");
-		let Some(proto_network) = self.compile(network, resolve_inputs).into_iter().next() else {
+		let Some(proto_network) = self.compile(network, resolve_inputs).next() else {
 			return Err("Failed to convert graph into proto graph".to_string());
 		};
 		Ok(proto_network)

--- a/node-graph/gstd/src/any.rs
+++ b/node-graph/gstd/src/any.rs
@@ -73,7 +73,7 @@ where
 	N: Node<'input, Any<'input>, Output = Any<'input>>,
 {
 	let node_name = core::any::type_name::<N>();
-	let out = dyn_any::downcast(node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e} in:\n{node_name}"));
+	let out = dyn_any::downcast(node.eval(input)).unwrap_or_else(|e| panic!("DowncastNode Input {e} in:\n{node_name}"));
 	*out
 }
 
@@ -91,7 +91,7 @@ impl<'n: 'input, 'input, O: 'input + StaticType, I: 'input + StaticType> Node<'i
 	fn eval<'node: 'input>(&'node self, input: I) -> Self::Output {
 		{
 			let input = Box::new(input);
-			let out = dyn_any::downcast(self.node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e}"));
+			let out = dyn_any::downcast(self.node.eval(input)).unwrap_or_else(|e| panic!("DowncastBothNode Input {e}"));
 			*out
 		}
 	}
@@ -118,7 +118,7 @@ impl<'n: 'input, 'input, O: 'input + StaticType, I: 'input + StaticType> Node<'i
 	fn eval<'node: 'input>(&'node self, input: I) -> Self::Output {
 		{
 			let input = Box::new(input);
-			let out: Box<&_> = dyn_any::downcast::<&O>(self.node.eval(input)).unwrap_or_else(|e| panic!("DynAnyNode Input {e}"));
+			let out: Box<&_> = dyn_any::downcast::<&O>(self.node.eval(input)).unwrap_or_else(|e| panic!("DowncastBothRefNode Input {e}"));
 			*out
 		}
 	}

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -83,7 +83,7 @@ static NODE_REGISTRY: &[(NodeIdentifier, NodeConstructor)] = &[
 	(
 		NodeIdentifier::new("graphene_std::raster::ImaginateNode<_>", &[concrete!("Image"), concrete!("Option<std::sync::Arc<Image>>")]),
 		|args| {
-			let cached = graphene_std::any::input_node::<Option<std::sync::Arc<Image>>>(args[15]);
+			let cached = graphene_std::any::input_node::<Option<std::sync::Arc<Image>>>(args[16]);
 			let node = graphene_std::raster::ImaginateNode::new(cached);
 			let any = DynAnyNode::new(ValueNode::new(node));
 			any.into_type_erased()

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -1,4 +1,4 @@
-use glam::{DAffine2, DVec2};
+use glam::DAffine2;
 use graphene_core::ops::{CloneNode, IdNode, TypeNode};
 use graphene_core::raster::color::Color;
 use graphene_core::raster::*;


### PR DESCRIPTION
The imaginate node has a transform input. When the imaginate node exists, the graph is evaluated every frame. You can adapt any behaviour you want here @Keavon.

Some code to do with the node graph was removed from the portfolio message handler and moved to a new `node_graph_executor.rs` file.