### PR TITLE
Fix transform logic for mask node

### DIFF
--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -57,7 +57,7 @@ impl Alpha for Color {
 	fn alpha(&self) -> f32 {
 		self.alpha
 	}
-	fn multiply_alpha(&self, alpha: Self::AlphaChannel) -> Self {
+	fn multiplied_alpha(&self, alpha: Self::AlphaChannel) -> Self {
 		Self {
 			red: self.red * alpha,
 			green: self.green * alpha,


### PR DESCRIPTION
Fixes the transform logic for the mask node reverting the breakage introduced by #1123 

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

