### PR TITLE
Refactor vector data type from document-legacy into node graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,6 @@ dependencies = [
  "graphene-core",
  "log",
  "num-traits",
- "rand_chacha 0.3.1",
  "serde",
  "specta",
 ]
@@ -1647,8 +1646,10 @@ dependencies = [
  "log",
  "node-macro",
  "once_cell",
+ "rand_chacha 0.3.1",
  "serde",
  "specta",
+ "spin 0.9.4",
  "spirv-std",
 ]
 
@@ -1738,12 +1739,10 @@ dependencies = [
  "kurbo",
  "log",
  "once_cell",
- "rand_chacha 0.3.1",
  "remain",
  "serde",
  "serde_json",
  "specta",
- "spin 0.9.4",
  "test-case",
  "thiserror",
 ]
@@ -2173,7 +2172,6 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rand_chacha 0.3.1",
  "serde",
 ]
 
@@ -5122,7 +5120,6 @@ dependencies = [
  "graphene-core",
  "log",
  "num-traits",
- "rand_chacha 0.3.1",
  "serde",
  "vulkano",
 ]
@@ -5477,7 +5474,6 @@ dependencies = [
  "graphene-core",
  "log",
  "num-traits",
- "rand_chacha 0.3.1",
  "serde",
  "spirv",
  "wgpu",

--- a/document-legacy/src/consts.rs
+++ b/document-legacy/src/consts.rs
@@ -1,9 +1,3 @@
-use graphene_core::raster::color::Color;
-
-// RENDERING
-pub const LAYER_OUTLINE_STROKE_COLOR: Color = Color::BLACK;
-pub const LAYER_OUTLINE_STROKE_WEIGHT: f64 = 1.;
-
 // BOOLEAN OPERATIONS
 
 // Bezier curve intersection algorithm

--- a/document-legacy/src/layers/mod.rs
+++ b/document-legacy/src/layers/mod.rs
@@ -25,6 +25,13 @@ pub mod layer_info;
 pub mod nodegraph_layer;
 /// Contains the [ShapeLayer](shape_layer::ShapeLayer) type, a generic SVG element defined using Bezier paths.
 pub mod shape_layer;
-pub mod style;
 /// Contains the [TextLayer](text_layer::TextLayer) type.
 pub mod text_layer;
+
+mod render_data;
+pub use render_data::RenderData;
+
+pub mod style {
+	pub use super::RenderData;
+	pub use graphene_core::vector::style::*;
+}

--- a/document-legacy/src/layers/render_data.rs
+++ b/document-legacy/src/layers/render_data.rs
@@ -1,0 +1,22 @@
+use super::style::ViewMode;
+use super::text_layer::FontCache;
+
+use glam::DVec2;
+
+/// Contains metadata for rendering the document as an svg
+#[derive(Debug, Clone, Copy)]
+pub struct RenderData<'a> {
+	pub font_cache: &'a FontCache,
+	pub view_mode: ViewMode,
+	pub culling_bounds: Option<[DVec2; 2]>,
+}
+
+impl<'a> RenderData<'a> {
+	pub fn new(font_cache: &'a FontCache, view_mode: ViewMode, culling_bounds: Option<[DVec2; 2]>) -> Self {
+		Self {
+			font_cache,
+			view_mode,
+			culling_bounds,
+		}
+	}
+}

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -23,8 +23,6 @@ serde_json = { version = "1.0" }
 graphite-proc-macros = { path = "../proc-macros" }
 bezier-rs = { path = "../libraries/bezier-rs" }
 glam = { version="0.22", features = ["serde"] }
-rand_chacha = "0.3.1"
-spin = "0.9.2"
 kurbo = { git = "https://github.com/linebender/kurbo.git", features = [
 	"serde",
 ] }

--- a/editor/src/application.rs
+++ b/editor/src/application.rs
@@ -1,15 +1,7 @@
 use crate::dispatcher::Dispatcher;
 use crate::messages::prelude::*;
 
