### PR TITLE
Fix deleting the shape node

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -2474,10 +2474,7 @@ pub fn new_vector_network(subpaths: Vec<bezier_rs::Subpath<uuid::ManipulatorGrou
 	let stroke = resolve_document_node_type("Stroke").expect("Stroke node does not exist");
 	let output = resolve_document_node_type("Output").expect("Output node does not exist");
 
-	let mut network = NodeNetwork {
-		inputs: vec![0],
-		..Default::default()
-	};
+	let mut network = NodeNetwork::default();
 
 	network.push_node(
 		path_generator.to_document_node_default_inputs([Some(NodeInput::value(TaggedValue::Subpaths(subpaths), false))], DocumentNodeMetadata::position((0, 4))),


### PR DESCRIPTION
From #code-todo-list. The network's input was incorrectly set to the shape node despite it not requiring any network inputs.