### PR TITLE
Serialize images as base64 by rounding channels from floats to u8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ name = "graphene-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.13.1",
  "bezier-rs",
  "bytemuck",
  "dyn-any",

--- a/document-legacy/src/layers/layer_info.rs
+++ b/document-legacy/src/layers/layer_info.rs
@@ -438,7 +438,7 @@ impl Layer {
 
 	pub fn as_vector_data(&self) -> Option<&VectorData> {
 		match &self.data {
-			LayerDataType::NodeGraphFrame(NodeGraphFrameLayer { vector_data: Some(vector_data), .. }) => Some(vector_data),
+			LayerDataType::NodeGraphFrame(frame) => frame.as_vector_data(),
 			_ => None,
 		}
 	}
@@ -506,7 +506,7 @@ impl Layer {
 		match &self.data {
 			LayerDataType::Shape(s) => Ok(&s.style),
 			LayerDataType::Text(t) => Ok(&t.path_style),
-			LayerDataType::NodeGraphFrame(t) => t.vector_data.as_ref().map(|vector| &vector.style).ok_or(DocumentError::NotShape),
+			LayerDataType::NodeGraphFrame(t) => t.as_vector_data().map(|vector| &vector.style).ok_or(DocumentError::NotShape),
 			_ => Err(DocumentError::NotShape),
 		}
 	}

--- a/document-legacy/src/operation.rs
+++ b/document-legacy/src/operation.rs
@@ -51,10 +51,6 @@ pub enum Operation {
 		transform: [f64; 6],
 		network: graph_craft::document::NodeNetwork,
 	},
-	SetNodeGraphFrameImageData {
-		layer_path: Vec<LayerId>,
-		image_data: Vec<u8>,
-	},
 	/// Sets a blob URL as the image source for an Image or Imaginate layer type.
 	/// **Be sure to call `FrontendMessage::TriggerRevokeBlobUrl` together with this.**
 	SetLayerBlobUrl {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -3,7 +3,7 @@ use super::utility_types::misc::DocumentRenderMode;
 use crate::application::generate_uuid;
 use crate::consts::{ASYMPTOTIC_EFFECT, DEFAULT_DOCUMENT_NAME, FILE_SAVE_SUFFIX, GRAPHITE_DOCUMENT_VERSION, SCALE_EFFECT, SCROLLBAR_SPACING, VIEWPORT_ZOOM_TO_FIT_PADDING_SCALE_FACTOR};
 use crate::messages::frontend::utility_types::ExportBounds;
-use crate::messages::frontend::utility_types::{FileType, FrontendImageData};
+use crate::messages::frontend::utility_types::FileType;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
 use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup, Widget, WidgetCallback, WidgetHolder, WidgetLayout};
 use crate::messages::layout::utility_types::misc::LayoutTarget;
@@ -28,6 +28,7 @@ use document_legacy::document::Document as DocumentLegacy;
 use document_legacy::layers::blend_mode::BlendMode;
 use document_legacy::layers::folder_layer::FolderLayer;
 use document_legacy::layers::layer_info::{LayerDataType, LayerDataTypeDiscriminant};
+use document_legacy::layers::nodegraph_layer::CachedOutputData;
 use document_legacy::layers::style::{Fill, RenderData, ViewMode};
 use document_legacy::layers::text_layer::Font;
 use document_legacy::{DocumentError, DocumentResponse, LayerId, Operation as DocumentOperation};
@@ -422,7 +423,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 
 				let layer = self.document_legacy.layer(layer_path).expect("Clearing NodeGraphFrame image for invalid layer");
 				let previous_blob_url = match &layer.data {
-					LayerDataType::NodeGraphFrame(node_graph_frame) => &node_graph_frame.blob_url,
+					LayerDataType::NodeGraphFrame(node_graph_frame) => node_graph_frame.as_blob_url(),
 					x => panic!("Cannot find blob url for layer type {}", LayerDataTypeDiscriminant::from(x)),
 				};
 
@@ -839,7 +840,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 				// Revoke the old blob URL
 				match &layer.data {
 					LayerDataType::NodeGraphFrame(node_graph_frame) => {
-						if let Some(url) = &node_graph_frame.blob_url {
+						if let Some(url) = node_graph_frame.as_blob_url() {
 							responses.push_back(FrontendMessage::TriggerRevokeBlobUrl { url: url.clone() }.into());
 						}
 					}
@@ -1610,12 +1611,12 @@ impl DocumentMessageHandler {
 
 	/// Loads layer resources such as creating the blob URLs for the images and loading all of the fonts in the document
 	pub fn load_layer_resources(&self, responses: &mut VecDeque<Message>, root: &LayerDataType, mut path: Vec<LayerId>, document_id: u64) {
-		fn walk_layers(data: &LayerDataType, path: &mut Vec<LayerId>, image_data: &mut Vec<FrontendImageData>, fonts: &mut HashSet<Font>) {
+		fn walk_layers(data: &LayerDataType, path: &mut Vec<LayerId>, responses: &mut VecDeque<Message>, fonts: &mut HashSet<Font>) {
 			match data {
 				LayerDataType::Folder(folder) => {
 					for (id, layer) in folder.layer_ids.iter().zip(folder.layers().iter()) {
 						path.push(*id);
-						walk_layers(&layer.data, path, image_data, fonts);
+						walk_layers(&layer.data, path, responses, fonts);
 						path.pop();
 					}
 				}
@@ -1623,25 +1624,16 @@ impl DocumentMessageHandler {
 					fonts.insert(text.font.clone());
 				}
 				LayerDataType::NodeGraphFrame(node_graph_frame) => {
-					if let Some(data) = &node_graph_frame.image_data {
-						image_data.push(FrontendImageData {
-							path: path.clone(),
-							image_data: data.image_data.clone(),
-							mime: node_graph_frame.mime.clone(),
-							transform: None,
-						});
+					if node_graph_frame.cached_output_data == CachedOutputData::None {
+						responses.add(DocumentMessage::NodeGraphFrameGenerate { layer_path: path.clone() });
 					}
 				}
 				_ => {}
 			}
 		}
 
-		let mut image_data = Vec::new();
 		let mut fonts = HashSet::new();
-		walk_layers(root, &mut path, &mut image_data, &mut fonts);
-		if !image_data.is_empty() {
-			responses.push_front(FrontendMessage::UpdateImageData { document_id, image_data }.into());
-		}
+		walk_layers(root, &mut path, responses, &mut fonts);
 		for font in fonts {
 			responses.push_front(FrontendMessage::TriggerFontLoad { font, is_default: false }.into());
 		}

--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler/transform_utils.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler/transform_utils.rs
@@ -54,7 +54,7 @@ impl LayerBounds {
 		let layer = document.layer(layer_path).ok();
 		let bounds = layer
 			.and_then(|layer| layer.as_graph_frame().ok())
-			.and_then(|frame| frame.vector_data.as_ref().map(|vector| vector.nonzero_bounding_box()))
+			.and_then(|frame| frame.as_vector_data().as_ref().map(|vector| vector.nonzero_bounding_box()))
 			.unwrap_or([DVec2::ZERO, DVec2::ONE]);
 		let bounds_transform = DAffine2::IDENTITY;
 		let layer_transform = document.multiply_transforms(layer_path).unwrap_or_default();

--- a/editor/src/messages/tool/common_functionality/path_outline.rs
+++ b/editor/src/messages/tool/common_functionality/path_outline.rs
@@ -4,7 +4,6 @@ use crate::messages::prelude::*;
 
 use document_legacy::intersection::Quad;
 use document_legacy::layers::layer_info::LayerDataType;
-use document_legacy::layers::nodegraph_layer::NodeGraphFrameLayer;
 use document_legacy::layers::style::{self, Fill, RenderData, Stroke};
 use document_legacy::{LayerId, Operation};
 use graphene_std::vector::subpath::Subpath;
@@ -36,7 +35,7 @@ impl PathOutline {
 		let subpath = match &document_layer.data {
 			LayerDataType::Shape(layer_shape) => Some(layer_shape.shape.clone()),
 			LayerDataType::Text(text) => Some(text.to_subpath_nonmut(render_data)),
-			LayerDataType::NodeGraphFrame(NodeGraphFrameLayer { vector_data: Some(vector_data), .. }) => Some(Subpath::from_bezier_crate(&vector_data.subpaths)),
+			LayerDataType::NodeGraphFrame(frame) => frame.as_vector_data().map(|vector_data| Subpath::from_bezier_crate(&vector_data.subpaths)),
 			_ => document_layer.aabb_for_transform(DAffine2::IDENTITY, render_data).map(|[p1, p2]| Subpath::new_rect(p1, p2)),
 		}?;
 

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1230,7 +1230,7 @@ fn edit_layer_deepest_manipulation(intersect: &Layer, responses: &mut VecDeque<M
 		LayerDataType::Shape(_) => {
 			responses.push_front(ToolMessage::ActivateTool { tool_type: ToolType::Path }.into());
 		}
-		LayerDataType::NodeGraphFrame(frame) if frame.vector_data.is_some() => {
+		LayerDataType::NodeGraphFrame(frame) if frame.as_vector_data().is_some() => {
 			responses.push_front(ToolMessage::ActivateTool { tool_type: ToolType::Path }.into());
 		}
 		_ => {}

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -284,13 +284,6 @@ impl NodeGraphExecutor {
 				// Update the image data
 				let (image_data, _size) = Self::encode_img(image, None, image::ImageOutputFormat::Bmp)?;
 
-				responses.push_back(
-					Operation::SetNodeGraphFrameImageData {
-						layer_path: layer_path.clone(),
-						image_data: image_data.clone(),
-					}
-					.into(),
-				);
 				let mime = "image/bmp".to_string();
 				let image_data = std::sync::Arc::new(image_data);
 				let image_data = vec![FrontendImageData {

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 std = ["dyn-any", "dyn-any/std", "alloc", "glam/std", "specta"]
 default = ["async", "serde", "kurbo", "log", "std"]
 log = ["dep:log"]
-serde = ["dep:serde", "glam/serde", "bezier-rs/serde"]
+serde = ["dep:serde", "glam/serde", "bezier-rs/serde", "base64"]
 gpu = ["spirv-std", "bytemuck", "glam/bytemuck", "dyn-any", "glam/libm"]
 async = ["async-trait", "alloc"]
 nightly = []
@@ -43,6 +43,7 @@ glam = { version = "^0.22", default-features = false, features = [
 	"scalar-math",
 ] }
 node-macro = { path = "../node-macro" }
+base64 = { version = "0.13", optional = true }
 specta.workspace = true
 specta.optional = true
 once_cell = { version = "1.17.0", default-features = false, optional = true }


### PR DESCRIPTION
Serialise images as base64 with u8 channel.

Also removes serialisation of the output of the graphs, as it is usually faster just to rerender them.