### PR TITLE
Support for previewing the layer node

### DIFF
--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -715,6 +715,8 @@ impl NodeGraphExecutor {
 			TaggedValue::F64(render_object) => Self::render(render_object, transform, responses),
 			TaggedValue::OptionalColor(render_object) => Self::render(render_object, transform, responses),
 			TaggedValue::VectorData(render_object) => Self::render(render_object, transform, responses),
+			TaggedValue::GraphicGroup(render_object) => Self::render(render_object, transform, responses),
+			TaggedValue::Artboard(render_object) => Self::render(render_object, transform, responses),
 			TaggedValue::ImageFrame(render_object) => Self::render(render_object, transform, responses),
 			TaggedValue::Palette(render_object) => Self::render(render_object, transform, responses),
 			_ => {

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -568,6 +568,8 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		async_node!(graphene_core::memo::EndLetNode<_, _>, input: WasmEditorApi, output: RenderOutput, fn_params: [Footprint => ImageFrame<Color>]),
 		async_node!(graphene_core::memo::EndLetNode<_, _>, input: WasmEditorApi, output: RenderOutput, fn_params: [Footprint => Option<Color>]),
 		async_node!(graphene_core::memo::EndLetNode<_, _>, input: WasmEditorApi, output: RenderOutput, fn_params: [Footprint => Vec<Color>]),
+		async_node!(graphene_core::memo::EndLetNode<_, _>, input: WasmEditorApi, output: RenderOutput, fn_params: [Footprint => GraphicGroup]),
+		async_node!(graphene_core::memo::EndLetNode<_, _>, input: WasmEditorApi, output: RenderOutput, fn_params: [Footprint => Artboard]),
 		async_node!(
 			graphene_core::memo::EndLetNode<_, _>,
 			input: WasmEditorApi,


### PR DESCRIPTION
Support for previewing the layer node - the composited output is displayed during preview.

Part of #1394.