### PR TITLE
Bezier-rs: Add joins and caps to offsets and outlines

### DIFF
--- a/libraries/bezier-rs/src/bezier/core.rs
+++ b/libraries/bezier-rs/src/bezier/core.rs
@@ -211,6 +211,14 @@ impl Bezier {
 
 		self_points.len() == other_points.len() && self_points.into_iter().zip(other_points.into_iter()).all(|(a, b)| a.abs_diff_eq(b, max_abs_diff))
 	}
+
+	/// Returns true if the start, end and handles of the Bezier are all at the same location
+	pub fn is_single_point(&self) -> bool {
+		let points = self.get_points().collect::<Vec<DVec2>>();
+		let start = self.start();
+
+		points.iter().all(|point| point.abs_diff_eq(start, MAX_ABSOLUTE_DIFFERENCE))
+	}
 }
 
 #[cfg(test)]

--- a/libraries/bezier-rs/src/bezier/core.rs
+++ b/libraries/bezier-rs/src/bezier/core.rs
@@ -214,10 +214,9 @@ impl Bezier {
 
 	/// Returns true if the start, end and handles of the Bezier are all at the same location
 	pub fn is_point(&self) -> bool {
-		let points = self.get_points().collect::<Vec<DVec2>>();
 		let start = self.start();
 
-		points.iter().all(|point| point.abs_diff_eq(start, MAX_ABSOLUTE_DIFFERENCE))
+		self.get_points().all(|point| point.abs_diff_eq(start, MAX_ABSOLUTE_DIFFERENCE))
 	}
 }
 

--- a/libraries/bezier-rs/src/bezier/core.rs
+++ b/libraries/bezier-rs/src/bezier/core.rs
@@ -213,7 +213,7 @@ impl Bezier {
 	}
 
 	/// Returns true if the start, end and handles of the Bezier are all at the same location
