### PR TITLE
Fix Select tool's broken undo

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -809,7 +809,7 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 			}
 			Undo => {
 				self.undo_in_progress = true;
-
+				responses.add(ToolMessage::PreUndo);
 				responses.add(DocumentMessage::DocumentHistoryBackward);
 				responses.add(OverlaysMessage::Draw);
 				responses.add(DocumentMessage::UndoFinished);

--- a/editor/src/messages/tool/tool_message.rs
+++ b/editor/src/messages/tool/tool_message.rs
@@ -126,6 +126,7 @@ pub enum ToolMessage {
 	},
 	DeactivateTools,
 	InitTools,
+	PreUndo,
 	Redo,
 	RefreshToolOptions,
 	ResetColors,

--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -177,6 +177,15 @@ impl MessageHandler<ToolMessage, (&DocumentMessageHandler, DocumentId, &InputPre
 				tool_data.active_tool_mut().process_message(ToolMessage::UpdateHints, responses, &mut data);
 				tool_data.active_tool_mut().process_message(ToolMessage::UpdateCursor, responses, &mut data);
 			}
+			ToolMessage::PreUndo => {
+				let tool_data = &mut self.tool_state.tool_data;
+				match tool_data.active_tool_type {
+					ToolType::Pen => {}
+					_ => {
+						responses.add(BroadcastEvent::ToolAbort);
+					}
+				}
+			}
 			ToolMessage::Redo => {
 				let tool_data = &mut self.tool_state.tool_data;
 				match tool_data.active_tool_type {
@@ -236,9 +245,7 @@ impl MessageHandler<ToolMessage, (&DocumentMessageHandler, DocumentId, &InputPre
 					ToolType::Pen => {
 						responses.add(PenToolMessage::Undo);
 					}
-					_ => {
-						responses.add(BroadcastEvent::ToolAbort);
-					}
+					_ => {}
 				}
 			}
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

As a follow up of https://github.com/GraphiteEditor/Graphite/pull/1587. I find it affects normal select tool undo behavior. 
