### PR TITLE
Add support for handling MMB/RMB double click inputs

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -1,6 +1,7 @@
 use crate::consts::{BIG_NUDGE_AMOUNT, BRUSH_SIZE_CHANGE_KEYBOARD, NUDGE_AMOUNT};
 use crate::messages::input_mapper::key_mapping::MappingVariant;
 use crate::messages::input_mapper::utility_types::input_keyboard::{Key, KeyStates};
+use crate::messages::input_mapper::utility_types::input_mouse::MouseButton;
 use crate::messages::input_mapper::utility_types::macros::*;
 use crate::messages::input_mapper::utility_types::misc::MappingEntry;
 use crate::messages::input_mapper::utility_types::misc::{KeyMappingEntries, Mapping};
@@ -64,7 +65,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, select_deepest: Accel }),
 		entry!(KeyUp(Lmb); action_dispatch=SelectToolMessage::DragStop { remove_from_selection: Shift }),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::Enter),
-		entry!(DoubleClick(Lmb); action_dispatch=SelectToolMessage::EditLayer),
+		entry!(DoubleClick(MouseButton::Left); action_dispatch=SelectToolMessage::EditLayer),
 		entry!(KeyDown(Rmb); action_dispatch=SelectToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=SelectToolMessage::Abort),
 		//
@@ -127,7 +128,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=GradientToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
 		entry!(KeyUp(Lmb); action_dispatch=GradientToolMessage::PointerUp),
-		entry!(DoubleClick(Lmb); action_dispatch=GradientToolMessage::InsertStop),
+		entry!(DoubleClick(MouseButton::Left); action_dispatch=GradientToolMessage::InsertStop),
 		entry!(KeyDown(Delete); action_dispatch=GradientToolMessage::DeleteStop),
 		entry!(KeyDown(Backspace); action_dispatch=GradientToolMessage::DeleteStop),
 		//
@@ -182,7 +183,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Enter); action_dispatch=PathToolMessage::Enter {
 			add_to_selection: Shift
 		}),
-		entry!(DoubleClick(Lmb); action_dispatch=PathToolMessage::InsertPoint),
+		entry!(DoubleClick(MouseButton::Left); action_dispatch=PathToolMessage::InsertPoint),
 		entry!(KeyDown(ArrowRight); action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: NUDGE_AMOUNT, delta_y: 0. }),
 		entry!(KeyDown(ArrowRight); modifiers=[Shift], action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: BIG_NUDGE_AMOUNT, delta_y: 0. }),
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowUp], action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: NUDGE_AMOUNT, delta_y: -NUDGE_AMOUNT }),
@@ -371,10 +372,13 @@ pub fn default_mapping() -> Mapping {
 	}
 
 	let sort = |list: &mut KeyMappingEntries| list.0.sort_by(|u, v| v.modifiers.ones().cmp(&u.modifiers.ones()));
-	for list in [&mut key_up, &mut key_down, &mut key_up_no_repeat, &mut key_down_no_repeat, &mut double_click] {
+	for list in [&mut key_up, &mut key_down, &mut key_up_no_repeat, &mut key_down_no_repeat] {
 		for sublist in list {
 			sort(sublist);
 		}
+	}
+	for sublist in &mut double_click {
+		sort(sublist)
 	}
 	sort(&mut wheel_scroll);
 	sort(&mut pointer_move);

--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -64,7 +64,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, select_deepest: Accel }),
 		entry!(KeyUp(Lmb); action_dispatch=SelectToolMessage::DragStop { remove_from_selection: Shift }),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::Enter),
-		entry!(DoubleClick; action_dispatch=SelectToolMessage::EditLayer),
+		entry!(DoubleClick(Lmb); action_dispatch=SelectToolMessage::EditLayer),
 		entry!(KeyDown(Rmb); action_dispatch=SelectToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=SelectToolMessage::Abort),
 		//
@@ -127,7 +127,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=GradientToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
 		entry!(KeyUp(Lmb); action_dispatch=GradientToolMessage::PointerUp),