-use rand_chacha::rand_core::{RngCore, SeedableRng};
-use rand_chacha::ChaCha20Rng;
-use spin::Mutex;
-use std::cell::Cell;
-
-static RNG: Mutex<Option<ChaCha20Rng>> = Mutex::new(None);
-thread_local! {
-	pub static UUID_SEED: Cell<Option<u64>> = Cell::new(None);
-}
+pub use graphene_core::uuid::*;
 
 // TODO: serialize with serde to save the current editor state
 pub struct Editor {
@@ -37,21 +29,6 @@ impl Default for Editor {
 	fn default() -> Self {
 		Self::new()
 	}
-}
-
-pub fn set_uuid_seed(random_seed: u64) {
-	UUID_SEED.with(|seed| seed.set(Some(random_seed)))
-}
-
-pub fn generate_uuid() -> u64 {
-	let mut lock = RNG.lock();
-	if lock.is_none() {
-		UUID_SEED.with(|seed| {
-			let random_seed = seed.get().expect("Random seed not set before editor was initialized");
-			*lock = Some(ChaCha20Rng::seed_from_u64(random_seed));
-		})
-	}
-	lock.as_mut().map(ChaCha20Rng::next_u64).unwrap()
 }
 
 pub fn release_series() -> String {

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -33,6 +33,8 @@ kurbo = { git = "https://github.com/linebender/kurbo.git", features = [
 	"serde",
 ], optional = true }
 glam = { version = "^0.22", default-features = false, features = ["scalar-math", "libm"]}
+rand_chacha = "0.3.1"
+spin = "0.9.2"
 node-macro = {path = "../node-macro"}
 specta.workspace = true
 once_cell = { version = "1.17.0", default-features = false }

--- a/node-graph/gcore/src/consts.rs
+++ b/node-graph/gcore/src/consts.rs
@@ -1,0 +1,5 @@
+use crate::raster::Color;
+
+// RENDERING
+pub const LAYER_OUTLINE_STROKE_COLOR: Color = Color::BLACK;
+pub const LAYER_OUTLINE_STROKE_WEIGHT: f64 = 1.;

--- a/node-graph/gcore/src/lib.rs
+++ b/node-graph/gcore/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 #[cfg(feature = "log")]
 extern crate log;
 
+pub mod consts;
 pub mod generic;
 pub mod ops;
 pub mod structural;
@@ -22,6 +23,7 @@ pub mod raster;
 pub mod vector;
 
 use core::any::TypeId;
+pub use raster::Color;
 
 // pub trait Node: for<'n> NodeIO<'n> {
 pub trait Node<'i, Input: 'i>: 'i {

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -28,7 +28,7 @@ pub struct Color {
 	alpha: f32,
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Color {
 	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
 		self.red.to_bits().hash(state);

--- a/node-graph/gcore/src/uuid.rs
+++ b/node-graph/gcore/src/uuid.rs
@@ -40,3 +40,41 @@ mod u64_string {
 		u64::from_str(&s).map_err(serde::de::Error::custom)
 	}
 }
+
+mod uuid_generation {
+	use core::cell::Cell;
+	use rand_chacha::rand_core::{RngCore, SeedableRng};
+	use rand_chacha::ChaCha20Rng;
+	use spin::Mutex;
+
+	static RNG: Mutex<Option<ChaCha20Rng>> = Mutex::new(None);
+	thread_local! {
+		pub static UUID_SEED: Cell<Option<u64>> = Cell::new(None);
+	}
+
+	pub fn set_uuid_seed(random_seed: u64) {
+		UUID_SEED.with(|seed| seed.set(Some(random_seed)))
+	}
+
+	pub fn generate_uuid() -> u64 {
+		let mut lock = RNG.lock();
+		if lock.is_none() {
+			UUID_SEED.with(|seed| {
+				let random_seed = seed.get().unwrap_or(42);
+				*lock = Some(ChaCha20Rng::seed_from_u64(random_seed));
+			})
+		}
+		lock.as_mut().map(ChaCha20Rng::next_u64).expect("uuid mutex poisoned")
+	}
+}
+
+pub use uuid_generation::*;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ManipulatorGroupId(u64);
+
+impl bezier_rs::Identifier for ManipulatorGroupId {
+	fn new() -> Self {
+		Self(generate_uuid())
+	}
+}

--- a/node-graph/gcore/src/vector/mod.rs
+++ b/node-graph/gcore/src/vector/mod.rs
@@ -1,6 +1,16 @@
 pub mod consts;
 pub mod generator_nodes;
-pub mod id_vec;
 pub mod manipulator_group;
 pub mod manipulator_point;
+
+pub mod style;
+pub use style::PathStyle;
+
 pub mod subpath;
+pub use subpath::Subpath;
+
+mod vector_data;
+pub use vector_data::VectorData;
+
+mod id_vec;
+pub use id_vec::IdBackedVec;

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -1,0 +1,12 @@
+use glam::DAffine2;
+
+use super::style::PathStyle;
+use crate::uuid::ManipulatorGroupId;
+
+/// [VectorData] is passed between nodes.
+/// It contains a list of subpaths (that may be open or closed), a transform and some style information.
+pub struct VectorData {
+	pub subpaths: Vec<bezier_rs::Subpath<ManipulatorGroupId>>,
+	pub transform: DAffine2,
+	pub style: PathStyle,
+}

--- a/node-graph/gpu-compiler/Cargo.toml
+++ b/node-graph/gpu-compiler/Cargo.toml
@@ -16,7 +16,6 @@ graphene-core = { path = "../gcore", features = ["async", "std", "alloc"] }
 graph-craft = {path = "../graph-craft", features = ["serde"] }
 dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "rc", "glam"] }
 num-traits = "0.2"
-rand_chacha = "0.3.1"
 log = "0.4"
 serde = { version = "1", features = ["derive", "rc"]}
 glam = { version = "0.22" }

--- a/node-graph/graph-craft/Cargo.toml
+++ b/node-graph/graph-craft/Cargo.toml
@@ -15,7 +15,6 @@ graphene-core = { path = "../gcore", features = ["std"] }
 dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "rc", "glam"] }
 num-traits = "0.2"
 dyn-clone = "1.0"
