### PR TITLE
Add lock angle modifier to the Pen tool

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -171,7 +171,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(DoubleClick; action_dispatch=PathToolMessage::InsertPoint),
 		//
 		// PenToolMessage
-		entry!(PointerMove; refresh_keys=[Shift, Control], action_dispatch=PenToolMessage::PointerMove { snap_angle: Control, break_handle: Shift }),
+		entry!(PointerMove; refresh_keys=[Shift, Control], action_dispatch=PenToolMessage::PointerMove { snap_angle: Shift, break_handle: Alt, lock_angle: Control}),
 		entry!(KeyDown(Lmb); action_dispatch=PenToolMessage::DragStart),
 		entry!(KeyUp(Lmb); action_dispatch=PenToolMessage::DragStop),
 		entry!(KeyDown(Rmb); action_dispatch=PenToolMessage::Confirm),

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -600,11 +600,9 @@ impl Fsm for PenToolFsmState {
 		let hint_data = match self {
 			PenToolFsmState::Ready => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Draw Path")])]),
 			PenToolFsmState::DraggingHandle | PenToolFsmState::PlacingAnchor => HintData(vec![
-				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Add Handle")]),
-				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Add Anchor")]),
-				HintGroup(vec![HintInfo::keys([Key::Shift], "Snap 15°")]),
-				HintGroup(vec![HintInfo::keys([Key::Alt], "Break Handle")]),
-				HintGroup(vec![HintInfo::keys([Key::Control], "Lock Angle")]),
+				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Add Anchor"), HintInfo::mouse(MouseMotion::LmbDrag, "Add Handle")]),
+				HintGroup(vec![HintInfo::keys([Key::Shift], "Snap 15°"), HintInfo::keys([Key::Control], "Lock Angle")]),
+				HintGroup(vec![HintInfo::keys([Key::Alt], "Break Handle")]), // TODO: Show this only when dragging a handle
 				HintGroup(vec![HintInfo::keys([Key::Enter], "End Path")]),
 			]),
 		};


### PR DESCRIPTION
- [x] The current [Shift] Break Handle behavior should become Alt instead of Shift
- [x] The current [Ctrl] Snap 15° behavior should become Shift instead of Ctrl
- [x] Implement the extend-in-this-direction feature called [Ctrl] Lock Angle that exists in the Line tool, but doesn't yet exist in the Pen tool

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Fixes #1048  
