### PR TITLE
Prevent browser forward/backward navigation keys from crashing editor

### DIFF
--- a/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
@@ -39,6 +39,8 @@ bitflags! {
 		const ALT             = 0b_0000_0010;
 		const CONTROL         = 0b_0000_0100;
 		const META_OR_COMMAND = 0b_0000_1000;
+		const BROWSER_BACK    = 0b_0001_0000;
+		const BROWSER_FORWARD = 0b_0010_0000;
 	}
 }
 

--- a/frontend/src/utility-functions/keyboard-entry.ts
+++ b/frontend/src/utility-functions/keyboard-entry.ts
@@ -7,7 +7,11 @@ export function makeKeyboardModifiersBitfield(e: WheelEvent | PointerEvent | Mou
 		// Control (all platforms)
 		(Number(e.ctrlKey) << 2) |
 		// Meta (Windows/Linux) or Command (Mac)
-		(Number(e.metaKey) << 3)
+		(Number(e.metaKey) << 3) |
+		// Browser Back Button (Chrome)
+		(Number(e.getModifierState("BrowserBack")) << 4) |
+		// Browser Forward Button (Chrome)
+		(Number(e.getModifierState("BrowserForward")) << 5)
 	);
 }
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

This adds the `BrowserBack` and `BrowserForward` browser control keys to `ModifierKeys`.

Closes #1628.
