### PR TITLE
conditionally enable Select Tool's buttons

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -126,6 +126,7 @@ impl PropertyHolder for SelectTool {
 			})
 			.collect();
 
+		let deactivate_buttons = self.tool_data.selected_layers_count < 2;
 		Layout::WidgetLayout(WidgetLayout::new(vec![LayoutGroup::Row {
 			widgets: vec![
 				DropdownInput::new(vec![layer_selection_behavior_entries])
@@ -140,6 +141,7 @@ impl PropertyHolder for SelectTool {
 				WidgetHolder::section_separator(),
 				IconButton::new("AlignLeft", 24)
 					.tooltip("Align Left")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::X,
@@ -150,6 +152,7 @@ impl PropertyHolder for SelectTool {
 					.widget_holder(),
 				IconButton::new("AlignHorizontalCenter", 24)
 					.tooltip("Align Horizontal Center")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::X,
@@ -160,6 +163,7 @@ impl PropertyHolder for SelectTool {
 					.widget_holder(),
 				IconButton::new("AlignRight", 24)
 					.tooltip("Align Right")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::X,
@@ -171,6 +175,7 @@ impl PropertyHolder for SelectTool {
 				WidgetHolder::unrelated_separator(),
 				IconButton::new("AlignTop", 24)
 					.tooltip("Align Top")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::Y,
@@ -181,6 +186,7 @@ impl PropertyHolder for SelectTool {
 					.widget_holder(),
 				IconButton::new("AlignVerticalCenter", 24)
 					.tooltip("Align Vertical Center")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::Y,
@@ -191,6 +197,7 @@ impl PropertyHolder for SelectTool {
 					.widget_holder(),
 				IconButton::new("AlignBottom", 24)
 					.tooltip("Align Bottom")
+					.disabled(deactivate_buttons)
 					.on_update(|_| {
 						DocumentMessage::AlignSelectedLayers {
 							axis: AlignAxis::Y,
@@ -318,6 +325,7 @@ struct SelectToolData {
 	cursor: MouseCursorIcon,
 	pivot: Pivot,
 	nested_selection_behavior: NestedSelectionBehavior,
+	selected_layers_count: usize,
 }
 
 impl SelectToolData {
@@ -434,6 +442,11 @@ impl Fsm for SelectToolFsmState {
 		if let ToolMessage::Select(event) = event {
 			match (self, event) {
 				(_, DocumentIsDirty | SelectionChanged) => {
+					let selected_layers_count = document.selected_layers().count();
+					if selected_layers_count != tool_data.selected_layers_count {
+						tool_data.selected_layers_count = selected_layers_count
+					}
+
 					match (document.selected_visible_layers_bounding_box(render_data), tool_data.bounding_box_overlays.take()) {
 						(None, Some(bounding_box_overlays)) => bounding_box_overlays.delete(responses),
 						(Some(bounds), paths) => {

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -130,8 +130,6 @@ impl PropertyHolder for SelectTool {
 		let deactivate_alignment = selected_layers_count < 2;
 		let deactivate_pivot = selected_layers_count < 1;
 
-		warn!("selected layers atm: {}, disabling pivot? {}", selected_layers_count, deactivate_pivot);
-
 		Layout::WidgetLayout(WidgetLayout::new(vec![LayoutGroup::Row {
 			widgets: vec![
 				DropdownInput::new(vec![layer_selection_behavior_entries])
@@ -269,6 +267,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for SelectT
 		if self.tool_data.pivot.should_refresh_pivot_position() || self.tool_data.selected_layers_changed {
 			// Notify the frontend about the updated pivot position (a bit ugly to do it here not in the fsm but that doesn't have SelectTool)
 			self.register_properties(responses, LayoutTarget::ToolOptions);
+			self.tool_data.selected_layers_changed = false;
 		}
 	}
 
@@ -453,7 +452,6 @@ impl Fsm for SelectToolFsmState {
 					let selected_layers_changed = selected_layers_count != tool_data.selected_layers_count;
 
 					if selected_layers_changed {
-						warn!("updating count...");
 						tool_data.selected_layers_count = selected_layers_count;
 						tool_data.selected_layers_changed = true;
 					} else {


### PR DESCRIPTION
This PR aims to fix two minor issues mentioned in https://github.com/GraphiteEditor/Graphite/issues/989:
- Gray out the Select tool's alignment buttons when fewer than two layers are selected
- ~~Gray out the Select tool's boolean operation buttons when fewer than two vector shape layers are selected~~

Currently done with fixes for the first issue.

Since the Boolean operator feature is under works, I will pick up the other small issue of disabling pivot button when no layers are selected. 