-		entry!(DoubleClick; action_dispatch=GradientToolMessage::InsertStop),
+		entry!(DoubleClick(Lmb); action_dispatch=GradientToolMessage::InsertStop),
 		entry!(KeyDown(Delete); action_dispatch=GradientToolMessage::DeleteStop),
 		entry!(KeyDown(Backspace); action_dispatch=GradientToolMessage::DeleteStop),
 		//
@@ -182,7 +182,7 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Enter); action_dispatch=PathToolMessage::Enter {
 			add_to_selection: Shift
 		}),
-		entry!(DoubleClick; action_dispatch=PathToolMessage::InsertPoint),
+		entry!(DoubleClick(Lmb); action_dispatch=PathToolMessage::InsertPoint),
 		entry!(KeyDown(ArrowRight); action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: NUDGE_AMOUNT, delta_y: 0. }),
 		entry!(KeyDown(ArrowRight); modifiers=[Shift], action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: BIG_NUDGE_AMOUNT, delta_y: 0. }),
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowUp], action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: NUDGE_AMOUNT, delta_y: -NUDGE_AMOUNT }),
@@ -371,12 +371,11 @@ pub fn default_mapping() -> Mapping {
 	}
 
 	let sort = |list: &mut KeyMappingEntries| list.0.sort_by(|u, v| v.modifiers.ones().cmp(&u.modifiers.ones()));
