### PR TITLE
Fix "Failed to execute" dialog showing up at times

### DIFF
--- a/node-graph/interpreted-executor/src/executor.rs
+++ b/node-graph/interpreted-executor/src/executor.rs
@@ -54,7 +54,9 @@ impl DynamicExecutor {
 		let mut orphans = self.tree.update(proto_network, &self.typing_context)?;
 		core::mem::swap(&mut self.orphaned_nodes, &mut orphans);
 		for node_id in orphans {
-			self.tree.free_node(node_id)
+			if self.orphaned_nodes.contains(&node_id) {
+				self.tree.free_node(node_id)
+			}
 		}
 		Ok(())
 	}


### PR DESCRIPTION
Only remove orphaned nodes when they are still orphans in the current
execution iteration.

Test Plan:
Try to cause the "Failed to execute" bug and see if it
persists
