### PR TITLE
Fix path tool neighbours for normal snapping

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -102,7 +102,7 @@ impl ShapeState {
 
 						let mut push_neighbour = |group: ManipulatorGroup<ManipulatorGroupId>| {
 							if !state.is_selected(ManipulatorPointId::new(group.id, SelectedType::Anchor)) {
-								point.neighbors.push(group.anchor)
+								point.neighbors.push(to_document.transform_point2(group.anchor));
 							}
 						};
 						if handle == SelectedType::Anchor {


### PR DESCRIPTION
As suggested by @Keavon, the path tool supports snapping to tangent and normal.
