### PR TITLE
Make Brush tool use per-stroke options and improve its performance

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message.rs
@@ -1,6 +1,7 @@
 use crate::messages::prelude::*;
 
 use graphene_core::uuid::ManipulatorGroupId;
+use graphene_core::vector::brush_stroke::BrushStroke;
 use graphene_core::vector::style::{Fill, Stroke};
 use graphene_core::vector::ManipulatorPointId;
 
@@ -45,6 +46,10 @@ pub enum GraphOperationMessage {
 	Vector {
 		layer: LayerIdentifier,
 		modification: VectorDataModification,
+	},
+	Brush {
+		layer: LayerIdentifier,
+		strokes: Vec<BrushStroke>,
 	},
 }
 

--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -5,12 +5,13 @@ use document_legacy::document::Document;
 use document_legacy::{LayerId, Operation};
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{generate_uuid, NodeId, NodeInput, NodeNetwork};
+use graphene_core::vector::brush_stroke::BrushStroke;
 use graphene_core::vector::style::{Fill, FillType, Stroke};
 use transform_utils::LayerBounds;
 
 use glam::{DAffine2, DVec2};
 
-mod transform_utils;
+pub mod transform_utils;
 
 #[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct GraphOperationMessageHandler;
@@ -220,6 +221,16 @@ impl<'a> ModifyInputsContext<'a> {
 
 		self.update_bounds([old_bounds_min, old_bounds_max], [new_bounds_min, new_bounds_max]);
 	}
+
+	fn brush_modify(&mut self, strokes: Vec<BrushStroke>) {
+		self.modify_inputs("Brush", false, |inputs| {
+			if matches!(inputs[0], NodeInput::Node { .. }) {
+				inputs[1] = core::mem::replace(&mut inputs[0], NodeInput::value(TaggedValue::None, false));
+			}
+			inputs[0] = NodeInput::value(TaggedValue::None, false);
+			inputs[3] = NodeInput::value(TaggedValue::BrushStrokes(strokes), false);
+		});
+	}
 }
 
 impl MessageHandler<GraphOperationMessage, (&mut Document, &mut NodeGraphMessageHandler)> for GraphOperationMessageHandler {
@@ -302,6 +313,12 @@ impl MessageHandler<GraphOperationMessage, (&mut Document, &mut NodeGraphMessage
 			GraphOperationMessage::Vector { layer, modification } => {
 				if let Some(mut modify_inputs) = ModifyInputsContext::new(&layer, document, node_graph, responses) {
 					modify_inputs.vector_modify(modification);
+				}
+			}
+
+			GraphOperationMessage::Brush { layer, strokes } => {
+				if let Some(mut modify_inputs) = ModifyInputsContext::new(&layer, document, node_graph, responses) {
+					modify_inputs.brush_modify(strokes);
 				}
 			}
 		}

--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -255,7 +255,6 @@ impl MessageHandler<GraphOperationMessage, (&mut Document, &mut NodeGraphMessage
 					responses.add(Operation::SetLayerStroke { path: layer, stroke });
 				}
 			}
