### PR TITLE
Fix opacity blending on colored brush strokes

### DIFF
--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -608,7 +608,7 @@ impl Color {
 	}
 
 	pub fn apply_opacity(&self, opacity: f32) -> Self {
-		Self::from_rgbaf32_unchecked(self.r(), self.g(), self.b(), self.a() * opacity)
+		Self::from_rgbaf32_unchecked(self.r() * opacity, self.g() * opacity, self.b() * opacity, self.a() * opacity)
 	}
 
 	pub fn to_associated_alpha(&self, alpha: f32) -> Self {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

When using associated alpha, we have to scale the emission values when changing the alpha
