### PR TITLE
Fix BrushCache serailization

### DIFF
--- a/node-graph/gcore/src/raster/brush_cache.rs
+++ b/node-graph/gcore/src/raster/brush_cache.rs
@@ -23,7 +23,7 @@ struct BrushCacheImpl {
 	last_stroke_texture: ImageFrame<Color>,
 
 	// A cache for brush textures.
-	#[serde(skip)]
+	#[cfg_attr(feature = "serde", serde(skip))]
 	brush_texture_cache: HashMap<BrushStyle, Image<Color>>,
 }
 
@@ -99,6 +99,7 @@ pub struct BrushPlan {
 	pub first_stroke_point_skip: usize,
 }
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, DynAny, Default)]
 pub struct BrushCache {
 	inner: Arc<Mutex<BrushCacheImpl>>,

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -55,7 +55,6 @@ pub enum TaggedValue {
 	ManipulatorGroupIds(Vec<graphene_core::uuid::ManipulatorGroupId>),
 	Font(graphene_core::text::Font),
 	BrushStrokes(Vec<graphene_core::vector::brush_stroke::BrushStroke>),
-	#[cfg_attr(feature = "serde", serde(skip))]
 	BrushCache(BrushCache),
 	Segments(Vec<graphene_core::raster::ImageFrame<Color>>),
 	DocumentNode(DocumentNode),
@@ -294,7 +293,7 @@ impl<'a> TaggedValue {
 			x if x == TypeId::of::<Vec<graphene_core::uuid::ManipulatorGroupId>>() => Ok(TaggedValue::ManipulatorGroupIds(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::text::Font>() => Ok(TaggedValue::Font(*downcast(input).unwrap())),
 			x if x == TypeId::of::<Vec<graphene_core::vector::brush_stroke::BrushStroke>>() => Ok(TaggedValue::BrushStrokes(*downcast(input).unwrap())),
-			x if x == TypeId::of::<Vec<BrushCache>>() => Ok(TaggedValue::BrushCache(*downcast(input).unwrap())),
+			x if x == TypeId::of::<BrushCache>() => Ok(TaggedValue::BrushCache(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::raster::IndexNode<Vec<graphene_core::raster::ImageFrame<Color>>>>() => Ok(TaggedValue::Segments(*downcast(input).unwrap())),
 			x if x == TypeId::of::<crate::document::DocumentNode>() => Ok(TaggedValue::DocumentNode(*downcast(input).unwrap())),
 			x if x == TypeId::of::<graphene_core::GraphicGroup>() => Ok(TaggedValue::GraphicGroup(*downcast(input).unwrap())),


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Fixes error that happens when you try to try to save a document containing a brush stroke.
