### PR TITLE
Serve demo artwork in public folder

### DIFF
--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -5,16 +5,8 @@ use crate::messages::prelude::*;
 pub struct DemoArtworkDialog;
 
 const ARTWORK: [(&str, &str, &str); 2] = [
-	(
-		"Valley of Spires",
-		"ThumbnailValleyOfSpires",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/valley-of-spires-v2.graphite",
-	),
-	(
-		"Just a Potted Cactus",
-		"ThumbnailJustAPottedCactus",
-		"https://raw.githubusercontent.com/GraphiteEditor/Graphite/master/demo-artwork/just-a-potted-cactus-v2.graphite",
-	),
+	("Valley of Spires", "ThumbnailValleyOfSpires", "demo-artwork/valley-of-spires-v2.graphite"),
+	("Just a Potted Cactus", "ThumbnailJustAPottedCactus", "demo-artwork/just-a-potted-cactus-v2.graphite"),
 ];
 
 impl DialogLayoutHolder for DemoArtworkDialog {

--- a/frontend/public/.gitignore
+++ b/frontend/public/.gitignore
@@ -1,0 +1,1 @@
+/demo-artwork

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -47,10 +47,10 @@ export function createPortfolioState(editor: Editor) {
 	});
 	editor.subscriptions.subscribeJsMessage(TriggerFetchAndOpenDocument, async (triggerFetchAndOpenDocument) => {
 		try {
-			const url = new URL(triggerFetchAndOpenDocument.url);
+			const url = triggerFetchAndOpenDocument.url;
 			const data = await fetch(url);
 
-			const filename = url.pathname.split("/").pop() || "Untitled";
+			const filename = url.split("/").pop() || "Untitled";
 			const content = await data.text();
 
 			editor.instance.openDocumentFile(filename, content);

--- a/frontend/wasm/build.rs
+++ b/frontend/wasm/build.rs
@@ -1,0 +1,19 @@
+use std::io;
+use std::path::Path;
+
+fn main() -> io::Result<()> {
+	// Copy the demo artwork into the public folder so it is served.
+
+	let source = Path::new(".").join("..").join("..").join("demo-artwork");
+	let destination = Path::new(".").join("..").join("public").join("demo-artwork");
+	std::fs::create_dir_all(destination.clone())?;
+
+	for file in std::fs::read_dir(source)? {
+		let path = file?.path();
+		let name = path.file_name().unwrap();
+		let destination = destination.clone().join(name);
+		std::fs::copy(path, destination)?;
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
Serve demo artwork in public folder.


The js build system is too painful to deal with.

Typical js build system experience:
```[VITE] Failed to resolve import "env" from "wasm/pkg/graphite_wasm.js". Does the file exist?
[VITE] Failed to resolve import "env" from "wasm/pkg/graphite_wasm.js". Does the file exist?
[VITE] Failed to resolve import "env" from "wasm/pkg/graphite_wasm.js". Does the file exist?
[VITE] 20:54:44 [vite] Internal server error: Failed to resolve import "env" from "wasm/pkg/graphite_wasm.js". Does the file exist?
[VITE]   Plugin: vite:import-analysis
[VITE]   File: /home/hypercube/dev/opensrc/graphite/frontend/wasm/pkg/graphite_wasm.js:3:31
[VITE]   1  |  import { updateImage } from './snippets/graphite-wasm-0ce572453e0c4c9e/../src/wasm-communication/editor.ts';
[VITE]   2  |  import * as __wbg_star0 from './snippets/graphite-editor-22867c2a72952586/../frontend/src/wasm-communication/editor.ts';
[VITE]   3  |  import * as __wbg_star1 from 'env';
[VITE]      |                                ^
[VITE]   4  |  
[VITE]   5  |  let wasm;
[VITE]       at formatError (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:44062:46)
[VITE]       at TransformContext.error (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:44058:19)
[VITE]       at normalizeUrl (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:41844:33)
[VITE]       at async file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:41998:47
[VITE]       at async Promise.all (index 2)
[VITE]       at async TransformContext.transform (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:41914:13)
[VITE]       at async Object.transform (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:44352:30)
[VITE]       at async loadAndTransform (file:///home/hypercube/dev/opensrc/graphite/frontend/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55026:29)
[VITE] Failed to resolve import "env" from "wasm/pkg/graphite_wasm.js". Does the file exist?
````