### PR TITLE
Bezier-rs: Made wasm imports async in demos

### DIFF
--- a/website/other/bezier-rs-demos/src/components/BezierDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemo.ts
@@ -51,7 +51,7 @@ class BezierDemo extends HTMLElement implements Demo {
 		}
 	}
 
-	connectedCallback(): void {
+	async connectedCallback(): Promise<void> {
 		this.title = this.getAttribute("title") || "";
 		this.points = JSON.parse(this.getAttribute("points") || "[]");
 		this.key = this.getAttribute("key") as BezierFeatureKey;
@@ -66,14 +66,12 @@ class BezierDemo extends HTMLElement implements Demo {
 		this.activeIndex = undefined as number | undefined;
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
-
 		this.render();
-		const figure = this.querySelector("figure") as HTMLElement;
 
-		import("@/../wasm/pkg").then((wasm) => {
-			this.bezier = wasm.WasmBezier[getConstructorKey(curveType)](this.points);
-			this.drawDemo(figure);
-		});
+		const figure = this.querySelector("figure") as HTMLElement;
+		const wasm = await import("@/../wasm/pkg");
+		this.bezier = wasm.WasmBezier[getConstructorKey(curveType)](this.points);
+		this.drawDemo(figure);
 	}
 
 	render(): void {

--- a/website/other/bezier-rs-demos/src/components/BezierDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemo.ts
@@ -66,11 +66,11 @@ class BezierDemo extends HTMLElement implements Demo {
 		this.activeIndex = undefined as number | undefined;
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
-		
+
 		this.render();
 		const figure = this.querySelector("figure") as HTMLElement;
 
-		import("@/../wasm/pkg").then(wasm => {
+		import("@/../wasm/pkg").then((wasm) => {
 			this.bezier = wasm.WasmBezier[getConstructorKey(curveType)](this.points);
 			this.drawDemo(figure);
 		});

--- a/website/other/bezier-rs-demos/src/components/BezierDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemo.ts
@@ -63,14 +63,17 @@ class BezierDemo extends HTMLElement implements Demo {
 		const curveType = getCurveType(this.points.length);
 
 		this.manipulatorKeys = MANIPULATOR_KEYS_FROM_BEZIER_TYPE[curveType];
-		this.bezier = WasmBezier[getConstructorKey(curveType)](this.points);
 		this.activeIndex = undefined as number | undefined;
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
+		
 		this.render();
-
 		const figure = this.querySelector("figure") as HTMLElement;
-		this.drawDemo(figure);
+
+		import("@/../wasm/pkg").then(wasm => {
+			this.bezier = wasm.WasmBezier[getConstructorKey(curveType)](this.points);
+			this.drawDemo(figure);
+		});
 	}
 
 	render(): void {

--- a/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
@@ -58,14 +58,17 @@ class SubpathDemo extends HTMLElement {
 		this.tVariant = (this.getAttribute("tvariant") || "Parametric") as TVariant;
 
 		this.callback = subpathFeatures[this.key].callback as SubpathCallback;
-		this.subpath = WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
+		
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
 
 		this.render();
-
 		const figure = this.querySelector("figure") as HTMLElement;
-		this.drawDemo(figure);
+
+		import("@/../wasm/pkg").then(wasm => {
+			this.subpath = wasm.WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
+			this.drawDemo(figure);
+		});
 	}
 
 	render(): void {

--- a/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
@@ -58,14 +58,14 @@ class SubpathDemo extends HTMLElement {
 		this.tVariant = (this.getAttribute("tvariant") || "Parametric") as TVariant;
 
 		this.callback = subpathFeatures[this.key].callback as SubpathCallback;
-		
+
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
 
 		this.render();
 		const figure = this.querySelector("figure") as HTMLElement;
 
-		import("@/../wasm/pkg").then(wasm => {
+		import("@/../wasm/pkg").then((wasm) => {
 			this.subpath = wasm.WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
 			this.drawDemo(figure);
 		});

--- a/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
@@ -48,7 +48,7 @@ class SubpathDemo extends HTMLElement {
 		}
 	}
 
-	connectedCallback(): void {
+	async connectedCallback(): Promise<void> {
 		this.title = this.getAttribute("title") || "";
 		this.triples = JSON.parse(this.getAttribute("triples") || "[]");
 		this.key = this.getAttribute("key") as SubpathFeatureKey;
@@ -58,17 +58,14 @@ class SubpathDemo extends HTMLElement {
 		this.tVariant = (this.getAttribute("tvariant") || "Parametric") as TVariant;
 
 		this.callback = subpathFeatures[this.key].callback as SubpathCallback;
-
 		this.sliderData = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.default })));
 		this.sliderUnits = Object.assign({}, ...this.sliderOptions.map((s) => ({ [s.variable]: s.unit })));
-
 		this.render();
-		const figure = this.querySelector("figure") as HTMLElement;
 
-		import("@/../wasm/pkg").then((wasm) => {
-			this.subpath = wasm.WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
-			this.drawDemo(figure);
-		});
+		const figure = this.querySelector("figure") as HTMLElement;
+		const wasm = await import("@/../wasm/pkg");
+		this.subpath = wasm.WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
+		this.drawDemo(figure);
 	}
 
 	render(): void {


### PR DESCRIPTION
Bugfix for the issue that caused the following error:
![image](https://user-images.githubusercontent.com/25088940/223306960-fd9179dd-d1dc-4e7f-a7f4-05cc59abde1f.png)

wasm-bindgen documentation generally advises that wasm imports must be asynchronous. It seems that we weren't doing that, but were still somehow getting away with it. The wasm package was recently updated in Graphite, at which point the interactive demos broke because, likely because our synchronous imports caught up with us.
