### PR TITLE
Fix Levels and Exposure adjustment nodes

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -1007,13 +1007,7 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 					})
 					.disabled(transform_not_connected)
 					.on_update(update_value(
-						move |checkbox_input: &CheckboxInput| {
-							if checkbox_input.checked {
-								TaggedValue::OptionalDVec2(Some(vec2))
-							} else {
-								TaggedValue::OptionalDVec2(None)
-							}
-						},
+						move |checkbox_input: &CheckboxInput| TaggedValue::OptionalDVec2(if checkbox_input.checked { Some(vec2) } else { None }),
 						node_id,
 						resolution_index,
 					))
@@ -1021,6 +1015,8 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 				WidgetHolder::unrelated_separator(),
 				NumberInput::new(Some(vec2.x))
 					.label("W")
+					.min(64.)
+					.step(64.)
 					.unit(" px")
 					.disabled(dimensions_is_auto && !transform_not_connected)
 					.on_update(update_value(
@@ -1032,6 +1028,8 @@ pub fn imaginate_properties(document_node: &DocumentNode, node_id: NodeId, conte
 				WidgetHolder::related_separator(),
 				NumberInput::new(Some(vec2.y))
 					.label("H")
+					.min(64.)
+					.step(64.)
 					.unit(" px")
 					.disabled(dimensions_is_auto && !transform_not_connected)
 					.on_update(update_value(

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -563,8 +563,7 @@ impl Color {
 	pub fn gamma(&self, gamma: f32) -> Color {
 		// From https://www.dfstudios.co.uk/articles/programming/image-programming-algorithms/image-processing-algorithms-part-6-gamma-correction/
 		let inverse_gamma = 1. / gamma;
-		let per_channel = |channel: f32| channel.powf(inverse_gamma);
-		self.map_rgb(per_channel)
+		self.map_rgb(|c: f32| c.powf(inverse_gamma))
 	}
 
 	pub fn to_linear_srgb(&self) -> Self {


### PR DESCRIPTION
- The Levels node produced NaN if Shadows was dragged all the way to the right. It also could experience odd results if the subtraction resulting from applying shadows went negative.
- Exposure produced the wrong results since calculations weren't done in linear color. The three sliders were also applied in the wrong order.
- Unrelated bonus: the Imaginate resolution number inputs now step in increments of 64