### PR TITLE
Preserve group IDs in the Spline from Points node

### DIFF
--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -112,6 +112,11 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 		&self.manipulator_groups
 	}
 
+	/// Returns a mutable vec of the [ManipulatorGroup]s in the `Subpath`.
+	pub fn manipulator_groups_mut(&mut self) -> &mut Vec<ManipulatorGroup<ManipulatorGroupId>> {
+		&mut self.manipulator_groups
+	}
+
 	/// Returns a vector of all the anchors (DVec2) for this `Subpath`.
 	pub fn anchors(&self) -> Vec<DVec2> {
 		self.manipulator_groups().iter().map(|group| group.anchor).collect()

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -297,7 +297,14 @@ pub struct SplinesFromPointsNode;
 #[node_macro::node_fn(SplinesFromPointsNode)]
 fn splines_from_points(mut vector_data: VectorData) -> VectorData {
 	for subpath in &mut vector_data.subpaths {
-		*subpath = Subpath::new_cubic_spline(subpath.anchors());
+		let mut spline = Subpath::new_cubic_spline(subpath.anchors());
+
+		// Preserve the manipulator group ids
+		for (spline_manipulator_group, original_manipulator_group) in spline.manipulator_groups_mut().iter_mut().zip(subpath.manipulator_groups()) {
+			spline_manipulator_group.id = original_manipulator_group.id;
+		}
+
+		*subpath = spline;
 	}
 
 	vector_data


### PR DESCRIPTION
Fixes an issue whereby in the Christmas tree demo, the line was snapping to the spline constructed using the spline from points node.