### PR TITLE
Correct Snapping Offsets After Canvas Transformation When Using Snap-Reliant Tools

### DIFF
--- a/editor/src/messages/broadcast/broadcast_event.rs
+++ b/editor/src/messages/broadcast/broadcast_event.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[impl_message(Message, BroadcastMessage, TriggerEvent)]
 pub enum BroadcastEvent {
 	DocumentIsDirty,
+	CanvasTransformed,
 	ToolAbort,
 	SelectionChanged,
 	WorkingColorChanged,

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -212,6 +212,7 @@ impl MessageHandler<NavigationMessage, (&Document, Option<[DVec2; 2]>, &InputPre
 				self.tilt = self.snapped_angle();
 				self.zoom = self.snapped_scale();
 				responses.add(BroadcastEvent::DocumentIsDirty);
+				responses.add(BroadcastEvent::CanvasTransformed);
 				responses.add(ToolMessage::UpdateCursor);
 				responses.add(ToolMessage::UpdateHints);
 				self.snap_tilt = false;

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -211,8 +211,8 @@ impl MessageHandler<NavigationMessage, (&Document, Option<[DVec2; 2]>, &InputPre
 			TransformCanvasEnd => {
 				self.tilt = self.snapped_angle();
 				self.zoom = self.snapped_scale();
-				responses.add(BroadcastEvent::DocumentIsDirty);
 				responses.add(BroadcastEvent::CanvasTransformed);
+				responses.add(BroadcastEvent::DocumentIsDirty);
 				responses.add(ToolMessage::UpdateCursor);
 				responses.add(ToolMessage::UpdateHints);
 				self.snap_tilt = false;
@@ -226,6 +226,7 @@ impl MessageHandler<NavigationMessage, (&Document, Option<[DVec2; 2]>, &InputPre
 				let transformed_delta = document.root.transform.inverse().transform_vector2(delta);
 
 				self.pan += transformed_delta;
+				responses.add(BroadcastEvent::CanvasTransformed);
 				responses.add(BroadcastEvent::DocumentIsDirty);
 				self.create_document_transform(&ipp.viewport_bounds, responses);
 			}

--- a/editor/src/messages/tool/common_functionality/resize.rs
+++ b/editor/src/messages/tool/common_functionality/resize.rs
@@ -24,6 +24,11 @@ impl Resize {
 		self.drag_start = root_transform.inverse().transform_point2(self.snap_manager.snap_position(responses, document, input.mouse.position));
 	}
 
+	pub fn recalculate_snaps(&mut self, responses: &mut VecDeque<Message>, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, render_data: &RenderData) {
+		self.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
+		self.snap_manager.add_all_document_handles(document, input, &[], &[], &[]);
+	}
+
 	/// Calculate the drag start position in viewport space.
 	pub fn viewport_drag_start(&self, document: &DocumentMessageHandler) -> DVec2 {
 		let root_transform = document.document_legacy.root.transform;

--- a/editor/src/messages/tool/common_functionality/resize.rs
+++ b/editor/src/messages/tool/common_functionality/resize.rs
@@ -24,7 +24,8 @@ impl Resize {
 		self.drag_start = root_transform.inverse().transform_point2(self.snap_manager.snap_position(responses, document, input.mouse.position));
 	}
 
-	pub fn recalculate_snaps(&mut self, responses: &mut VecDeque<Message>, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, render_data: &RenderData) {
+	/// Recalculates snap targets without snapping the starting position.
+	pub fn recalculate_snaps(&mut self, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, render_data: &RenderData) {
 		self.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
 		self.snap_manager.add_all_document_handles(document, input, &[], &[], &[]);
 	}

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -213,7 +213,7 @@ impl Fsm for EllipseToolFsmState {
 		if let ToolMessage::Ellipse(event) = event {
 			match (self, event) {
 				(Drawing, CanvasTransformed) => {
-					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					tool_data.data.recalculate_snaps(document, input, render_data);
 					self
 				}
 				(Ready, DragStart) => {

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -54,6 +54,8 @@ pub enum EllipseOptionsUpdate {
 pub enum EllipseToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	CanvasTransformed,
+	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
 	WorkingColorChanged,
@@ -165,6 +167,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for Ellipse
 impl ToolTransition for EllipseTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: Some(EllipseToolMessage::CanvasTransformed.into()),
 			tool_abort: Some(EllipseToolMessage::Abort.into()),
 			working_color_changed: Some(EllipseToolMessage::WorkingColorChanged.into()),
 			..Default::default()
@@ -209,6 +212,10 @@ impl Fsm for EllipseToolFsmState {
 
 		if let ToolMessage::Ellipse(event) = event {
 			match (self, event) {
+				(Drawing, CanvasTransformed) => {
+					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					self
+				}
 				(Ready, DragStart) => {
 					shape_data.start(responses, document, input, render_data);
 					responses.add(DocumentMessage::StartTransaction);

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -44,6 +44,10 @@ impl Default for LineOptions {
 pub enum LineToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	DocumentIsDirty,
+	#[remain::unsorted]
+	CanvasTransformed,
+	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
 	WorkingColorChanged,
@@ -140,6 +144,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for LineToo
 impl ToolTransition for LineTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: None,
 			tool_abort: Some(LineToolMessage::Abort.into()),
 			working_color_changed: Some(LineToolMessage::WorkingColorChanged.into()),
 			..Default::default()

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -163,13 +163,10 @@ enum LineToolFsmState {
 struct LineToolData {
 	drag_start: ViewportPosition,
 	drag_current: ViewportPosition,
-	drag_start_viewport: ViewportPosition,
-	drag_current_viewport: ViewportPosition,
 	angle: f64,
 	weight: f64,
 	path: Option<Vec<LayerId>>,
 	snap_manager: SnapManager,
-	canvas_has_transformed: bool,
 }
 
 impl Fsm for LineToolFsmState {
@@ -195,24 +192,10 @@ impl Fsm for LineToolFsmState {
 
 		if let ToolMessage::Line(event) = event {
 			match (self, event) {
-				(_, CanvasTransformed) => {
-					warn!("canvas transform");
-					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
-
-					// tool_data.drag_start = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					// tool_data.drag_start = document.document_legacy.root.transform.transform_point2(tool_data.drag_start);
-
-					// tool_data.drag_current_viewport = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					// tool_data.drag_current = document.document_legacy.root.transform.transform_point2(input.mouse.position);
-
-					tool_data.canvas_has_transformed = true;
-					self
-				}
 				(Ready, DragStart) => {
 					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
 					tool_data.snap_manager.add_all_document_handles(document, input, &[], &[], &[]);
-					tool_data.drag_start_viewport = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					tool_data.drag_start = document.document_legacy.root.transform.transform_point2(input.mouse.position);
+					tool_data.drag_start = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
 
 					let subpath = bezier_rs::Subpath::new_line(DVec2::ZERO, DVec2::X);
 
@@ -230,19 +213,10 @@ impl Fsm for LineToolFsmState {
 					Drawing
 				}
 				(Drawing, Redraw { center, snap_angle, lock_angle }) => {
-					warn!("redraw");
-
-					// if tool_data.canvas_has_transformed {
-					// 	let keyboard = &input.keyboard;
-					// 	responses.add(generate_transform(document, tool_data, keyboard.key(lock_angle), keyboard.key(snap_angle), keyboard.key(center)));
-					// 	return Drawing;
-					// }
-
-					tool_data.drag_current_viewport = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
-					tool_data.drag_current = document.document_legacy.root.transform.transform_point2(input.mouse.position);
+					tool_data.drag_current = tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
 
 					let keyboard = &input.keyboard;
-					responses.add(generate_transform(document, tool_data, keyboard.key(lock_angle), keyboard.key(snap_angle), keyboard.key(center)));
+					responses.add(generate_transform(tool_data, keyboard.key(lock_angle), keyboard.key(snap_angle), keyboard.key(center)));
 
 					Drawing
 				}
@@ -250,17 +224,12 @@ impl Fsm for LineToolFsmState {
 					tool_data.snap_manager.cleanup(responses);
 					input.mouse.finish_transaction(tool_data.drag_start, responses);
 					tool_data.path = None;
-
-					tool_data.canvas_has_transformed = false;
-					warn!("drag stop");
 					Ready
 				}
 				(Drawing, Abort) => {
 					tool_data.snap_manager.cleanup(responses);
 					responses.add(DocumentMessage::AbortTransaction);
 					tool_data.path = None;
-					tool_data.canvas_has_transformed = false;
-					warn!("abort");
 					Ready
 				}
 				(_, WorkingColorChanged) => {
@@ -300,9 +269,9 @@ impl Fsm for LineToolFsmState {
 	}
 }
 
-fn generate_transform(document: &mut &DocumentMessageHandler, tool_data: &mut LineToolData, lock_angle: bool, snap_angle: bool, center: bool) -> Message {
+fn generate_transform(tool_data: &mut LineToolData, lock_angle: bool, snap_angle: bool, center: bool) -> Message {
 	let mut start = tool_data.drag_start;
-	let mut line_vector = tool_data.drag_current - start;
+	let line_vector = tool_data.drag_current - start;
 
 	let mut angle = -line_vector.angle_between(DVec2::X);
 
@@ -332,7 +301,7 @@ fn generate_transform(document: &mut &DocumentMessageHandler, tool_data: &mut Li
 	GraphOperationMessage::TransformSet {
 		layer: tool_data.path.clone().unwrap(),
 		transform: glam::DAffine2::from_scale_angle_translation(DVec2::new(line_length, 1.), angle, start),
-		transform_in: TransformIn::Local,
+		transform_in: TransformIn::Viewport,
 		skip_rerender: false,
 	}
 	.into()

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -52,6 +52,8 @@ impl Default for PenOptions {
 pub enum PenToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	CanvasTransformed,
+	#[remain::unsorted]
 	DocumentIsDirty,
 	#[remain::unsorted]
 	Abort,
@@ -193,6 +195,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for PenTool
 impl ToolTransition for PenTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: Some(PenToolMessage::CanvasTransformed.into()),
 			document_dirty: Some(PenToolMessage::DocumentIsDirty.into()),
 			tool_abort: Some(PenToolMessage::Abort.into()),
 			selection_changed: Some(PenToolMessage::SelectionChanged.into()),
@@ -589,9 +592,11 @@ impl Fsm for PenToolFsmState {
 
 		if let ToolMessage::Pen(event) = event {
 			match (self, event) {
-				(_, PenToolMessage::DocumentIsDirty) => {
+				(_, PenToolMessage::CanvasTransformed) => {
 					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
-
+					self
+				}
+				(_, PenToolMessage::DocumentIsDirty) => {
 					// When the document has moved / needs to be redraw, re-render the overlays
 					// TODO the overlay system should probably receive this message instead of the tool
 					for layer_path in document.selected_visible_layers() {

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -590,6 +590,8 @@ impl Fsm for PenToolFsmState {
 		if let ToolMessage::Pen(event) = event {
 			match (self, event) {
 				(_, PenToolMessage::DocumentIsDirty) => {
+					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
+
 					// When the document has moved / needs to be redraw, re-render the overlays
 					// TODO the overlay system should probably receive this message instead of the tool
 					for layer_path in document.selected_visible_layers() {

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -253,7 +253,7 @@ impl Fsm for PolygonToolFsmState {
 		if let ToolMessage::Polygon(event) = event {
 			match (self, event) {
 				(Drawing, CanvasTransformed) => {
-					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					tool_data.data.recalculate_snaps(document, input, render_data);
 					self
 				}
 				(Ready, DragStart) => {

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -47,6 +47,8 @@ impl Default for PolygonOptions {
 pub enum PolygonToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	CanvasTransformed,
+	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
 	WorkingColorChanged,
@@ -205,6 +207,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for Polygon
 impl ToolTransition for PolygonTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: Some(PolygonToolMessage::CanvasTransformed.into()),
 			tool_abort: Some(PolygonToolMessage::Abort.into()),
 			working_color_changed: Some(PolygonToolMessage::WorkingColorChanged.into()),
 			..Default::default()
@@ -249,6 +252,10 @@ impl Fsm for PolygonToolFsmState {
 
 		if let ToolMessage::Polygon(event) = event {
 			match (self, event) {
+				(Drawing, CanvasTransformed) => {
+					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					self
+				}
 				(Ready, DragStart) => {
 					polygon_data.start(responses, document, input, render_data);
 					responses.add(DocumentMessage::StartTransaction);

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -53,6 +53,8 @@ pub enum RectangleOptionsUpdate {
 pub enum RectangleToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	CanvasTransformed,
+	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
 	WorkingColorChanged,
@@ -164,6 +166,7 @@ impl ToolMetadata for RectangleTool {
 impl ToolTransition for RectangleTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: Some(RectangleToolMessage::CanvasTransformed.into()),
 			tool_abort: Some(RectangleToolMessage::Abort.into()),
 			working_color_changed: Some(RectangleToolMessage::WorkingColorChanged.into()),
 			..Default::default()
@@ -208,6 +211,10 @@ impl Fsm for RectangleToolFsmState {
 
 		if let ToolMessage::Rectangle(event) = event {
 			match (self, event) {
+				(Drawing, CanvasTransformed) => {
+					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					self
+				}
 				(Ready, DragStart) => {
 					shape_data.start(responses, document, input, render_data);
 

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -212,7 +212,7 @@ impl Fsm for RectangleToolFsmState {
 		if let ToolMessage::Rectangle(event) = event {
 			match (self, event) {
 				(Drawing, CanvasTransformed) => {
-					tool_data.data.recalculate_snaps(responses, document, input, render_data);
+					tool_data.data.recalculate_snaps(document, input, render_data);
 					self
 				}
 				(Ready, DragStart) => {

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -45,7 +45,7 @@ impl Default for SplineOptions {
 pub enum SplineToolMessage {
 	// Standard messages
 	#[remain::unsorted]
-	DocumentIsDirty,
+	CanvasTransformed,
 	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
@@ -180,7 +180,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for SplineT
 impl ToolTransition for SplineTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
-			document_dirty: Some(SplineToolMessage::DocumentIsDirty.into()),
+			canvas_transformed: Some(SplineToolMessage::CanvasTransformed.into()),
 			tool_abort: Some(SplineToolMessage::Abort.into()),
 			working_color_changed: Some(SplineToolMessage::WorkingColorChanged.into()),
 			..Default::default()
@@ -222,7 +222,7 @@ impl Fsm for SplineToolFsmState {
 
 		if let ToolMessage::Spline(event) = event {
 			match (self, event) {
-				(_, DocumentIsDirty) => {
+				(_, CanvasTransformed) => {
 					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
 					self
 				}

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -45,6 +45,8 @@ impl Default for SplineOptions {
 pub enum SplineToolMessage {
 	// Standard messages
 	#[remain::unsorted]
+	DocumentIsDirty,
+	#[remain::unsorted]
 	Abort,
 	#[remain::unsorted]
 	WorkingColorChanged,
@@ -178,6 +180,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for SplineT
 impl ToolTransition for SplineTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			document_dirty: Some(SplineToolMessage::DocumentIsDirty.into()),
 			tool_abort: Some(SplineToolMessage::Abort.into()),
 			working_color_changed: Some(SplineToolMessage::WorkingColorChanged.into()),
 			..Default::default()
@@ -219,6 +222,10 @@ impl Fsm for SplineToolFsmState {
 
 		if let ToolMessage::Spline(event) = event {
 			match (self, event) {
+				(_, DocumentIsDirty) => {
+					tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(None, None, render_data), true, true);
+					self
+				}
 				(Ready, DragStart) => {
 					responses.add(DocumentMessage::StartTransaction);
 					responses.add(DocumentMessage::DeselectAllLayers);

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -200,6 +200,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for TextToo
 impl ToolTransition for TextTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
 		EventToMessageMap {
+			canvas_transformed: None,
 			document_dirty: Some(TextToolMessage::DocumentIsDirty.into()),
 			tool_abort: Some(TextToolMessage::Abort.into()),
 			selection_changed: Some(TextToolMessage::DocumentIsDirty.into()),

--- a/editor/src/messages/tool/utility_types.rs
+++ b/editor/src/messages/tool/utility_types.rs
@@ -169,6 +169,7 @@ impl DocumentToolData {
 
 #[derive(Clone, Debug, Default)]
 pub struct EventToMessageMap {
+	pub canvas_transformed: Option<ToolMessage>,
 	pub document_dirty: Option<ToolMessage>,
 	pub selection_changed: Option<ToolMessage>,
 	pub tool_abort: Option<ToolMessage>,
@@ -189,6 +190,7 @@ pub trait ToolTransition {
 		};
 
 		let event_to_tool_map = self.event_to_message_map();
+		subscribe_message(event_to_tool_map.canvas_transformed, BroadcastEvent::CanvasTransformed);
 		subscribe_message(event_to_tool_map.document_dirty, BroadcastEvent::DocumentIsDirty);
 		subscribe_message(event_to_tool_map.tool_abort, BroadcastEvent::ToolAbort);
 		subscribe_message(event_to_tool_map.selection_changed, BroadcastEvent::SelectionChanged);
@@ -206,6 +208,7 @@ pub trait ToolTransition {
 		};
 
 		let event_to_tool_map = self.event_to_message_map();
+		unsubscribe_message(event_to_tool_map.canvas_transformed, BroadcastEvent::CanvasTransformed);
 		unsubscribe_message(event_to_tool_map.document_dirty, BroadcastEvent::DocumentIsDirty);
 		unsubscribe_message(event_to_tool_map.tool_abort, BroadcastEvent::ToolAbort);
 		unsubscribe_message(event_to_tool_map.selection_changed, BroadcastEvent::SelectionChanged);


### PR DESCRIPTION
This PR aims to fix the current state of tools using snapping, where they currently use old snapping offsets even when the canvas has transformed through panning. 