### PR TITLE
Bezier-rs: Add lookup table function for subpath and make it support euclidean parameterization

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -375,7 +375,7 @@ impl ShapeState {
 
 		for subpath in &vector_data.subpaths {
 			for (manipulator_index, bezier) in subpath.iter().enumerate() {
-				let t = bezier.project(layer_pos, projection_options);
+				let t = bezier.project(layer_pos, Some(projection_options));
 				let layerspace = bezier.evaluate(TValue::Parametric(t));
 
 				let screenspace = transform.transform_point2(layerspace);

--- a/libraries/bezier-rs/src/bezier/lookup.rs
+++ b/libraries/bezier-rs/src/bezier/lookup.rs
@@ -117,9 +117,10 @@ impl Bezier {
 	}
 
 	/// Returns the parametric `t`-value that corresponds to the closest point on the curve to the provided point.
-	/// Uses a searching algorithm akin to binary search that can be customized using the [ProjectionOptions] structure.
+	/// Uses a searching algorithm akin to binary search that can be customized using the optional [ProjectionOptions] struct.
 	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#bezier/project/solo" title="Project Demo"></iframe>
-	pub fn project(&self, point: DVec2, options: ProjectionOptions) -> f64 {
+	pub fn project(&self, point: DVec2, options: Option<ProjectionOptions>) -> f64 {
+		let options = options.unwrap_or_default();
 		let ProjectionOptions {
 			lut_size,
 			convergence_epsilon,
@@ -267,13 +268,11 @@ mod tests {
 
 	#[test]
 	fn test_project() {
-		let project_options = ProjectionOptions::default();
-
 		let bezier1 = Bezier::from_cubic_coordinates(4., 4., 23., 45., 10., 30., 56., 90.);
-		assert_eq!(bezier1.project(DVec2::ZERO, project_options), 0.);
-		assert_eq!(bezier1.project(DVec2::new(100., 100.), project_options), 1.);
+		assert_eq!(bezier1.project(DVec2::ZERO, None), 0.);
+		assert_eq!(bezier1.project(DVec2::new(100., 100.), None), 1.);
 
 		let bezier2 = Bezier::from_quadratic_coordinates(0., 0., 0., 100., 100., 100.);
-		assert_eq!(bezier2.project(DVec2::new(100., 0.), project_options), 0.);
+		assert_eq!(bezier2.project(DVec2::new(100., 0.), None), 0.);
 	}
 }

--- a/libraries/bezier-rs/src/bezier/lookup.rs
+++ b/libraries/bezier-rs/src/bezier/lookup.rs
@@ -75,20 +75,18 @@ impl Bezier {
 	/// If no value is provided for `steps`, then the function will default `steps` to be 10.
 	/// <iframe frameBorder="0" width="100%" height="375px" src="https://graphite.rs/bezier-rs-demos#bezier/lookup-table/solo" title="Lookup-Table Demo"></iframe>
 	pub fn compute_lookup_table(&self, steps: Option<usize>, tvalue_type: Option<TValueType>) -> Vec<DVec2> {
-		let steps_unwrapped = steps.unwrap_or(DEFAULT_LUT_STEP_SIZE);
-		let tvalue_type_unwrapped = tvalue_type.unwrap_or(TValueType::Parametric);
-		let ratio: f64 = 1. / (steps_unwrapped as f64);
-		let mut steps_array = Vec::with_capacity(steps_unwrapped + 1);
+		let steps = steps.unwrap_or(DEFAULT_LUT_STEP_SIZE);
+		let tvalue_type = tvalue_type.unwrap_or(TValueType::Parametric);
 
-		for t in 0..steps_unwrapped + 1 {
-			if tvalue_type_unwrapped == TValueType::Parametric {
-				steps_array.push(self.evaluate(TValue::Parametric(f64::from(t as i32) * ratio)))
-			} else {
-				steps_array.push(self.evaluate(TValue::Euclidean(f64::from(t as i32) * ratio)))
-			}
-		}
-
-		steps_array
+		(0..=steps)
+			.map(|t| {
+				let tvalue = match tvalue_type {
+					TValueType::Parametric => TValue::Parametric(t as f64 / steps as f64),
+					TValueType::Euclidean => TValue::Euclidean(t as f64 / steps as f64),
+				};
+				self.evaluate(tvalue)
+			})
+			.collect()
 	}
 
 	/// Return an approximation of the length of the bezier curve.

--- a/libraries/bezier-rs/src/bezier/transform.rs
+++ b/libraries/bezier-rs/src/bezier/transform.rs
@@ -315,12 +315,12 @@ impl Bezier {
 				BezierHandles::Linear => Bezier::from_linear_dvec2(transformed_start, transformed_end),
 				BezierHandles::Quadratic { handle: _ } => unreachable!(),
 				BezierHandles::Cubic { handle_start, handle_end } => {
-					let handle_start_closest_t = intermediate.project(handle_start, ProjectionOptions::default());
+					let handle_start_closest_t = intermediate.project(handle_start, None);
 					let handle_start_scale_distance = (1. - handle_start_closest_t) * start_distance + handle_start_closest_t * end_distance;
 					let transformed_handle_start =
 						utils::scale_point_from_direction_vector(handle_start, intermediate.normal(TValue::Parametric(handle_start_closest_t)), false, handle_start_scale_distance);
 
-					let handle_end_closest_t = intermediate.project(handle_start, ProjectionOptions::default());
+					let handle_end_closest_t = intermediate.project(handle_start, None);
 					let handle_end_scale_distance = (1. - handle_end_closest_t) * start_distance + handle_end_closest_t * end_distance;
 					let transformed_handle_end = utils::scale_point_from_direction_vector(handle_end, intermediate.normal(TValue::Parametric(handle_end_closest_t)), false, handle_end_scale_distance);
 					Bezier::from_cubic_dvec2(transformed_start, transformed_handle_start, transformed_handle_end, transformed_end)
@@ -810,7 +810,7 @@ mod tests {
 					.iter()
 					.map(|t| {
 						let offset_point = offset_segment.evaluate(TValue::Parametric(*t));
-						let closest_point_t = bezier.project(offset_point, ProjectionOptions::default());
+						let closest_point_t = bezier.project(offset_point, None);
 						let closest_point = bezier.evaluate(TValue::Parametric(closest_point_t));
 						let actual_distance = offset_point.distance(closest_point);
 

--- a/libraries/bezier-rs/src/lib.rs
+++ b/libraries/bezier-rs/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 
 pub use bezier::*;
 pub use subpath::*;
-pub use utils::{Cap, Join, SubpathTValue, TValue};
+pub use utils::{Cap, Join, SubpathTValue, TValue, TValueType};

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -98,7 +98,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Returns the segment index and `t` value that corresponds to the closest point on the curve to the provided point.
 	/// Uses a searching algorithm akin to binary search that can be customized using the [ProjectionOptions] structure.
 	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/project/solo" title="Project Demo"></iframe>
-	pub fn project(&self, point: DVec2, options: ProjectionOptions) -> Option<(usize, f64)> {
+	pub fn project(&self, point: DVec2, options: Option<ProjectionOptions>) -> Option<(usize, f64)> {
 		if self.is_empty() {
 			return None;
 		}

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -10,20 +10,18 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// If no value is provided for `steps`, then the function will default `steps` to be 10.
 	/// <iframe frameBorder="0" width="100%" height="375px" src="https://graphite.rs/bezier-rs-demos#subpath/lookup-table/solo" title="Lookup-Table Demo"></iframe>
 	pub fn compute_lookup_table(&self, steps: Option<usize>, tvalue_type: Option<TValueType>) -> Vec<DVec2> {
-		let steps_unwrapped = steps.unwrap_or(DEFAULT_LUT_STEP_SIZE);
-		let tvalue_type_unwrapped = tvalue_type.unwrap_or(TValueType::Parametric);
-		let ratio: f64 = 1. / (steps_unwrapped as f64);
-		let mut steps_array = Vec::with_capacity(steps_unwrapped + 1);
+		let steps = steps.unwrap_or(DEFAULT_LUT_STEP_SIZE);
+		let tvalue_type = tvalue_type.unwrap_or(TValueType::Parametric);
 
-		for t in 0..steps_unwrapped + 1 {
-			if tvalue_type_unwrapped == TValueType::Parametric {
-				steps_array.push(self.evaluate(SubpathTValue::GlobalParametric(f64::from(t as i32) * ratio)))
-			} else {
-				steps_array.push(self.evaluate(SubpathTValue::GlobalEuclidean(f64::from(t as i32) * ratio)))
-			}
-		}
-
-		steps_array
+		(0..=steps)
+			.map(|t| {
+				let tvalue = match tvalue_type {
+					TValueType::Parametric => SubpathTValue::GlobalParametric(t as f64 / steps as f64),
+					TValueType::Euclidean => SubpathTValue::GlobalEuclidean(t as f64 / steps as f64),
+				};
+				self.evaluate(tvalue)
+			})
+			.collect()
 	}
 
 	/// Return the sum of the approximation of the length of each `Bezier` curve along the `Subpath`.

--- a/libraries/bezier-rs/src/subpath/lookup.rs
+++ b/libraries/bezier-rs/src/subpath/lookup.rs
@@ -25,7 +25,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 		steps_array
 	}
-	
+
 	/// Return the sum of the approximation of the length of each `Bezier` curve along the `Subpath`.
 	/// - `num_subdivisions` - Number of subdivisions used to approximate the curve. The default value is `1000`.
 	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/length/solo" title="Length Demo"></iframe>

--- a/libraries/bezier-rs/src/utils.rs
+++ b/libraries/bezier-rs/src/utils.rs
@@ -20,6 +20,12 @@ pub enum TValue {
 }
 
 #[derive(Copy, Clone, PartialEq)]
+pub enum TValueType {
+	Parametric, 
+	Euclidean,
+}
+
+#[derive(Copy, Clone, PartialEq)]
 pub enum SubpathTValue {
 	Parametric { segment_index: usize, t: f64 },
 	GlobalParametric(f64),

--- a/libraries/bezier-rs/src/utils.rs
+++ b/libraries/bezier-rs/src/utils.rs
@@ -21,7 +21,7 @@ pub enum TValue {
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum TValueType {
-	Parametric, 
+	Parametric,
 	Euclidean,
 }
 

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -76,10 +76,11 @@ const bezierFeatures = {
 	},
 	"lookup-table": {
 		name: "Lookup Table",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>, _: undefined, tVariant: TVariant): string => bezier.compute_lookup_table(options.steps, tVariant),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>, _: undefined): string => bezier.compute_lookup_table(options.steps, BEZIER_T_VALUE_VARIANTS[options.TVariant]),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
+					bezierTValueVariantOptions,
 					{
 						min: 2,
 						max: 15,
@@ -90,7 +91,6 @@ const bezierFeatures = {
 				],
 			},
 		},
-		chooseTVariant: true,
 	},
 	derivative: {
 		name: "Derivative",

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -76,7 +76,7 @@ const bezierFeatures = {
 	},
 	"lookup-table": {
 		name: "Lookup Table",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.compute_lookup_table(options.steps),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>, _: undefined, tVariant: TVariant): string => bezier.compute_lookup_table(options.steps, tVariant),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -90,6 +90,7 @@ const bezierFeatures = {
 				],
 			},
 		},
+		chooseTVariant: true,
 	},
 	derivative: {
 		name: "Derivative",

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -22,8 +22,9 @@ const subpathFeatures = {
 	},
 	"lookup-table": {
 		name: "Lookup Table",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined, tVariant: TVariant): string => subpath.compute_lookup_table(options.steps, tVariant),
-		sliderOptions: [
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined): string => subpath.compute_lookup_table(options.steps, SUBPATH_T_VALUE_VARIANTS[options.TVariant]),
+		inputOptions: [
+			subpathTValueVariantOptions,
 			{
 				min: 2,
 				max: 15,
@@ -32,7 +33,6 @@ const subpathFeatures = {
 				variable: "steps",
 			},
 		],
-		chooseTVariant: true,
 	},
 	project: {
 		name: "Project",

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -27,7 +27,7 @@ const subpathFeatures = {
 			subpathTValueVariantOptions,
 			{
 				min: 2,
-				max: 15,
+				max: 30,
 				step: 1,
 				default: 5,
 				variable: "steps",

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -20,6 +20,20 @@ const subpathFeatures = {
 		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined): string => subpath.evaluate(options.t, SUBPATH_T_VALUE_VARIANTS[options.TVariant]),
 		inputOptions: [subpathTValueVariantOptions, tSliderOptions],
 	},
+	"lookup-table": {
+		name: "Lookup Table",
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>, _: undefined, tVariant: TVariant): string => subpath.compute_lookup_table(options.steps, tVariant),
+		sliderOptions: [
+			{
+				min: 2,
+				max: 15,
+				step: 1,
+				default: 5,
+				variable: "steps",
+			},
+		],
+		chooseTVariant: true,
+	},
 	project: {
 		name: "Project",
 		callback: (subpath: WasmSubpathInstance, _: Record<string, number>, mouseLocation?: [number, number]): string =>

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -1,7 +1,7 @@
 use crate::svg_drawing::*;
 use crate::utils::parse_cap;
 
-use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, ProjectionOptions, TValue, TValueType};
+use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, TValue, TValueType};
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -292,7 +292,7 @@ impl WasmBezier {
 	}
 
 	pub fn project(&self, x: f64, y: f64) -> String {
-		let projected_t_value = self.0.project(DVec2::new(x, y), ProjectionOptions::default());
+		let projected_t_value = self.0.project(DVec2::new(x, y), None);
 		let projected_point = self.0.evaluate(TValue::Parametric(projected_t_value));
 
 		let bezier = self.get_bezier_path();

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -1,7 +1,7 @@
 use crate::svg_drawing::*;
 use crate::utils::parse_cap;
 
-use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, ProjectionOptions, TValue};
+use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, ProjectionOptions, TValue, TValueType};
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -156,9 +156,14 @@ impl WasmBezier {
 		wrap_svg_tag(content)
 	}
 
-	pub fn compute_lookup_table(&self, steps: usize) -> String {
+	pub fn compute_lookup_table(&self, steps: usize, t_variant: String) -> String {
 		let bezier = self.get_bezier_path();
-		let table_values: Vec<DVec2> = self.0.compute_lookup_table(Some(steps));
+		let tvalue_type = match t_variant.as_str() {
+			"Parametric" => TValueType::Parametric,
+			"Euclidean" => TValueType::Euclidean,
+			_ => panic!("Unexpected TValue string: '{}'", t_variant),
+		};
+		let table_values: Vec<DVec2> = self.0.compute_lookup_table(Some(steps), Some(tvalue_type));
 		let circles: String = table_values
 			.iter()
 			.map(|point| draw_circle(*point, 3., RED, 1.5, WHITE))

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,7 +1,7 @@
 use crate::svg_drawing::*;
 use crate::utils::{parse_cap, parse_join};
 
-use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
+use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue, TValueType};
 
 use glam::DVec2;
 use std::fmt::Write;
@@ -97,6 +97,22 @@ impl WasmSubpath {
 
 		let point_text = draw_circle(point, 4., RED, 1.5, WHITE);
 		wrap_svg_tag(format!("{}{}", self.to_default_svg(), point_text))
+	}
+
+	pub fn compute_lookup_table(&self, steps: usize, t_variant: String) -> String {
+		let subpath = self.to_default_svg();
+		let tvalue_type = match t_variant.as_str() {
+			"Parametric" => TValueType::Parametric,
+			"Euclidean" =>  TValueType::Euclidean,
+			_ => panic!("Unexpected TValue string: '{}'", t_variant),
+		};
+		let table_values: Vec<DVec2> = self.0.compute_lookup_table(Some(steps), Some(tvalue_type));
+		let circles: String = table_values
+			.iter()
+			.map(|point| draw_circle(*point, 3., RED, 1.5, WHITE))
+			.fold("".to_string(), |acc, circle| acc + &circle);
+		let content = format!("{subpath}{circles}");
+		wrap_svg_tag(content)
 	}
 
 	pub fn tangent(&self, t: f64, t_variant: String) -> String {

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -103,7 +103,7 @@ impl WasmSubpath {
 		let subpath = self.to_default_svg();
 		let tvalue_type = match t_variant.as_str() {
 			"Parametric" => TValueType::Parametric,
-			"Euclidean" =>  TValueType::Euclidean,
+			"Euclidean" => TValueType::Euclidean,
 			_ => panic!("Unexpected TValue string: '{}'", t_variant),
 		};
 		let table_values: Vec<DVec2> = self.0.compute_lookup_table(Some(steps), Some(tvalue_type));

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,7 +1,7 @@
 use crate::svg_drawing::*;
 use crate::utils::{parse_cap, parse_join};
 
-use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue, TValueType};
+use bezier_rs::{Bezier, ManipulatorGroup, Subpath, SubpathTValue, TValueType};
 
 use glam::DVec2;
 use std::fmt::Write;
@@ -220,7 +220,7 @@ impl WasmSubpath {
 	}
 
 	pub fn project(&self, x: f64, y: f64) -> String {
-		let (segment_index, projected_t) = self.0.project(DVec2::new(x, y), ProjectionOptions::default()).unwrap();
+		let (segment_index, projected_t) = self.0.project(DVec2::new(x, y), None).unwrap();
 		let projected_point = self.0.evaluate(SubpathTValue::Parametric { segment_index, t: projected_t });
 
 		let subpath_svg = self.to_default_svg();

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -102,8 +102,8 @@ impl WasmSubpath {
 	pub fn compute_lookup_table(&self, steps: usize, t_variant: String) -> String {
 		let subpath = self.to_default_svg();
 		let tvalue_type = match t_variant.as_str() {
-			"Parametric" => TValueType::Parametric,
-			"Euclidean" => TValueType::Euclidean,
+			"GlobalParametric" => TValueType::Parametric,
+			"GlobalEuclidean" => TValueType::Euclidean,
 			_ => panic!("Unexpected TValue string: '{}'", t_variant),
 		};
 		let table_values: Vec<DVec2> = self.0.compute_lookup_table(Some(steps), Some(tvalue_type));

--- a/website/other/bezier-rs-demos/wasm/src/svg_drawing.rs
+++ b/website/other/bezier-rs-demos/wasm/src/svg_drawing.rs
@@ -10,7 +10,7 @@ pub const WHITE: &str = "white";
 pub const GRAY: &str = "gray";
 pub const RED: &str = "red";
 pub const ORANGE: &str = "orange";
-pub const PINK: &str = "pink";
+// pub const PINK: &str = "pink";
 pub const GREEN: &str = "green";
 pub const NONE: &str = "none";
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Added `compute_lookup_table` to subpath class.
Added `tvalue_type: Option<TValueType>` to `compute_lookup_table` in both bezier and subpath classes which allows computation based on euclidean distances rather than parametric.