### PR TITLE
Fix multiple dragged nodes snapping back sometimes

### DIFF
--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -646,7 +646,7 @@
 
 			return;
 		} else if (draggingNodes) {
-			if (draggingNodes.startX === e.x || draggingNodes.startY === e.y) {
+			if (draggingNodes.startX === e.x && draggingNodes.startY === e.y) {
 				if (selectIfNotDragged !== undefined && ($nodeGraph.selected.length !== 1 || $nodeGraph.selected[0] !== selectIfNotDragged)) {
 					editor.instance.selectNodes(new BigUint64Array([selectIfNotDragged]));
 				}


### PR DESCRIPTION
Fix dragging a selection of nodes on one axis (in screen pixels) resetting the selection as reported by @Ezbaze and @Keavon.