### PR TITLE
Add Luma struct

### DIFF
--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -9,7 +9,7 @@ use num_traits::{cast::cast as num_cast, Num, NumCast};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::{cast::cast as num_cast, float::Float, FromPrimitive, Num, NumCast, ToPrimitive};
 
-pub use self::color::Color;
+pub use self::color::{Color, Luma};
 
 pub mod adjustments;
 #[cfg(not(target_arch = "spirv"))]

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -14,6 +14,21 @@ use bytemuck::{Pod, Zeroable};
 
 use super::{Alpha, AssociatedAlpha, Luminance, Pixel, Rec709Primaries, RGB, SRGB};
 
+#[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", derive(specta::Type))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable)]
+pub struct Luma(f32);
+
+impl Luminance for Luma {
+	type LuminanceChannel = f32;
+	fn luminance(&self) -> f32 {
+		self.0
+	}
+}
+
+impl Pixel for Luma {}
+
 /// Structure that represents a color.
 /// Internally alpha is stored as `f32` that ranges from `0.0` (transparent) to `1.0` (opaque).
 /// The other components (RGB) are stored as `f32` that range from `0.0` up to `f32::MAX`,

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -18,11 +18,24 @@ use super::{Alpha, AssociatedAlpha, Luminance, Pixel, Rec709Primaries, RGB, SRGB
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", derive(specta::Type))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable)]
-pub struct Luma(f32);
+pub struct Luma(pub f32);
 
 impl Luminance for Luma {
 	type LuminanceChannel = f32;
 	fn luminance(&self) -> f32 {
+		self.0
+	}
+}
+
+impl RGB for Luma {
+	type ColorChannel = f32;
+	fn red(&self) -> f32 {
+		self.0
+	}
+	fn green(&self) -> f32 {
+		self.0
+	}
+	fn blue(&self) -> f32 {
 		self.0
 	}
 }

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -478,7 +478,7 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 		#[cfg(feature = "quantization")]
 		register_node!(graphene_std::quantization::GenerateQuantizationNode<_, _>, input: ImageFrame<Color>, params: [u32, u32]),
 		raster_node!(graphene_core::quantization::QuantizeNode<_>, Color, params: [QuantizationChannels]),
-		raster_node!(graphene_core::quantization::DeQuantizeNode<_>, Color,  params: [QuantizationChannels]),
+		raster_node!(graphene_core::quantization::DeQuantizeNode<_>, Color, params: [QuantizationChannels]),
 		register_node!(graphene_core::ops::CloneNode<_>, input: &QuantizationChannels, params: []),
 		register_node!(graphene_core::transform::TransformNode<_, _, _, _, _>, input: VectorData, params: [DVec2, f64, DVec2, DVec2, DVec2]),
 		register_node!(graphene_core::transform::TransformNode<_, _, _, _, _>, input: ImageFrame<Color>, params: [DVec2, f64, DVec2, DVec2, DVec2]),

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -140,6 +140,7 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 		register_node!(graphene_core::ops::SomeNode, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_std::raster::DownresNode<_>, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_std::raster::MaskImageNode<_, _, _>, input: ImageFrame<Color>, params: [ImageFrame<Color>]),
+		register_node!(graphene_std::raster::MaskImageNode<_, _, _>, input: ImageFrame<Color>, params: [ImageFrame<Luma>]),
 		register_node!(graphene_std::raster::EmptyImageNode<_, _>, input: DAffine2, params: [Color]),
 		#[cfg(feature = "gpu")]
 		register_node!(graphene_std::executor::MapGpuSingleImageNode<_>, input: Image<Color>, params: [String]),

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -5,7 +5,6 @@ use graphene_core::vector::VectorData;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
-use graphene_core::raster::color::Color;
 use graphene_core::raster::*;
 use graphene_core::structural::Then;
 use graphene_core::value::{ClonedNode, ForgetNode, ValueNode};
@@ -41,6 +40,23 @@ macro_rules! construct_node {
 	}}
 }
 
