### PR TITLE
Change tauri build directory back to `../dist`

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
-dist/
+dist/**
+!dist/.git-keep-directory
 pkg/

--- a/frontend/dist-tauri/.git-keep-directory
+++ b/frontend/dist-tauri/.git-keep-directory
@@ -1,1 +1,0 @@
-This file exists just so Git keeps this directory.

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
 	"build": {
 		"beforeBuildCommand": "npm run build",
 		"beforeDevCommand": "npm start",
-		"distDir": "../dist-tauri",
+		"distDir": "../dist",
 		"devPath": "http://127.0.0.1:8080"
 	},
 	"package": {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Reimplements #946

This does change the tauri build folder back to `../dist` but ensures that the dist file is included in git

Closes #946
