### PR TITLE
Fix undo not immediately removing copy/pasted layer

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -393,16 +393,16 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 						for entry in data.iter().rev() {
 							let destination_path = [shallowest_common_folder.to_vec(), vec![generate_uuid()]].concat();
 
-							responses.add_front(DocumentMessage::UpdateLayerMetadata {
-								layer_path: destination_path.clone(),
-								layer_metadata: entry.layer_metadata,
-							});
 							document.load_layer_resources(responses, &entry.layer.data, destination_path.clone(), self.active_document_id.unwrap());
-							responses.add_front(DocumentOperation::InsertLayer {
+							responses.add(DocumentOperation::InsertLayer {
 								layer: Box::new(entry.layer.clone()),
-								destination_path,
+								destination_path: destination_path.clone(),
 								insert_index: -1,
 								duplicating: false,
+							});
+							responses.add(DocumentMessage::UpdateLayerMetadata {
+								layer_path: destination_path,
+								layer_metadata: entry.layer_metadata,
 							});
 						}
 


### PR DESCRIPTION
This should fix the following item in the approachable starters (#989):


> Undo does not work when copy/pasting layers (or groups), it should remove the layer that was pasted. [(As posted in Discord)](https://discord.com/channels/731730685944922173/881073965047636018/1080691819593076847)

The problem was the ordering of the responses vector. I don't quite understand what the rational was to use `add_front` for `DocumentOperation::InsertLayer`. 