-	for list in [&mut key_up, &mut key_down, &mut key_up_no_repeat, &mut key_down_no_repeat] {
+	for list in [&mut key_up, &mut key_down, &mut key_up_no_repeat, &mut key_down_no_repeat, &mut double_click] {
 		for sublist in list {
 			sort(sublist);
 		}
 	}
-	sort(&mut double_click);
 	sort(&mut wheel_scroll);
 	sort(&mut pointer_move);
 

--- a/editor/src/messages/input_mapper/input_mapper_message.rs
+++ b/editor/src/messages/input_mapper/input_mapper_message.rs
@@ -20,9 +20,15 @@ pub enum InputMapperMessage {
 	#[remain::unsorted]
 	#[child]
 	KeyUpNoRepeat(Key),
+	/// The only valid [Key]s for `DoubleClick` are:
+	/// - [Key::Lmb]
+	/// - [Key::Rmb]
+	/// - [Key::Mmb]
+	#[remain::unsorted]
+	#[child]
+	DoubleClick(Key),
 
 	// Messages
-	DoubleClick,
 	PointerMove,
 	WheelScroll,
 }

--- a/editor/src/messages/input_mapper/input_mapper_message.rs
+++ b/editor/src/messages/input_mapper/input_mapper_message.rs
@@ -1,4 +1,4 @@
-use crate::messages::input_mapper::utility_types::input_keyboard::Key;
+use crate::messages::input_mapper::utility_types::{input_keyboard::Key, input_mouse::MouseButton};
 use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
@@ -20,14 +20,9 @@ pub enum InputMapperMessage {
 	#[remain::unsorted]
 	#[child]
 	KeyUpNoRepeat(Key),
-	/// The only valid [Key]s for `DoubleClick` are:
-	/// - [Key::Lmb]
-	/// - [Key::Rmb]
-	/// - [Key::Mmb]
-	// TODO: Change this from `Key` to `MouseKeys` so the aforementioned valid keys can be enforced
 	#[remain::unsorted]
 	#[child]
-	DoubleClick(Key),
+	DoubleClick(MouseButton),
 
 	// Messages
 	PointerMove,

--- a/editor/src/messages/input_mapper/input_mapper_message.rs
+++ b/editor/src/messages/input_mapper/input_mapper_message.rs
@@ -24,6 +24,7 @@ pub enum InputMapperMessage {
 	/// - [Key::Lmb]
 	/// - [Key::Rmb]
 	/// - [Key::Mmb]
+	// TODO: Change this from `Key` to `MouseKeys` so the aforementioned valid keys can be enforced
 	#[remain::unsorted]
 	#[child]
 	DoubleClick(Key),

--- a/editor/src/messages/input_mapper/input_mapper_message_handler.rs
+++ b/editor/src/messages/input_mapper/input_mapper_message_handler.rs
@@ -51,7 +51,7 @@ impl InputMapperMessageHandler {
 			.chain(self.mapping.key_down.iter())
 			.chain(self.mapping.key_up_no_repeat.iter())
 			.chain(self.mapping.key_down_no_repeat.iter())
-			.chain(std::iter::once(&self.mapping.double_click))
+			.chain(self.mapping.double_click.iter())
 			.chain(std::iter::once(&self.mapping.wheel_scroll))
 			.chain(std::iter::once(&self.mapping.pointer_move));
 		let all_mapping_entries = all_key_mapping_entries.flat_map(|entry| entry.0.iter());

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -1,4 +1,3 @@
-use super::input_keyboard::Key;
 use crate::consts::DRAG_THRESHOLD;
 use crate::messages::prelude::*;
 
@@ -148,22 +147,13 @@ bitflags! {
 	}
 }
 
-impl MouseKeys {
-	pub fn from_key(key: &Key) -> Self {
-		match key {
-			Key::Lmb => Self::LEFT,
-			Key::Rmb => Self::RIGHT,
-			Key::Mmb => Self::MIDDLE,
-			_ => unreachable!(),
-		}
-	}
-
-	pub fn to_key(&self) -> Key {
-		match self {
-			&Self::LEFT => Key::Lmb,
-			&Self::RIGHT => Key::Rmb,
-			&Self::MIDDLE => Key::Mmb,
-			_ => unreachable!(),
-		}
-	}
+#[impl_message(Message, InputMapperMessage, DoubleClick)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize, specta::Type, num_enum::TryFromPrimitive)]
+#[repr(u8)]
+pub enum MouseButton {
+	Left,
+	Right,
+	Middle,
 }
+
+pub const NUMBER_OF_MOUSE_BUTTONS: usize = 3;

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -1,3 +1,4 @@
+use super::input_keyboard::Key;
 use crate::consts::DRAG_THRESHOLD;
 use crate::messages::prelude::*;
 
@@ -144,5 +145,25 @@ bitflags! {
 		const LEFT   = 0b0000_0001;
 		const RIGHT  = 0b0000_0010;
 		const MIDDLE = 0b0000_0100;
+	}
+}
+
+impl MouseKeys {
+	pub fn from_key(key: &Key) -> Self {
+		match key {
+			Key::Lmb => Self::LEFT,
+			Key::Rmb => Self::RIGHT,
+			Key::Mmb => Self::MIDDLE,
+			_ => unreachable!(),
+		}
+	}
+
+	pub fn to_key(&self) -> Key {
+		match self {
+			&Self::LEFT => Key::Lmb,
+			&Self::RIGHT => Key::Rmb,
+			&Self::MIDDLE => Key::Mmb,
+			_ => unreachable!(),
+		}
 	}
 }

--- a/editor/src/messages/input_mapper/utility_types/macros.rs
+++ b/editor/src/messages/input_mapper/utility_types/macros.rs
@@ -77,7 +77,7 @@ macro_rules! mapping {
 		let mut key_down = KeyMappingEntries::key_array();
 		let mut key_up_no_repeat = KeyMappingEntries::key_array();
 		let mut key_down_no_repeat = KeyMappingEntries::key_array();
-		let mut double_click = KeyMappingEntries::key_array();
+		let mut double_click = KeyMappingEntries::mouse_buttons_arrays();
 		let mut wheel_scroll = KeyMappingEntries::new();
 		let mut pointer_move = KeyMappingEntries::new();
 

--- a/editor/src/messages/input_mapper/utility_types/macros.rs
+++ b/editor/src/messages/input_mapper/utility_types/macros.rs
@@ -77,7 +77,7 @@ macro_rules! mapping {
 		let mut key_down = KeyMappingEntries::key_array();
 		let mut key_up_no_repeat = KeyMappingEntries::key_array();
 		let mut key_down_no_repeat = KeyMappingEntries::key_array();
-		let mut double_click = KeyMappingEntries::new();
+		let mut double_click = KeyMappingEntries::key_array();
 		let mut wheel_scroll = KeyMappingEntries::new();
 		let mut pointer_move = KeyMappingEntries::new();
 
@@ -91,7 +91,7 @@ macro_rules! mapping {
 					InputMapperMessage::KeyUp(key) => &mut key_up[key as usize],
 					InputMapperMessage::KeyDownNoRepeat(key) => &mut key_down_no_repeat[key as usize],
 					InputMapperMessage::KeyUpNoRepeat(key) => &mut key_up_no_repeat[key as usize],
-					InputMapperMessage::DoubleClick => &mut double_click,
+					InputMapperMessage::DoubleClick(key) => &mut double_click[key as usize],
 					InputMapperMessage::WheelScroll => &mut wheel_scroll,
 					InputMapperMessage::PointerMove => &mut pointer_move,
 				};

--- a/editor/src/messages/input_mapper/utility_types/misc.rs
+++ b/editor/src/messages/input_mapper/utility_types/misc.rs
@@ -1,6 +1,7 @@
 use super::input_keyboard::{all_required_modifiers_pressed, KeysGroup, LayoutKeysGroup};
 use crate::messages::input_mapper::key_mapping::MappingVariant;
 use crate::messages::input_mapper::utility_types::input_keyboard::{KeyStates, NUMBER_OF_KEYS};
+use crate::messages::input_mapper::utility_types::input_mouse::NUMBER_OF_MOUSE_BUTTONS;
 use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
@@ -11,7 +12,7 @@ pub struct Mapping {
 	pub key_down: [KeyMappingEntries; NUMBER_OF_KEYS],
 	pub key_up_no_repeat: [KeyMappingEntries; NUMBER_OF_KEYS],
 	pub key_down_no_repeat: [KeyMappingEntries; NUMBER_OF_KEYS],
-	pub double_click: [KeyMappingEntries; NUMBER_OF_KEYS],
+	pub double_click: [KeyMappingEntries; NUMBER_OF_MOUSE_BUTTONS],
 	pub wheel_scroll: KeyMappingEntries,
 	pub pointer_move: KeyMappingEntries,
 }
@@ -96,6 +97,11 @@ impl KeyMappingEntries {
 	pub fn key_array() -> [Self; NUMBER_OF_KEYS] {
 		const DEFAULT: KeyMappingEntries = KeyMappingEntries::new();
 		[DEFAULT; NUMBER_OF_KEYS]
+	}
+
+	pub fn mouse_buttons_arrays() -> [Self; NUMBER_OF_MOUSE_BUTTONS] {
+		const DEFAULT: KeyMappingEntries = KeyMappingEntries::new();
+		[DEFAULT; NUMBER_OF_MOUSE_BUTTONS]
 	}
 }
 

--- a/editor/src/messages/input_mapper/utility_types/misc.rs
+++ b/editor/src/messages/input_mapper/utility_types/misc.rs
@@ -11,7 +11,7 @@ pub struct Mapping {
 	pub key_down: [KeyMappingEntries; NUMBER_OF_KEYS],
 	pub key_up_no_repeat: [KeyMappingEntries; NUMBER_OF_KEYS],
 	pub key_down_no_repeat: [KeyMappingEntries; NUMBER_OF_KEYS],
-	pub double_click: KeyMappingEntries,
+	pub double_click: [KeyMappingEntries; NUMBER_OF_KEYS],
 	pub wheel_scroll: KeyMappingEntries,
 	pub pointer_move: KeyMappingEntries,
 }
@@ -44,7 +44,7 @@ impl Mapping {
 			InputMapperMessage::KeyUp(key) => &self.key_up[*key as usize],
 			InputMapperMessage::KeyDownNoRepeat(key) => &self.key_down_no_repeat[*key as usize],
 			InputMapperMessage::KeyUpNoRepeat(key) => &self.key_up_no_repeat[*key as usize],
-			InputMapperMessage::DoubleClick => &self.double_click,
+			InputMapperMessage::DoubleClick(key) => &self.double_click[*key as usize],
 			InputMapperMessage::WheelScroll => &self.wheel_scroll,
 			InputMapperMessage::PointerMove => &self.pointer_move,
 		}
@@ -56,7 +56,7 @@ impl Mapping {
 			InputMapperMessage::KeyUp(key) => &mut self.key_up[*key as usize],
 			InputMapperMessage::KeyDownNoRepeat(key) => &mut self.key_down_no_repeat[*key as usize],
 			InputMapperMessage::KeyUpNoRepeat(key) => &mut self.key_up_no_repeat[*key as usize],
-			InputMapperMessage::DoubleClick => &mut self.double_click,
+			InputMapperMessage::DoubleClick(key) => &mut self.double_click[*key as usize],
 			InputMapperMessage::WheelScroll => &mut self.wheel_scroll,
 			InputMapperMessage::PointerMove => &mut self.pointer_move,
 		}

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -37,7 +37,8 @@ impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputP
 				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
 				self.mouse.position = mouse_state.position;
 
-				responses.add(InputMapperMessage::DoubleClick);
+				let key = mouse_state.mouse_keys.to_key();
+				responses.add(InputMapperMessage::DoubleClick(key));
 			}
 			InputPreprocessorMessage::KeyDown { key, key_repeat, modifier_keys } => {
 				self.update_states_of_modifier_keys(modifier_keys, keyboard_platform, responses);

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -1,5 +1,5 @@
 use crate::messages::input_mapper::utility_types::input_keyboard::{Key, KeyStates, ModifierKeys};
-use crate::messages::input_mapper::utility_types::input_mouse::{MouseKeys, MouseState, ViewportBounds};
+use crate::messages::input_mapper::utility_types::input_mouse::{MouseButton, MouseKeys, MouseState, ViewportBounds};
 use crate::messages::portfolio::utility_types::KeyboardPlatformLayout;
 use crate::messages::prelude::*;
 
@@ -37,8 +37,14 @@ impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputP
 				let mouse_state = editor_mouse_state.to_mouse_state(&self.viewport_bounds);
 				self.mouse.position = mouse_state.position;
 
-				let key = mouse_state.mouse_keys.to_key();
-				responses.add(InputMapperMessage::DoubleClick(key));
+				for key in mouse_state.mouse_keys {
+					responses.add(InputMapperMessage::DoubleClick(match key {
+						MouseKeys::LEFT => MouseButton::Left,
+						MouseKeys::RIGHT => MouseButton::Right,
+						MouseKeys::MIDDLE => MouseButton::Middle,
+						_ => unimplemented!(),
+					}));
+				}
 			}
 			InputPreprocessorMessage::KeyDown { key, key_repeat, modifier_keys } => {
 				self.update_states_of_modifier_keys(modifier_keys, keyboard_platform, responses);

--- a/frontend/src/utility-functions/keyboard-entry.ts
+++ b/frontend/src/utility-functions/keyboard-entry.ts
@@ -1,4 +1,4 @@
-export function makeKeyboardModifiersBitfield(e: WheelEvent | PointerEvent | KeyboardEvent): number {
+export function makeKeyboardModifiersBitfield(e: WheelEvent | PointerEvent | MouseEvent | KeyboardEvent): number {
 	return (
 		// Shift (all platforms)
 		(Number(e.shiftKey) << 0) |

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -421,6 +421,7 @@ impl JsEditorHandle {
 	#[wasm_bindgen(js_name = onDoubleClick)]
 	pub fn on_double_click(&self, x: f64, y: f64, mouse_keys: u8, modifiers: u8) {
 		let editor_mouse_state = EditorMouseState::from_keys_and_editor_position(mouse_keys, (x, y).into());
+
 		let modifier_keys = ModifierKeys::from_bits(modifiers).expect("Invalid modifier keys");
 
 		let message = InputPreprocessorMessage::DoubleClick { editor_mouse_state, modifier_keys };


### PR DESCRIPTION
This PR extends the input handler to correctly plumb double-clicks with MMB and RMB into the input preprocessor. Now it's possible to bind actions to MMB and RMB double-clicks.

(There is currently no double-click hint icon.)

Closes #1406