+macro_rules! node_io {
+	($path:ty, $input:ty, [$($type:ty),*]) => {
+        {
+            let node = IdNode::new().into_type_erased();
+            let node = NodeContainer::new(node, vec![]);
+            let _node = unsafe { node.erase_lifetime().static_ref() };
+            let node = <$path>::new($(
+                graphene_std::any::input_node::<$type>(_node)
+            ),*);
+            let params = vec![$(value_fn!($type)),*];
+            let mut node_io = <$path as NodeIO<'_, $input>>::to_node_io(&node, params);
+            node_io.input = concrete!(<$input as StaticType>::Static);
+            node_io
+        }
+    }
+}
+
 macro_rules! register_node {
 	($path:ty, input: $input:ty, params: [$($type:ty),*]) => {
 		vec![
@@ -52,23 +68,14 @@ macro_rules! register_node {
 				Box::pin(any)
 			},
 			{
-				let node = IdNode::new().into_type_erased();
-				let node = NodeContainer::new(node, vec![]);
-				let _node = unsafe { node.erase_lifetime().static_ref() };
-				let node = <$path>::new($(
-					graphene_std::any::input_node::<$type>(_node)
-				),*);
-				let params = vec![$(value_fn!($type)),*];
-				let mut node_io = <$path as NodeIO<'_, $input>>::to_node_io(&node, params);
-				node_io.input = concrete!(<$input as StaticType>::Static);
-				node_io
+                node_io!($path, $input, [$($type), *])
 			},
 		)
 		]
 	};
 }
 macro_rules! raster_node {
-	($path:ty, params: [$($type:ty),*]) => {
+	($path:ty, $color:ty, params: [$($type:ty),*]) => {
 		vec![
 		(
 			NodeIdentifier::new(stringify!($path)),
@@ -78,8 +85,7 @@ macro_rules! raster_node {
 				Box::pin(any)
 			},
 			{
-				let params = vec![$(value_fn!($type)),*];
-				NodeIOTypes::new(concrete!(Color), concrete!(Color), params)
+                node_io!($path, $color, [$($type), *])
 			},
 		),
 		(
@@ -87,12 +93,11 @@ macro_rules! raster_node {
 			|args| {
 				let node = construct_node!(args, $path, [$($type),*]);
 				let map_node = graphene_std::raster::MapImageNode::new(graphene_core::value::ValueNode::new(node));
-				let any: DynAnyNode<Image<Color>, _, _> = graphene_std::any::DynAnyNode::new(graphene_core::value::ValueNode::new(map_node));
+				let any: DynAnyNode<Image<$color>, _, _> = graphene_std::any::DynAnyNode::new(graphene_core::value::ValueNode::new(map_node));
 				Box::pin(any)
 			},
 			{
-				let params = vec![$(value_fn!($type)),*];
-				NodeIOTypes::new(concrete!(Image<Color>), concrete!(Image<Color>), params)
+                node_io!($path, $color, [$($type), *])
 			},
 		),
 		(
@@ -100,12 +105,11 @@ macro_rules! raster_node {
 			|args| {
 				let node = construct_node!(args, $path, [$($type),*]);
 				let map_node = graphene_std::raster::MapImageNode::new(graphene_core::value::ValueNode::new(node));
-				let any: DynAnyNode<ImageFrame<Color>, _, _> = graphene_std::any::DynAnyNode::new(graphene_core::value::ValueNode::new(map_node));
+				let any: DynAnyNode<ImageFrame<$color>, _, _> = graphene_std::any::DynAnyNode::new(graphene_core::value::ValueNode::new(map_node));
 				Box::pin(any)
 			},
 			{
-				let params = vec![$(value_fn!($type)),*];
-				NodeIOTypes::new(concrete!(ImageFrame<Color>), concrete!(ImageFrame<Color>), params)
+                node_io!($path, $color, [$($type), *])
 			},
 		)
 		]
@@ -140,6 +144,7 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 		register_node!(graphene_core::ops::SomeNode, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_std::raster::DownresNode<_>, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_std::raster::MaskImageNode<_, _, _>, input: ImageFrame<Color>, params: [ImageFrame<Color>]),
+		register_node!(graphene_std::raster::MaskImageNode<_, _, _>, input: ImageFrame<Color>, params: [ImageFrame<Luma>]),
 		register_node!(graphene_std::raster::EmptyImageNode<_, _>, input: DAffine2, params: [Color]),
 		#[cfg(feature = "gpu")]
 		register_node!(graphene_std::executor::MapGpuSingleImageNode<_>, input: Image<Color>, params: [String]),
@@ -216,8 +221,8 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 			),
 		)],
 		// Filters
-		raster_node!(graphene_core::raster::LuminanceNode<_>, params: [LuminanceCalculation]),
-		raster_node!(graphene_core::raster::LevelsNode<_, _, _, _, _>, params: [f64, f64, f64, f64, f64]),
+		raster_node!(graphene_core::raster::LuminanceNode<_>, Color, params: [LuminanceCalculation]),
+		raster_node!(graphene_core::raster::LevelsNode<_, _, _, _, _>, Color, params: [f64, f64, f64, f64, f64]),
 		register_node!(graphene_std::image_segmentation::ImageSegmentationNode<_>, input: ImageFrame<Color>, params: [ImageFrame<Color>]),
 		register_node!(graphene_core::raster::IndexNode<_>, input: Vec<ImageFrame<Color>>, params: [u32]),
 		vec![
@@ -253,17 +258,19 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 				NodeIOTypes::new(concrete!(ImageFrame<Color>), concrete!(ImageFrame<Color>), vec![value_fn!(ImageFrame<Color>), value_fn!(f64)]),
 			),
 		],
-		raster_node!(graphene_core::raster::GrayscaleNode<_, _, _, _, _, _, _>, params: [Color, f64, f64, f64, f64, f64, f64]),
-		raster_node!(graphene_core::raster::HueSaturationNode<_, _, _>, params: [f64, f64, f64]),
-		raster_node!(graphene_core::raster::InvertRGBNode, params: []),
-		raster_node!(graphene_core::raster::ThresholdNode<_, _, _>, params: [f64, f64, LuminanceCalculation]),
-		raster_node!(graphene_core::raster::VibranceNode<_>, params: [f64]),
+		raster_node!(graphene_core::raster::GrayscaleNode<_, _, _, _, _, _, _>, Color, params: [Color, f64, f64, f64, f64, f64, f64]),
+		raster_node!(graphene_core::raster::HueSaturationNode<_, _, _>, Color, params: [f64, f64, f64]),
+		raster_node!(graphene_core::raster::InvertRGBNode, Color, params: []),
+		raster_node!(graphene_core::raster::ThresholdNode<_, _, _>, Color, params: [f64, f64, LuminanceCalculation]),
+		raster_node!(graphene_core::raster::VibranceNode<_>, Color, params: [f64]),
 		raster_node!(
 			graphene_core::raster::ChannelMixerNode<_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _>,
+			Color,
 			params: [bool, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64]
 		),
 		raster_node!(
 			graphene_core::raster::SelectiveColorNode<_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _>,
+			Color,
 			params: [RelativeAbsolute, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64]
 		),
 		vec![(
@@ -291,9 +298,9 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 			},
 			NodeIOTypes::new(concrete!(ImageFrame<Color>), concrete!(ImageFrame<Color>), vec![value_fn!(f64), value_fn!(f64), value_fn!(bool)]),
 		)],
