### PR TITLE
Fix github CI branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
     steps:
       - name: 📥 Clone and checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Check git branch
-        run: git branch && git checkout ${{ github.ref_name }} && git branch
 
       - name: 🗑 Clear wasm-bindgen cache
         run: rm -r ~/.cache/.wasm-pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Check git branch
+        run: git branch && git checkout ${{ github.ref_name }} && git branch
+
       - name: 🗑 Clear wasm-bindgen cache
         run: rm -r ~/.cache/.wasm-pack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: 📥 Clone and checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: 🗑 Clear wasm-bindgen cache
         run: rm -r ~/.cache/.wasm-pack

--- a/editor/build.rs
+++ b/editor/build.rs
@@ -17,6 +17,6 @@ fn main() {
 	// They are accessed with the `env!("...")` macro in the codebase.
 	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_DATE={}", git_command(&["log", "-1", "--format=%cd"]));
 	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_HASH={}", git_command(&["rev-parse", "HEAD"]));
-	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_BRANCH={}", git_command(&["rev-parse", "--abbrev-ref", "HEAD"]));
+	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_BRANCH={}", git_command(&["name-rev", "--name-only", "HEAD"]));
 	println!("cargo:rustc-env=GRAPHITE_RELEASE_SERIES={}", GRAPHITE_RELEASE_SERIES);
 }

--- a/editor/build.rs
+++ b/editor/build.rs
@@ -17,6 +17,9 @@ fn main() {
 	// They are accessed with the `env!("...")` macro in the codebase.
 	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_DATE={}", git_command(&["log", "-1", "--format=%cd"]));
 	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_HASH={}", git_command(&["rev-parse", "HEAD"]));
-	println!("cargo:rustc-env=GRAPHITE_GIT_COMMIT_BRANCH={}", git_command(&["name-rev", "--name-only", "HEAD"]));
+	println!(
+		"cargo:rustc-env=GRAPHITE_GIT_COMMIT_BRANCH={}",
+		std::env::var("GITHUB_HEAD_REF").unwrap_or_else(|_| git_command(&["name-rev", "--name-only", "HEAD"]))
+	);
 	println!("cargo:rustc-env=GRAPHITE_RELEASE_SERIES={}", GRAPHITE_RELEASE_SERIES);
 }


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1384

The issue was that for PRs in github actions - running `git name-rev --name-only HEAD` gave `refs/pull/<pr_number>/merge` instead of the actual branch name. For PRs, the `GITHUB_HEAD_REF` environment variable is available giving the actual branch name.