### PR TITLE
Revert @graphite/ path imports in website

### DIFF
--- a/website/other/bezier-rs-demos/.eslintrc.js
+++ b/website/other/bezier-rs-demos/.eslintrc.js
@@ -65,7 +65,7 @@ module.exports = {
 		"no-bitwise": "off",
 		"no-shadow": "off",
 		"no-use-before-define": "off",
-		"no-restricted-imports": ["error", { patterns: [".*", "!@graphite/*"] }],
+		"no-restricted-imports": ["error", { patterns: [".*", "!@/*"] }],
 
 		// TypeScript plugin config
 		"@typescript-eslint/indent": "off",

--- a/website/other/bezier-rs-demos/src/components/BezierDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemo.ts
@@ -1,7 +1,7 @@
-import { WasmBezier } from "@graphite/../wasm/pkg";
-import bezierFeatures, { BezierFeatureKey } from "@graphite/features/bezier-features";
-import { renderDemo } from "@graphite/utils/render";
-import { getConstructorKey, getCurveType, BezierCallback, BezierCurveType, InputOption, WasmBezierManipulatorKey, Demo } from "@graphite/utils/types";
+import { WasmBezier } from "@/../wasm/pkg";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
+import { renderDemo } from "@/utils/render";
+import { getConstructorKey, getCurveType, BezierCallback, BezierCurveType, InputOption, WasmBezierManipulatorKey, Demo } from "@/utils/types";
 
 const SELECTABLE_RANGE = 10;
 
@@ -54,7 +54,7 @@ class BezierDemo extends HTMLElement implements Demo {
 		this.render();
 
 		const figure = this.querySelector("figure") as HTMLElement;
-		const wasm = await import("@graphite/../wasm/pkg");
+		const wasm = await import("@/../wasm/pkg");
 		this.bezier = wasm.WasmBezier[getConstructorKey(curveType)](this.points);
 		this.drawDemo(figure);
 	}

--- a/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/BezierDemoPane.ts
@@ -1,6 +1,6 @@
-import bezierFeatures, { BezierFeatureKey } from "@graphite/features/bezier-features";
-import { renderDemoPane } from "@graphite/utils/render";
-import { BezierCurveType, BEZIER_CURVE_TYPE, BezierDemoOptions, InputOption, Demo, DemoPane, BezierDemoArgs } from "@graphite/utils/types";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
+import { renderDemoPane } from "@/utils/render";
+import { BezierCurveType, BEZIER_CURVE_TYPE, BezierDemoOptions, InputOption, Demo, DemoPane, BezierDemoArgs } from "@/utils/types";
 
 const demoDefaults = {
 	Linear: {

--- a/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemo.ts
@@ -1,8 +1,8 @@
-import { WasmSubpath } from "@graphite/../wasm/pkg";
-import subpathFeatures, { SubpathFeatureKey } from "@graphite/features/subpath-features";
-import { renderDemo } from "@graphite/utils/render";
+import { WasmSubpath } from "@/../wasm/pkg";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
+import { renderDemo } from "@/utils/render";
 
-import { SubpathCallback, WasmSubpathInstance, WasmSubpathManipulatorKey, InputOption } from "@graphite/utils/types";
+import { SubpathCallback, WasmSubpathInstance, WasmSubpathManipulatorKey, InputOption } from "@/utils/types";
 
 const SELECTABLE_RANGE = 10;
 const POINT_INDEX_TO_MANIPULATOR: WasmSubpathManipulatorKey[] = ["set_anchor", "set_in_handle", "set_out_handle"];
@@ -48,7 +48,7 @@ class SubpathDemo extends HTMLElement {
 		this.render();
 
 		const figure = this.querySelector("figure") as HTMLElement;
-		const wasm = await import("@graphite/../wasm/pkg");
+		const wasm = await import("@/../wasm/pkg");
 		this.subpath = wasm.WasmSubpath.from_triples(this.triples, this.closed) as WasmSubpathInstance;
 		this.drawDemo(figure);
 	}

--- a/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
+++ b/website/other/bezier-rs-demos/src/components/SubpathDemoPane.ts
@@ -1,6 +1,6 @@
-import subpathFeatures, { SubpathFeatureKey } from "@graphite/features/subpath-features";
-import { renderDemoPane } from "@graphite/utils/render";
-import { Demo, DemoPane, SubpathDemoArgs, SubpathInputOption } from "@graphite/utils/types";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
+import { renderDemoPane } from "@/utils/render";
+import { Demo, DemoPane, SubpathDemoArgs, SubpathInputOption } from "@/utils/types";
 
 class SubpathDemoPane extends HTMLElement implements DemoPane {
 	// Props

--- a/website/other/bezier-rs-demos/src/features/bezier-features.ts
+++ b/website/other/bezier-rs-demos/src/features/bezier-features.ts
@@ -1,6 +1,6 @@
-import { WasmBezier } from "@graphite/../wasm/pkg";
-import { capOptions, tSliderOptions, bezierTValueVariantOptions, errorOptions, minimumSeparationOptions } from "@graphite/utils/options";
-import { BezierDemoOptions, WasmBezierInstance, BezierCallback, InputOption, BEZIER_T_VALUE_VARIANTS } from "@graphite/utils/types";
+import { WasmBezier } from "@/../wasm/pkg";
+import { capOptions, tSliderOptions, bezierTValueVariantOptions, errorOptions, minimumSeparationOptions } from "@/utils/options";
+import { BezierDemoOptions, WasmBezierInstance, BezierCallback, InputOption, BEZIER_T_VALUE_VARIANTS } from "@/utils/types";
 
 const bezierFeatures = {
 	constructor: {

--- a/website/other/bezier-rs-demos/src/features/subpath-features.ts
+++ b/website/other/bezier-rs-demos/src/features/subpath-features.ts
@@ -1,5 +1,5 @@
-import { capOptions, joinOptions, tSliderOptions, subpathTValueVariantOptions, intersectionErrorOptions, minimumSeparationOptions } from "@graphite/utils/options";
-import { SubpathCallback, SubpathInputOption, WasmSubpathInstance, SUBPATH_T_VALUE_VARIANTS } from "@graphite/utils/types";
+import { capOptions, joinOptions, tSliderOptions, subpathTValueVariantOptions, intersectionErrorOptions, minimumSeparationOptions } from "@/utils/options";
+import { SubpathCallback, SubpathInputOption, WasmSubpathInstance, SUBPATH_T_VALUE_VARIANTS } from "@/utils/types";
 
 const subpathFeatures = {
 	constructor: {

--- a/website/other/bezier-rs-demos/src/main.ts
+++ b/website/other/bezier-rs-demos/src/main.ts
@@ -1,12 +1,12 @@
-import BezierDemo from "@graphite/components/BezierDemo";
-import BezierDemoPane from "@graphite/components/BezierDemoPane";
-import SubpathDemo from "@graphite/components/SubpathDemo";
-import SubpathDemoPane from "@graphite/components/SubpathDemoPane";
+import BezierDemo from "@/components/BezierDemo";
+import BezierDemoPane from "@/components/BezierDemoPane";
+import SubpathDemo from "@/components/SubpathDemo";
+import SubpathDemoPane from "@/components/SubpathDemoPane";
 
-import bezierFeatures, { BezierFeatureKey } from "@graphite/features/bezier-features";
-import subpathFeatures, { SubpathFeatureKey } from "@graphite/features/subpath-features";
+import bezierFeatures, { BezierFeatureKey } from "@/features/bezier-features";
+import subpathFeatures, { SubpathFeatureKey } from "@/features/subpath-features";
 
-import "@graphite/style.css";
+import "@/style.css";
 
 declare global {
 	interface HTMLElementTagNameMap {

--- a/website/other/bezier-rs-demos/src/utils/options.ts
+++ b/website/other/bezier-rs-demos/src/utils/options.ts
@@ -1,4 +1,4 @@
-import { BEZIER_T_VALUE_VARIANTS, SUBPATH_T_VALUE_VARIANTS } from "@graphite/utils/types";
+import { BEZIER_T_VALUE_VARIANTS, SUBPATH_T_VALUE_VARIANTS } from "@/utils/types";
 
 export const tSliderOptions = {
 	min: 0,

--- a/website/other/bezier-rs-demos/src/utils/render.ts
+++ b/website/other/bezier-rs-demos/src/utils/render.ts
@@ -1,4 +1,4 @@
-import { Demo, DemoPane, InputOption } from "@graphite/utils/types";
+import { Demo, DemoPane, InputOption } from "@/utils/types";
 
 export function renderDemo(demo: Demo): void {
 	const header = document.createElement("h4");

--- a/website/other/bezier-rs-demos/src/utils/types.ts
+++ b/website/other/bezier-rs-demos/src/utils/types.ts
@@ -1,4 +1,4 @@
-export type WasmRawInstance = typeof import("@graphite/../wasm/pkg");
+export type WasmRawInstance = typeof import("@/../wasm/pkg");
 export type WasmBezierInstance = InstanceType<WasmRawInstance["WasmBezier"]>;
 
 export type WasmBezierKey = keyof WasmBezierInstance;
@@ -9,7 +9,7 @@ export type WasmSubpathInstance = InstanceType<WasmRawInstance["WasmSubpath"]>;
 export type WasmSubpathManipulatorKey = "set_anchor" | "set_in_handle" | "set_out_handle";
 
 export const BEZIER_CURVE_TYPE = ["Linear", "Quadratic", "Cubic"] as const;
-export type BezierCurveType = typeof BEZIER_CURVE_TYPE[number];
+export type BezierCurveType = (typeof BEZIER_CURVE_TYPE)[number];
 
 export type BezierCallback = (bezier: WasmBezierInstance, options: Record<string, number>, mouseLocation?: [number, number]) => string;
 export type SubpathCallback = (subpath: WasmSubpathInstance, options: Record<string, number>, mouseLocation?: [number, number]) => string;

--- a/website/other/bezier-rs-demos/tsconfig.json
+++ b/website/other/bezier-rs-demos/tsconfig.json
@@ -16,7 +16,7 @@
 			"node"
 		],
 		"paths": {
-			"@graphite/*": [
+			"@/*": [
 				"src/*"
 			]
 		},

--- a/website/other/bezier-rs-demos/vue.config.js
+++ b/website/other/bezier-rs-demos/vue.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
 	// https://cli.vuejs.org/guide/webpack.html
 	chainWebpack: (config) => {
 		// WASM Pack Plugin integrates compiled Rust code (.wasm) and generated wasm-bindgen code (.js) with the webpack bundle
-		// Use this JS to import the bundled Rust entry points: const wasm = import("@graphite/../wasm/pkg").then(panicProxy);
+		// Use this JS to import the bundled Rust entry points: const wasm = import("@/../wasm/pkg").then(panicProxy);
 		// Then call WASM functions with: (await wasm).function_name()
 		// https://github.com/wasm-tool/wasm-pack-plugin
 		config


### PR DESCRIPTION
Reverted `@graphite/` import changes introduced from #1087 in `bezier-rs-demos`
