### PR TITLE
Implement bounds input to constrain the output frame of the brush node

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -470,6 +470,7 @@ fn static_nodes() -> Vec<DocumentNodeType> {
 			inputs: vec![
 				DocumentInputType::value("None", TaggedValue::None, false),
 				DocumentInputType::value("Background", TaggedValue::ImageFrame(ImageFrame::empty()), true),
+				DocumentInputType::value("Bounds", TaggedValue::ImageFrame(ImageFrame::empty()), true),
 				DocumentInputType::value("Trace", TaggedValue::VecDVec2((0..2).map(|x| DVec2::new(x as f64 * 10., 0.)).collect()), true),
 				DocumentInputType::value("Diameter", TaggedValue::F64(40.), false),
 				DocumentInputType::value("Hardness", TaggedValue::F64(50.), false),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -588,11 +588,11 @@ pub fn blur_image_properties(document_node: &DocumentNode, node_id: NodeId, _con
 }
 
 pub fn brush_node_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
-	let color = color_widget(document_node, node_id, 6, "Color", ColorInput::default(), true);
+	let color = color_widget(document_node, node_id, 7, "Color", ColorInput::default(), true);
 
-	let size = number_widget(document_node, node_id, 3, "Diameter", NumberInput::default().min(1.).max(100.).unit(" px"), true);
-	let hardness = number_widget(document_node, node_id, 4, "Hardness", NumberInput::default().min(0.).max(100.).unit("%"), true);
-	let flow = number_widget(document_node, node_id, 5, "Flow", NumberInput::default().min(1.).max(100.).unit("%"), true);
+	let size = number_widget(document_node, node_id, 4, "Diameter", NumberInput::default().min(1.).max(100.).unit(" px"), true);
+	let hardness = number_widget(document_node, node_id, 5, "Hardness", NumberInput::default().min(0.).max(100.).unit("%"), true);
+	let flow = number_widget(document_node, node_id, 6, "Flow", NumberInput::default().min(1.).max(100.).unit("%"), true);
 
 	vec![color, LayoutGroup::Row { widgets: size }, LayoutGroup::Row { widgets: hardness }, LayoutGroup::Row { widgets: flow }]
 }

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -190,7 +190,7 @@ impl BrushToolData {
 			responses.add(NodeGraphMessage::SetQualifiedInputValue {
 				layer_path,
 				node_path: vec![0],
-				input_index: 2,
+				input_index: 3,
 				value: TaggedValue::VecDVec2(points),
 			});
 		}
@@ -334,6 +334,7 @@ fn add_brush_render(data: &BrushToolData, tool_data: &DocumentToolData, response
 		inputs: vec![
 			NodeInput::value(TaggedValue::None, false),
 			NodeInput::value(TaggedValue::ImageFrame(ImageFrame::empty()), true),
+			NodeInput::value(TaggedValue::ImageFrame(ImageFrame::empty()), true),
 			NodeInput::value(TaggedValue::VecDVec2(data.points.last().cloned().unwrap_or_default()), false),
 			// Diameter
 			NodeInput::value(TaggedValue::F64(data.diameter), false),
@@ -374,11 +375,12 @@ fn load_existing_points(document: &DocumentMessageHandler) -> Option<(Vec<LayerI
 		tagged_value: TaggedValue::ImageFrame(image_frame),
 		..
 	} = image_input else { return None };
-	let points_input = brush_node.inputs.get(2)?;
+	let points_input = brush_node.inputs.get(3)?;
 	let NodeInput::Value {
 		tagged_value: TaggedValue::VecDVec2(points),
 		..
-	} = points_input else { return None };
+	} = points_input else {
+		return None };
 
 	Some((layer_path, points.clone(), image_frame.clone()))
 }


### PR DESCRIPTION


Test Plan:
Hook up a constraint to the brush node in the editor and
verify the result looks correct
