### PR TITLE
Fix frontend webmanifest so installing a PWA isn't broken

### DIFF
--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -16,6 +16,15 @@
         }
     ],
     "theme_color": "#ffffff",
-    "background_color": "#ffffff",
-    "display": "standalone"
+    "background_color": "#222222",
+    "display": "standalone",
+    "screenshots": [
+        {
+            "src": "https://static.graphite.rs/content/index/gui-demo-valley-of-spires__2.avif",
+            "sizes": "1920x1080",
+            "type": "image/avif",
+            "form_factor": "wide",
+            "label": "Graphite Editor on desktop."
+        }
+    ]
 }

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,6 +1,8 @@
 {
     "name": "Graphite",
     "short_name": "Graphite",
+    "start_url": "/",
+    "id": "/",
     "icons": [
         {
             "src": "./android-chrome-192x192.png",

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -17,14 +17,5 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#222222",
-    "display": "standalone",
-    "screenshots": [
-        {
-            "src": "https://static.graphite.rs/content/index/gui-demo-valley-of-spires__2.avif",
-            "sizes": "1920x1080",
-            "type": "image/avif",
-            "form_factor": "wide",
-            "label": "Graphite Editor on desktop."
-        }
-    ]
+    "display": "standalone"
 }


### PR DESCRIPTION
This makes the app installable as a PWA:

![Screenshot 2023-11-06 at 09 21 56](https://github.com/GraphiteEditor/Graphite/assets/145676/a68bd2c4-9bba-44ff-8186-346aa69b1fb5)
