### PR TITLE
Fix missing popover text

### DIFF
--- a/frontend/src/components/widgets/WidgetRow.svelte
+++ b/frontend/src/components/widgets/WidgetRow.svelte
@@ -141,7 +141,7 @@
 		{#if popoverButton}
 			<PopoverButton {...exclude(popoverButton, ["header", "text", "optionsWidget"])}>
 				<TextLabel bold={true}>{popoverButton.header}</TextLabel>
-				{#if popoverButton.optionsWidget}
+				{#if popoverButton.optionsWidget?.length}
 					<WidgetLayout layout={{ layout: popoverButton.optionsWidget, layoutTarget: layoutTarget }} />
 				{:else}
 					<TextLabel multiline={true}>{popoverButton.text}</TextLabel>


### PR DESCRIPTION
Fix missing popover text
![image](https://github.com/GraphiteEditor/Graphite/assets/78500760/b9db6d07-dd9d-4c44-b56c-98dc5189a83b)
is now
![image](https://github.com/GraphiteEditor/Graphite/assets/78500760/1c89176b-05da-4105-aa97-d029c1b74942)
