### PR TITLE
Bézier-rs: Add ids to manipulator groups

### DIFF
--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -4,7 +4,7 @@ use crate::consts::*;
 use std::fmt::Write;
 
 /// Functionality relating to core `Subpath` operations, such as constructors and `iter`.
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Create a new `Subpath` using a list of [ManipulatorGroup]s.
 	/// A `Subpath` with less than 2 [ManipulatorGroup]s may not be closed.
 	pub fn new(manipulator_groups: Vec<ManipulatorGroup<ManipulatorGroupId>>, closed: bool) -> Self {

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -4,10 +4,10 @@ use crate::consts::*;
 use std::fmt::Write;
 
 /// Functionality relating to core `Subpath` operations, such as constructors and `iter`.
-impl Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
 	/// Create a new `Subpath` using a list of [ManipulatorGroup]s.
 	/// A `Subpath` with less than 2 [ManipulatorGroup]s may not be closed.
-	pub fn new(manipulator_groups: Vec<ManipulatorGroup>, closed: bool) -> Self {
+	pub fn new(manipulator_groups: Vec<ManipulatorGroup<ManipulatorGroupId>>, closed: bool) -> Self {
 		assert!(!closed || manipulator_groups.len() > 1, "A closed Subpath must contain more than 1 ManipulatorGroup.");
 		Self { manipulator_groups, closed }
 	}
@@ -20,11 +20,13 @@ impl Subpath {
 					anchor: bezier.start(),
 					in_handle: None,
 					out_handle: bezier.handle_start(),
+					id: ManipulatorGroupId::new(),
 				},
 				ManipulatorGroup {
 					anchor: bezier.end(),
 					in_handle: bezier.handle_end(),
 					out_handle: None,
+					id: ManipulatorGroupId::new(),
 				},
 			],
 			false,
@@ -59,7 +61,7 @@ impl Subpath {
 	}
 
 	/// Returns an iterator of the [Bezier]s along the `Subpath`.
-	pub fn iter(&self) -> SubpathIter {
+	pub fn iter(&self) -> SubpathIter<ManipulatorGroupId> {
 		SubpathIter { sub_path: self, index: 0 }
 	}
 

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -5,7 +5,7 @@ use crate::ProjectionOptions;
 use glam::DVec2;
 
 /// Functionality relating to looking up properties of the `Subpath` or points along the `Subpath`.
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Return the sum of the approximation of the length of each `Bezier` curve along the `Subpath`.
 	/// - `num_subdivisions` - Number of subdivisions used to approximate the curve. The default value is `1000`.
 	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/length/solo" title="Length Demo"></iframe>
@@ -126,19 +126,19 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle2),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
@@ -168,19 +168,19 @@ mod tests {
 					anchor: start,
 					in_handle: Some(handle3),
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle2),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
@@ -197,7 +197,7 @@ mod tests {
 			anchor: DVec2::new(0., 0.),
 			in_handle: None,
 			out_handle: None,
-			id: EmptyManipulatorGroupId,
+			id: EmptyId,
 		};
 		let open_subpath = Subpath {
 			manipulator_groups: vec![mock_manipulator_group; 5],
@@ -219,7 +219,7 @@ mod tests {
 			anchor: DVec2::new(0., 0.),
 			in_handle: None,
 			out_handle: None,
-			id: EmptyManipulatorGroupId,
+			id: EmptyId,
 		};
 		let closed_subpath = Subpath {
 			manipulator_groups: vec![mock_manipulator_group; 5],

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -5,7 +5,7 @@ use crate::ProjectionOptions;
 use glam::DVec2;
 
 /// Functionality relating to looking up properties of the `Subpath` or points along the `Subpath`.
-impl Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
 	/// Return the sum of the approximation of the length of each `Bezier` curve along the `Subpath`.
 	/// - `num_subdivisions` - Number of subdivisions used to approximate the curve. The default value is `1000`.
 	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/length/solo" title="Length Demo"></iframe>
@@ -126,16 +126,19 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle2),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
@@ -165,16 +168,19 @@ mod tests {
 					anchor: start,
 					in_handle: Some(handle3),
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle2),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
@@ -191,6 +197,7 @@ mod tests {
 			anchor: DVec2::new(0., 0.),
 			in_handle: None,
 			out_handle: None,
+			id: EmptyManipulatorGroupId,
 		};
 		let open_subpath = Subpath {
 			manipulator_groups: vec![mock_manipulator_group; 5],
@@ -212,6 +219,7 @@ mod tests {
 			anchor: DVec2::new(0., 0.),
 			in_handle: None,
 			out_handle: None,
+			id: EmptyManipulatorGroupId,
 		};
 		let closed_subpath = Subpath {
 			manipulator_groups: vec![mock_manipulator_group; 5],

--- a/libraries/bezier-rs/src/subpath/manipulators.rs
+++ b/libraries/bezier-rs/src/subpath/manipulators.rs
@@ -3,7 +3,7 @@ use crate::consts::MAX_ABSOLUTE_DIFFERENCE;
 use crate::utils::f64_compare;
 use crate::{SubpathTValue, TValue};
 
-impl Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
 	/// Inserts a `ManipulatorGroup` at a certain point along the subpath based on the parametric `t`-value provided.
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	pub fn insert(&mut self, t: SubpathTValue) {
@@ -22,6 +22,7 @@ impl Subpath {
 			anchor: first.end(),
 			in_handle: first.handle_end(),
 			out_handle: second.handle_start(),
+			id: ManipulatorGroupId::new(),
 		};
 		let number_of_groups = self.manipulator_groups.len() + 1;
 		self.manipulator_groups.insert((segment_index) + 1, new_group);
@@ -37,7 +38,7 @@ mod tests {
 	use super::*;
 	use glam::DVec2;
 
-	fn set_up_open_subpath() -> Subpath {
+	fn set_up_open_subpath() -> Subpath<EmptyManipulatorGroupId> {
 		let start = DVec2::new(20., 30.);
 		let middle1 = DVec2::new(80., 90.);
 		let middle2 = DVec2::new(100., 100.);
@@ -53,28 +54,32 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle1,
 					in_handle: None,
 					out_handle: Some(handle2),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle2,
 					in_handle: None,
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
 		)
 	}
 
-	fn set_up_closed_subpath() -> Subpath {
+	fn set_up_closed_subpath() -> Subpath<EmptyManipulatorGroupId> {
 		let mut subpath = set_up_open_subpath();
 		subpath.closed = true;
 		subpath

--- a/libraries/bezier-rs/src/subpath/manipulators.rs
+++ b/libraries/bezier-rs/src/subpath/manipulators.rs
@@ -3,7 +3,7 @@ use crate::consts::MAX_ABSOLUTE_DIFFERENCE;
 use crate::utils::f64_compare;
 use crate::{SubpathTValue, TValue};
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Inserts a `ManipulatorGroup` at a certain point along the subpath based on the parametric `t`-value provided.
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	pub fn insert(&mut self, t: SubpathTValue) {
@@ -38,7 +38,7 @@ mod tests {
 	use super::*;
 	use glam::DVec2;
 
-	fn set_up_open_subpath() -> Subpath<EmptyManipulatorGroupId> {
+	fn set_up_open_subpath() -> Subpath<EmptyId> {
 		let start = DVec2::new(20., 30.);
 		let middle1 = DVec2::new(80., 90.);
 		let middle2 = DVec2::new(100., 100.);
@@ -54,32 +54,32 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle1,
 					in_handle: None,
 					out_handle: Some(handle2),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle2,
 					in_handle: None,
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
 		)
 	}
 
-	fn set_up_closed_subpath() -> Subpath<EmptyManipulatorGroupId> {
+	fn set_up_closed_subpath() -> Subpath<EmptyId> {
 		let mut subpath = set_up_open_subpath();
 		subpath.closed = true;
 		subpath

--- a/libraries/bezier-rs/src/subpath/mod.rs
+++ b/libraries/bezier-rs/src/subpath/mod.rs
@@ -12,18 +12,18 @@ use std::ops::{Index, IndexMut};
 
 /// Structure used to represent a path composed of [Bezier] curves.
 #[derive(Clone, PartialEq)]
-pub struct Subpath<ManipulatorGroupId: crate::ManipulatorGroupId> {
+pub struct Subpath<ManipulatorGroupId: crate::Identifier> {
 	manipulator_groups: Vec<ManipulatorGroup<ManipulatorGroupId>>,
 	closed: bool,
 }
 
 /// Iteration structure for iterating across each curve of a `Subpath`, using an intermediate `Bezier` representation.
-pub struct SubpathIter<'a, ManipulatorGroupId: crate::ManipulatorGroupId> {
+pub struct SubpathIter<'a, ManipulatorGroupId: crate::Identifier> {
 	index: usize,
 	sub_path: &'a Subpath<ManipulatorGroupId>,
 }
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Index<usize> for Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Index<usize> for Subpath<ManipulatorGroupId> {
 	type Output = ManipulatorGroup<ManipulatorGroupId>;
 
 	fn index(&self, index: usize) -> &Self::Output {
@@ -32,14 +32,14 @@ impl<ManipulatorGroupId: crate::ManipulatorGroupId> Index<usize> for Subpath<Man
 	}
 }
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> IndexMut<usize> for Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> IndexMut<usize> for Subpath<ManipulatorGroupId> {
 	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
 		assert!(index < self.len(), "Index out of bounds in trait IndexMut of SubPath.");
 		&mut self.manipulator_groups[index]
 	}
 }
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Iterator for SubpathIter<'_, ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Iterator for SubpathIter<'_, ManipulatorGroupId> {
 	type Item = Bezier;
 
 	// Returns the Bezier representation of each `Subpath` segment, defined between a pair of adjacent manipulator points.

--- a/libraries/bezier-rs/src/subpath/mod.rs
+++ b/libraries/bezier-rs/src/subpath/mod.rs
@@ -12,19 +12,19 @@ use std::ops::{Index, IndexMut};
 
 /// Structure used to represent a path composed of [Bezier] curves.
 #[derive(Clone, PartialEq)]
-pub struct Subpath {
-	manipulator_groups: Vec<ManipulatorGroup>,
+pub struct Subpath<ManipulatorGroupId: crate::ManipulatorGroupId> {
+	manipulator_groups: Vec<ManipulatorGroup<ManipulatorGroupId>>,
 	closed: bool,
 }
 
 /// Iteration structure for iterating across each curve of a `Subpath`, using an intermediate `Bezier` representation.
-pub struct SubpathIter<'a> {
+pub struct SubpathIter<'a, ManipulatorGroupId: crate::ManipulatorGroupId> {
 	index: usize,
-	sub_path: &'a Subpath,
+	sub_path: &'a Subpath<ManipulatorGroupId>,
 }
 
-impl Index<usize> for Subpath {
-	type Output = ManipulatorGroup;
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Index<usize> for Subpath<ManipulatorGroupId> {
+	type Output = ManipulatorGroup<ManipulatorGroupId>;
 
 	fn index(&self, index: usize) -> &Self::Output {
 		assert!(index < self.len(), "Index out of bounds in trait Index of SubPath.");
@@ -32,14 +32,14 @@ impl Index<usize> for Subpath {
 	}
 }
 
-impl IndexMut<usize> for Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> IndexMut<usize> for Subpath<ManipulatorGroupId> {
 	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
 		assert!(index < self.len(), "Index out of bounds in trait IndexMut of SubPath.");
 		&mut self.manipulator_groups[index]
 	}
 }
 
-impl Iterator for SubpathIter<'_> {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Iterator for SubpathIter<'_, ManipulatorGroupId> {
 	type Item = Bezier;
 
 	// Returns the Bezier representation of each `Subpath` segment, defined between a pair of adjacent manipulator points.

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -5,7 +5,7 @@ use crate::TValue;
 
 use glam::DVec2;
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Calculate the point on the subpath based on the parametric `t`-value provided.
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/evaluate/solo" title="Evaluate Demo"></iframe>
@@ -144,13 +144,13 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
@@ -188,19 +188,19 @@ mod tests {
 					anchor: start,
 					in_handle: Some(handle3),
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle2),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
@@ -295,19 +295,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			true,
@@ -374,19 +374,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			true,
@@ -442,19 +442,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			true,

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -5,7 +5,7 @@ use crate::TValue;
 
 use glam::DVec2;
 
-impl Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
 	/// Calculate the point on the subpath based on the parametric `t`-value provided.
 	/// Expects `t` to be within the inclusive range `[0, 1]`.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/evaluate/solo" title="Evaluate Demo"></iframe>
@@ -144,11 +144,13 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
@@ -186,16 +188,19 @@ mod tests {
 					anchor: start,
 					in_handle: Some(handle3),
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle,
 					in_handle: None,
 					out_handle: Some(handle1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle2),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
@@ -290,16 +295,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			true,
@@ -366,16 +374,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			true,
@@ -431,16 +442,19 @@ mod tests {
 					anchor: cubic_start,
 					in_handle: None,
 					out_handle: Some(cubic_handle_1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: cubic_end,
 					in_handle: Some(cubic_handle_2),
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: quadratic_end,
 					in_handle: Some(quadratic_1_handle),
 					out_handle: Some(quadratic_2_handle),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			true,

--- a/libraries/bezier-rs/src/subpath/structs.rs
+++ b/libraries/bezier-rs/src/subpath/structs.rs
@@ -4,17 +4,17 @@ use glam::DVec2;
 use std::fmt::{Debug, Formatter, Result};
 
 /// An id type used for each [ManipulatorGroup].
-pub trait ManipulatorGroupId: Sized + Clone {
+pub trait Identifier: Sized + Clone + PartialEq {
 	fn new() -> Self;
 }
 
 /// An empty id type for use in tests
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg(test)]
-pub(crate) struct EmptyManipulatorGroupId;
+pub(crate) struct EmptyId;
 
 #[cfg(test)]
-impl ManipulatorGroupId for EmptyManipulatorGroupId {
+impl Identifier for EmptyId {
 	fn new() -> Self {
 		Self
 	}
@@ -22,14 +22,14 @@ impl ManipulatorGroupId for EmptyManipulatorGroupId {
 
 /// Structure used to represent a single anchor with up to two optional associated handles along a `Subpath`
 #[derive(Copy, Clone, PartialEq)]
-pub struct ManipulatorGroup<ManipulatorGroupId: crate::ManipulatorGroupId> {
+pub struct ManipulatorGroup<ManipulatorGroupId: crate::Identifier> {
 	pub anchor: DVec2,
 	pub in_handle: Option<DVec2>,
 	pub out_handle: Option<DVec2>,
 	pub id: ManipulatorGroupId,
 }
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Debug for ManipulatorGroup<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Debug for ManipulatorGroup<ManipulatorGroupId> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		if self.in_handle.is_some() && self.out_handle.is_some() {
 			write!(f, "anchor: {}, in: {}, out: {}", self.anchor, self.in_handle.unwrap(), self.out_handle.unwrap())
@@ -43,7 +43,7 @@ impl<ManipulatorGroupId: crate::ManipulatorGroupId> Debug for ManipulatorGroup<M
 	}
 }
 
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> ManipulatorGroup<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> ManipulatorGroup<ManipulatorGroupId> {
 	pub fn to_bezier(&self, end_group: &ManipulatorGroup<ManipulatorGroupId>) -> Bezier {
 		let start = self.anchor;
 		let end = end_group.anchor;

--- a/libraries/bezier-rs/src/subpath/structs.rs
+++ b/libraries/bezier-rs/src/subpath/structs.rs
@@ -3,15 +3,33 @@ use super::Bezier;
 use glam::DVec2;
 use std::fmt::{Debug, Formatter, Result};
 
+/// An id type used for each [ManipulatorGroup].
+pub trait ManipulatorGroupId: Sized + Clone {
+	fn new() -> Self;
+}
+
+/// An empty id type for use in tests
+#[derive(Clone)]
+#[cfg(test)]
+pub(crate) struct EmptyManipulatorGroupId;
+
+#[cfg(test)]
+impl ManipulatorGroupId for EmptyManipulatorGroupId {
+	fn new() -> Self {
+		Self
+	}
+}
+
 /// Structure used to represent a single anchor with up to two optional associated handles along a `Subpath`
 #[derive(Copy, Clone, PartialEq)]
-pub struct ManipulatorGroup {
+pub struct ManipulatorGroup<ManipulatorGroupId: crate::ManipulatorGroupId> {
 	pub anchor: DVec2,
 	pub in_handle: Option<DVec2>,
 	pub out_handle: Option<DVec2>,
+	pub id: ManipulatorGroupId,
 }
 
-impl Debug for ManipulatorGroup {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Debug for ManipulatorGroup<ManipulatorGroupId> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
 		if self.in_handle.is_some() && self.out_handle.is_some() {
 			write!(f, "anchor: {}, in: {}, out: {}", self.anchor, self.in_handle.unwrap(), self.out_handle.unwrap())
@@ -25,8 +43,8 @@ impl Debug for ManipulatorGroup {
 	}
 }
 
-impl ManipulatorGroup {
-	pub fn to_bezier(&self, end_group: &ManipulatorGroup) -> Bezier {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> ManipulatorGroup<ManipulatorGroupId> {
+	pub fn to_bezier(&self, end_group: &ManipulatorGroup<ManipulatorGroupId>) -> Bezier {
 		let start = self.anchor;
 		let end = end_group.anchor;
 		let out_handle = self.out_handle;

--- a/libraries/bezier-rs/src/subpath/structs.rs
+++ b/libraries/bezier-rs/src/subpath/structs.rs
@@ -9,7 +9,7 @@ pub trait ManipulatorGroupId: Sized + Clone {
 }
 
 /// An empty id type for use in tests
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg(test)]
 pub(crate) struct EmptyManipulatorGroupId;
 

--- a/libraries/bezier-rs/src/subpath/transform.rs
+++ b/libraries/bezier-rs/src/subpath/transform.rs
@@ -3,7 +3,7 @@ use crate::utils::SubpathTValue;
 use crate::utils::TValue;
 
 /// Functionality that transforms Subpaths, such as split, reduce, offset, etc.
-impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
+impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Returns either one or two Subpaths that result from splitting the original Subpath at the point corresponding to `t`.
 	/// If the original Subpath was closed, a single open Subpath will be returned.
 	/// If the original Subpath was open, two open Subpaths will be returned.
@@ -87,7 +87,7 @@ mod tests {
 	use super::*;
 	use glam::DVec2;
 
-	fn set_up_open_subpath() -> Subpath<EmptyManipulatorGroupId> {
+	fn set_up_open_subpath() -> Subpath<EmptyId> {
 		let start = DVec2::new(20., 30.);
 		let middle1 = DVec2::new(80., 90.);
 		let middle2 = DVec2::new(100., 100.);
@@ -103,32 +103,32 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle1,
 					in_handle: None,
 					out_handle: Some(handle2),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: middle2,
 					in_handle: None,
 					out_handle: None,
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
-					id: EmptyManipulatorGroupId,
+					id: EmptyId,
 				},
 			],
 			false,
 		)
 	}
 
-	fn set_up_closed_subpath() -> Subpath<EmptyManipulatorGroupId> {
+	fn set_up_closed_subpath() -> Subpath<EmptyId> {
 		let mut subpath = set_up_open_subpath();
 		subpath.closed = true;
 		subpath
@@ -162,7 +162,7 @@ mod tests {
 				anchor: location,
 				in_handle: None,
 				out_handle: None,
-				id: EmptyManipulatorGroupId,
+				id: EmptyId,
 			}
 		);
 		assert_eq!(first.manipulator_groups.len(), 1);
@@ -186,7 +186,7 @@ mod tests {
 				anchor: location,
 				in_handle: None,
 				out_handle: None,
-				id: EmptyManipulatorGroupId,
+				id: EmptyId,
 			}
 		);
 		assert_eq!(second.manipulator_groups.len(), 1);

--- a/libraries/bezier-rs/src/subpath/transform.rs
+++ b/libraries/bezier-rs/src/subpath/transform.rs
@@ -3,12 +3,12 @@ use crate::utils::SubpathTValue;
 use crate::utils::TValue;
 
 /// Functionality that transforms Subpaths, such as split, reduce, offset, etc.
-impl Subpath {
+impl<ManipulatorGroupId: crate::ManipulatorGroupId> Subpath<ManipulatorGroupId> {
 	/// Returns either one or two Subpaths that result from splitting the original Subpath at the point corresponding to `t`.
 	/// If the original Subpath was closed, a single open Subpath will be returned.
 	/// If the original Subpath was open, two open Subpaths will be returned.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/split/solo" title="Split Demo"></iframe>
-	pub fn split(&self, t: SubpathTValue) -> (Subpath, Option<Subpath>) {
+	pub fn split(&self, t: SubpathTValue) -> (Subpath<ManipulatorGroupId>, Option<Subpath<ManipulatorGroupId>>) {
 		let (segment_index, t) = self.t_value_to_parametric(t);
 		let curve = self.get_segment(segment_index).unwrap();
 
@@ -33,6 +33,7 @@ impl Subpath {
 				anchor: first_bezier.end(),
 				in_handle: last_curve.handle_end(),
 				out_handle: None,
+				id: ManipulatorGroupId::new(),
 			});
 		} else {
 			if !first_split.is_empty() {
@@ -52,6 +53,7 @@ impl Subpath {
 					anchor: first_bezier.end(),
 					in_handle: first_bezier.handle_end(),
 					out_handle: None,
+					id: ManipulatorGroupId::new(),
 				});
 			}
 
@@ -62,6 +64,7 @@ impl Subpath {
 						anchor: second_bezier.start(),
 						in_handle: None,
 						out_handle: second_bezier.handle_start(),
+						id: ManipulatorGroupId::new(),
 					},
 				);
 			}
@@ -84,7 +87,7 @@ mod tests {
 	use super::*;
 	use glam::DVec2;
 
-	fn set_up_open_subpath() -> Subpath {
+	fn set_up_open_subpath() -> Subpath<EmptyManipulatorGroupId> {
 		let start = DVec2::new(20., 30.);
 		let middle1 = DVec2::new(80., 90.);
 		let middle2 = DVec2::new(100., 100.);
@@ -100,28 +103,32 @@ mod tests {
 					anchor: start,
 					in_handle: None,
 					out_handle: Some(handle1),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle1,
 					in_handle: None,
 					out_handle: Some(handle2),
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: middle2,
 					in_handle: None,
 					out_handle: None,
+					id: EmptyManipulatorGroupId,
 				},
 				ManipulatorGroup {
 					anchor: end,
 					in_handle: None,
 					out_handle: Some(handle3),
+					id: EmptyManipulatorGroupId,
 				},
 			],
 			false,
 		)
 	}
 
-	fn set_up_closed_subpath() -> Subpath {
+	fn set_up_closed_subpath() -> Subpath<EmptyManipulatorGroupId> {
 		let mut subpath = set_up_open_subpath();
 		subpath.closed = true;
 		subpath
@@ -154,7 +161,8 @@ mod tests {
 			ManipulatorGroup {
 				anchor: location,
 				in_handle: None,
-				out_handle: None
+				out_handle: None,
+				id: EmptyManipulatorGroupId,
 			}
 		);
 		assert_eq!(first.manipulator_groups.len(), 1);
@@ -177,7 +185,8 @@ mod tests {
 			ManipulatorGroup {
 				anchor: location,
 				in_handle: None,
-				out_handle: None
+				out_handle: None,
+				id: EmptyManipulatorGroupId,
 			}
 		);
 		assert_eq!(second.manipulator_groups.len(), 1);

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -6,10 +6,10 @@ use glam::DVec2;
 use std::fmt::Write;
 use wasm_bindgen::prelude::*;
 
-#[derive(Clone)]
-pub(crate) struct EmptyManipulatorGroupId;
+#[derive(Clone, PartialEq)]
+pub(crate) struct EmptyId;
 
-impl bezier_rs::Identifier for EmptyManipulatorGroupId {
+impl bezier_rs::Identifier for EmptyId {
 	fn new() -> Self {
 		Self
 	}
@@ -17,7 +17,7 @@ impl bezier_rs::Identifier for EmptyManipulatorGroupId {
 
 /// Wrapper of the `Subpath` struct to be used in JS.
 #[wasm_bindgen]
-pub struct WasmSubpath(Subpath<EmptyManipulatorGroupId>);
+pub struct WasmSubpath(Subpath<EmptyId>);
 
 const SCALE_UNIT_VECTOR_FACTOR: f64 = 50.;
 
@@ -40,7 +40,7 @@ impl WasmSubpath {
 				anchor: point_triple[0].unwrap(),
 				in_handle: point_triple[1],
 				out_handle: point_triple[2],
-				id: EmptyManipulatorGroupId,
+				id: EmptyId,
 			})
 			.collect();
 		WasmSubpath(Subpath::new(manipulator_groups, closed))

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::*;
 #[derive(Clone)]
 pub(crate) struct EmptyManipulatorGroupId;
 
-impl bezier_rs::ManipulatorGroupId for EmptyManipulatorGroupId {
+impl bezier_rs::Identifier for EmptyManipulatorGroupId {
 	fn new() -> Self {
 		Self
 	}

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -6,9 +6,18 @@ use glam::DVec2;
 use std::fmt::Write;
 use wasm_bindgen::prelude::*;
 
+#[derive(Clone)]
+pub(crate) struct EmptyManipulatorGroupId;
+
+impl bezier_rs::ManipulatorGroupId for EmptyManipulatorGroupId {
+	fn new() -> Self {
+		Self
+	}
+}
+
 /// Wrapper of the `Subpath` struct to be used in JS.
 #[wasm_bindgen]
-pub struct WasmSubpath(Subpath);
+pub struct WasmSubpath(Subpath<EmptyManipulatorGroupId>);
 
 const SCALE_UNIT_VECTOR_FACTOR: f64 = 50.;
 
@@ -31,6 +40,7 @@ impl WasmSubpath {
 				anchor: point_triple[0].unwrap(),
 				in_handle: point_triple[1],
 				out_handle: point_triple[2],
+				id: EmptyManipulatorGroupId,
 			})
 			.collect();
 		WasmSubpath(Subpath::new(manipulator_groups, closed))


### PR DESCRIPTION
Each manipulator group now has a generic id type that implements the `ManipulatorGroupId` trait. This allows the subpaths to integrate with Graphite's UUID system without having to depend on additional libraries or adding extra overhead to other users who may not need the ids.