-
 			GraphOperationMessage::TransformChange {
 				layer,
 				transform,
@@ -309,13 +308,11 @@ impl MessageHandler<GraphOperationMessage, (&mut Document, &mut NodeGraphMessage
 				let pivot = pivot.into();
 				responses.add(Operation::SetPivot { layer_path: layer, pivot });
 			}
-
 			GraphOperationMessage::Vector { layer, modification } => {
 				if let Some(mut modify_inputs) = ModifyInputsContext::new(&layer, document, node_graph, responses) {
 					modify_inputs.vector_modify(modification);
 				}
 			}
-
 			GraphOperationMessage::Brush { layer, strokes } => {
 				if let Some(mut modify_inputs) = ModifyInputsContext::new(&layer, document, node_graph, responses) {
 					modify_inputs.brush_modify(strokes);

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -644,10 +644,6 @@ fn static_nodes() -> Vec<DocumentNodeType> {
 				DocumentInputType::value("Background", TaggedValue::ImageFrame(ImageFrame::empty()), true),
 				DocumentInputType::value("Bounds", TaggedValue::ImageFrame(ImageFrame::empty()), true),
 				DocumentInputType::value("Trace", TaggedValue::BrushStrokes(Vec::new()), true),
-				DocumentInputType::value("Diameter", TaggedValue::F64(40.), false),
-				DocumentInputType::value("Hardness", TaggedValue::F64(50.), false),
-				DocumentInputType::value("Flow", TaggedValue::F64(100.), false),
-				DocumentInputType::value("Color", TaggedValue::Color(Color::BLACK), false),
 			],
 			outputs: vec![DocumentOutputType {
 				name: "Image",

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -649,7 +649,7 @@ fn static_nodes() -> Vec<DocumentNodeType> {
 				name: "Image",
 				data_type: FrontendGraphDataType::Raster,
 			}],
-			properties: node_properties::brush_node_properties,
+			properties: node_properties::no_properties,
 		},
 		DocumentNodeType {
 			name: "Extract Vector Points",

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -643,7 +643,7 @@ fn static_nodes() -> Vec<DocumentNodeType> {
 				DocumentInputType::value("None", TaggedValue::None, false),
 				DocumentInputType::value("Background", TaggedValue::ImageFrame(ImageFrame::empty()), true),
 				DocumentInputType::value("Bounds", TaggedValue::ImageFrame(ImageFrame::empty()), true),
-				DocumentInputType::value("Trace", TaggedValue::VecDVec2((0..2).map(|x| DVec2::new(x as f64 * 10., 0.)).collect()), true),
+				DocumentInputType::value("Trace", TaggedValue::BrushStrokes(Vec::new()), true),
 				DocumentInputType::value("Diameter", TaggedValue::F64(40.), false),
 				DocumentInputType::value("Hardness", TaggedValue::F64(50.), false),
 				DocumentInputType::value("Flow", TaggedValue::F64(100.), false),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -643,7 +643,7 @@ fn static_nodes() -> Vec<DocumentNodeType> {
 				DocumentInputType::value("None", TaggedValue::None, false),
 				DocumentInputType::value("Background", TaggedValue::ImageFrame(ImageFrame::empty()), true),
 				DocumentInputType::value("Bounds", TaggedValue::ImageFrame(ImageFrame::empty()), true),
-				DocumentInputType::value("Trace", TaggedValue::BrushStrokes(Vec::new()), true),
+				DocumentInputType::value("Trace", TaggedValue::BrushStrokes(Vec::new()), false),
 			],
 			outputs: vec![DocumentOutputType {
 				name: "Image",

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -707,14 +707,8 @@ pub fn blur_image_properties(document_node: &DocumentNode, node_id: NodeId, _con
 	vec![LayoutGroup::Row { widgets: radius }, LayoutGroup::Row { widgets: sigma }]
 }
 
-pub fn brush_node_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
-	let color = color_widget(document_node, node_id, 7, "Color", ColorInput::default().allow_none(false), true);
-
-	let size = number_widget(document_node, node_id, 4, "Diameter", NumberInput::default().min(1.).max(100.).unit(" px"), true);
-	let hardness = number_widget(document_node, node_id, 5, "Hardness", NumberInput::default().min(0.).max(100.).unit("%"), true);
-	let flow = number_widget(document_node, node_id, 6, "Flow", NumberInput::default().min(1.).max(100.).unit("%"), true);
-
-	vec![color, LayoutGroup::Row { widgets: size }, LayoutGroup::Row { widgets: hardness }, LayoutGroup::Row { widgets: flow }]
+pub fn brush_node_properties(_document_node: &DocumentNode, _node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
+	vec![]
 }
 
 pub fn adjust_threshold_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -1,21 +1,17 @@
+use super::document_node_types::NodePropertiesContext;
+use super::FrontendGraphDataType;
 use crate::messages::layout::utility_types::widget_prelude::*;
-
 use crate::messages::prelude::*;
 
-use document_legacy::layers::layer_info::LayerDataTypeDiscriminant;
-use document_legacy::Operation;
-use glam::{DVec2, IVec2};
 use graph_craft::concrete;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, NodeId, NodeInput};
 use graphene_core::raster::{BlendMode, Color, ImageFrame, LuminanceCalculation, RedGreenBlue, RelativeAbsolute, SelectiveColorChoice};
 use graphene_core::text::Font;
 use graphene_core::vector::style::{FillType, GradientType, LineCap, LineJoin};
-
 use graphene_core::{Cow, Type, TypeDescriptor};
 
-use super::document_node_types::NodePropertiesContext;
-use super::FrontendGraphDataType;
+use glam::{DVec2, IVec2};
 
 pub fn string_properties(text: impl Into<String>) -> Vec<LayoutGroup> {
 	let widget = WidgetHolder::text_widget(text);
@@ -129,7 +125,7 @@ fn bool_widget(document_node: &DocumentNode, node_id: NodeId, index: usize, name
 	widgets
 }
 
-fn vec2_widget(document_node: &DocumentNode, node_id: NodeId, index: usize, name: &str, x: &str, y: &str, mut assist: impl FnMut(&mut Vec<WidgetHolder>)) -> LayoutGroup {
+fn vec2_widget(document_node: &DocumentNode, node_id: NodeId, index: usize, name: &str, x: &str, y: &str, unit: &str, mut assist: impl FnMut(&mut Vec<WidgetHolder>)) -> LayoutGroup {
 	let mut widgets = start_widgets(document_node, node_id, index, name, FrontendGraphDataType::Vector, false);
 
 	assist(&mut widgets);
@@ -143,13 +139,13 @@ fn vec2_widget(document_node: &DocumentNode, node_id: NodeId, index: usize, name
 			WidgetHolder::unrelated_separator(),
 			NumberInput::new(Some(vec2.x))
 				.label(x)
-				.unit(" px")
+				.unit(unit)
 				.on_update(update_value(move |input: &NumberInput| TaggedValue::DVec2(DVec2::new(input.value.unwrap(), vec2.y)), node_id, index))
 				.widget_holder(),
 			WidgetHolder::related_separator(),
 			NumberInput::new(Some(vec2.y))
 				.label(y)
-				.unit(" px")
+				.unit(unit)
 				.on_update(update_value(move |input: &NumberInput| TaggedValue::DVec2(DVec2::new(vec2.x, input.value.unwrap())), node_id, index))
 				.widget_holder(),
 		]);
@@ -165,14 +161,14 @@ fn vec2_widget(document_node: &DocumentNode, node_id: NodeId, index: usize, name
 			NumberInput::new(Some(vec2.x as f64))
 				.int()
 				.label(x)
-				.unit(" px")
+				.unit(unit)
 				.on_update(update_value(update_x, node_id, index))
 				.widget_holder(),
 			WidgetHolder::related_separator(),
 			NumberInput::new(Some(vec2.y as f64))
 				.int()
 				.label(y)
-				.unit(" px")
+				.unit(unit)
 				.on_update(update_value(update_y, node_id, index))
 				.widget_holder(),
 		]);
@@ -707,10 +703,6 @@ pub fn blur_image_properties(document_node: &DocumentNode, node_id: NodeId, _con
 	vec![LayoutGroup::Row { widgets: radius }, LayoutGroup::Row { widgets: sigma }]
 }
 
-pub fn brush_node_properties(_document_node: &DocumentNode, _node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
-	vec![]
-}
-
 pub fn adjust_threshold_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
 	let thereshold_min = number_widget(document_node, node_id, 1, "Min Luminance", NumberInput::default().min(0.).max(100.).unit("%"), true);
 	let thereshold_max = number_widget(document_node, node_id, 2, "Max Luminance", NumberInput::default().min(0.).max(100.).unit("%"), true);
@@ -939,7 +931,7 @@ pub fn transform_properties(document_node: &DocumentNode, node_id: NodeId, _cont
 			add_blank_assist(widgets);
 		}
 	};
-	let translation = vec2_widget(document_node, node_id, 1, "Translation", "X", "Y", translation_assist);
+	let translation = vec2_widget(document_node, node_id, 1, "Translation", "X", "Y", " px", translation_assist);
 
 	let rotation = {
 		let index = 2;
@@ -966,7 +958,7 @@ pub fn transform_properties(document_node: &DocumentNode, node_id: NodeId, _cont
 		LayoutGroup::Row { widgets }
 	};
 
-	let scale = vec2_widget(document_node, node_id, 3, "Scale", "X", "Y", add_blank_assist);
+	let scale = vec2_widget(document_node, node_id, 3, "Scale", "W", "H", "x", add_blank_assist);
 	vec![translation, rotation, scale]
 }
 
@@ -1652,8 +1644,8 @@ pub fn layer_properties(document_node: &DocumentNode, node_id: NodeId, _context:
 	]
 }
 pub fn artboard_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
-	let location = vec2_widget(document_node, node_id, 1, "Location", "X", "Y", add_blank_assist);
-	let dimensions = vec2_widget(document_node, node_id, 2, "Dimensions", "W", "H", add_blank_assist);
+	let location = vec2_widget(document_node, node_id, 1, "Location", "X", "Y", " px", add_blank_assist);
+	let dimensions = vec2_widget(document_node, node_id, 2, "Dimensions", "W", "H", " px", add_blank_assist);
 	let background = color_widget(document_node, node_id, 3, "Background", ColorInput::default().allow_none(false), true);
 	vec![location, dimensions, background]
 }

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -40,7 +40,7 @@ impl Default for BrushOptions {
 			diameter: 40.,
 			hardness: 50.,
 			flow: 100.,
-			spacing: 10.,
+			spacing: 50.,
 			color: ToolColorOptions::default(),
 		}
 	}

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -317,6 +317,7 @@ impl Fsm for BrushToolFsmState {
 
 					Drawing
 				}
+
 				(Drawing, DragStop) | (Drawing, Abort) => {
 					if !tool_data.strokes.is_empty() {
 						responses.add(DocumentMessage::CommitTransaction);
@@ -329,6 +330,7 @@ impl Fsm for BrushToolFsmState {
 
 					Ready
 				}
+
 				(_, WorkingColorChanged) => {
 					responses.add(BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::WorkingColors(
 						Some(global_tool_data.primary_color),

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -288,6 +288,7 @@ impl Fsm for BrushToolFsmState {
 						responses.add(DocumentMessage::DeselectAllLayers);
 						tool_data.layer_path = document.get_path_for_new_layer();
 					}
+					let layer_position = tool_data.transform.inverse().transform_point2(document_position);
 
 					// Start a new stroke with a single sample.
 					tool_data.strokes.push(BrushStroke {

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -127,7 +127,7 @@ impl PropertyHolder for BrushTool {
 			NumberInput::new(Some(self.options.spacing))
 				.label("Spacing")
 				.min(1.)
-				.max(300.)
+				.max(100.)
 				.unit("%")
 				.on_update(|number_input: &NumberInput| BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::Spacing(number_input.value.unwrap())).into())
 				.widget_holder(),
@@ -292,9 +292,9 @@ impl Fsm for BrushToolFsmState {
 					let layer_position = tool_data.transform.inverse().transform_point2(document_position);
 					// TODO: Also scale it based on the input image ('Background' parameter).
 					// TODO: Resizing the input image results in a different brush size from the chosen diameter.
-					let layer_scale = ((tool_data.transform.matrix2 * glam::DVec2::X).length())
-						.max((tool_data.transform.matrix2 * glam::DVec2::Y).length())
-						.max(0.0001); // Safety against division by zero
+					let layer_scale = 0.0001_f64 // Safety against division by zero
+						.max((tool_data.transform.matrix2 * glam::DVec2::X).length())
+						.max((tool_data.transform.matrix2 * glam::DVec2::Y).length());
 
 					// Start a new stroke with a single sample
 					tool_data.strokes.push(BrushStroke {

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -30,6 +30,7 @@ pub struct BrushOptions {
 	diameter: f64,
 	hardness: f64,
 	flow: f64,
+	spacing: f64,
 	color: ToolColorOptions,
 }
 
@@ -39,6 +40,7 @@ impl Default for BrushOptions {
 			diameter: 40.,
 			hardness: 50.,
 			flow: 100.,
+			spacing: 10.,
 			color: ToolColorOptions::default(),
 		}
 	}
@@ -70,6 +72,7 @@ pub enum BrushToolMessageOptionsUpdate {
 	Diameter(f64),
 	Flow(f64),
 	Hardness(f64),
+	Spacing(f64),
 	WorkingColors(Option<Color>, Option<Color>),
 }
 
@@ -117,6 +120,14 @@ impl PropertyHolder for BrushTool {
 				.unit("%")
 				.on_update(|number_input: &NumberInput| BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::Flow(number_input.value.unwrap())).into())
 				.widget_holder(),
+			WidgetHolder::related_separator(),
+			NumberInput::new(Some(self.options.spacing))
+				.label("Spacing")
+				.min(1.)
+				.max(300.)
+				.unit("%")
+				.on_update(|number_input: &NumberInput| BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::Spacing(number_input.value.unwrap())).into())
+				.widget_holder(),
 		];
 
 		widgets.push(WidgetHolder::section_separator());
@@ -152,6 +163,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for BrushTo
 				BrushToolMessageOptionsUpdate::Diameter(diameter) => self.options.diameter = diameter,
 				BrushToolMessageOptionsUpdate::Hardness(hardness) => self.options.hardness = hardness,
 				BrushToolMessageOptionsUpdate::Flow(flow) => self.options.flow = flow,
+				BrushToolMessageOptionsUpdate::Spacing(spacing) => self.options.spacing = spacing,
 				BrushToolMessageOptionsUpdate::Color(color) => {
 					self.options.color.custom_color = color;
 					self.options.color.color_type = ToolColorType::Custom;
@@ -282,6 +294,7 @@ impl Fsm for BrushToolFsmState {
 							diameter: tool_options.diameter,
 							hardness: tool_options.hardness,
 							flow: tool_options.flow,
+							spacing: tool_options.spacing,
 						},
 					});
 

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -4,19 +4,22 @@ use crate::messages::layout::utility_types::layout_widget::{Layout, LayoutGroup,
 use crate::messages::layout::utility_types::misc::LayoutTarget;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::layout::utility_types::widgets::input_widgets::NumberInput;
+use crate::messages::portfolio::document::node_graph::transform_utils::get_current_transform;
 use crate::messages::prelude::*;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::utility_types::{EventToMessageMap, Fsm, ToolActionHandlerData, ToolMetadata, ToolTransition, ToolType};
 use crate::messages::tool::utility_types::{HintData, HintGroup, HintInfo};
 
+use document_legacy::layers::layer_layer::CachedOutputData;
 use document_legacy::LayerId;
 use graph_craft::document::value::TaggedValue;
-use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeInput, NodeNetwork};
-use graphene_core::raster::ImageFrame;
+use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeId, NodeInput, NodeNetwork};
+use graphene_core::raster::{Image, ImageFrame};
 use graphene_core::vector::brush_stroke::{BrushInputSample, BrushStroke, BrushStyle};
 use graphene_core::Color;
 
+use glam::DAffine2;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -219,37 +222,44 @@ impl ToolTransition for BrushTool {
 #[derive(Clone, Debug, Default)]
 struct BrushToolData {
 	strokes: Vec<BrushStroke>,
-	path: Option<Vec<LayerId>>,
+	layer_path: Vec<LayerId>,
+	node_path: Vec<NodeId>,
+	transform: DAffine2,
 }
 
 impl BrushToolData {
-	fn update_strokes(&self, responses: &mut VecDeque<Message>) {
-		if let Some(layer_path) = self.path.clone() {
-			responses.add(NodeGraphMessage::SetQualifiedInputValue {
-				layer_path,
-				node_path: vec![0],
-				input_index: 3,
-				value: TaggedValue::BrushStrokes(self.strokes.clone()),
-			});
+	fn load_existing_strokes(&mut self, document: &DocumentMessageHandler) -> Option<&Vec<LayerId>> {
+		self.transform = DAffine2::IDENTITY;
+		if document.selected_layers().count() != 1 {
+			return None;
 		}
+		self.layer_path = document.selected_layers().next()?.to_vec();
+		let layer = document.document_legacy.layer(&self.layer_path).ok().and_then(|layer| layer.as_layer().ok())?;
+		let network = &layer.network;
+		for (node, node_id) in network.primary_flow() {
+			if node.name == "Brush" {
+				let points_input = node.inputs.get(3)?;
+				let NodeInput::Value { tagged_value: TaggedValue::BrushStrokes(strokes), .. } = points_input else {
+					continue;
+				};
+				self.strokes = strokes.clone();
+
+				return Some(&self.layer_path);
+			} else if node.name == "Transform" {
+				self.transform = get_current_transform(&node.inputs) * self.transform;
+			}
+		}
+
+		self.transform = DAffine2::IDENTITY;
+
+		matches!(layer.cached_output_data, CachedOutputData::BlobURL(_)).then_some(&self.layer_path)
 	}
 
-	// fn update_image(&self, node_graph: &NodeGraphExecutor, responses: &mut VecDeque<Message>) {
-	// 	let Some(image) = node_graph.introspect_node(&[1]) else { return; };
-	// 	let image: &ImageFrame<Color> = image.downcast_ref().unwrap();
-	// 	self.set_image(image.clone(), responses)
-	// }
-	//
-	// fn set_image(&self, image_frame: ImageFrame<Color>, responses: &mut VecDeque<Message>) {
-	// 	if let Some(layer_path) = self.path.clone() {
-	// 		responses.add(NodeGraphMessage::SetQualifiedInputValue {
-	// 			layer_path,
-	// 			node_path: vec![0],
-	// 			input_index: 1,
-	// 			value: TaggedValue::ImageFrame(image_frame),
-	// 		});
-	// 	}
-	// }
+	fn update_strokes(&self, brush_options: &BrushOptions, responses: &mut VecDeque<Message>) {
+		let layer = self.layer_path.clone();
+		let strokes = self.strokes.clone();
+		responses.add(GraphOperationMessage::Brush { layer, strokes });
+	}
 }
 
 impl Fsm for BrushToolFsmState {
@@ -266,38 +276,22 @@ impl Fsm for BrushToolFsmState {
 		tool_options: &Self::ToolOptions,
 		responses: &mut VecDeque<Message>,
 	) -> Self {
-		use BrushToolFsmState::*;
-		use BrushToolMessage::*;
-
-		let viewport_to_docspace = document.document_legacy.root.transform.inverse();
-		// let mut docspace_to_layerspace = DAffine2::default();
-		// if let Some(layer_path) = &tool_data.path {
-		// 	if let Some(transform) = get_layer_transform(document, layer_path) {
-		// 		docspace_to_layerspace = transform.inverse();
-		// 	} else {
-		// 		log::error!("could not get layer transform");
-		// 	}
-		// }
-
-		let document_position = viewport_to_docspace.transform_point2(input.mouse.position);
-		// let layer_position = docspace_to_layerspace.transform_point2(document_position);
+		let document_position = (document.document_legacy.root.transform).inverse().transform_point2(input.mouse.position);
+		let layer_position = tool_data.transform.inverse().transform_point2(document_position);
 		if let ToolMessage::Brush(event) = event {
 			match (self, event) {
-				(Ready, DragStart) => {
+				(BrushToolFsmState::Ready, BrushToolMessage::DragStart) => {
 					responses.add(DocumentMessage::StartTransaction);
-					let existing_strokes = load_existing_strokes(document);
-					let new_layer = existing_strokes.is_none();
-					if let Some((layer_path, strokes)) = existing_strokes {
-						tool_data.path = Some(layer_path);
-						tool_data.strokes = strokes;
-					} else {
+					let layer_path = tool_data.load_existing_strokes(document);
+					let new_layer = layer_path.is_none();
+					if new_layer {
 						responses.add(DocumentMessage::DeselectAllLayers);
-						tool_data.path = Some(document.get_path_for_new_layer());
+						tool_data.layer_path = document.get_path_for_new_layer();
 					}
 
 					// Start a new stroke with a single sample.
 					tool_data.strokes.push(BrushStroke {
-						trace: vec![BrushInputSample { position: document_position }],
+						trace: vec![BrushInputSample { position: layer_position }],
 						style: BrushStyle {
 							color: tool_options.color.active_color().unwrap_or_default(),
 							diameter: tool_options.diameter,
@@ -309,24 +303,22 @@ impl Fsm for BrushToolFsmState {
 
 					if new_layer {
 						add_brush_render(tool_options, tool_data, responses);
-					} else {
-						//tool_data.update_image(node_graph, responses);
-						tool_data.update_strokes(responses);
 					}
+					tool_data.update_strokes(tool_options, responses);
 
-					Drawing
+					BrushToolFsmState::Drawing
 				}
 
-				(Drawing, PointerMove) => {
+				(BrushToolFsmState::Drawing, BrushToolMessage::PointerMove) => {
 					if let Some(stroke) = tool_data.strokes.last_mut() {
-						stroke.trace.push(BrushInputSample { position: document_position })
+						stroke.trace.push(BrushInputSample { position: layer_position })
 					}
-					tool_data.update_strokes(responses);
+					tool_data.update_strokes(tool_options, responses);
 
-					Drawing
+					BrushToolFsmState::Drawing
 				}
 
-				(Drawing, DragStop) | (Drawing, Abort) => {
+				(BrushToolFsmState::Drawing, BrushToolMessage::DragStop) | (BrushToolFsmState::Drawing, BrushToolMessage::Abort) => {
 					if !tool_data.strokes.is_empty() {
 						responses.add(DocumentMessage::CommitTransaction);
 					} else {
@@ -334,12 +326,11 @@ impl Fsm for BrushToolFsmState {
 					}
 
 					tool_data.strokes.clear();
-					tool_data.path = None;
 
-					Ready
+					BrushToolFsmState::Ready
 				}
 
-				(_, WorkingColorChanged) => {
+				(_, BrushToolMessage::WorkingColorChanged) => {
 					responses.add(BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::WorkingColors(
 						Some(global_tool_data.primary_color),
 						Some(global_tool_data.secondary_color),
@@ -355,7 +346,7 @@ impl Fsm for BrushToolFsmState {
 
 	fn update_hints(&self, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
-			BrushToolFsmState::Ready => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Draw Polyline")])]),
+			BrushToolFsmState::Ready => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Add Trace")])]),
 			BrushToolFsmState::Drawing => HintData(vec![]),
 		};
 
@@ -368,62 +359,10 @@ impl Fsm for BrushToolFsmState {
 }
 
 fn add_brush_render(tool_options: &BrushOptions, data: &BrushToolData, responses: &mut VecDeque<Message>) {
-	let layer_path = data.path.clone().unwrap();
-
-	let brush_node = DocumentNode {
-		name: "Brush".to_string(),
-		inputs: vec![
-			NodeInput::value(TaggedValue::None, false),
-			NodeInput::value(TaggedValue::ImageFrame(ImageFrame::empty()), true),
-			NodeInput::value(TaggedValue::ImageFrame(ImageFrame::empty()), true),
-			NodeInput::value(TaggedValue::BrushStrokes(data.strokes.clone()), false),
-			// Diameter
-			NodeInput::value(TaggedValue::F64(tool_options.diameter), false),
-			// Hardness
-			NodeInput::value(TaggedValue::F64(tool_options.hardness), false),
-			// Flow
-			NodeInput::value(TaggedValue::F64(tool_options.flow), false),
-			// Color
-			NodeInput::value(TaggedValue::Color(tool_options.color.active_color().unwrap()), false),
-		],
-		implementation: DocumentNodeImplementation::Unresolved("graphene_std::brush::BrushNode".into()),
-		metadata: graph_craft::document::DocumentNodeMetadata { position: (8, 4).into() },
-		..Default::default()
-	};
-	// let monitor_node = DocumentNode {
-	// 	name: "Monitor".to_string(),
-	// 	implementation: DocumentNodeImplementation::Unresolved("graphene_std::memo::MonitorNode<_>".into()),
-	// 	..Default::default()
-	// };
-	let mut network = NodeNetwork::value_network(brush_node);
-	//network.push_node(monitor_node, true);
-	network.push_output_node();
-	graph_modification_utils::new_custom_layer(network, layer_path, responses);
-}
-
-fn load_existing_strokes(document: &DocumentMessageHandler) -> Option<(Vec<LayerId>, Vec<BrushStroke>)> {
-	if document.selected_layers().count() != 1 {
-		return None;
+	let mut network = NodeNetwork::default();
+	let output_node = network.push_output_node();
+	if let Some(node) = network.nodes.get_mut(&output_node) {
+		node.inputs.push(NodeInput::value(TaggedValue::ImageFrame(ImageFrame::empty()), true))
 	}
-	let layer_path = document.selected_layers().next()?.to_vec();
-	let network = document.document_legacy.layer(&layer_path).ok().and_then(|layer| layer.as_layer_network().ok())?;
-	let brush_node = network.nodes.get(&0)?;
-	if brush_node.implementation != DocumentNodeImplementation::Unresolved("graphene_std::brush::BrushNode".into()) {
-		return None;
-	}
-	let points_input = brush_node.inputs.get(3)?;
-	let NodeInput::Value {
-		tagged_value: TaggedValue::BrushStrokes(strokes),
-		..
-	} = points_input else {
-		return None };
-
-	Some((layer_path, strokes.clone()))
+	graph_modification_utils::new_custom_layer(network, data.layer_path.clone(), responses);
 }
-
-/*
-fn get_layer_transform(document: &DocumentMessageHandler, layer_path: &[LayerId]) -> Option<DAffine2> {
-	let layer = document.document_legacy.layer(layer_path).ok()?;
-	Some(layer.transform)
-}
-*/

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -10,7 +10,6 @@ use document_legacy::{LayerId, Operation};
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{generate_uuid, DocumentNodeImplementation, NodeId, NodeNetwork};
 use graph_craft::executor::Compiler;
-use graph_craft::imaginate_input::*;
 use graph_craft::{concrete, Type, TypeDescriptor};
 use graphene_core::raster::{Image, ImageFrame};
 use graphene_core::renderer::{SvgSegment, SvgSegmentList};

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -8,6 +8,7 @@ use glam::DVec2;
 pub use self::color::{Color, Luma};
 
 pub mod adjustments;
+pub mod bbox;
 #[cfg(not(target_arch = "spirv"))]
 pub mod brightness_contrast;
 pub mod color;

--- a/node-graph/gcore/src/raster/bbox.rs
+++ b/node-graph/gcore/src/raster/bbox.rs
@@ -1,0 +1,84 @@
+use dyn_any::{DynAny, StaticType};
+use glam::{DAffine2, DVec2};
+
+#[derive(Debug, Clone, DynAny)]
+pub struct AxisAlignedBbox {
+	pub start: DVec2,
+	pub end: DVec2,
+}
+
+impl AxisAlignedBbox {
+	pub fn size(&self) -> DVec2 {
+		self.end - self.start
+	}
+
+	pub fn to_transform(&self) -> DAffine2 {
+		DAffine2::from_translation(self.start) * DAffine2::from_scale(self.size())
+	}
+
+	pub fn contains(&self, point: DVec2) -> bool {
+		point.x >= self.start.x && point.x <= self.end.x && point.y >= self.start.y && point.y <= self.end.y
+	}
+
+	pub fn intersects(&self, other: &AxisAlignedBbox) -> bool {
+		other.start.x <= self.end.x && other.end.x >= self.start.x && other.start.y <= self.end.y && other.end.y >= self.start.y
+	}
+
+	pub fn union(&self, other: &AxisAlignedBbox) -> AxisAlignedBbox {
+		AxisAlignedBbox {
+			start: DVec2::new(self.start.x.min(other.start.x), self.start.y.min(other.start.y)),
+			end: DVec2::new(self.end.x.max(other.end.x), self.end.y.max(other.end.y)),
+		}
+	}
+	pub fn union_non_empty(&self, other: &AxisAlignedBbox) -> Option<AxisAlignedBbox> {
+		match (self.size() == DVec2::ZERO, other.size() == DVec2::ZERO) {
+			(true, true) => None,
+			(true, _) => Some(other.clone()),
+			(_, true) => Some(self.clone()),
+			_ => Some(AxisAlignedBbox {
+				start: DVec2::new(self.start.x.min(other.start.x), self.start.y.min(other.start.y)),
+				end: DVec2::new(self.end.x.max(other.end.x), self.end.y.max(other.end.y)),
+			}),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct Bbox {
+	pub top_left: DVec2,
+	pub top_right: DVec2,
+	pub bottom_left: DVec2,
+	pub bottom_right: DVec2,
+}
+
+impl Bbox {
+	pub fn unit() -> Self {
+		Self {
+			top_left: DVec2::new(0., 1.),
+			top_right: DVec2::new(1., 1.),
+			bottom_left: DVec2::new(0., 0.),
+			bottom_right: DVec2::new(1., 0.),
+		}
+	}
+
+	pub fn affine_transform(self, transform: DAffine2) -> Self {
+		Self {
+			top_left: transform.transform_point2(self.top_left),
+			top_right: transform.transform_point2(self.top_right),
+			bottom_left: transform.transform_point2(self.bottom_left),
+			bottom_right: transform.transform_point2(self.bottom_right),
+		}
+	}
+
+	pub fn to_axis_aligned_bbox(&self) -> AxisAlignedBbox {
+		let start_x = self.top_left.x.min(self.top_right.x).min(self.bottom_left.x).min(self.bottom_right.x);
+		let start_y = self.top_left.y.min(self.top_right.y).min(self.bottom_left.y).min(self.bottom_right.y);
+		let end_x = self.top_left.x.max(self.top_right.x).max(self.bottom_left.x).max(self.bottom_right.x);
+		let end_y = self.top_left.y.max(self.top_right.y).max(self.bottom_left.y).max(self.bottom_right.y);
+
+		AxisAlignedBbox {
+			start: DVec2::new(start_x, start_y),
+			end: DVec2::new(end_x, end_y),
+		}
+	}
+}

--- a/node-graph/gcore/src/raster/bbox.rs
+++ b/node-graph/gcore/src/raster/bbox.rs
@@ -8,6 +8,8 @@ pub struct AxisAlignedBbox {
 }
 
 impl AxisAlignedBbox {
+	pub const ZERO: Self = Self { start: DVec2::ZERO, end: DVec2::ZERO };
+
 	pub fn size(&self) -> DVec2 {
 		self.end - self.start
 	}

--- a/node-graph/gcore/src/raster/image.rs
+++ b/node-graph/gcore/src/raster/image.rs
@@ -144,11 +144,11 @@ where
 		assert!(data.len() == width as usize * height as usize);
 
 		// Cache the last sRGB value we computed, speeds up fills.
-		let mut last_r = 0.0;
+		let mut last_r = 0.;
 		let mut last_r_srgb = 0u8;
-		let mut last_g = 0.0;
+		let mut last_g = 0.;
 		let mut last_g_srgb = 0u8;
-		let mut last_b = 0.0;
+		let mut last_b = 0.;
 		let mut last_b_srgb = 0u8;
 
 		let mut result = vec![0; data.len() * 4];
@@ -157,8 +157,8 @@ where
 			let a = color.a().to_f32();
 			// Smaller alpha values than this would map to fully transparent
 			// anyway, avoid expensive encoding.
-			if a >= 0.5 / 255.0 {
-				let undo_premultiply = 1.0 / a;
+			if a >= 0.5 / 255. {
+				let undo_premultiply = 1. / a;
 				let r = color.r().to_f32() * undo_premultiply;
 				let g = color.g().to_f32() * undo_premultiply;
 				let b = color.b().to_f32() * undo_premultiply;
@@ -180,7 +180,7 @@ where
 				result[i] = last_r_srgb;
 				result[i + 1] = last_g_srgb;
 				result[i + 2] = last_b_srgb;
-				result[i + 3] = (a * 255.0 + 0.5) as u8;
+				result[i + 3] = (a * 255. + 0.5) as u8;
 			}
 
 			i += 4;

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -12,6 +12,7 @@ pub struct BrushStyle {
 	pub diameter: f64,
 	pub hardness: f64,
 	pub flow: f64,
+	pub spacing: f64, // Spacing as a fraction of the diameter.
 }
 
 impl Default for BrushStyle {
@@ -21,6 +22,7 @@ impl Default for BrushStyle {
 			diameter: 40.0,
 			hardness: 50.0,
 			flow: 100.0,
+			spacing: 10.0, // Percentage of diameter.
 		}
 	}
 }

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -1,0 +1,58 @@
+use dyn_any::{DynAny, StaticType};
+use glam::DVec2;
+use std::hash::{Hash, Hasher};
+
+use crate::Color;
+
+/// The style of a brush.
+#[derive(Clone, Debug, PartialEq, DynAny)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BrushStyle {
+	pub color: Color,
+	pub diameter: f64,
+	pub hardness: f64,
+	pub flow: f64,
+}
+
+impl Default for BrushStyle {
+	fn default() -> Self {
+		Self {
+			color: Color::BLACK,
+			diameter: 40.0,
+			hardness: 50.0,
+			flow: 100.0,
+		}
+	}
+}
+
+impl Hash for BrushStyle {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.color.hash(state);
+		self.diameter.to_bits().hash(state);
+		self.hardness.to_bits().hash(state);
+		self.flow.to_bits().hash(state);
+	}
+}
+
+/// A single sample of brush parameters across the brush stroke.
+#[derive(Clone, Debug, PartialEq, DynAny)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BrushInputSample {
+	pub position: DVec2,
+	// Future work: pressure, stylus angle, etc.
+}
+
+impl Hash for BrushInputSample {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.position.x.to_bits().hash(state);
+		self.position.y.to_bits().hash(state);
+	}
+}
+
+/// The parameters for a single stroke brush.
+#[derive(Clone, Debug, PartialEq, Hash, Default, DynAny)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BrushStroke {
+	pub style: BrushStyle,
+	pub trace: Vec<BrushInputSample>,
+}

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -1,9 +1,9 @@
+use crate::raster::bbox::AxisAlignedBbox;
+use crate::Color;
+
 use dyn_any::{DynAny, StaticType};
 use glam::DVec2;
 use std::hash::{Hash, Hasher};
-
-use crate::raster::bbox::AxisAlignedBbox;
-use crate::Color;
 
 /// The style of a brush.
 #[derive(Clone, Debug, PartialEq, DynAny)]
@@ -20,10 +20,10 @@ impl Default for BrushStyle {
 	fn default() -> Self {
 		Self {
 			color: Color::BLACK,
-			diameter: 40.0,
-			hardness: 50.0,
-			flow: 100.0,
-			spacing: 50.0, // Percentage of diameter.
+			diameter: 40.,
+			hardness: 50.,
+			flow: 100.,
+			spacing: 50., // Percentage of diameter.
 		}
 	}
 }
@@ -62,7 +62,7 @@ pub struct BrushStroke {
 
 impl BrushStroke {
 	pub fn bounding_box(&self) -> AxisAlignedBbox {
-		let radius = self.style.diameter / 2.0;
+		let radius = self.style.diameter / 2.;
 		self.trace
 			.iter()
 			.map(|sample| AxisAlignedBbox {
@@ -76,7 +76,7 @@ impl BrushStroke {
 	pub fn compute_blit_points(&self) -> Vec<DVec2> {
 		// We always travel in a straight line towards the next user input,
 		// placing a blit point every time we travelled our spacing distance.
-		let spacing_dist = self.style.spacing / 100.0 * self.style.diameter;
+		let spacing_dist = self.style.spacing / 100. * self.style.diameter;
 
 		let Some(first_sample) = self.trace.first() else { return Vec::new(); };
 
@@ -90,7 +90,7 @@ impl BrushStroke {
 			let unit_step = delta / dist_left;
 
 			while dist_left >= dist_until_next_blit {
-				// Take a step to the next blitpoint.
+				// Take a step to the next blit point.
 				cur_pos += dist_until_next_blit * unit_step;
 				dist_left -= dist_until_next_blit;
 

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -23,7 +23,7 @@ impl Default for BrushStyle {
 			diameter: 40.0,
 			hardness: 50.0,
 			flow: 100.0,
-			spacing: 10.0, // Percentage of diameter.
+			spacing: 50.0, // Percentage of diameter.
 		}
 	}
 }

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -2,6 +2,7 @@ use dyn_any::{DynAny, StaticType};
 use glam::DVec2;
 use std::hash::{Hash, Hasher};
 
+use crate::raster::bbox::AxisAlignedBbox;
 use crate::Color;
 
 /// The style of a brush.
@@ -60,6 +61,18 @@ pub struct BrushStroke {
 }
 
 impl BrushStroke {
+	pub fn bounding_box(&self) -> AxisAlignedBbox {
+		let radius = self.style.diameter / 2.0;
+		self.trace
+			.iter()
+			.map(|sample| AxisAlignedBbox {
+				start: sample.position + DVec2::new(-radius, -radius),
+				end: sample.position + DVec2::new(radius, radius),
+			})
+			.reduce(|a, b| a.union(&b))
+			.unwrap_or(AxisAlignedBbox::ZERO)
+	}
+
 	pub fn compute_blit_points(&self) -> Vec<DVec2> {
 		// We always travel in a straight line towards the next user input,
 		// placing a blit point every time we travelled our spacing distance.

--- a/node-graph/gcore/src/vector/mod.rs
+++ b/node-graph/gcore/src/vector/mod.rs
@@ -1,3 +1,4 @@
+pub mod brush_stroke;
 pub mod consts;
 pub mod generator_nodes;
 pub mod manipulator_group;

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -285,7 +285,7 @@ impl<'a> TaggedValue {
 			x if x == TypeId::of::<Option<graphene_core::Color>>() => Some(TaggedValue::OptionalColor(*downcast(input).unwrap())),
 			x if x == TypeId::of::<Vec<graphene_core::uuid::ManipulatorGroupId>>() => Some(TaggedValue::ManipulatorGroupIds(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::text::Font>() => Some(TaggedValue::Font(*downcast(input).unwrap())),
-			x if x == TypeId::of::<Vec<DVec2>>() => Some(TaggedValue::VecDVec2(*downcast(input).unwrap())),
+			x if x == TypeId::of::<Vec<graphene_core::vector::brush_stroke::BrushStroke>>() => Some(TaggedValue::BrushStrokes(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::raster::IndexNode<Vec<graphene_core::raster::ImageFrame<Color>>>>() => Some(TaggedValue::Segments(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::EditorApi>() => Some(TaggedValue::EditorApi(*downcast(input).unwrap())),
 			x if x == TypeId::of::<crate::document::DocumentNode>() => Some(TaggedValue::DocumentNode(*downcast(input).unwrap())),

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -53,7 +53,7 @@ pub enum TaggedValue {
 	OptionalColor(Option<graphene_core::raster::color::Color>),
 	ManipulatorGroupIds(Vec<graphene_core::uuid::ManipulatorGroupId>),
 	Font(graphene_core::text::Font),
-	VecDVec2(Vec<DVec2>),
+	BrushStrokes(Vec<graphene_core::vector::brush_stroke::BrushStroke>),
 	Segments(Vec<graphene_core::raster::ImageFrame<Color>>),
 	EditorApi(graphene_core::EditorApi<'static>),
 	DocumentNode(DocumentNode),
@@ -114,12 +114,7 @@ impl Hash for TaggedValue {
 			Self::OptionalColor(color) => color.hash(state),
 			Self::ManipulatorGroupIds(mirror) => mirror.hash(state),
 			Self::Font(font) => font.hash(state),
-			Self::VecDVec2(vec_dvec2) => {
-				vec_dvec2.len().hash(state);
-				for dvec2 in vec_dvec2 {
-					dvec2.to_array().iter().for_each(|x| x.to_bits().hash(state));
-				}
-			}
+			Self::BrushStrokes(brush_strokes) => brush_strokes.hash(state),
 			Self::Segments(segments) => {
 				for segment in segments {
 					segment.hash(state)
@@ -175,7 +170,7 @@ impl<'a> TaggedValue {
 			TaggedValue::OptionalColor(x) => Box::new(x),
 			TaggedValue::ManipulatorGroupIds(x) => Box::new(x),
 			TaggedValue::Font(x) => Box::new(x),
-			TaggedValue::VecDVec2(x) => Box::new(x),
+			TaggedValue::BrushStrokes(x) => Box::new(x),
 			TaggedValue::Segments(x) => Box::new(x),
 			TaggedValue::EditorApi(x) => Box::new(x),
 			TaggedValue::DocumentNode(x) => Box::new(x),
@@ -238,7 +233,7 @@ impl<'a> TaggedValue {
 			TaggedValue::OptionalColor(_) => concrete!(Option<graphene_core::Color>),
 			TaggedValue::ManipulatorGroupIds(_) => concrete!(Vec<graphene_core::uuid::ManipulatorGroupId>),
 			TaggedValue::Font(_) => concrete!(graphene_core::text::Font),
-			TaggedValue::VecDVec2(_) => concrete!(Vec<DVec2>),
+			TaggedValue::BrushStrokes(_) => concrete!(Vec<graphene_core::vector::brush_stroke::BrushStroke>),
 			TaggedValue::Segments(_) => concrete!(graphene_core::raster::IndexNode<Vec<graphene_core::raster::ImageFrame<Color>>>),
 			TaggedValue::EditorApi(_) => concrete!(graphene_core::EditorApi),
 			TaggedValue::DocumentNode(_) => concrete!(crate::document::DocumentNode),

--- a/node-graph/gstd/src/brush.rs
+++ b/node-graph/gstd/src/brush.rs
@@ -1,8 +1,7 @@
 use std::marker::PhantomData;
 
 use glam::{DAffine2, DVec2};
-use graphene_core::raster::bbox::Bbox;
-use graphene_core::raster::{Alpha, Color, Image, ImageFrame, Pixel, Raster, RasterMut, Sample};
+use graphene_core::raster::{Alpha, Color, ImageFrame, Pixel, Sample};
 use graphene_core::transform::{Transform, TransformMut};
 use graphene_core::vector::VectorData;
 use graphene_core::Node;

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -236,10 +236,10 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 				let stamp = stamp.eval(diameter.eval(()));
 
 				let strokes_eval = strokes.eval(());
-				let flat_positions = strokes_eval.iter().flat_map(|s| s.trace.iter().map(|sample| sample.position));
+				let blit_points = strokes_eval.iter().map(|s| s.compute_blit_points());
 				let translated = TranslateNode::new(CopiedNode::new(stamp));
 				let mapped = MapNode::new(ValueNode::new(translated));
-				let positions = mapped.eval(flat_positions).collect::<Vec<_>>();
+				let positions = mapped.eval(blit_points.flatten()).collect::<Vec<_>>();
 
 				let background_bounds = ReduceNode::new(ClonedNode::new(None), ValueNode::new(MergeBoundingBoxNode::new()));
 				let background_bounds = background_bounds.eval(positions.clone().into_iter());

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -228,10 +228,6 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 				let image: DowncastBothNode<(), ImageFrame<Color>> = DowncastBothNode::new(args[0]);
 				let bounds: DowncastBothNode<(), ImageFrame<Color>> = DowncastBothNode::new(args[1]);
 				let strokes: DowncastBothNode<(), Vec<BrushStroke>> = DowncastBothNode::new(args[2]);
-				let _diameter: DowncastBothNode<(), f64> = DowncastBothNode::new(args[3]);
-				let _hardness: DowncastBothNode<(), f64> = DowncastBothNode::new(args[4]);
-				let _flow: DowncastBothNode<(), f64> = DowncastBothNode::new(args[5]);
-				let _color: DowncastBothNode<(), Color> = DowncastBothNode::new(args[6]);
 
 				let strokes = strokes.eval(());
 				let bbox = strokes.iter().map(|s| s.bounding_box()).reduce(|a, b| a.union(&b)).unwrap_or(AxisAlignedBbox::ZERO);
@@ -267,15 +263,7 @@ fn node_registry() -> HashMap<NodeIdentifier, HashMap<NodeIOTypes, NodeConstruct
 			NodeIOTypes::new(
 				concrete!(()),
 				concrete!(ImageFrame<Color>),
-				vec![
-					value_fn!(ImageFrame<Color>),
-					value_fn!(ImageFrame<Color>),
-					value_fn!(Vec<BrushStroke>),
-					value_fn!(f64),
-					value_fn!(f64),
-					value_fn!(f64),
-					value_fn!(Color),
-				],
+				vec![value_fn!(ImageFrame<Color>), value_fn!(ImageFrame<Color>), value_fn!(Vec<BrushStroke>)],
 			),
 		)],
 		vec![(


### PR DESCRIPTION
This pull request introduces per-stroke parameters, meaning each stroke of the brush can have an independent size, color, etc.

It also introduces the new spacing parameter that allows you to put blits along the brush path closer or further apart.

It also contains some optimizations that makes drawing overall quite a bit faster.

Closes #1252. Closes #1237.