### PR TITLE
Bezier-rs: Add self_intersection to subpath

### DIFF
--- a/libraries/bezier-rs/src/bezier/solvers.rs
+++ b/libraries/bezier-rs/src/bezier/solvers.rs
@@ -359,13 +359,17 @@ impl Bezier {
 		let (self2, self2_t_values) = (self1.clone(), self1_t_values.clone());
 		let num_curves = self1.len();
 
+		// Adjacent reduced curves cannot intersect
+		if num_curves <= 2 {
+			return vec![];
+		}
+
 		// Create iterators that combine a subcurve with the `t` value pair that it was trimmed with
 		let combined_iterator1 = self1.into_iter().zip(self1_t_values.windows(2).map(|t_pair| Range { start: t_pair[0], end: t_pair[1] }));
 		// Second one needs to be a list because Iterator does not implement copy
 		let combined_list2: Vec<(Bezier, Range<f64>)> = self2.into_iter().zip(self2_t_values.windows(2).map(|t_pair| Range { start: t_pair[0], end: t_pair[1] })).collect();
 
-		// Adjacent reduced curves cannot intersect
-		// So for each curve, look for intersections with every curve that is at least 2 indices away
+		// For each curve, look for intersections with every curve that is at least 2 indices away
 		combined_iterator1
 			.take(num_curves - 2)
 			.enumerate()

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -37,7 +37,7 @@ impl Subpath {
 		match t {
 			SubpathTValue::Parametric { segment_index, t } => {
 				assert!((0.0..=1.).contains(&t));
-				assert!((0..self.len_segments() - 1).contains(&segment_index));
+				assert!((0..self.len_segments()).contains(&segment_index));
 				(segment_index, t)
 			}
 			SubpathTValue::GlobalParametric(global_t) => {

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -10,7 +10,14 @@ impl Subpath {
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/evaluate/solo" title="Evaluate Demo"></iframe>
 	pub fn evaluate(&self, t: SubpathTValue) -> DVec2 {
-		let (segment_index, t) = self.t_value_to_parametric(t);
+		let (segment_index, t) = match t {
+			SubpathTValue::GlobalEuclidean(_) => todo!(),
+			SubpathTValue::Parametric { segment_index, t: segment_t } => (segment_index, segment_t),
+			SubpathTValue::GlobalParametric(_) => self.t_value_to_parametric(t),
+			SubpathTValue::Euclidean { segment_index, t } => todo!(),
+			SubpathTValue::EuclideanWithinError { segment_index, t, error } => todo!(),
+			SubpathTValue::GlobalEuclideanWithinError { t, error } => todo!(),
+		};
 		self.get_segment(segment_index).unwrap().evaluate(TValue::Parametric(t))
 	}
 

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::consts::{MAX_ABSOLUTE_DIFFERENCE, MIN_SEPERATION_VALUE};
+use crate::consts::MAX_ABSOLUTE_DIFFERENCE;
 use crate::utils::SubpathTValue;
 use crate::TValue;
 
@@ -28,14 +28,6 @@ impl Subpath {
 			.enumerate()
 			.flat_map(|(index, bezier)| bezier.intersections(other, error, minimum_seperation).into_iter().map(|t| (index, t)).collect::<Vec<(usize, f64)>>())
 			.collect();
-
-		intersection_t_values.iter().fold(Vec::<(usize, f64)>::new(), |mut accumulator, (index, t)| {
-			if !accumulator.is_empty() && (accumulator.last().unwrap().1 - t).abs() < minimum_seperation.unwrap_or(MIN_SEPERATION_VALUE) {
-				accumulator.pop();
-			}
-			accumulator.push((*index, *t));
-			accumulator
-		});
 
 		intersection_t_values
 	}

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -27,7 +27,7 @@ impl Subpath {
 	/// - `error`: an optional f64 value to provide an error bound
 	/// - `minimum_seperation`: the minimum difference two adjacent `t`-values must have when comparing adjacent `t`-values in sorted order.
 	/// If the comparison condition is not satisfied, the function takes the larger `t`-value of the two.
-	/// /// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
 	pub fn intersections(&self, other: &Bezier, error: Option<f64>, minimum_seperation: Option<f64>) -> Vec<(usize, f64)> {
 		// TODO: account for either euclidean or parametric type
 		let intersection_t_values: Vec<(usize, f64)> = self

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -60,7 +60,7 @@ impl Subpath {
 	/// If the comparison condition is not satisfied, the function takes the larger `t`-value of the two
 	///
 	/// **NOTE**: if an intersection were to occur within an `error` distance away from an anchor point, the algorithm will filter that intersection out.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/normal/solo" title="Normal Demo"></iframe>
+	// TODO: add iframe to rustdocs
 	pub fn self_intersections(&self, error: Option<f64>, minimum_seperation: Option<f64>) -> Vec<(usize, f64)> {
 		let mut intersections_vec = Vec::new();
 		let err = error.unwrap_or(MAX_ABSOLUTE_DIFFERENCE);
@@ -80,6 +80,7 @@ impl Subpath {
 		intersections_vec
 	}
 
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/normal/solo" title="Normal Demo"></iframe>
 	pub fn normal(&self, t: SubpathTValue) -> DVec2 {
 		let (segment_index, t) = self.t_value_to_parametric(t);
 		self.get_segment(segment_index).unwrap().normal(TValue::Parametric(t))

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -14,7 +14,9 @@ impl Subpath {
 		self.get_segment(segment_index).unwrap().evaluate(TValue::Parametric(t))
 	}
 
-	/// Calculates the intersection points the subpath has with a given curve and returns a list of parameteric `t`-values.
+	/// Calculates the intersection points the subpath has with a given curve and returns a list of `(usize, f64)` tuples,
+	/// where the `usize` represents the index of the curve in the subpath, and the `f64` represents the `t`-value local to
+	/// that curve where the intersection occured.
 	/// This function expects the following:
 	/// - `other`: a [Bezier] curve to check intersections against
 	/// - `error`: an optional f64 value to provide an error bound
@@ -65,6 +67,7 @@ impl Subpath {
 		intersections_vec
 	}
 
+	/// Returns a normalized unit vector representing the direction of the normal on the subpath based on the parametric `t`-value provided.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/normal/solo" title="Normal Demo"></iframe>
 	pub fn normal(&self, t: SubpathTValue) -> DVec2 {
 		let (segment_index, t) = self.t_value_to_parametric(t);

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -10,11 +10,7 @@ impl Subpath {
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/evaluate/solo" title="Evaluate Demo"></iframe>
 	pub fn evaluate(&self, t: SubpathTValue) -> DVec2 {
-		let (segment_index, t) = match t {
-			SubpathTValue::Parametric { segment_index, t: segment_t } => (segment_index, segment_t),
-			SubpathTValue::GlobalParametric(_) => self.t_value_to_parametric(t),
-			_ => todo!(),
-		};
+		let (segment_index, t) = self.t_value_to_parametric(t);
 		self.get_segment(segment_index).unwrap().evaluate(TValue::Parametric(t))
 	}
 

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -11,12 +11,9 @@ impl Subpath {
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/evaluate/solo" title="Evaluate Demo"></iframe>
 	pub fn evaluate(&self, t: SubpathTValue) -> DVec2 {
 		let (segment_index, t) = match t {
-			SubpathTValue::GlobalEuclidean(_) => todo!(),
 			SubpathTValue::Parametric { segment_index, t: segment_t } => (segment_index, segment_t),
 			SubpathTValue::GlobalParametric(_) => self.t_value_to_parametric(t),
-			SubpathTValue::Euclidean { segment_index, t } => todo!(),
-			SubpathTValue::EuclideanWithinError { segment_index, t, error } => todo!(),
-			SubpathTValue::GlobalEuclideanWithinError { t, error } => todo!(),
+			_ => todo!(),
 		};
 		self.get_segment(segment_index).unwrap().evaluate(TValue::Parametric(t))
 	}
@@ -60,7 +57,7 @@ impl Subpath {
 	/// If the comparison condition is not satisfied, the function takes the larger `t`-value of the two
 	///
 	/// **NOTE**: if an intersection were to occur within an `error` distance away from an anchor point, the algorithm will filter that intersection out.
-	// TODO: add iframe to rustdocs
+	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/self-intersect/solo" title="Self-Intersection Demo"></iframe>
 	pub fn self_intersections(&self, error: Option<f64>, minimum_seperation: Option<f64>) -> Vec<(usize, f64)> {
 		let mut intersections_vec = Vec::new();
 		let err = error.unwrap_or(MAX_ABSOLUTE_DIFFERENCE);

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -1,4 +1,4 @@
-import { tSliderOptions } from "@/utils/options";
+import { tSliderOptions, intersectionErrorOptions, minimumSeparationOptions } from "@/utils/options";
 import { TVariant, SliderOption, SubpathCallback, WasmSubpathInstance } from "@/utils/types";
 
 const subpathFeatures = {
@@ -54,30 +54,50 @@ const subpathFeatures = {
 	},
 	"intersect-linear": {
 		name: "Intersect (Line Segment)",
-		callback: (subpath: WasmSubpathInstance): string =>
-			subpath.intersect_line_segment([
-				[150, 150],
-				[20, 20],
-			]),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string =>
+			subpath.intersect_line_segment(
+				[
+					[150, 150],
+					[20, 20],
+				],
+				options.error,
+				options.minimum_seperation
+			),
+		sliderOptions: [intersectionErrorOptions, minimumSeparationOptions],
 	},
 	"intersect-quadratic": {
-		name: "Intersect (Quadratic segment)",
-		callback: (subpath: WasmSubpathInstance): string =>
-			subpath.intersect_quadratic_segment([
-				[20, 80],
-				[180, 10],
-				[90, 120],
-			]),
+		name: "Intersect (Quadratic Segment)",
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string =>
+			subpath.intersect_quadratic_segment(
+				[
+					[20, 80],
+					[180, 10],
+					[90, 120],
+				],
+				options.error,
+				options.minimum_seperation
+			),
+		sliderOptions: [intersectionErrorOptions, minimumSeparationOptions],
 	},
 	"intersect-cubic": {
-		name: "Intersect (Cubic segment)",
-		callback: (subpath: WasmSubpathInstance): string =>
-			subpath.intersect_cubic_segment([
-				[40, 20],
-				[100, 40],
-				[40, 120],
-				[175, 140],
-			]),
+		name: "Intersect (Cubic Segment)",
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string =>
+			subpath.intersect_cubic_segment(
+				[
+					[40, 20],
+					[100, 40],
+					[40, 120],
+					[175, 140],
+				],
+				options.error,
+				options.minimum_seperation
+			),
+		sliderOptions: [intersectionErrorOptions, minimumSeparationOptions],
+	},
+	"self-intersect": {
+		name: "Self Intersect",
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.self_intersections(options.error, options.minimum_seperation),
+		sliderOptions: [intersectionErrorOptions, minimumSeparationOptions],
 	},
 	split: {
 		name: "Split",

--- a/website/other/bezier-rs-demos/src/utils/options.ts
+++ b/website/other/bezier-rs-demos/src/utils/options.ts
@@ -21,3 +21,11 @@ export const minimumSeparationOptions = {
 	step: 0.001,
 	default: 0.05,
 };
+
+export const intersectionErrorOptions = {
+	variable: "error",
+	min: 0.001,
+	max: 0.525,
+	step: 0.0025,
+	default: 0.02,
+};

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -199,8 +199,11 @@ impl WasmSubpath {
 			.0
 			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
-			.map(|intersection_t| {
-				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
+			.map(|(segment_index, intersection_t)| {
+				let point = self.0.evaluate(SubpathTValue::Parametric {
+					segment_index: *segment_index,
+					t: *intersection_t,
+				});
 				draw_circle(point, 4., RED, 1.5, WHITE)
 			})
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));
@@ -228,8 +231,11 @@ impl WasmSubpath {
 			.0
 			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
-			.map(|intersection_t| {
-				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
+			.map(|(segment_index, intersection_t)| {
+				let point = self.0.evaluate(SubpathTValue::Parametric {
+					segment_index: *segment_index,
+					t: *intersection_t,
+				});
 				draw_circle(point, 4., RED, 1.5, WHITE)
 			})
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));
@@ -257,8 +263,11 @@ impl WasmSubpath {
 			.0
 			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
-			.map(|intersection_t| {
-				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
+			.map(|(segment_index, intersection_t)| {
+				let point = self.0.evaluate(SubpathTValue::Parametric {
+					segment_index: *segment_index,
+					t: *intersection_t,
+				});
 				draw_circle(point, 4., RED, 1.5, WHITE)
 			})
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));
@@ -273,7 +282,10 @@ impl WasmSubpath {
 			.self_intersections(Some(error), Some(minimum_separation))
 			.iter()
 			.map(|(segment_index, intersection_t)| {
-				let point = self.0.evaluate(TValue::Parametric(((*segment_index as f64) + *intersection_t) / (self.0.len_segments() as f64)));
+				let point = self.0.evaluate(SubpathTValue::Parametric {
+					segment_index: *segment_index,
+					t: *intersection_t,
+				});
 				draw_circle(point, 4., RED, 1.5, WHITE)
 			})
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -179,7 +179,7 @@ impl WasmSubpath {
 		wrap_svg_tag(content)
 	}
 
-	pub fn intersect_line_segment(&self, js_points: JsValue) -> String {
+	pub fn intersect_line_segment(&self, js_points: JsValue, error: f64, minimum_separation: f64) -> String {
 		let points: [DVec2; 2] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_linear_dvec2(points[0], points[1]);
 
@@ -197,7 +197,7 @@ impl WasmSubpath {
 
 		let intersections_svg = self
 			.0
-			.intersections(&line, None, None)
+			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
 			.map(|intersection_t| {
 				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
@@ -208,7 +208,7 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_quadratic_segment(&self, js_points: JsValue) -> String {
+	pub fn intersect_quadratic_segment(&self, js_points: JsValue, error: f64, minimum_separation: f64) -> String {
 		let points: [DVec2; 3] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_quadratic_dvec2(points[0], points[1], points[2]);
 
@@ -226,7 +226,7 @@ impl WasmSubpath {
 
 		let intersections_svg = self
 			.0
-			.intersections(&line, None, None)
+			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
 			.map(|intersection_t| {
 				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
@@ -237,7 +237,7 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
 	}
 
-	pub fn intersect_cubic_segment(&self, js_points: JsValue) -> String {
+	pub fn intersect_cubic_segment(&self, js_points: JsValue, error: f64, minimum_separation: f64) -> String {
 		let points: [DVec2; 4] = serde_wasm_bindgen::from_value(js_points).unwrap();
 		let line = Bezier::from_cubic_dvec2(points[0], points[1], points[2], points[3]);
 
@@ -255,7 +255,7 @@ impl WasmSubpath {
 
 		let intersections_svg = self
 			.0
-			.intersections(&line, None, None)
+			.intersections(&line, Some(error), Some(minimum_separation))
 			.iter()
 			.map(|intersection_t| {
 				let point = self.0.evaluate(SubpathTValue::GlobalParametric(*intersection_t));
@@ -264,6 +264,21 @@ impl WasmSubpath {
 			.fold(String::new(), |acc, item| format!("{acc}{item}"));
 
 		wrap_svg_tag(format!("{subpath_svg}{line_svg}{intersections_svg}"))
+	}
+
+	pub fn self_intersections(&self, error: f64, minimum_separation: f64) -> String {
+		let subpath_svg = self.to_default_svg();
+		let self_intersections_svg = self
+			.0
+			.self_intersections(Some(error), Some(minimum_separation))
+			.iter()
+			.map(|(segment_index, intersection_t)| {
+				let point = self.0.evaluate(TValue::Parametric(((*segment_index as f64) + *intersection_t) / (self.0.len_segments() as f64)));
+				draw_circle(point, 4., RED, 1.5, WHITE)
+			})
+			.fold(String::new(), |acc, item| format!("{acc}{item}"));
+
+		wrap_svg_tag(format!("{subpath_svg}{self_intersections_svg}"))
 	}
 
 	pub fn split(&self, t: f64, t_variant: String) -> String {


### PR DESCRIPTION
This PR adds a naive brute-force implementation of the self_intersections function to the Subpath library. This PR also updates the function description of the intersections function to include the minimum_separation variable.

This PR is a rebase of the work done in #915.