### PR TITLE
Run CI for non-master pushes/PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master ]
 
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Disables the requirement of merging into master to run the ci.

Test Plan:
- Create a pr against a non master branch and verify the ci runs
    - Push to a non master branch and verify the ci runs
