### PR TITLE
Auto-create `frontend/dist` on first build.

### DIFF
--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,3 +1,8 @@
+use std::{fs, path::PathBuf};
+
 fn main() {
+	// Directory required for compilation, but not tracked by git if empty.
+	let dist_dir: PathBuf = ["..", "dist"].iter().collect();
+	fs::create_dir_all(dist_dir).unwrap();
 	tauri_build::build()
 }


### PR DESCRIPTION
Hello, `cargo build` failed on my machine with the following error after a fresh `git clone`:

```
error: proc macro panicked
  --> frontend/src-tauri/src/main.rs:76:8
   |
76 |         .run(tauri::generate_context!())
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: The `distDir` configuration is set to `"../dist"` but this path doesn't exist

error: could not compile `graphite-desktop` (bin "graphite-desktop") due to previous error
```

I suppose this is just because git [cannot track](https://archive.kernel.org/oldwiki/git.wiki.kernel.org/index.php/GitFaq.html#Can_I_add_empty_directories.3F) empty directories like `frontend/dist`. This small patch makes sure to create the directory before compilation happens, hopefully fixing this the right way.

Alternate option: add an empty [`frontend/dist/.gitkeep`](https://stackoverflow.com/a/8418403/3719101) or a dummy [`frontend/dist/.gitignore`](https://stackoverflow.com/a/932982/3719101) to the repo instead?

(Disclaimer: I am not exactly sure what this folder is and why it is needed. Feel free to ignore if I miss something.)