-rand_chacha = "0.3.1"
 log = "0.4"
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 glam = { version = "0.22" }

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -4,27 +4,14 @@ use graphene_core::{NodeIdentifier, Type};
 
 use dyn_any::{DynAny, StaticType};
 use glam::IVec2;
+pub use graphene_core::uuid::generate_uuid;
 use graphene_core::TypeDescriptor;
-use rand_chacha::{
-	rand_core::{RngCore, SeedableRng},
-	ChaCha20Rng,
-};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 
 pub mod value;
 
 pub type NodeId = u64;
-static RNG: Mutex<Option<ChaCha20Rng>> = Mutex::new(None);
-
-pub fn generate_uuid() -> u64 {
-	let mut lock = RNG.lock().expect("uuid mutex poisoned");
-	if lock.is_none() {
-		*lock = Some(ChaCha20Rng::seed_from_u64(0));
-	}
-	lock.as_mut().map(ChaCha20Rng::next_u64).unwrap()
-}
 
 fn merge_ids(a: u64, b: u64) -> u64 {
 	use std::hash::{Hash, Hasher};

--- a/node-graph/interpreted-executor/Cargo.toml
+++ b/node-graph/interpreted-executor/Cargo.toml
@@ -20,7 +20,6 @@ dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "glam
 num-traits = "0.2"
 borrow_stack = { path = "../borrow_stack" }
 dyn-clone = "1.0"
-rand_chacha = "0.3.1"
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 glam = { version = "0.22" }

--- a/node-graph/vulkan-executor/Cargo.toml
+++ b/node-graph/vulkan-executor/Cargo.toml
@@ -14,7 +14,6 @@ graphene-core = { path = "../gcore", features = ["async", "std", "alloc", "gpu"]
 graph-craft = {path = "../graph-craft" }
 dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "rc", "glam"] }
 num-traits = "0.2"
-rand_chacha = "0.3.1"
 log = "0.4"
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 glam = { version = "0.22" }

--- a/node-graph/wgpu-executor/Cargo.toml
+++ b/node-graph/wgpu-executor/Cargo.toml
@@ -15,7 +15,6 @@ graph-craft = {path = "../graph-craft" }
 dyn-any = { path = "../../libraries/dyn-any", features = ["log-bad-types", "rc", "glam"] }
 future-executor = { path = "../future-executor" }
 num-traits = "0.2"
-rand_chacha = "0.3.1"
 log = "0.4"
 serde = { version = "1", features = ["derive", "rc"], optional = true }
 glam = { version = "0.22" }


### PR DESCRIPTION
Part of #997

The VectorData struct has now been added to graphene_core (along with the relevant structs for style).
