### PR TITLE
Fix the Path tool's smooth/sharp buttons

### DIFF
--- a/editor/src/messages/tool/common_functionality/overlay_renderer.rs
+++ b/editor/src/messages/tool/common_functionality/overlay_renderer.rs
@@ -343,7 +343,7 @@ impl OverlayRenderer {
 		let deselected_style = style::PathStyle::new(Some(Stroke::new(Some(COLOR_ACCENT), POINT_STROKE_WEIGHT)), Fill::solid(Color::WHITE));
 		let selected_shape_state = state.get(&layer);
 		// Update if the manipulator points are shown as selected
-		// Here the index is important, even though overlays[..] has five elements we only care about the first three
+		// Here the index is important, even though overlays has five elements we only care about the first three
 		for (index, overlay) in [&overlays.in_handle, &overlays.out_handle, &overlays.anchor].into_iter().enumerate() {
 			let selected_type = [SelectedType::InHandle, SelectedType::OutHandle, SelectedType::Anchor][index];
 			if let Some(overlay_path) = overlay {

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -1,3 +1,4 @@
+use super::graph_modification_utils;
 use crate::consts::DRAG_THRESHOLD;
 use crate::messages::portfolio::document::node_graph::VectorDataModification;
 use crate::messages::prelude::*;
@@ -10,8 +11,6 @@ use graphene_core::uuid::ManipulatorGroupId;
 use graphene_core::vector::{ManipulatorPointId, SelectedType};
 
 use glam::DVec2;
-
-use super::graph_modification_utils;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ManipulatorAngle {

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -540,6 +540,10 @@ enum SelectionStatus {
 }
 
 impl SelectionStatus {
+	fn is_none(&self) -> bool {
+		self == &SelectionStatus::None
+	}
+
 	fn as_one(&self) -> Option<&SingleSelectedPoint> {
 		match self {
 			SelectionStatus::One(one) => Some(one),
@@ -552,10 +556,6 @@ impl SelectionStatus {
 			SelectionStatus::Multiple(multiple) => Some(multiple),
 			_ => None,
 		}
-	}
-
-	fn is_none(&self) -> bool {
-		self == &SelectionStatus::None
 	}
 }
 

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -82,7 +82,7 @@ impl DocumentNode {
 				NodeInput::Inline(inline) => (ProtoNodeInput::None, ConstructionArgs::Inline(inline)),
 			}
 		};
-		assert!(!self.inputs.iter().any(|input| matches!(input, NodeInput::Network(_))), "recieved non resolved parameter");
+		assert!(!self.inputs.iter().any(|input| matches!(input, NodeInput::Network(_))), "received non resolved parameter");
 		assert!(
 			!self.inputs.iter().any(|input| matches!(input, NodeInput::Value { .. })),
 			"received value as parameter. inputs: {:#?}, construction_args: {:#?}",
@@ -91,7 +91,7 @@ impl DocumentNode {
 		);
 
 		// If we have one parameter of the type inline, set it as the construction args
-		if let &[NodeInput::Inline(ref inline)] = &self.inputs[..] {
+		if let &[NodeInput::Inline(ref inline)] = self.inputs.as_slice() {
 			args = ConstructionArgs::Inline(inline.clone());
 		}
 		if let ConstructionArgs::Nodes(nodes) = &mut args {


### PR DESCRIPTION
The smooth button and the position in the path tool bar at the top were broken following the document graph migration.