### PR TITLE
Drag and drop files to empty editor

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -562,8 +562,8 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 				let image_size = DVec2::new(image.width as f64, image.height as f64);
 
 				// Align the layer with the mouse or center of viewport
-				let viewport_location = mouse.map_or(ipp.viewport_bounds.center(), |pos| pos.into());
-				let center_in_viewport = DAffine2::from_translation(viewport_location - ipp.viewport_bounds.top_left);
+				let viewport_location = mouse.map_or(ipp.viewport_bounds.center() + ipp.viewport_bounds.top_left, |pos| pos.into());
+				let center_in_viewport = DAffine2::from_translation(self.metadata().document_to_viewport.inverse().transform_point2(viewport_location - ipp.viewport_bounds.top_left));
 				let center_in_viewport_layerspace = center_in_viewport;
 
 				// Scale the image to fit into a 512x512 box

--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -88,6 +88,10 @@ pub enum PortfolioMessage {
 		document_is_saved: bool,
 		document_serialized_content: String,
 	},
+	OpenNewDocument {
+		x: u32,
+		y: u32,
+	},
 	PasteIntoFolder {
 		clipboard: Clipboard,
 		parent: LayerNodeIdentifier,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -1,6 +1,6 @@
 use super::utility_types::PersistentData;
 use crate::application::generate_uuid;
-use crate::consts::{DEFAULT_DOCUMENT_NAME, GRAPHITE_DOCUMENT_VERSION};
+use crate::consts::{DEFAULT_DOCUMENT_NAME, GRAPHITE_DOCUMENT_VERSION, VIEWPORT_ZOOM_TO_FIT_PADDING_SCALE_FACTOR};
 use crate::messages::dialog::simple_dialogs;
 use crate::messages::frontend::utility_types::FrontendDocumentDetails;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
@@ -12,6 +12,7 @@ use crate::messages::tool::utility_types::{HintData, HintGroup};
 use crate::node_graph_executor::NodeGraphExecutor;
 
 use document_legacy::layers::style::RenderData;
+use glam::{DVec2, IVec2, UVec2};
 use graph_craft::document::NodeId;
 use graphene_core::text::Font;
 
@@ -392,6 +393,24 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 						}
 					}
 				}
+			}
+			PortfolioMessage::OpenNewDocument { x, y } => {
+				// This portfolio message wraps the frontend message so it can be listed as an action, which isn't possible for frontend messages
+				warn!("Testing things");
+
+				responses.add(PortfolioMessage::NewDocumentWithName { name: "Untitled Doc".to_string() });
+
+				let id = generate_uuid();
+				let dimensions = UVec2 { x, y };
+				responses.add(GraphOperationMessage::NewArtboard {
+					id,
+					artboard: graphene_core::Artboard::new(IVec2::ZERO, dimensions.as_ivec2()),
+				});
+				responses.add(NavigationMessage::FitViewportToBounds {
+					bounds: [DVec2::ZERO, dimensions.as_dvec2()],
+					padding_scale_factor: None,
+					prevent_zoom_past_100: true,
+				});
 			}
 			PortfolioMessage::PasteIntoFolder { clipboard, parent, insert_index } => {
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>| {

--- a/frontend/src/components/window/workspace/Panel.svelte
+++ b/frontend/src/components/window/workspace/Panel.svelte
@@ -1,11 +1,12 @@
 <script lang="ts" context="module">
+	import { extractPixelData, rasterizeSVGCanvas } from "@graphite/utility-functions/rasterization";
+
 	import Document from "@graphite/components/panels/Document.svelte";
 	import LayerTree from "@graphite/components/panels/LayerTree.svelte";
 	import Properties from "@graphite/components/panels/Properties.svelte";
 	import IconButton from "@graphite/components/widgets/buttons/IconButton.svelte";
 	import PopoverButton from "@graphite/components/widgets/buttons/PopoverButton.svelte";
 	import TextButton from "@graphite/components/widgets/buttons/TextButton.svelte";
-	import { extractPixelData, rasterizeSVGCanvas } from "@graphite/utility-functions/rasterization";
 
 	const PANEL_COMPONENTS = {
 		Document,
@@ -83,6 +84,7 @@
 				if (file?.type.startsWith("image")) {
 					const imageData = await extractPixelData(file);
 					editor.instance.openNewDocument(imageData.width, imageData.height);
+					await tick();
 					editor.instance.pasteImage(new Uint8Array(imageData.data), imageData.width, imageData.height);
 					console.log("Doc opened");
 				}

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -330,6 +330,12 @@ impl JsEditorHandle {
 		self.dispatch(message);
 	}
 
+	#[wasm_bindgen(js_name = openNewDocument)]
+	pub fn open_new_document(&self, x: u32, y: u32) {
+		let message = PortfolioMessage::OpenNewDocument { x, y };
+		self.dispatch(message);
+	}
+
 	#[wasm_bindgen(js_name = openAutoSavedDocument)]
 	pub fn open_auto_saved_document(&self, document_id: u64, document_name: String, document_is_saved: bool, document_serialized_content: String) {
 		let message = PortfolioMessage::OpenDocumentFileWithId {


### PR DESCRIPTION
Drag and dropping images or `.graphite` files into an empty editor should open them.

Closes #1140

TODO:
- [ ] Code cleanup
- [ ] Fix dragging in large images being incorrectly sized compared to the artboard.