### PR TITLE
Fix point translation bug in Path tool

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -452,7 +452,7 @@ impl ShapeState {
 		layer: LayerNodeIdentifier,
 	) -> Option<()> {
 		let subpaths = get_subpaths(layer, document_network)?;
-		let transform = document_metadata.transform_to_viewport(layer).inverse();
+		let transform = document_metadata.transform_to_document(layer).inverse();
 		let position = transform.transform_point2(new_position);
 		let group = graph_modification_utils::get_manipulator_from_id(subpaths, point.group)?;
 		let delta = position - point.manipulator_type.get_position(group)?;


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Fixes the bug where the coordinate fields in the Path tool do not behave as expected.

This bug has been demonstrated in Discord: https://discord.com/channels/731730685944922173/881073965047636018/1210661135053758564