### PR TITLE
Make 'Close All Documents' not confirm if all open documents are already saved

### DIFF
--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -71,8 +71,8 @@ impl LayoutHolder for MenuBarMessageHandler {
 						},
 						MenuBarEntry {
 							label: "Close All".into(),
-							shortcut: action_keys!(DialogMessageDiscriminant::CloseAllDocumentsWithConfirmation),
-							action: MenuBarEntry::create_action(|_| DialogMessage::CloseAllDocumentsWithConfirmation.into()),
+							shortcut: action_keys!(PortfolioMessageDiscriminant::CloseAllDocumentsWithConfirmation),
+							action: MenuBarEntry::create_action(|_| PortfolioMessage::CloseAllDocumentsWithConfirmation.into()),
 							disabled: no_active_document,
 							..MenuBarEntry::default()
 						},

--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -31,6 +31,7 @@ pub enum PortfolioMessage {
 	},
 	CloseActiveDocumentWithConfirmation,
 	CloseAllDocuments,
+	CloseAllDocumentsWithConfirmation,
 	CloseDocument {
 		document_id: u64,
 	},

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -552,6 +552,7 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 			GraphViewOverlayToggleDisabled,
 			CloseActiveDocumentWithConfirmation,
 			CloseAllDocuments,
+			CloseAllDocumentsWithConfirmation,
 			Import,
 			NextDocument,
 			OpenDocument,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -105,6 +105,9 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 				responses.add(PortfolioMessage::DestroyAllDocuments);
 				responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 			}
+			PortfolioMessage::CloseAllDocumentsWithConfirmation => {
+				debug!("Hello world!")
+			}
 			PortfolioMessage::CloseDocument { document_id } => {
 				// Is this the last document?
 				if self.documents.len() == 1 && self.document_ids[0] == document_id {

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -106,7 +106,11 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 				responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 			}
 			PortfolioMessage::CloseAllDocumentsWithConfirmation => {
-				debug!("Hello world!")
+				if self.unsaved_document_names().is_empty() {
+					responses.add(PortfolioMessage::CloseAllDocuments)
+				} else {
+					responses.add(DialogMessage::CloseAllDocumentsWithConfirmation)
+				}
 			}
 			PortfolioMessage::CloseDocument { document_id } => {
 				// Is this the last document?

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -739,7 +739,7 @@ impl Color {
 	/// ```
 	/// use graphene_core::raster::color::Color;
 	/// let color = Color::from_rgba8_srgb(0x52, 0x67, 0xFA, 0x61).to_gamma_srgb();
-	/// assert_eq!("5267FA61", color.rgba_hex())
+	/// assert_eq!("3240A261", color.rgba_hex())
 	/// ```
 	#[cfg(feature = "std")]
 	pub fn rgba_hex(&self) -> String {
@@ -756,7 +756,7 @@ impl Color {
 	/// ```
 	/// use graphene_core::raster::color::Color;
 	/// let color = Color::from_rgba8_srgb(0x52, 0x67, 0xFA, 0x61).to_gamma_srgb();
-	/// assert_eq!("5267FA", color.rgb_hex())
+	/// assert_eq!("3240A2", color.rgb_hex())
 	/// ```
 	#[cfg(feature = "std")]
 	pub fn rgb_hex(&self) -> String {


### PR DESCRIPTION
**TASK** 
From #code-todo-list ([link here](https://discord.com/channels/731730685944922173/881073965047636018/1150153442833223802))

**ADDITIONS** 
After pressing "Close All", the "Save" dialogue no longer pops if none of the documents have unsaved changes. Some outdated doctests in color.rs were also updated.

**COMMENTS**
Previously, pressing "Close All" would immediately trigger a DialogMessage asking if the user wishes to save their work before closing all documents. I have replaced this with a new PortfolioMessage which checks if there are any unsaved documents currently open. If there are, we pop the previous DialogMessage. If not, we just run the usual "CloseAllDocuments" message without the dialog.

I have decided to call the new message the same as the corresponding DialogMessage for consistency, but if you think this is confusing I would be happy to rename it. 

Please note that I have not added a keyboard shortcut to this action as one did not exist in the original build. 

If you would like me to make any changes or if I have not approached this task correctly please don't hesitate to let me know! 