-	pub fn is_single_point(&self) -> bool {
+	pub fn is_point(&self) -> bool {
 		let points = self.get_points().collect::<Vec<DVec2>>();
 		let start = self.start();
 

--- a/libraries/bezier-rs/src/bezier/solvers.rs
+++ b/libraries/bezier-rs/src/bezier/solvers.rs
@@ -64,7 +64,12 @@ impl Bezier {
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#bezier/tangent/solo" title="Tangent Demo"></iframe>
 	pub fn tangent(&self, t: TValue) -> DVec2 {
 		let t = self.t_value_to_parametric(t);
-		self.non_normalized_tangent(t).normalize()
+		let tangent = self.non_normalized_tangent(t);
+		if tangent.length() > 0. {
+			tangent.normalize()
+		} else {
+			tangent
+		}
 	}
 
 	/// Returns a normalized unit vector representing the direction of the normal at the point `t` along the curve.
@@ -88,7 +93,7 @@ impl Bezier {
 
 		let numerator = d.x * dd.y - d.y * dd.x;
 		let denominator = (d.x.powf(2.) + d.y.powf(2.)).powf(1.5);
-		if denominator == 0. {
+		if denominator.abs() < MAX_ABSOLUTE_DIFFERENCE {
 			0.
 		} else {
 			numerator / denominator
@@ -369,9 +374,9 @@ impl Bezier {
 		}
 
 		// Create iterators that combine a subcurve with the `t` value pair that it was trimmed with
-		let combined_iterator1 = self1.into_iter().zip(self1_t_values.windows(2).map(|t_pair| Range { start: t_pair[0], end: t_pair[1] }));
+		let combined_iterator1 = self1.into_iter().zip(self1_t_values.iter().map(|t_pair| Range { start: t_pair[0], end: t_pair[1] }));
 		// Second one needs to be a list because Iterator does not implement copy
-		let combined_list2: Vec<(Bezier, Range<f64>)> = self2.into_iter().zip(self2_t_values.windows(2).map(|t_pair| Range { start: t_pair[0], end: t_pair[1] })).collect();
+		let combined_list2: Vec<(Bezier, Range<f64>)> = self2.into_iter().zip(self2_t_values.iter().map(|t_pair| Range { start: t_pair[0], end: t_pair[1] })).collect();
 
 		// For each curve, look for intersections with every curve that is at least 2 indices away
 		combined_iterator1

--- a/libraries/bezier-rs/src/bezier/transform.rs
+++ b/libraries/bezier-rs/src/bezier/transform.rs
@@ -419,7 +419,7 @@ impl Bezier {
 	/// The 'caps', the linear segments at opposite ends of the outline, intersect the original curve at the midpoint of the cap.
 	/// Outline takes the following parameter:
 	/// - `distance` - The outline's distance from the curve.
-	/// <iframe frameBorder="0" width="100%" height="375px" src="https://graphite.rs/bezier-rs-demos#bezier/outline/solo" title="Outline Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#bezier/outline/solo" title="Outline Demo"></iframe>
 	pub fn outline<ManipulatorGroupId: crate::Identifier>(&self, distance: f64, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		let first_segment = self.offset(distance);
 		let third_segment = self.reverse().offset(distance);
@@ -433,13 +433,13 @@ impl Bezier {
 
 	/// Version of the `outline` function which draws the outline at the specified distances away from the curve.
 	/// The outline begins `start_distance` away, and gradually move to being `end_distance` away.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#bezier/graduated-outline/solo" title="Graduated Outline Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="450px" src="https://graphite.rs/bezier-rs-demos#bezier/graduated-outline/solo" title="Graduated Outline Demo"></iframe>
 	pub fn graduated_outline<ManipulatorGroupId: crate::Identifier>(&self, start_distance: f64, end_distance: f64, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		self.skewed_outline(start_distance, end_distance, end_distance, start_distance, cap)
 	}
 
 	/// Version of the `graduated_outline` function that allows for the 4 corners of the outline to be different distances away from the curve.
-	/// <iframe frameBorder="0" width="100%" height="475px" src="https://graphite.rs/bezier-rs-demos#bezier/skewed-outline/solo" title="Skewed Outline Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="550px" src="https://graphite.rs/bezier-rs-demos#bezier/skewed-outline/solo" title="Skewed Outline Demo"></iframe>
 	pub fn skewed_outline<ManipulatorGroupId: crate::Identifier>(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		let first_segment = self.graduated_offset(distance1, distance2);
 		let third_segment = self.reverse().graduated_offset(distance3, distance4);

--- a/libraries/bezier-rs/src/bezier/transform.rs
+++ b/libraries/bezier-rs/src/bezier/transform.rs
@@ -426,8 +426,8 @@ impl Bezier {
 	pub fn outline<ManipulatorGroupId: crate::Identifier>(&self, distance: f64, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		let (pos_offset, neg_offset) = if self.is_point() {
 			(
-				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::Y * distance)], false),
 				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::NEG_Y * distance)], false),
+				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::Y * distance)], false),
 			)
 		} else {
 			(self.offset(distance), self.reverse().offset(distance))
@@ -452,8 +452,8 @@ impl Bezier {
 	pub fn skewed_outline<ManipulatorGroupId: crate::Identifier>(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		let (pos_offset, neg_offset) = if self.is_point() {
 			(
-				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::Y * distance1)], false),
 				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::NEG_Y * distance1)], false),
+				Subpath::new(vec![ManipulatorGroup::new_anchor(self.start() + DVec2::Y * distance1)], false),
 			)
 		} else {
 			(self.graduated_offset(distance1, distance2), self.reverse().graduated_offset(distance3, distance4))
@@ -915,7 +915,7 @@ mod tests {
 
 	#[test]
 	fn test_outline_single_point_circle() {
-		let ellipse: Subpath<EmptyId> = Subpath::new_ellipse(DVec2::new(50., 50.), DVec2::new(0., 0.)).reverse();
+		let ellipse: Subpath<EmptyId> = Subpath::new_ellipse(DVec2::new(0., 0.), DVec2::new(50., 50.)).reverse();
 		let p = DVec2::new(25., 25.);
 
 		let line = Bezier::from_linear_dvec2(p, p);
@@ -931,12 +931,12 @@ mod tests {
 	fn test_outline_single_point_square() {
 		let square: Subpath<EmptyId> = Subpath::from_anchors(
 			[
-				DVec2::new(25., 50.),
-				DVec2::new(50., 50.),
-				DVec2::new(50., 0.),
 				DVec2::new(25., 0.),
 				DVec2::new(0., 0.),
 				DVec2::new(0., 50.),
+				DVec2::new(25., 50.),
+				DVec2::new(50., 50.),
+				DVec2::new(50., 0.),
 			],
 			true,
 		);

--- a/libraries/bezier-rs/src/lib.rs
+++ b/libraries/bezier-rs/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 
 pub use bezier::*;
 pub use subpath::*;
-pub use utils::{Joint, SubpathTValue, TValue};
+pub use utils::{Cap, Joint, SubpathTValue, TValue};

--- a/libraries/bezier-rs/src/lib.rs
+++ b/libraries/bezier-rs/src/lib.rs
@@ -8,4 +8,4 @@ mod utils;
 
 pub use bezier::*;
 pub use subpath::*;
-pub use utils::{Cap, Joint, SubpathTValue, TValue};
+pub use utils::{Cap, Join, SubpathTValue, TValue};

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -113,7 +113,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	}
 
 	/// Returns if the Subpath is equivalent to a single point.
-	pub fn is_single_point(&self) -> bool {
+	pub fn is_point(&self) -> bool {
 		if self.is_empty() {
 			return false;
 		}

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -88,7 +88,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// Returns the number of segments contained within the `Subpath`.
 	pub fn len_segments(&self) -> usize {
 		let mut number_of_curves = self.len();
-		if !self.closed {
+		if !self.closed && number_of_curves > 0 {
 			number_of_curves -= 1
 		}
 		number_of_curves

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -112,6 +112,17 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 		&self.manipulator_groups
 	}
 
+	/// Returns if the Subpath is equivalent to a single point.
+	pub fn is_single_point(&self) -> bool {
+		if self.is_empty() {
+			return false;
+		}
+		let point = self.manipulator_groups[0].anchor;
+		self.manipulator_groups
+			.iter()
+			.all(|manipulator_group| manipulator_group.anchor.abs_diff_eq(point, MAX_ABSOLUTE_DIFFERENCE))
+	}
+
 	/// Appends to the `svg` mutable string with an SVG shape representation of the curve.
 	pub fn curve_to_svg(&self, svg: &mut String, attributes: String) {
 		let curve_start_argument = format!("{SVG_ARG_MOVE}{} {}", self[0].anchor.x, self[0].anchor.y);

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -231,6 +231,18 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 			right + center_to_right.perp() * HANDLE_OFFSET_FACTOR,
 		)
 	}
+
+	pub(crate) fn square_cap(&self, other: &Subpath<ManipulatorGroupId>) -> [ManipulatorGroup<ManipulatorGroupId>; 2] {
+		let left = self.manipulator_groups[self.len() - 1].anchor;
+		let right = other.manipulator_groups[0].anchor;
+
+		let center = (right + left) / 2.;
+		let center_to_right = right - center;
+
+		let translation = center_to_right.perp();
+
+		[ManipulatorGroup::new_anchor(left + translation), ManipulatorGroup::new_anchor(right + translation)]
+	}
 }
 
 #[cfg(test)]
@@ -264,14 +276,14 @@ mod tests {
 		let result = Subpath::new(
 			vec![
 				ManipulatorGroup {
-					anchor: pos_offset.evaluate(1.),
+					anchor: pos_offset.evaluate(SubpathTValue::GlobalParametric(1.)),
 					out_handle: Some(out_handle),
 					in_handle: None,
 					id: EmptyId,
 				},
 				manip.clone(),
 				ManipulatorGroup {
-					anchor: neg_offset.evaluate(0.),
+					anchor: neg_offset.evaluate(SubpathTValue::GlobalParametric(0.)),
 					out_handle: None,
 					in_handle: Some(in_handle),
 					id: EmptyId,

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -23,7 +23,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// - `error`: an optional f64 value to provide an error bound
 	/// - `minimum_separation`: the minimum difference two adjacent `t`-values must have when comparing adjacent `t`-values in sorted order.
 	/// If the comparison condition is not satisfied, the function takes the larger `t`-value of the two.
-	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
 	pub fn intersections(&self, other: &Bezier, error: Option<f64>, minimum_separation: Option<f64>) -> Vec<(usize, f64)> {
 		self.iter()
 			.enumerate()
@@ -35,18 +35,11 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// This function expects the following:
 	/// - other: a [Bezier] curve to check intersections against
 	/// - error: an optional f64 value to provide an error bound
-	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/intersect-cubic/solo" title="Intersection Demo"></iframe>
 	pub fn subpath_intersections(&self, other: &Subpath<ManipulatorGroupId>, error: Option<f64>, minimum_separation: Option<f64>) -> Vec<(usize, f64)> {
 		let mut intersection_t_values: Vec<(usize, f64)> = other.iter().flat_map(|bezier| self.intersections(&bezier, error, minimum_separation)).collect();
 		intersection_t_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
 		intersection_t_values
-	}
-
-	/// Returns a normalized unit vector representing the tangent on the subpath based on the parametric `t`-value provided.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/tangent/solo" title="Tangent Demo"></iframe>
-	pub fn tangent(&self, t: SubpathTValue) -> DVec2 {
-		let (segment_index, t) = self.t_value_to_parametric(t);
-		self.get_segment(segment_index).unwrap().tangent(TValue::Parametric(t))
 	}
 
 	/// Returns a list of `t` values that correspond to the self intersection points of the subpath. For each intersection point, the returned `t` value is the smaller of the two that correspond to the point.
@@ -75,6 +68,13 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 		intersections_vec
 	}
 
+	/// Returns a normalized unit vector representing the tangent on the subpath based on the parametric `t`-value provided.
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/tangent/solo" title="Tangent Demo"></iframe>
+	pub fn tangent(&self, t: SubpathTValue) -> DVec2 {
+		let (segment_index, t) = self.t_value_to_parametric(t);
+		self.get_segment(segment_index).unwrap().tangent(TValue::Parametric(t))
+	}
+
 	/// Returns a normalized unit vector representing the direction of the normal on the subpath based on the parametric `t`-value provided.
 	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/normal/solo" title="Normal Demo"></iframe>
 	pub fn normal(&self, t: SubpathTValue) -> DVec2 {
@@ -84,7 +84,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 	/// Returns two lists of `t`-values representing the local extrema of the `x` and `y` parametric subpaths respectively.
 	/// The list of `t`-values returned are filtered such that they fall within the range `[0, 1]`.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/local-extrema/solo" title="Local Extrema Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/local-extrema/solo" title="Local Extrema Demo"></iframe>
 	pub fn local_extrema(&self) -> [Vec<f64>; 2] {
 		let number_of_curves = self.len_segments() as f64;
 
@@ -99,7 +99,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	}
 
 	/// Return the min and max corners that represent the bounding box of the subpath.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/bounding-box/solo" title="Bounding Box Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="325px" src="https://graphite.rs/bezier-rs-demos#subpath/bounding-box/solo" title="Bounding Box Demo"></iframe>
 	pub fn bounding_box(&self) -> Option<[DVec2; 2]> {
 		self.iter().map(|bezier| bezier.bounding_box()).reduce(|bbox1, bbox2| [bbox1[0].min(bbox2[0]), bbox1[1].max(bbox2[1])])
 	}
@@ -113,7 +113,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 	/// Returns list of `t`-values representing the inflection points of the subpath.
 	/// The list of `t`-values returned are filtered such that they fall within the range `[0, 1]`.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/inflections/solo" title="Inflections Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="300px" src="https://graphite.rs/bezier-rs-demos#subpath/inflections/solo" title="Inflections Demo"></iframe>
 	pub fn inflections(&self) -> Vec<f64> {
 		let number_of_curves = self.len_segments() as f64;
 		let inflection_t_values: Vec<f64> = self

--- a/libraries/bezier-rs/src/subpath/transform.rs
+++ b/libraries/bezier-rs/src/subpath/transform.rs
@@ -386,7 +386,10 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 					Joint::Round => {
 						let round_subpath = subpaths[i].round_line_join(&subpaths[j], self.manipulator_groups[j].anchor);
 						if let Some(round_subpath) = round_subpath {
-							subpaths[i].manipulator_groups.extend(round_subpath.manipulator_groups);
+							let last_index = subpaths[i].manipulator_groups.len() - 1;
+							subpaths[i].manipulator_groups[last_index].out_handle = round_subpath.manipulator_groups[0].out_handle;
+							subpaths[i].manipulator_groups.push(round_subpath.manipulator_groups[1].clone());
+							subpaths[j].manipulator_groups[0].in_handle = round_subpath.manipulator_groups[2].in_handle;
 						}
 						drop_common_point[j] = false;
 					}
@@ -427,7 +430,14 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 						drop_common_point[0] = false;
 					}
 					Joint::Round => {
-						// TODO: Handle this
+						let last_subpath_index = subpaths.len() - 1;
+						let round_subpath = subpaths[last_subpath_index].round_line_join(&subpaths[0], self.manipulator_groups[0].anchor);
+						if let Some(round_subpath) = round_subpath {
+							let last_index = subpaths[last_subpath_index].manipulator_groups.len() - 1;
+							subpaths[last_subpath_index].manipulator_groups[last_index].out_handle = round_subpath.manipulator_groups[0].out_handle;
+							subpaths[last_subpath_index].manipulator_groups.push(round_subpath.manipulator_groups[1].clone());
+							subpaths[0].manipulator_groups[0].in_handle = round_subpath.manipulator_groups[2].in_handle;
+						}
 						drop_common_point[0] = false;
 					}
 				}

--- a/libraries/bezier-rs/src/subpath/transform.rs
+++ b/libraries/bezier-rs/src/subpath/transform.rs
@@ -121,7 +121,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// The resulting Subpath will wind from the given `t1` to `t2`.
 	/// That means, if the value of `t1` > `t2`, it will cross the break between endpoints from `t1` to `t = 1 = 0` to `t2`.
 	/// If a path winding in the reverse direction is desired, call `trim` on the `Subpath` returned from `Subpath::reverse`.
-	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/trim/solo" title="Trim Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="450px" src="https://graphite.rs/bezier-rs-demos#subpath/trim/solo" title="Trim Demo"></iframe>
 	pub fn trim(&self, t1: SubpathTValue, t2: SubpathTValue) -> Subpath<ManipulatorGroupId> {
 		// Return a clone of the Subpath if it is not long enough to be a valid Bezier
 		if self.manipulator_groups.is_empty() {
@@ -330,7 +330,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 	/// Reduces the segments of the subpath into simple subcurves, then scales each subcurve a set `distance` away.
 	/// The intersections of segments of the subpath are joined using the method specified by the `join` argument.
-	/// <iframe frameBorder="0" width="100%" height="375px" src="https://graphite.rs/bezier-rs-demos#subpath/offset/solo" title="Offset Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="400px" src="https://graphite.rs/bezier-rs-demos#subpath/offset/solo" title="Offset Demo"></iframe>
 	pub fn offset(&self, distance: f64, join: Join) -> Subpath<ManipulatorGroupId> {
 		assert!(self.len_segments() > 1, "Cannot offset an empty Subpath.");
 
@@ -469,7 +469,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 		Subpath::new(manipulator_groups, self.closed)
 	}
 
-	// TODO: Add comment and consider refactoring
+	/// Helper function to combine the two offsets that make up an outline.
 	pub(crate) fn combine_outline(&self, other: &Subpath<ManipulatorGroupId>, cap: Cap) -> Subpath<ManipulatorGroupId> {
 		let mut result_manipulator_groups: Vec<ManipulatorGroup<ManipulatorGroupId>> = vec![];
 		result_manipulator_groups.extend_from_slice(self.manipulator_groups());
@@ -507,7 +507,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	/// an approximate outline around the subpath at a specified distance from the curve. Outline takes the following parameters:
 	/// - `distance` - The outline's distance from the curve.
 	/// - `join` - The join type used to cap the endpoints of open bezier curves, and join successive subpath segments.
-	/// <iframe frameBorder="0" width="100%" height="375px" src="https://graphite.rs/bezier-rs-demos#subpath/outline/solo" title="Outline Demo"></iframe>
+	/// <iframe frameBorder="0" width="100%" height="450px" src="https://graphite.rs/bezier-rs-demos#subpath/outline/solo" title="Outline Demo"></iframe>
 	pub fn outline(&self, distance: f64, join: Join, cap: Cap) -> (Subpath<ManipulatorGroupId>, Option<Subpath<ManipulatorGroupId>>) {
 		let pos_offset = self.offset(distance, join);
 		let neg_offset = self.reverse().offset(distance, join);

--- a/libraries/bezier-rs/src/subpath/transform.rs
+++ b/libraries/bezier-rs/src/subpath/transform.rs
@@ -509,8 +509,8 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 		let (pos_offset, neg_offset) = if is_point {
 			let point = self.manipulator_groups[0].anchor;
 			(
-				Subpath::new(vec![ManipulatorGroup::new_anchor(point + DVec2::Y * distance)], false),
 				Subpath::new(vec![ManipulatorGroup::new_anchor(point + DVec2::NEG_Y * distance)], false),
+				Subpath::new(vec![ManipulatorGroup::new_anchor(point + DVec2::Y * distance)], false),
 			)
 		} else {
 			(self.offset(distance, join), self.reverse().offset(distance, join))
@@ -1024,7 +1024,7 @@ mod tests {
 
 	#[test]
 	fn outline_single_point_circle() {
-		let ellipse: Subpath<EmptyId> = Subpath::new_ellipse(DVec2::new(50., 50.), DVec2::new(0., 0.)).reverse();
+		let ellipse: Subpath<EmptyId> = Subpath::new_ellipse(DVec2::new(0., 0.), DVec2::new(50., 50.)).reverse();
 		let p = DVec2::new(25., 25.);
 
 		let subpath: Subpath<EmptyId> = Subpath::from_anchors([p, p, p], false);
@@ -1042,12 +1042,12 @@ mod tests {
 	fn outline_single_point_square() {
 		let square: Subpath<EmptyId> = Subpath::from_anchors(
 			[
-				DVec2::new(25., 50.),
-				DVec2::new(50., 50.),
-				DVec2::new(50., 0.),
 				DVec2::new(25., 0.),
 				DVec2::new(0., 0.),
 				DVec2::new(0., 50.),
+				DVec2::new(25., 50.),
+				DVec2::new(50., 50.),
+				DVec2::new(50., 0.),
 			],
 			true,
 		);

--- a/libraries/bezier-rs/src/utils.rs
+++ b/libraries/bezier-rs/src/utils.rs
@@ -29,7 +29,7 @@ pub enum SubpathTValue {
 }
 
 #[derive(Copy, Clone)]
-pub enum Joint {
+pub enum Join {
 	Bevel,
 	Miter,
 	Round,

--- a/libraries/bezier-rs/src/utils.rs
+++ b/libraries/bezier-rs/src/utils.rs
@@ -30,9 +30,16 @@ pub enum SubpathTValue {
 
 #[derive(Copy, Clone)]
 pub enum Joint {
-	Miter,
 	Bevel,
+	Miter,
 	Round,
+}
+
+#[derive(Copy, Clone)]
+pub enum Cap {
+	Butt,
+	Round,
+	Square,
 }
 
 /// Helper to perform the computation of a and c, where b is the provided point on the curve.

--- a/libraries/bezier-rs/src/utils.rs
+++ b/libraries/bezier-rs/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::consts::{MAX_ABSOLUTE_DIFFERENCE, MIN_SEPARATION_VALUE, STRICT_MAX_ABSOLUTE_DIFFERENCE};
+use crate::ManipulatorGroup;
 
 use glam::{BVec2, DMat2, DVec2};
 use std::f64::consts::PI;
@@ -29,6 +30,8 @@ pub enum SubpathTValue {
 }
 
 #[derive(Copy, Clone)]
+/// Enum to represent the join type between subpaths.
+/// As defined in SVG: https://www.w3.org/TR/SVG2/painting.html#LineJoin.
 pub enum Join {
 	Bevel,
 	Miter,
@@ -36,6 +39,8 @@ pub enum Join {
 }
 
 #[derive(Copy, Clone)]
+/// Enum to represent the cap type at the ends of an outline
+/// As defined in SVG: https://www.w3.org/TR/SVG2/painting.html#LineCaps.
 pub enum Cap {
 	Butt,
 	Round,
@@ -271,6 +276,31 @@ pub fn scale_point_from_direction_vector(point: DVec2, direction_unit_vector: DV
 /// Scale a point by a given distance with respect to the provided origin.
 pub fn scale_point_from_origin(point: DVec2, origin: DVec2, should_flip_direction: bool, distance: f64) -> DVec2 {
 	scale_point_from_direction_vector(point, (origin - point).normalize(), should_flip_direction, distance)
+}
+
+/// Computes the necessary details to form a circular join from `left` to `right`, along a circle around `center`.
+/// By default, the angle is assumed to be 180 degrees.
+pub fn compute_circular_subpath_details<ManipulatorGroupId: crate::Identifier>(
+	left: DVec2,
+	arc_point: DVec2,
+	right: DVec2,
+	center: DVec2,
+	angle: Option<f64>,
+) -> (DVec2, ManipulatorGroup<ManipulatorGroupId>, DVec2) {
+	let center_to_arc_point = arc_point - center;
+
+	// Based on https://pomax.github.io/bezierinfo/#circles_cubic
+	let handle_offset_factor = if let Some(angle) = angle { 4. / 3. * (angle / 4.).tan() } else { 0.551784777779014 };
+
+	(
+		left - (left - center).perp() * handle_offset_factor,
+		ManipulatorGroup::new(
+			arc_point,
+			Some(arc_point + center_to_arc_point.perp() * handle_offset_factor),
+			Some(arc_point - center_to_arc_point.perp() * handle_offset_factor),
+		),
+		right + (right - center).perp() * handle_offset_factor,
+	)
 }
 
 #[cfg(test)]

--- a/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
@@ -1,6 +1,6 @@
 import subpathFeatures, { SubpathFeatureKey } from "@graphite/features/subpath-features";
 import { renderDemoPane } from "@graphite/utils/render";
-import { Demo, DemoPane, InputOption, SubpathDemoArgs } from "@graphite/utils/types";
+import { Demo, DemoPane, SubpathDemoArgs, SubpathInputOption } from "@graphite/utils/types";
 
 class SubpathDemoPane extends HTMLElement implements DemoPane {
 	// Props
@@ -8,7 +8,7 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 
 	name!: string;
 
-	inputOptions!: InputOption[];
+	inputOptions!: SubpathInputOption[];
 
 	triggerOnMouseMove!: boolean;
 
@@ -62,7 +62,12 @@ class SubpathDemoPane extends HTMLElement implements DemoPane {
 		subpathDemo.setAttribute("triples", JSON.stringify(demo.triples));
 		subpathDemo.setAttribute("closed", String(demo.closed));
 		subpathDemo.setAttribute("key", this.key);
-		subpathDemo.setAttribute("inputOptions", JSON.stringify(this.inputOptions));
+
+		const inputOptions = this.inputOptions.map((option) => ({
+			...option,
+			disabled: option.isDisabledForClosed && demo.closed,
+		}));
+		subpathDemo.setAttribute("inputOptions", JSON.stringify(inputOptions));
 		subpathDemo.setAttribute("triggerOnMouseMove", String(this.triggerOnMouseMove));
 		return subpathDemo;
 	}

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -251,7 +251,7 @@ const bezierFeatures = {
 	},
 	outline: {
 		name: "Outline",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.outline(options.distance, options.joint),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.outline(options.distance, options.cap),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -263,12 +263,12 @@ const bezierFeatures = {
 						default: 15,
 					},
 					{
-						variable: "joint",
+						variable: "cap",
 						min: 0,
 						max: 2,
 						step: 1,
 						default: 0,
-						unit: [": Bevel", ": Miter", ": Round"],
+						unit: [": Butt", ": Round", ": Square"],
 					},
 				],
 			},
@@ -276,7 +276,7 @@ const bezierFeatures = {
 	},
 	"graduated-outline": {
 		name: "Graduated Outline",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance, options.joint),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance, options.cap),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -295,12 +295,12 @@ const bezierFeatures = {
 						default: 15,
 					},
 					{
-						variable: "joint",
+						variable: "cap",
 						min: 0,
 						max: 2,
 						step: 1,
 						default: 0,
-						unit: [": Bevel", ": Miter", ": Round"],
+						unit: [": Butt", ": Round", ": Square"],
 					},
 				],
 			},
@@ -317,7 +317,7 @@ const bezierFeatures = {
 	"skewed-outline": {
 		name: "Skewed Outline",
 		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string =>
-			bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4, options.joint),
+			bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4, options.cap),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -350,12 +350,12 @@ const bezierFeatures = {
 						default: 5,
 					},
 					{
-						variable: "joint",
+						variable: "cap",
 						min: 0,
 						max: 2,
 						step: 1,
 						default: 0,
-						unit: [": Bevel", ": Miter", ": Round"],
+						unit: [": Butt", ": Round", ": Square"],
 					},
 				],
 			},

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -251,7 +251,7 @@ const bezierFeatures = {
 	},
 	outline: {
 		name: "Outline",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.outline(options.distance),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.outline(options.distance, options.joint),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -262,13 +262,21 @@ const bezierFeatures = {
 						step: 1,
 						default: 15,
 					},
+					{
+						variable: "joint",
+						min: 0,
+						max: 2,
+						step: 1,
+						default: 0,
+						unit: [": Bevel", ": Miter", ": Round"],
+					},
 				],
 			},
 		},
 	},
 	"graduated-outline": {
 		name: "Graduated Outline",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.graduated_outline(options.start_distance, options.end_distance, options.joint),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -286,6 +294,14 @@ const bezierFeatures = {
 						step: 1,
 						default: 15,
 					},
+					{
+						variable: "joint",
+						min: 0,
+						max: 2,
+						step: 1,
+						default: 0,
+						unit: [": Bevel", ": Miter", ": Round"],
+					},
 				],
 			},
 		},
@@ -300,7 +316,8 @@ const bezierFeatures = {
 	},
 	"skewed-outline": {
 		name: "Skewed Outline",
-		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string => bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4),
+		callback: (bezier: WasmBezierInstance, options: Record<string, number>): string =>
+			bezier.skewed_outline(options.distance1, options.distance2, options.distance3, options.distance4, options.joint),
 		demoOptions: {
 			Quadratic: {
 				inputOptions: [
@@ -331,6 +348,14 @@ const bezierFeatures = {
 						max: 30,
 						step: 1,
 						default: 5,
+					},
+					{
+						variable: "joint",
+						min: 0,
+						max: 2,
+						step: 1,
+						default: 0,
+						unit: [": Bevel", ": Miter", ": Round"],
 					},
 				],
 			},

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -1,5 +1,5 @@
 import { WasmBezier } from "@graphite/../wasm/pkg";
-import { tSliderOptions, bezierTValueVariantOptions, errorOptions, minimumSeparationOptions } from "@graphite/utils/options";
+import { capOptions, tSliderOptions, bezierTValueVariantOptions, errorOptions, minimumSeparationOptions } from "@graphite/utils/options";
 import { BezierDemoOptions, WasmBezierInstance, BezierCallback, InputOption, BEZIER_T_VALUE_VARIANTS } from "@graphite/utils/types";
 
 const bezierFeatures = {
@@ -262,14 +262,7 @@ const bezierFeatures = {
 						step: 1,
 						default: 15,
 					},
-					{
-						variable: "cap",
-						min: 0,
-						max: 2,
-						step: 1,
-						default: 0,
-						unit: [": Butt", ": Round", ": Square"],
-					},
+					capOptions,
 				],
 			},
 		},
@@ -294,14 +287,7 @@ const bezierFeatures = {
 						step: 1,
 						default: 15,
 					},
-					{
-						variable: "cap",
-						min: 0,
-						max: 2,
-						step: 1,
-						default: 0,
-						unit: [": Butt", ": Round", ": Square"],
-					},
+					capOptions,
 				],
 			},
 		},
@@ -349,14 +335,7 @@ const bezierFeatures = {
 						step: 1,
 						default: 5,
 					},
-					{
-						variable: "cap",
-						min: 0,
-						max: 2,
-						step: 1,
-						default: 0,
-						unit: [": Butt", ": Round", ": Square"],
-					},
+					capOptions,
 				],
 			},
 		},

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -107,7 +107,7 @@ const subpathFeatures = {
 	},
 	offset: {
 		name: "Offset",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.offset(options.distance),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.offset(options.distance, options.joint),
 		inputOptions: [
 			{
 				variable: "distance",
@@ -116,11 +116,19 @@ const subpathFeatures = {
 				step: 1,
 				default: 10,
 			},
+			{
+				variable: "joint",
+				min: 0,
+				max: 2,
+				step: 1,
+				default: 0,
+				unit: [": Bevel", ": Miter", ": Round"],
+			},
 		],
 	},
 	outline: {
 		name: "Outline",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance, options.joint),
 		inputOptions: [
 			{
 				variable: "distance",
@@ -128,6 +136,14 @@ const subpathFeatures = {
 				max: 25,
 				step: 1,
 				default: 10,
+			},
+			{
+				variable: "joint",
+				min: 0,
+				max: 2,
+				step: 1,
+				default: 0,
+				unit: [": Bevel", ": Miter", ": Round"],
 			},
 		],
 	},

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -1,5 +1,5 @@
 import { capOptions, joinOptions, tSliderOptions, subpathTValueVariantOptions, intersectionErrorOptions, minimumSeparationOptions } from "@graphite/utils/options";
-import { InputOption, SubpathCallback, WasmSubpathInstance, SUBPATH_T_VALUE_VARIANTS } from "@graphite/utils/types";
+import { SubpathCallback, SubpathInputOption, WasmSubpathInstance, SUBPATH_T_VALUE_VARIANTS } from "@graphite/utils/types";
 
 const subpathFeatures = {
 	constructor: {
@@ -131,7 +131,7 @@ const subpathFeatures = {
 				default: 10,
 			},
 			joinOptions,
-			capOptions,
+			{ ...capOptions, isDisabledForClosed: true },
 		],
 	},
 };
@@ -140,7 +140,7 @@ export type SubpathFeatureKey = keyof typeof subpathFeatures;
 export type SubpathFeatureOptions = {
 	name: string;
 	callback: SubpathCallback;
-	inputOptions?: InputOption[];
+	inputOptions?: SubpathInputOption[];
 	triggerOnMouseMove?: boolean;
 };
 export default subpathFeatures as Record<SubpathFeatureKey, SubpathFeatureOptions>;

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -128,7 +128,7 @@ const subpathFeatures = {
 	},
 	outline: {
 		name: "Outline",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance, options.joint),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance, options.joint, options.cap),
 		inputOptions: [
 			{
 				variable: "distance",
@@ -144,6 +144,14 @@ const subpathFeatures = {
 				step: 1,
 				default: 0,
 				unit: [": Bevel", ": Miter", ": Round"],
+			},
+			{
+				variable: "cap",
+				min: 0,
+				max: 2,
+				step: 1,
+				default: 0,
+				unit: [": Butt", ": Round", ": Square"],
 			},
 		],
 	},

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -107,7 +107,7 @@ const subpathFeatures = {
 	},
 	offset: {
 		name: "Offset",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.offset(options.distance, options.joint),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.offset(options.distance, options.join),
 		inputOptions: [
 			{
 				variable: "distance",
@@ -117,7 +117,7 @@ const subpathFeatures = {
 				default: 10,
 			},
 			{
-				variable: "joint",
+				variable: "join",
 				min: 0,
 				max: 2,
 				step: 1,
@@ -128,7 +128,7 @@ const subpathFeatures = {
 	},
 	outline: {
 		name: "Outline",
-		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance, options.joint, options.cap),
+		callback: (subpath: WasmSubpathInstance, options: Record<string, number>): string => subpath.outline(options.distance, options.join, options.cap),
 		inputOptions: [
 			{
 				variable: "distance",
@@ -138,7 +138,7 @@ const subpathFeatures = {
 				default: 10,
 			},
 			{
-				variable: "joint",
+				variable: "join",
 				min: 0,
 				max: 2,
 				step: 1,

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -1,4 +1,4 @@
-import { tSliderOptions, subpathTValueVariantOptions, intersectionErrorOptions, minimumSeparationOptions } from "@graphite/utils/options";
+import { capOptions, joinOptions, tSliderOptions, subpathTValueVariantOptions, intersectionErrorOptions, minimumSeparationOptions } from "@graphite/utils/options";
 import { InputOption, SubpathCallback, WasmSubpathInstance, SUBPATH_T_VALUE_VARIANTS } from "@graphite/utils/types";
 
 const subpathFeatures = {
@@ -116,14 +116,7 @@ const subpathFeatures = {
 				step: 1,
 				default: 10,
 			},
-			{
-				variable: "join",
-				min: 0,
-				max: 2,
-				step: 1,
-				default: 0,
-				unit: [": Bevel", ": Miter", ": Round"],
-			},
+			joinOptions,
 		],
 	},
 	outline: {
@@ -137,22 +130,8 @@ const subpathFeatures = {
 				step: 1,
 				default: 10,
 			},
-			{
-				variable: "join",
-				min: 0,
-				max: 2,
-				step: 1,
-				default: 0,
-				unit: [": Bevel", ": Miter", ": Round"],
-			},
-			{
-				variable: "cap",
-				min: 0,
-				max: 2,
-				step: 1,
-				default: 0,
-				unit: [": Butt", ": Round", ": Square"],
-			},
+			joinOptions,
+			capOptions,
 		],
 	},
 };

--- a/website/other/bezier-rs-demos/src/utils/options.ts
+++ b/website/other/bezier-rs-demos/src/utils/options.ts
@@ -45,3 +45,17 @@ export const subpathTValueVariantOptions = {
 	inputType: "dropdown",
 	options: SUBPATH_T_VALUE_VARIANTS,
 };
+
+export const joinOptions = {
+	variable: "join",
+	default: 0,
+	inputType: "dropdown",
+	options: ["Bevel", "Miter", "Round"],
+};
+
+export const capOptions = {
+	variable: "cap",
+	default: 0,
+	inputType: "dropdown",
+	options: ["Butt", "Round", "Square"],
+};

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -43,6 +43,10 @@ export function renderDemo(demo: Demo): void {
 				selectInput.append(option);
 			});
 
+			if (inputOption.disabled) {
+				selectInput.disabled = true;
+			}
+
 			selectInput.addEventListener("change", (event: Event): void => {
 				demo.sliderData[inputOption.variable] = Number((event.target as HTMLInputElement).value);
 				demo.drawDemo(figure);

--- a/website/other/bezier-rs-demos/src/utils/types.ts
+++ b/website/other/bezier-rs-demos/src/utils/types.ts
@@ -22,6 +22,10 @@ export type BezierDemoOptions = {
 	};
 };
 
+export type SubpathInputOption = InputOption & {
+	isDisabledForClosed?: boolean;
+};
+
 export type InputOption = {
 	variable: string;
 	min?: number;
@@ -31,6 +35,7 @@ export type InputOption = {
 	unit?: string | string[];
 	inputType?: "slider" | "dropdown";
 	options?: string[];
+	disabled?: boolean;
 };
 
 export function getCurveType(numPoints: number): BezierCurveType {

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -247,19 +247,10 @@ impl WasmBezier {
 		let t = parse_t_variant(&t_variant, raw_t);
 		let beziers: [Bezier; 2] = self.0.split(t);
 
-		let mut original_bezier_svg = String::new();
-		self.0.to_svg(
-			&mut original_bezier_svg,
-			CURVE_ATTRIBUTES.to_string().replace(BLACK, WHITE),
-			ANCHOR_ATTRIBUTES.to_string().replace(BLACK, WHITE),
-			HANDLE_ATTRIBUTES.to_string(),
-			HANDLE_LINE_ATTRIBUTES.to_string(),
-		);
-
 		let mut bezier_svg_1 = String::new();
 		beziers[0].to_svg(
 			&mut bezier_svg_1,
-			CURVE_ATTRIBUTES.to_string().replace(BLACK, ORANGE),
+			CURVE_ATTRIBUTES.to_string().replace(BLACK, ORANGE).replace("stroke-width=\"2\"", "stroke-width=\"8\"") + " opacity=\"0.5\"",
 			ANCHOR_ATTRIBUTES.to_string().replace(BLACK, ORANGE),
 			HANDLE_ATTRIBUTES.to_string().replace(GRAY, ORANGE),
 			HANDLE_LINE_ATTRIBUTES.to_string().replace(GRAY, ORANGE),
@@ -268,13 +259,13 @@ impl WasmBezier {
 		let mut bezier_svg_2 = String::new();
 		beziers[1].to_svg(
 			&mut bezier_svg_2,
-			CURVE_ATTRIBUTES.to_string().replace(BLACK, RED),
+			CURVE_ATTRIBUTES.to_string().replace(BLACK, RED).replace("stroke-width=\"2\"", "stroke-width=\"8\"") + " opacity=\"0.5\"",
 			ANCHOR_ATTRIBUTES.to_string().replace(BLACK, RED),
 			HANDLE_ATTRIBUTES.to_string().replace(GRAY, RED),
 			HANDLE_LINE_ATTRIBUTES.to_string().replace(GRAY, RED),
 		);
 
-		wrap_svg_tag(format!("{original_bezier_svg}{bezier_svg_1}{bezier_svg_2}"))
+		wrap_svg_tag(format!("{}{bezier_svg_1}{bezier_svg_2}", self.get_bezier_path()))
 	}
 
 	pub fn trim(&self, raw_t1: f64, raw_t2: f64, t_variant: String) -> String {
@@ -284,7 +275,7 @@ impl WasmBezier {
 		let mut trimmed_bezier_svg = String::new();
 		trimmed_bezier.to_svg(
 			&mut trimmed_bezier_svg,
-			CURVE_ATTRIBUTES.to_string().replace(BLACK, RED),
+			CURVE_ATTRIBUTES.to_string().replace(BLACK, RED).replace("stroke-width=\"2\"", "stroke-width=\"8\"") + " opacity=\"0.5\"",
 			ANCHOR_ATTRIBUTES.to_string().replace(BLACK, RED),
 			HANDLE_ATTRIBUTES.to_string().replace(GRAY, RED),
 			HANDLE_LINE_ATTRIBUTES.to_string().replace(GRAY, RED),

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -221,22 +221,25 @@ impl WasmBezier {
 	}
 
 	pub fn curvature(&self, raw_t: f64, t_variant: String) -> String {
-		let bezier = self.get_bezier_path();
+		let mut content = self.get_bezier_path();
 		let t = parse_t_variant(&t_variant, raw_t);
 
-		let radius = 1. / self.0.curvature(t);
-		let normal_point = self.0.normal(t);
-		let intersection_point = self.0.evaluate(t);
+		let curvature = self.0.curvature(t);
+		if curvature > 0. {
+			let radius = 1. / self.0.curvature(t);
+			let normal_point = self.0.normal(t);
+			let intersection_point = self.0.evaluate(t);
 
-		let curvature_center = intersection_point + normal_point * radius;
+			let curvature_center = intersection_point + normal_point * radius;
 
-		let content = format!(
-			"{bezier}{}{}{}{}",
-			draw_circle(curvature_center, radius.abs(), RED, 1., NONE),
-			draw_line(intersection_point.x, intersection_point.y, curvature_center.x, curvature_center.y, RED, 1.),
-			draw_circle(intersection_point, 3., RED, 1., WHITE),
-			draw_circle(curvature_center, 3., RED, 1., WHITE),
-		);
+			content = format!(
+				"{content}{}{}{}{}",
+				draw_circle(curvature_center, radius.abs(), RED, 1., NONE),
+				draw_line(intersection_point.x, intersection_point.y, curvature_center.x, curvature_center.y, RED, 1.),
+				draw_circle(intersection_point, 3., RED, 1., WHITE),
+				draw_circle(curvature_center, 3., RED, 1., WHITE),
+			);
+		}
 		wrap_svg_tag(content)
 	}
 

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -1,5 +1,5 @@
 use crate::svg_drawing::*;
-use crate::utils::parse_joint;
+use crate::utils::parse_cap;
 
 use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, ProjectionOptions, TValue};
 use glam::DVec2;
@@ -572,9 +572,9 @@ impl WasmBezier {
 		wrap_svg_tag(bezier_curves_svg)
 	}
 
-	pub fn outline(&self, distance: f64, joint: i32) -> String {
-		let joint = parse_joint(joint);
-		let outline_subpath = self.0.outline::<EmptyId>(distance, joint);
+	pub fn outline(&self, distance: f64, cap: i32) -> String {
+		let cap = parse_cap(cap);
+		let outline_subpath = self.0.outline::<EmptyId>(distance, cap);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}
@@ -586,9 +586,9 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_svg}{outline_svg}"))
 	}
 
-	pub fn graduated_outline(&self, start_distance: f64, end_distance: f64, joint: i32) -> String {
-		let joint = parse_joint(joint);
-		let outline_subpath = self.0.graduated_outline::<EmptyId>(start_distance, end_distance, joint);
+	pub fn graduated_outline(&self, start_distance: f64, end_distance: f64, cap: i32) -> String {
+		let cap = parse_cap(cap);
+		let outline_subpath = self.0.graduated_outline::<EmptyId>(start_distance, end_distance, cap);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}
@@ -600,9 +600,9 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_svg}{outline_svg}"))
 	}
 
-	pub fn skewed_outline(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64, joint: i32) -> String {
-		let joint = parse_joint(joint);
-		let outline_subpath = self.0.skewed_outline::<EmptyId>(distance1, distance2, distance3, distance4, joint);
+	pub fn skewed_outline(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64, cap: i32) -> String {
+		let cap = parse_cap(cap);
+		let outline_subpath = self.0.skewed_outline::<EmptyId>(distance1, distance2, distance3, distance4, cap);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}

--- a/website/other/bezier-rs-demos/wasm/src/bezier.rs
+++ b/website/other/bezier-rs-demos/wasm/src/bezier.rs
@@ -1,4 +1,6 @@
 use crate::svg_drawing::*;
+use crate::utils::parse_joint;
+
 use bezier_rs::{ArcStrategy, ArcsOptions, Bezier, Identifier, ProjectionOptions, TValue};
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
@@ -570,8 +572,9 @@ impl WasmBezier {
 		wrap_svg_tag(bezier_curves_svg)
 	}
 
-	pub fn outline(&self, distance: f64) -> String {
-		let outline_subpath = self.0.outline::<EmptyId>(distance);
+	pub fn outline(&self, distance: f64, joint: i32) -> String {
+		let joint = parse_joint(joint);
+		let outline_subpath = self.0.outline::<EmptyId>(distance, joint);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}
@@ -583,8 +586,9 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_svg}{outline_svg}"))
 	}
 
-	pub fn graduated_outline(&self, start_distance: f64, end_distance: f64) -> String {
-		let outline_subpath = self.0.graduated_outline::<EmptyId>(start_distance, end_distance);
+	pub fn graduated_outline(&self, start_distance: f64, end_distance: f64, joint: i32) -> String {
+		let joint = parse_joint(joint);
+		let outline_subpath = self.0.graduated_outline::<EmptyId>(start_distance, end_distance, joint);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}
@@ -596,8 +600,9 @@ impl WasmBezier {
 		wrap_svg_tag(format!("{bezier_svg}{outline_svg}"))
 	}
 
-	pub fn skewed_outline(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64) -> String {
-		let outline_subpath = self.0.skewed_outline::<EmptyId>(distance1, distance2, distance3, distance4);
+	pub fn skewed_outline(&self, distance1: f64, distance2: f64, distance3: f64, distance4: f64, joint: i32) -> String {
+		let joint = parse_joint(joint);
+		let outline_subpath = self.0.skewed_outline::<EmptyId>(distance1, distance2, distance3, distance4, joint);
 		if outline_subpath.is_empty() {
 			return String::new();
 		}

--- a/website/other/bezier-rs-demos/wasm/src/lib.rs
+++ b/website/other/bezier-rs-demos/wasm/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod bezier;
 pub mod subpath;
 mod svg_drawing;
+mod utils;

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,6 +1,7 @@
 use crate::svg_drawing::*;
+use crate::utils::parse_joint;
 
-use bezier_rs::{Bezier, Joint, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
+use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
 
 use glam::DVec2;
 use std::fmt::Write;
@@ -26,15 +27,6 @@ fn parse_t_variant(t_variant: &String, t: f64) -> SubpathTValue {
 		"GlobalParametric" => SubpathTValue::GlobalParametric(t),
 		"GlobalEuclidean" => SubpathTValue::GlobalEuclidean(t),
 		_ => panic!("Unexpected TValue string: '{}'", t_variant),
-	}
-}
-
-fn parse_joint(joint: i32) -> Joint {
-	match joint {
-		0 => Joint::Bevel,
-		1 => Joint::Miter,
-		2 => Joint::Round,
-		_ => panic!("Unexpected Joint string: '{}'", joint),
 	}
 }
 

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,5 +1,5 @@
 use crate::svg_drawing::*;
-use crate::utils::{parse_cap, parse_joint};
+use crate::utils::{parse_cap, parse_join};
 
 use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
 
@@ -378,9 +378,9 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{}", self.to_default_svg(), trimmed_subpath_svg))
 	}
 
-	pub fn offset(&self, distance: f64, joint: i32) -> String {
-		let joint = parse_joint(joint);
-		let offset_subpath = self.0.offset(distance, joint);
+	pub fn offset(&self, distance: f64, join: i32) -> String {
+		let join = parse_join(join);
+		let offset_subpath = self.0.offset(distance, join);
 
 		let mut offset_svg = String::new();
 		offset_subpath.to_svg(&mut offset_svg, CURVE_ATTRIBUTES.to_string().replace(BLACK, RED), String::new(), String::new(), String::new());
@@ -388,10 +388,10 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{offset_svg}", self.to_default_svg()))
 	}
 
-	pub fn outline(&self, distance: f64, joint: i32, cap: i32) -> String {
-		let joint = parse_joint(joint);
+	pub fn outline(&self, distance: f64, join: i32, cap: i32) -> String {
+		let join = parse_join(join);
 		let cap = parse_cap(cap);
-		let (outline_piece1, outline_piece2) = self.0.outline(distance, joint, cap);
+		let (outline_piece1, outline_piece2) = self.0.outline(distance, join, cap);
 
 		let mut outline_piece1_svg = String::new();
 		outline_piece1.to_svg(&mut outline_piece1_svg, CURVE_ATTRIBUTES.to_string().replace(BLACK, RED), String::new(), String::new(), String::new());

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,6 +1,6 @@
 use crate::svg_drawing::*;
 
-use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
+use bezier_rs::{Bezier, Joint, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
 
 use glam::DVec2;
 use std::fmt::Write;
@@ -26,6 +26,15 @@ fn parse_t_variant(t_variant: &String, t: f64) -> SubpathTValue {
 		"GlobalParametric" => SubpathTValue::GlobalParametric(t),
 		"GlobalEuclidean" => SubpathTValue::GlobalEuclidean(t),
 		_ => panic!("Unexpected TValue string: '{}'", t_variant),
+	}
+}
+
+fn parse_joint(joint: i32) -> Joint {
+	match joint {
+		0 => Joint::Bevel,
+		1 => Joint::Miter,
+		2 => Joint::Round,
+		_ => panic!("Unexpected Joint string: '{}'", joint),
 	}
 }
 
@@ -377,8 +386,9 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{}", self.to_default_svg(), trimmed_subpath_svg))
 	}
 
-	pub fn offset(&self, distance: f64) -> String {
-		let offset_subpath = self.0.offset(distance, bezier_rs::Joint::Bevel);
+	pub fn offset(&self, distance: f64, joint: i32) -> String {
+		let joint = parse_joint(joint);
+		let offset_subpath = self.0.offset(distance, joint);
 
 		let mut offset_svg = String::new();
 		offset_subpath.to_svg(&mut offset_svg, CURVE_ATTRIBUTES.to_string().replace(BLACK, RED), String::new(), String::new(), String::new());
@@ -386,8 +396,9 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{offset_svg}", self.to_default_svg()))
 	}
 
-	pub fn outline(&self, distance: f64) -> String {
-		let (outline_piece1, outline_piece2) = self.0.outline(distance, bezier_rs::Joint::Bevel);
+	pub fn outline(&self, distance: f64, joint: i32) -> String {
+		let joint = parse_joint(joint);
+		let (outline_piece1, outline_piece2) = self.0.outline(distance, joint);
 
 		let mut outline_piece1_svg = String::new();
 		outline_piece1.to_svg(&mut outline_piece1_svg, CURVE_ATTRIBUTES.to_string().replace(BLACK, RED), String::new(), String::new(), String::new());

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -1,5 +1,5 @@
 use crate::svg_drawing::*;
-use crate::utils::parse_joint;
+use crate::utils::{parse_cap, parse_joint};
 
 use bezier_rs::{Bezier, ManipulatorGroup, ProjectionOptions, Subpath, SubpathTValue};
 
@@ -388,9 +388,10 @@ impl WasmSubpath {
 		wrap_svg_tag(format!("{}{offset_svg}", self.to_default_svg()))
 	}
 
-	pub fn outline(&self, distance: f64, joint: i32) -> String {
+	pub fn outline(&self, distance: f64, joint: i32, cap: i32) -> String {
 		let joint = parse_joint(joint);
-		let (outline_piece1, outline_piece2) = self.0.outline(distance, joint);
+		let cap = parse_cap(cap);
+		let (outline_piece1, outline_piece2) = self.0.outline(distance, joint, cap);
 
 		let mut outline_piece1_svg = String::new();
 		outline_piece1.to_svg(&mut outline_piece1_svg, CURVE_ATTRIBUTES.to_string().replace(BLACK, RED), String::new(), String::new(), String::new());

--- a/website/other/bezier-rs-demos/wasm/src/utils.rs
+++ b/website/other/bezier-rs-demos/wasm/src/utils.rs
@@ -1,11 +1,11 @@
-use bezier_rs::{Cap, Joint};
+use bezier_rs::{Cap, Join};
 
-pub fn parse_joint(joint: i32) -> Joint {
-	match joint {
-		0 => Joint::Bevel,
-		1 => Joint::Miter,
-		2 => Joint::Round,
-		_ => panic!("Unexpected Joint value: '{}'", joint),
+pub fn parse_join(join: i32) -> Join {
+	match join {
+		0 => Join::Bevel,
+		1 => Join::Miter,
+		2 => Join::Round,
+		_ => panic!("Unexpected Join value: '{}'", join),
 	}
 }
 

--- a/website/other/bezier-rs-demos/wasm/src/utils.rs
+++ b/website/other/bezier-rs-demos/wasm/src/utils.rs
@@ -1,10 +1,19 @@
-use bezier_rs::Joint;
+use bezier_rs::{Cap, Joint};
 
 pub fn parse_joint(joint: i32) -> Joint {
 	match joint {
 		0 => Joint::Bevel,
 		1 => Joint::Miter,
 		2 => Joint::Round,
-		_ => panic!("Unexpected Joint string: '{}'", joint),
+		_ => panic!("Unexpected Joint value: '{}'", joint),
+	}
+}
+
+pub fn parse_cap(cap: i32) -> Cap {
+	match cap {
+		0 => Cap::Butt,
+		1 => Cap::Round,
+		2 => Cap::Square,
+		_ => panic!("Unexpected Cap value: '{}'", cap),
 	}
 }

--- a/website/other/bezier-rs-demos/wasm/src/utils.rs
+++ b/website/other/bezier-rs-demos/wasm/src/utils.rs
@@ -1,0 +1,10 @@
+use bezier_rs::Joint;
+
+pub fn parse_joint(joint: i32) -> Joint {
+	match joint {
+		0 => Joint::Bevel,
+		1 => Joint::Miter,
+		2 => Joint::Round,
+		_ => panic!("Unexpected Joint string: '{}'", joint),
+	}
+}


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

- Add the following caps: Butt, Round, and Square
- Add the following joins: Bevel, Miter, Round

- Handle bad offset cases where the object being offset was essentially a single point
- Fix issue with attempting to normalize a zero vector
- Change `reduced_curves_and_t_values` to return pairs of `t` values