### PR TITLE
Serve the demo artwork in each build

### DIFF
--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -4,7 +4,18 @@ use crate::messages::prelude::*;
 /// A dialog to let the user browse a gallery of demo artwork that can be opened.
 pub struct DemoArtworkDialog;
 
-const ARTWORK: [(&str, &str); 2] = [("Valley of Spires", "ThumbnailValleyOfSpires"), ("Just a Potted Cactus", "ThumbnailJustAPottedCactus")];
+const ARTWORK: [(&str, &str, &str); 2] = [
+	(
+		"Valley of Spires",
+		"ThumbnailValleyOfSpires",
+		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/valley-of-spires-v2.graphite",
+	),
+	(
+		"Just a Potted Cactus",
+		"ThumbnailJustAPottedCactus",
+		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/just-a-potted-cactus-v2.graphite",
+	),
+];
 
 impl DialogLayoutHolder for DemoArtworkDialog {
 	const ICON: &'static str = "Image";
@@ -21,17 +32,17 @@ impl LayoutHolder for DemoArtworkDialog {
 	fn layout(&self) -> Layout {
 		let images = ARTWORK
 			.into_iter()
-			.map(|(_, thumbnail)| ImageLabel::new(thumbnail.to_string()).width(Some("256px".into())).widget_holder())
+			.map(|(_, thumbnail, _)| ImageLabel::new(thumbnail.to_string()).width(Some("256px".into())).widget_holder())
 			.collect();
 
 		let buttons = ARTWORK
 			.into_iter()
-			.map(|(label, _)| {
+			.map(|(label, _, url)| {
 				TextButton::new(label)
 					.min_width(256)
 					.on_update(|_| {
 						DialogMessage::CloseDialogAndThen {
-							followups: vec![FrontendMessage::TriggerOpenDemoArtwork { name: label.to_string() }.into()],
+							followups: vec![FrontendMessage::TriggerFetchAndOpenDocument { url: url.to_string() }.into()],
 						}
 						.into()
 					})

--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -4,17 +4,10 @@ use crate::messages::prelude::*;
 /// A dialog to let the user browse a gallery of demo artwork that can be opened.
 pub struct DemoArtworkDialog;
 
+/// `(name, thumbnail, filename)`
 const ARTWORK: [(&str, &str, &str); 2] = [
-	(
-		"Valley of Spires",
-		"ThumbnailValleyOfSpires",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/valley-of-spires-v2.graphite",
-	),
-	(
-		"Just a Potted Cactus",
-		"ThumbnailJustAPottedCactus",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/just-a-potted-cactus-v2.graphite",
-	),
+	("Valley of Spires", "ThumbnailValleyOfSpires", "valley-of-spires-v2.graphite"),
+	("Just a Potted Cactus", "ThumbnailJustAPottedCactus", "just-a-potted-cactus-v2.graphite"),
 ];
 
 impl DialogLayoutHolder for DemoArtworkDialog {
@@ -37,12 +30,16 @@ impl LayoutHolder for DemoArtworkDialog {
 
 		let buttons = ARTWORK
 			.into_iter()
-			.map(|(label, _, url)| {
-				TextButton::new(label)
+			.map(|(name, _, filename)| {
+				TextButton::new(name)
 					.min_width(256)
 					.on_update(|_| {
 						DialogMessage::CloseDialogAndThen {
-							followups: vec![FrontendMessage::TriggerFetchAndOpenDocument { url: url.to_string() }.into()],
+							followups: vec![FrontendMessage::TriggerFetchAndOpenDocument {
+								name: name.to_string(),
+								filename: filename.to_string(),
+							}
+							.into()],
 						}
 						.into()
 					})

--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -4,18 +4,7 @@ use crate::messages::prelude::*;
 /// A dialog to let the user browse a gallery of demo artwork that can be opened.
 pub struct DemoArtworkDialog;
 
-const ARTWORK: [(&str, &str, &str); 2] = [
-	(
-		"Valley of Spires",
-		"ThumbnailValleyOfSpires",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/valley-of-spires-v2.graphite",
-	),
-	(
-		"Just a Potted Cactus",
-		"ThumbnailJustAPottedCactus",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/just-a-potted-cactus-v2.graphite",
-	),
-];
+const ARTWORK: [(&str, &str); 2] = [("Valley of Spires", "ThumbnailValleyOfSpires"), ("Just a Potted Cactus", "ThumbnailJustAPottedCactus")];
 
 impl DialogLayoutHolder for DemoArtworkDialog {
 	const ICON: &'static str = "Image";
@@ -32,17 +21,17 @@ impl LayoutHolder for DemoArtworkDialog {
 	fn layout(&self) -> Layout {
 		let images = ARTWORK
 			.into_iter()
-			.map(|(_, thumbnail, _)| ImageLabel::new(thumbnail.to_string()).width(Some("256px".into())).widget_holder())
+			.map(|(_, thumbnail)| ImageLabel::new(thumbnail.to_string()).width(Some("256px".into())).widget_holder())
 			.collect();
 
 		let buttons = ARTWORK
 			.into_iter()
-			.map(|(label, _, url)| {
+			.map(|(label, _)| {
 				TextButton::new(label)
 					.min_width(256)
 					.on_update(|_| {
 						DialogMessage::CloseDialogAndThen {
-							followups: vec![FrontendMessage::TriggerFetchAndOpenDocument { url: url.to_string() }.into()],
+							followups: vec![FrontendMessage::TriggerOpenDemoArtwork { name: label.to_string() }.into()],
 						}
 						.into()
 					})

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -67,7 +67,8 @@ pub enum FrontendMessage {
 		name: String,
 	},
 	TriggerFetchAndOpenDocument {
-		url: String,
+		name: String,
+		filename: String,
 	},
 	TriggerFontLoad {
 		font: Font,

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -66,6 +66,9 @@ pub enum FrontendMessage {
 		document: String,
 		name: String,
 	},
+	TriggerFetchAndOpenDocument {
+		url: String,
+	},
 	TriggerFontLoad {
 		font: Font,
 		#[serde(rename = "isDefault")]
@@ -86,9 +89,6 @@ pub enum FrontendMessage {
 	},
 	TriggerLoadAutoSaveDocuments,
 	TriggerLoadPreferences,
-	TriggerOpenDemoArtwork {
-		name: String,
-	},
 	TriggerOpenDocument,
 	TriggerPaste,
 	TriggerRasterizeRegionBelowLayer {

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -66,9 +66,6 @@ pub enum FrontendMessage {
 		document: String,
 		name: String,
 	},
-	TriggerFetchAndOpenDocument {
-		url: String,
-	},
 	TriggerFontLoad {
 		font: Font,
 		#[serde(rename = "isDefault")]
@@ -89,6 +86,9 @@ pub enum FrontendMessage {
 	},
 	TriggerLoadAutoSaveDocuments,
 	TriggerLoadPreferences,
+	TriggerOpenDemoArtwork {
+		name: String,
+	},
 	TriggerOpenDocument,
 	TriggerPaste,
 	TriggerRasterizeRegionBelowLayer {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,8 @@
 				"svelte-preprocess": "^5.0.3",
 				"ts-node": "^10.9.1",
 				"typescript": "^5.0.4",
-				"vite": "^4.4.5"
+				"vite": "^4.4.5",
+				"vite-multiple-assets": "^1.2.6"
 			},
 			"optionalDependencies": {
 				"wasm-pack": "0.12.1"
@@ -3898,6 +3899,29 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/mimic-fn": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5752,6 +5776,16 @@
 				"terser": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-multiple-assets": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/vite-multiple-assets/-/vite-multiple-assets-1.2.6.tgz",
+			"integrity": "sha512-/ZQdpCqNWdqj/jO5wQHtvWaV1nYKbUH+e/1lDNy+OXiQot2YbWGoGDDFxAu8PI/k3nRpAXpPpmpv48CvhNlVWg==",
+			"dev": true,
+			"peerDependencies": {
+				"mime-types": "^2.1.35",
+				"vite": ">=2.9.6"
 			}
 		},
 		"node_modules/vitefu": {
@@ -8448,6 +8482,23 @@
 				"picomatch": "^2.3.1"
 			}
 		},
+		"mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"peer": true
+		},
+		"mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"mime-db": "1.52.0"
+			}
+		},
 		"mimic-fn": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -9656,6 +9707,13 @@
 				"postcss": "^8.4.27",
 				"rollup": "^3.27.1"
 			}
+		},
+		"vite-multiple-assets": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/vite-multiple-assets/-/vite-multiple-assets-1.2.6.tgz",
+			"integrity": "sha512-/ZQdpCqNWdqj/jO5wQHtvWaV1nYKbUH+e/1lDNy+OXiQot2YbWGoGDDFxAu8PI/k3nRpAXpPpmpv48CvhNlVWg==",
+			"dev": true,
+			"requires": {}
 		},
 		"vitefu": {
 			"version": "0.2.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,8 @@
 		"svelte-preprocess": "^5.0.3",
 		"ts-node": "^10.9.1",
 		"typescript": "^5.0.4",
-		"vite": "^4.4.5"
+		"vite": "^4.4.5",
+		"vite-multiple-assets": "^1.2.6"
 	},
 	"optionalDependencies": {
 		"wasm-pack": "0.12.1"

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
+import justAPottedCactusUrl from "@graphite/../../demo-artwork/just-a-potted-cactus-v2.graphite";
+import valleyOfSpiresUrl from "@graphite/../../demo-artwork/valley-of-spires-v2.graphite";
 import { writable } from "svelte/store";
 
 import { copyToClipboardFileURL } from "@graphite/io-managers/clipboard";
@@ -9,7 +11,7 @@ import { type Editor } from "@graphite/wasm-communication/editor";
 import {
 	type FrontendDocumentDetails,
 	TriggerCopyToClipboardBlobUrl,
-	TriggerFetchAndOpenDocument,
+	TriggerOpenDemoArtwork,
 	TriggerDownloadBlobUrl,
 	TriggerDownloadImage,
 	TriggerDownloadTextFile,
@@ -21,7 +23,8 @@ import {
 	UpdateImageData,
 	UpdateOpenDocumentsList,
 } from "@graphite/wasm-communication/messages";
-
+const demoArtwork = { "Valley of Spires": valleyOfSpiresUrl, "Just a Potted Cactus": justAPottedCactusUrl };
+console.info(demoArtwork);
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createPortfolioState(editor: Editor) {
 	const { subscribe, update } = writable({
@@ -45,12 +48,11 @@ export function createPortfolioState(editor: Editor) {
 			return state;
 		});
 	});
-	editor.subscriptions.subscribeJsMessage(TriggerFetchAndOpenDocument, async (triggerFetchAndOpenDocument) => {
+	editor.subscriptions.subscribeJsMessage(TriggerOpenDemoArtwork, async (triggerOpenDemoArtwork) => {
 		try {
-			const url = new URL(triggerFetchAndOpenDocument.url);
-			const data = await fetch(url);
+			const data = await fetch(demoArtwork[triggerOpenDemoArtwork.name]);
 
-			const filename = url.pathname.split("/").pop() || "Untitled";
+			const filename = triggerOpenDemoArtwork.name;
 			const content = await data.text();
 
 			editor.instance.openDocumentFile(filename, content);

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 /* eslint-disable max-classes-per-file */
 
 import justAPottedCactusUrl from "@graphite/../../demo-artwork/just-a-potted-cactus-v2.graphite";

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -1,8 +1,5 @@
-/* eslint-disable no-restricted-imports */
 /* eslint-disable max-classes-per-file */
 
-import justAPottedCactusUrl from "@graphite/../../demo-artwork/just-a-potted-cactus-v2.graphite";
-import valleyOfSpiresUrl from "@graphite/../../demo-artwork/valley-of-spires-v2.graphite";
 import { writable } from "svelte/store";
 
 import { copyToClipboardFileURL } from "@graphite/io-managers/clipboard";
@@ -12,7 +9,7 @@ import { type Editor } from "@graphite/wasm-communication/editor";
 import {
 	type FrontendDocumentDetails,
 	TriggerCopyToClipboardBlobUrl,
-	TriggerOpenDemoArtwork,
+	TriggerFetchAndOpenDocument,
 	TriggerDownloadBlobUrl,
 	TriggerDownloadImage,
 	TriggerDownloadTextFile,
@@ -24,8 +21,7 @@ import {
 	UpdateImageData,
 	UpdateOpenDocumentsList,
 } from "@graphite/wasm-communication/messages";
-const demoArtwork = { "Valley of Spires": valleyOfSpiresUrl, "Just a Potted Cactus": justAPottedCactusUrl };
-console.info(demoArtwork);
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createPortfolioState(editor: Editor) {
 	const { subscribe, update } = writable({
@@ -49,11 +45,12 @@ export function createPortfolioState(editor: Editor) {
 			return state;
 		});
 	});
-	editor.subscriptions.subscribeJsMessage(TriggerOpenDemoArtwork, async (triggerOpenDemoArtwork) => {
+	editor.subscriptions.subscribeJsMessage(TriggerFetchAndOpenDocument, async (triggerFetchAndOpenDocument) => {
 		try {
-			const data = await fetch(demoArtwork[triggerOpenDemoArtwork.name]);
+			const url = new URL(triggerFetchAndOpenDocument.url);
+			const data = await fetch(url);
 
-			const filename = triggerOpenDemoArtwork.name;
+			const filename = url.pathname.split("/").pop() || "Untitled";
 			const content = await data.text();
 
 			editor.instance.openDocumentFile(filename, content);

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -47,15 +47,17 @@ export function createPortfolioState(editor: Editor) {
 	});
 	editor.subscriptions.subscribeJsMessage(TriggerFetchAndOpenDocument, async (triggerFetchAndOpenDocument) => {
 		try {
-			const url = new URL(triggerFetchAndOpenDocument.url);
+			const { name, filename } = triggerFetchAndOpenDocument;
+			const url = new URL(filename, document.location.href);
 			const data = await fetch(url);
-
-			const filename = url.pathname.split("/").pop() || "Untitled";
 			const content = await data.text();
 
-			editor.instance.openDocumentFile(filename, content);
+			editor.instance.openDocumentFile(name, content);
 		} catch {
-			editor.instance.errorDialog("Failed to open document", "The file could not be reached over the internet. You may be offline, or it may be missing.");
+			// Needs to be delayed until the end of the current call stack so the existing demo artwork dialog can be closed first, otherwise this dialog won't show
+			setTimeout(() => {
+				editor.instance.errorDialog("Failed to open document", "The file could not be reached over the internet. You may be offline, or it may be missing.");
+			}, 0);
 		}
 	});
 	editor.subscriptions.subscribeJsMessage(TriggerOpenDocument, async () => {

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -521,8 +521,8 @@ export class TriggerLoadAutoSaveDocuments extends JsMessage {}
 
 export class TriggerLoadPreferences extends JsMessage {}
 
-export class TriggerOpenDemoArtwork extends JsMessage {
-	readonly name!: string;
+export class TriggerFetchAndOpenDocument extends JsMessage {
+	readonly url!: string;
 }
 
 export class TriggerOpenDocument extends JsMessage {}
@@ -1400,7 +1400,7 @@ export const messageMakers: Record<string, MessageMaker> = {
 	DisplayRemoveEditableTextbox,
 	TriggerAboutGraphiteLocalizedCommitDate,
 	TriggerCopyToClipboardBlobUrl,
-	TriggerOpenDemoArtwork,
+	TriggerFetchAndOpenDocument,
 	TriggerDownloadBlobUrl,
 	TriggerDownloadImage,
 	TriggerDownloadTextFile,

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -522,7 +522,9 @@ export class TriggerLoadAutoSaveDocuments extends JsMessage {}
 export class TriggerLoadPreferences extends JsMessage {}
 
 export class TriggerFetchAndOpenDocument extends JsMessage {
-	readonly url!: string;
+	readonly name!: string;
+
+	readonly filename!: string;
 }
 
 export class TriggerOpenDocument extends JsMessage {}

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -521,8 +521,8 @@ export class TriggerLoadAutoSaveDocuments extends JsMessage {}
 
 export class TriggerLoadPreferences extends JsMessage {}
 
-export class TriggerFetchAndOpenDocument extends JsMessage {
-	readonly url!: string;
+export class TriggerOpenDemoArtwork extends JsMessage {
+	readonly name!: string;
 }
 
 export class TriggerOpenDocument extends JsMessage {}
@@ -1400,7 +1400,7 @@ export const messageMakers: Record<string, MessageMaker> = {
 	DisplayRemoveEditableTextbox,
 	TriggerAboutGraphiteLocalizedCommitDate,
 	TriggerCopyToClipboardBlobUrl,
-	TriggerFetchAndOpenDocument,
+	TriggerOpenDemoArtwork,
 	TriggerDownloadBlobUrl,
 	TriggerDownloadImage,
 	TriggerDownloadTextFile,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
 			{ find: /@graphite-frontend\/(.*\.svg)/, replacement: path.resolve(projectRootDir, "$1?raw") },
 			{ find: "@graphite-frontend", replacement: projectRootDir },
 			{ find: "@graphite/../assets", replacement: path.resolve(projectRootDir, "assets") },
-			{ find: "@graphite/../demo-artwork", replacement: path.resolve(projectRootDir, "..", "demo-artwork") },
 			{ find: "@graphite/../public", replacement: path.resolve(projectRootDir, "public") },
 			{ find: "@graphite", replacement: path.resolve(projectRootDir, "src") },
 		],
@@ -79,7 +78,6 @@ export default defineConfig({
 			},
 		},
 	},
-	assetsInclude: ["**/*.graphite"],
 });
 
 type LicenseInfo = {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import rollupPluginLicense, { type Dependency } from "rollup-plugin-license";
 import { sveltePreprocess } from "svelte-preprocess/dist/autoProcess";
 import { defineConfig } from "vite";
+import { default as viteMultipleAssets } from "vite-multiple-assets";
 
 const projectRootDir = path.resolve(__dirname);
 
@@ -40,6 +41,7 @@ export default defineConfig({
 				defaultHandler?.(warning);
 			},
 		}),
+		viteMultipleAssets(["../demo-artwork"]),
 	],
 	resolve: {
 		alias: [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
 			{ find: /@graphite-frontend\/(.*\.svg)/, replacement: path.resolve(projectRootDir, "$1?raw") },
 			{ find: "@graphite-frontend", replacement: projectRootDir },
 			{ find: "@graphite/../assets", replacement: path.resolve(projectRootDir, "assets") },
+			{ find: "@graphite/../demo-artwork", replacement: path.resolve(projectRootDir, "..", "demo-artwork") },
 			{ find: "@graphite/../public", replacement: path.resolve(projectRootDir, "public") },
 			{ find: "@graphite", replacement: path.resolve(projectRootDir, "src") },
 		],
@@ -78,6 +79,7 @@ export default defineConfig({
 			},
 		},
 	},
+	assetsInclude: ["**/*.graphite"],
 });
 
 type LicenseInfo = {


### PR DESCRIPTION
Instead of importing the demo artwork from a GitHub link, which means the dev has to share the same file used by prod even though they aren't compatible, now we copy the demo artwork files into each deployed build's distributables.