### PR TITLE
Dragging selected folder now drags all children

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -590,7 +590,7 @@ impl Fsm for SelectToolFsmState {
 						tool_data.layers_dragging = selected;
 
 						RotatingBounds
-					} else if intersection.last().map(|last| selected.contains(last)).unwrap_or(false) {
+					} else if intersection.last().map(|last| selected.iter().any(|selected_layer| last.starts_with(selected_layer))).unwrap_or(false) {
 						responses.add(DocumentMessage::StartTransaction);
 
 						tool_data.layers_dragging = selected;


### PR DESCRIPTION
Fixes an issue mentioned in #989:
> If a folder is selected (and thus, its children have a bounding box) then the user should be able to drag any of the shapes within the group to drag the group. Right now it deselects everything and selects only the targeted shape being dragged. [(As posted in Discord)](https://discord.com/channels/731730685944922173/881073965047636018/937420016515690497)