-		raster_node!(graphene_core::raster::OpacityNode<_>, params: [f64]),
-		raster_node!(graphene_core::raster::PosterizeNode<_>, params: [f64]),
-		raster_node!(graphene_core::raster::ExposureNode<_, _, _>, params: [f64, f64, f64]),
+		raster_node!(graphene_core::raster::OpacityNode<_>, Color, params: [f64]),
+		raster_node!(graphene_core::raster::PosterizeNode<_>, Color, params: [f64]),
+		raster_node!(graphene_core::raster::ExposureNode<_, _, _>, Color, params: [f64, f64, f64]),
 		vec![
 			(
 				NodeIdentifier::new("graphene_std::memo::LetNode<_>"),
@@ -470,8 +477,8 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 		register_node!(graphene_std::raster::ImageFrameNode<_, _>, input: Image<Color>, params: [DAffine2]),
 		#[cfg(feature = "quantization")]
 		register_node!(graphene_std::quantization::GenerateQuantizationNode<_, _>, input: ImageFrame<Color>, params: [u32, u32]),
-		raster_node!(graphene_core::quantization::QuantizeNode<_>, params: [QuantizationChannels]),
-		raster_node!(graphene_core::quantization::DeQuantizeNode<_>, params: [QuantizationChannels]),
+		raster_node!(graphene_core::quantization::QuantizeNode<_>, Color, params: [QuantizationChannels]),
+		raster_node!(graphene_core::quantization::DeQuantizeNode<_>, Color,  params: [QuantizationChannels]),
 		register_node!(graphene_core::ops::CloneNode<_>, input: &QuantizationChannels, params: []),
 		register_node!(graphene_core::transform::TransformNode<_, _, _, _, _>, input: VectorData, params: [DVec2, f64, DVec2, DVec2, DVec2]),
 		register_node!(graphene_core::transform::TransformNode<_, _, _, _, _>, input: ImageFrame<Color>, params: [DVec2, f64, DVec2, DVec2, DVec2]),


### PR DESCRIPTION
Adds a Luma struct that can be used to store a Luminance Channel for
usage as a mask.

Test Plan:
Create a node that accepts T: Luminance an input and feed it
the new struct
