### PR TITLE
Fix artboard thumbnails

### DIFF
--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -27,8 +27,6 @@ impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputP
 					let new_size = bounds.size();
 					let existing_size = self.viewport_bounds.size();
 
-					let translation = ((new_size - existing_size) / 2.).round();
-
 					// TODO: Extend this to multiple viewports instead of setting it to the value of this last loop iteration
 					self.viewport_bounds = bounds;
 

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -24,9 +24,6 @@ impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputP
 				assert_eq!(bounds_of_viewports.len(), 1, "Only one viewport is currently supported");
 
 				for bounds in bounds_of_viewports {
-					let new_size = bounds.size();
-					let existing_size = self.viewport_bounds.size();
-
 					// TODO: Extend this to multiple viewports instead of setting it to the value of this last loop iteration
 					self.viewport_bounds = bounds;
 

--- a/editor/src/messages/portfolio/document/artboard/artboard_message_handler.rs
+++ b/editor/src/messages/portfolio/document/artboard/artboard_message_handler.rs
@@ -3,7 +3,7 @@ use crate::messages::portfolio::utility_types::PersistentData;
 use crate::messages::prelude::*;
 
 use document_legacy::document::Document as DocumentLegacy;
-use document_legacy::layers::style::{self, Fill, RenderData, ViewMode};
+use document_legacy::layers::style::{self, Fill};
 use document_legacy::DocumentResponse;
 use document_legacy::LayerId;
 use document_legacy::Operation as DocumentOperation;
@@ -20,7 +20,7 @@ pub struct ArtboardMessageHandler {
 
 impl MessageHandler<ArtboardMessage, &PersistentData> for ArtboardMessageHandler {
 	#[remain::check]
-	fn process_message(&mut self, message: ArtboardMessage, responses: &mut VecDeque<Message>, persistent_data: &PersistentData) {
+	fn process_message(&mut self, message: ArtboardMessage, responses: &mut VecDeque<Message>, _persistent_data: &PersistentData) {
 		use ArtboardMessage::*;
 
 		#[remain::sorted]

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -201,7 +201,7 @@ impl MessageHandler<DocumentMessage, (u64, &InputPreprocessorMessageHandler, &Pe
 			#[remain::unsorted]
 			PropertiesPanel(message) => {
 				let properties_panel_message_handler_data = PropertiesPanelMessageHandlerData {
-					document_name: &self.name.as_str(),
+					document_name: self.name.as_str(),
 					artwork_document: &self.document_legacy,
 					artboard_document: &self.artboard_message_handler.artboards_document,
 					selected_layers: &mut self.layer_metadata.iter().filter_map(|(path, data)| data.selected.then_some(path.as_slice())),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -2,7 +2,7 @@ pub use self::document_node_types::*;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::prelude::*;
-use crate::node_graph_executor::NodeGraphExecutor;
+use crate::node_graph_executor::{GraphIdentifier, NodeGraphExecutor};
 
 use document_legacy::document::Document;
 use document_legacy::LayerId;
@@ -347,7 +347,8 @@ impl NodeGraphMessageHandler {
 				})
 				.collect();
 
-			let thumbnail_svg = executor.thumbnails.get(&layer_id).and_then(|thumbnails| thumbnails.get(id)).map(|svg| svg.to_string());
+			let graph_identifier = GraphIdentifier::new(layer_id);
+			let thumbnail_svg = executor.thumbnails.get(&graph_identifier).and_then(|thumbnails| thumbnails.get(id)).map(|svg| svg.to_string());
 
 			nodes.push(FrontendNode {
 				id: *id,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -347,10 +347,7 @@ impl NodeGraphMessageHandler {
 				})
 				.collect();
 
-			let thumbnail_svg = layer_id
-				.and_then(|layer_id| executor.thumbnails.get(&layer_id))
-				.and_then(|layer| layer.get(id))
-				.map(|svg| svg.to_string());
+			let thumbnail_svg = executor.thumbnails.get(&layer_id).and_then(|thumbnails| thumbnails.get(id)).map(|svg| svg.to_string());
 
 			nodes.push(FrontendNode {
 				id: *id,

--- a/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/utility_functions.rs
@@ -12,7 +12,7 @@ use crate::messages::prelude::*;
 use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::document::Document;
-use document_legacy::layers::layer_info::{Layer, LayerDataType, LayerDataTypeDiscriminant};
+use document_legacy::layers::layer_info::{Layer, LayerDataType};
 use document_legacy::layers::style::{Fill, Gradient, GradientType, LineCap, LineJoin, RenderData, Stroke, ViewMode};
 use graphene_core::raster::color::Color;
 

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -482,8 +482,8 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 				blob_url,
 				resolution,
 			} => {
-				if let (Some(layer_id), Some(node_id)) = (layer_path.last().copied(), node_id) {
-					self.executor.insert_thumbnail_blob_url(blob_url, layer_id, node_id, responses);
+				if let Some(node_id) = node_id {
+					self.executor.insert_thumbnail_blob_url(blob_url, layer_path.last().copied(), node_id, responses);
 					return;
 				}
 				let message = DocumentMessage::SetImageBlobUrl {

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -29,6 +29,22 @@ use std::rc::Rc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 
+/// Identifies a node graph, either the document graph or a node graph associated with a legacy layer.
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+pub enum GraphIdentifier {
+	DocumentGraph,
+	LayerGraph(LayerId),
+}
+
+impl GraphIdentifier {
+	pub const fn new(layer_id: Option<LayerId>) -> Self {
+		match layer_id {
+			Some(layer_id) => Self::LayerGraph(layer_id),
+			None => Self::DocumentGraph,
+		}
+	}
+}
+
 pub struct NodeRuntime {
 	pub(crate) executor: DynamicExecutor,
 	font_cache: FontCache,
@@ -36,7 +52,7 @@ pub struct NodeRuntime {
 	sender: InternalNodeGraphUpdateSender,
 	wasm_io: Option<WasmApplicationIo>,
 	imaginate_preferences: ImaginatePreferences,
-	pub(crate) thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
+	pub(crate) thumbnails: HashMap<GraphIdentifier, HashMap<NodeId, SvgSegmentList>>,
 	canvas_cache: HashMap<Vec<LayerId>, SurfaceId>,
 }
 
@@ -57,7 +73,7 @@ pub(crate) struct GenerationResponse {
 	generation_id: u64,
 	result: Result<TaggedValue, String>,
 	updates: VecDeque<Message>,
-	new_thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
+	new_thumbnails: HashMap<GraphIdentifier, HashMap<NodeId, SvgSegmentList>>,
 }
 
 enum NodeGraphUpdate {
@@ -209,7 +225,8 @@ impl NodeRuntime {
 			debug!("SVG {}", render.svg);
 
 			if let Some(node_id) = node_path.get(node_path.len() - 2).copied() {
-				let old_thumbnail = self.thumbnails.entry(layer_path.last().copied()).or_default().entry(node_id).or_default();
+				let graph_identifier = GraphIdentifier::new(layer_path.last().copied());
+				let old_thumbnail = self.thumbnails.entry(graph_identifier).or_default().entry(node_id).or_default();
 				if *old_thumbnail != render.svg {
 					*old_thumbnail = render.svg;
 					thumbnails_changed = true;
@@ -263,7 +280,7 @@ pub struct NodeGraphExecutor {
 	receiver: Receiver<NodeGraphUpdate>,
 	// TODO: This is a memory leak since layers are never removed
 	pub(crate) last_output_type: HashMap<Vec<LayerId>, Option<Type>>,
-	pub(crate) thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
+	pub(crate) thumbnails: HashMap<GraphIdentifier, HashMap<NodeId, SvgSegmentList>>,
 	futures: HashMap<u64, ExecutionContext>,
 }
 
@@ -516,7 +533,7 @@ impl NodeGraphExecutor {
 
 	/// When a blob url for a thumbnail is loaded, update the state and the UI.
 	pub fn insert_thumbnail_blob_url(&mut self, blob_url: String, layer_id: Option<LayerId>, node_id: NodeId, responses: &mut VecDeque<Message>) {
-		if let Some(layer) = self.thumbnails.get_mut(&layer_id) {
+		if let Some(layer) = self.thumbnails.get_mut(&GraphIdentifier::new(layer_id)) {
 			if let Some(segment) = layer.values_mut().flat_map(|segments| segments.iter_mut()).find(|segment| **segment == SvgSegment::BlobUrl(node_id)) {
 				*segment = SvgSegment::String(blob_url);
 				responses.add(NodeGraphMessage::SendGraph { should_rerender: false });

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -36,7 +36,7 @@ pub struct NodeRuntime {
 	sender: InternalNodeGraphUpdateSender,
 	wasm_io: Option<WasmApplicationIo>,
 	imaginate_preferences: ImaginatePreferences,
-	pub(crate) thumbnails: HashMap<LayerId, HashMap<NodeId, SvgSegmentList>>,
+	pub(crate) thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
 	canvas_cache: HashMap<Vec<LayerId>, SurfaceId>,
 }
 
@@ -57,7 +57,7 @@ pub(crate) struct GenerationResponse {
 	generation_id: u64,
 	result: Result<TaggedValue, String>,
 	updates: VecDeque<Message>,
-	new_thumbnails: HashMap<LayerId, HashMap<NodeId, SvgSegmentList>>,
+	new_thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
 }
 
 enum NodeGraphUpdate {
@@ -118,7 +118,13 @@ impl NodeRuntime {
 					path,
 					..
 				}) => {
-					let (network, monitor_nodes) = Self::wrap_network(graph);
+					let network = wrap_network_in_scope(graph);
+
+					let monitor_nodes = network
+						.recursive_nodes()
+						.filter(|node| node.implementation == DocumentNodeImplementation::proto("graphene_core::memo::MonitorNode<_>"))
+						.map(|node| node.path.clone().unwrap_or_default())
+						.collect();
 
 					let result = self.execute_network(&path, network, image_frame).await;
 					let mut responses = VecDeque::new();
@@ -133,20 +139,6 @@ impl NodeRuntime {
 				}
 			}
 		}
-	}
-
-	/// Wraps a network in a scope and returns the new network and the paths to the monitor nodes.
-	fn wrap_network(network: NodeNetwork) -> (NodeNetwork, Vec<Vec<NodeId>>) {
-		let scoped_network = wrap_network_in_scope(network);
-
-		//scoped_network.generate_node_paths(&[]);
-		let monitor_nodes = scoped_network
-			.recursive_nodes()
-			.filter(|(node, _, _)| node.implementation == DocumentNodeImplementation::proto("graphene_std::memo::MonitorNode<_>"))
-			.map(|(_, _, path)| path)
-			.collect();
-
-		(scoped_network, monitor_nodes)
 	}
 
 	async fn execute_network<'a>(&'a mut self, path: &[LayerId], scoped_network: NodeNetwork, image_frame: Option<ImageFrame<Color>>) -> Result<TaggedValue, String> {
@@ -216,8 +208,8 @@ impl NodeRuntime {
 			render.format_svg(min, max);
 			debug!("SVG {}", render.svg);
 
-			if let (Some(layer_id), Some(node_id)) = (layer_path.last().copied(), node_path.get(node_path.len() - 2).copied()) {
-				let old_thumbnail = self.thumbnails.entry(layer_id).or_default().entry(node_id).or_default();
+			if let Some(node_id) = node_path.get(node_path.len() - 2).copied() {
+				let old_thumbnail = self.thumbnails.entry(layer_path.last().copied()).or_default().entry(node_id).or_default();
 				if *old_thumbnail != render.svg {
 					*old_thumbnail = render.svg;
 					thumbnails_changed = true;
@@ -271,7 +263,7 @@ pub struct NodeGraphExecutor {
 	receiver: Receiver<NodeGraphUpdate>,
 	// TODO: This is a memory leak since layers are never removed
 	pub(crate) last_output_type: HashMap<Vec<LayerId>, Option<Type>>,
-	pub(crate) thumbnails: HashMap<LayerId, HashMap<NodeId, SvgSegmentList>>,
+	pub(crate) thumbnails: HashMap<Option<LayerId>, HashMap<NodeId, SvgSegmentList>>,
 	futures: HashMap<u64, ExecutionContext>,
 }
 
@@ -456,7 +448,7 @@ impl NodeGraphExecutor {
 		Ok(())
 	}
 
-	fn process_node_graph_output(&mut self, node_graph_output: TaggedValue, layer_path: Vec<LayerId>, transform: DAffine2, responses: &mut VecDeque<Message>, document_id: u64) -> Result<(), String> {
+	fn process_node_graph_output(&mut self, node_graph_output: TaggedValue, layer_path: Vec<LayerId>, _transform: DAffine2, responses: &mut VecDeque<Message>, document_id: u64) -> Result<(), String> {
 		self.last_output_type.insert(layer_path.clone(), Some(node_graph_output.ty()));
 		match node_graph_output {
 			TaggedValue::VectorData(vector_data) => {
@@ -494,7 +486,7 @@ impl NodeGraphExecutor {
 			}
 			TaggedValue::GraphicGroup(graphic_group) => {
 				debug!("{graphic_group:#?}");
-				use graphene_core::renderer::{format_transform_matrix, GraphicElementRendered, RenderParams, SvgRender};
+				use graphene_core::renderer::{GraphicElementRendered, RenderParams, SvgRender};
 
 				// Setup rendering
 				let mut render = SvgRender::new();
@@ -523,7 +515,7 @@ impl NodeGraphExecutor {
 	}
 
 	/// When a blob url for a thumbnail is loaded, update the state and the UI.
-	pub fn insert_thumbnail_blob_url(&mut self, blob_url: String, layer_id: LayerId, node_id: NodeId, responses: &mut VecDeque<Message>) {
+	pub fn insert_thumbnail_blob_url(&mut self, blob_url: String, layer_id: Option<LayerId>, node_id: NodeId, responses: &mut VecDeque<Message>) {
 		if let Some(layer) = self.thumbnails.get_mut(&layer_id) {
 			if let Some(segment) = layer.values_mut().flat_map(|segments| segments.iter_mut()).find(|segment| **segment == SvgSegment::BlobUrl(node_id)) {
 				*segment = SvgSegment::String(blob_url);

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -887,24 +887,24 @@ impl NodeNetwork {
 
 	/// Create a [`RecursiveNodeIter`] that iterates over all [`DocumentNode`]s, including ones that are deeply nested.
 	pub fn recursive_nodes(&self) -> RecursiveNodeIter {
-		let nodes = self.nodes.iter().map(|(id, node)| (node, self, vec![*id])).collect();
+		let nodes = self.nodes.values().collect();
 		RecursiveNodeIter { nodes }
 	}
 }
 
 /// An iterator over all [`DocumentNode`]s, including ones that are deeply nested.
 pub struct RecursiveNodeIter<'a> {
-	nodes: Vec<(&'a DocumentNode, &'a NodeNetwork, Vec<NodeId>)>,
+	nodes: Vec<&'a DocumentNode>,
 }
 
 impl<'a> Iterator for RecursiveNodeIter<'a> {
-	type Item = (&'a DocumentNode, &'a NodeNetwork, Vec<NodeId>);
+	type Item = &'a DocumentNode;
 	fn next(&mut self) -> Option<Self::Item> {
-		let (node, network, path) = self.nodes.pop()?;
+		let node = self.nodes.pop()?;
 		if let DocumentNodeImplementation::Network(network) = &node.implementation {
-			self.nodes.extend(network.nodes.iter().map(|(id, node)| (node, network, [path.as_slice(), &[*id]].concat())));
+			self.nodes.extend(network.nodes.values());
 		}
-		Some((node, network, path))
+		Some(node)
 	}
 }
 


### PR DESCRIPTION
The layer nodes now have thumbnails again. These were broken because the string identifer pointed to "graphene_std" instead of "graphene_core", the document id paths are different, and because the nodes are now not part of a layer.