### PR TITLE
Folder bounds

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -404,6 +404,7 @@ impl<'a> ModifyInputsContext<'a> {
 				TransformIn::Viewport => parent_transform,
 			};
 			let pivot = DAffine2::from_translation(upstream_transform.transform_point2(bounds.layerspace_pivot(transform_utils::get_current_normalized_pivot(inputs))));
+			//let pivot = DAffine2::IDENTITY;
 
 			if current_transform
 				.filter(|transform| transform.matrix2.determinant() != 0. && upstream_transform.matrix2.determinant() != 0.)

--- a/node-graph/gcore/src/transform.rs
+++ b/node-graph/gcore/src/transform.rs
@@ -59,12 +59,20 @@ impl Transform for GraphicGroup {
 	fn transform(&self) -> DAffine2 {
 		self.transform
 	}
+	fn local_pivot(&self, pivot: DVec2) -> DVec2 {
+		self.local_pivot(pivot)
+	}
 }
+
 impl Transform for &GraphicGroup {
 	fn transform(&self) -> DAffine2 {
 		self.transform
 	}
+	fn local_pivot(&self, pivot: DVec2) -> DVec2 {
+		(*self).local_pivot(pivot)
+	}
 }
+
 impl TransformMut for GraphicGroup {
 	fn transform_mut(&mut self) -> &mut DAffine2 {
 		&mut self.transform


### PR DESCRIPTION
**Blocked on the magic pivot system #1530**

- The bounding box of a layer is now computed based of it and any of its descendants (with the appropriate relative transform applied)
- Transform nodes on folders correctly transform around the pivot
- Everything else is broken.

![transformissue.webm](https://github.com/GraphiteEditor/Graphite/assets/78500760/ebb39b88-0319-4031-88c4-60584ed41174)

For the transform node in the footprint system - the footprint is incorrect in cases where there is a transform node with a scale if the bounding box is not 1x1.

This is because the transform for the footprint in the transform node is computed using the pivot transform assuming that the bounding box of the layer is 1x1. We then call the upstream nodes with this incorrect footprint. Then we get the actual data and compute the real pivot based on the bounding box of the layer.

I noticed this whilst trying to debug transforming folders - I made the folder's pivot be the centre of its bounding box (which it should presumably be so that it transforms around the actual middle) and I can no longer properly transform the inner layer due to this bug.

The issue is that the transformations with the select tool are based of a monitor node which stores the footprint that is passed into the layer. If the footprints are incorrect then the transformations will be incorrect (causing the to transform incorrectly). 

Closes #1508