### PR TITLE
Fix inferred types memory leak

### DIFF
--- a/node-graph/graph-craft/src/proto.rs
+++ b/node-graph/graph-craft/src/proto.rs
@@ -648,9 +648,17 @@ impl TypingContext {
 	/// and store them in the `inferred` field. The proto network has to be topologically sorted
 	/// and contain fully resolved stable node ids.
 	pub fn update(&mut self, network: &ProtoNetwork) -> Result<(), GraphErrors> {
+		let mut deleted_nodes = self.inferred.keys().copied().collect::<HashSet<_>>();
+
 		for (id, node) in network.nodes.iter() {
 			self.infer(*id, node)?;
+			deleted_nodes.remove(id);
 		}
+
+		for node in deleted_nodes {
+			self.inferred.remove(&node);
+		}
+
 		Ok(())
 	}
 


### PR DESCRIPTION
The inferred types hash map no longer grows massively as you use the editor.