### PR TITLE
Add Mirror node

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -2813,6 +2813,18 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 			properties: node_properties::image_color_palette,
 			..Default::default()
 		},
+		DocumentNodeDefinition {
+			name: "Mirror",
+			category: "Vector",
+			inputs: vec![
+				DocumentInputType::value("Vector Data", TaggedValue::VectorData(graphene_core::vector::VectorData::empty()), true),
+				DocumentInputType::value("Mirror X", TaggedValue::Bool(true), false),
+				DocumentInputType::value("Mirror Y", TaggedValue::Bool(false), false),
+			],
+			outputs: vec![DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
+			properties: node_properties::mirror_properties,
+			..Default::default()
+		},
 	]
 }
 

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -2816,6 +2816,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 		DocumentNodeDefinition {
 			name: "Mirror",
 			category: "Vector",
+			implementation: DocumentNodeImplementation::proto("graphene_core::vector::MirrorNode<_, _>"),
 			inputs: vec![
 				DocumentInputType::value("Vector Data", TaggedValue::VectorData(graphene_core::vector::VectorData::empty()), true),
 				DocumentInputType::value("Mirror X", TaggedValue::Bool(true), false),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/node_properties.rs
@@ -2278,3 +2278,10 @@ pub fn image_color_palette(document_node: &DocumentNode, node_id: NodeId, _conte
 
 	vec![LayoutGroup::Row { widgets: size }]
 }
+
+pub fn mirror_properties(document_node: &DocumentNode, node_id: NodeId, _context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
+	let mirror_x = bool_widget(document_node, node_id, 1, "Mirror X", true);
+	let mirror_y = bool_widget(document_node, node_id, 2, "Mirror Y", true);
+
+	vec![LayoutGroup::Row { widgets: mirror_x }, LayoutGroup::Row { widgets: mirror_y }]
+}

--- a/node-graph/gcore/src/transform.rs
+++ b/node-graph/gcore/src/transform.rs
@@ -25,6 +25,14 @@ pub trait Transform {
 			self.transform().transform_vector2((0., 1.).into()).length(),
 		)
 	}
+	fn pivot_mut(&mut self) -> Option<&mut Option<DVec2>> {
+		None
+	}
+	fn set_pivot(&mut self, pivot: DVec2) -> () {
+		if let Some(pivot_ref) = self.pivot_mut() {
+			*pivot_ref = Some(pivot);
+		}
+	}
 }
 
 pub trait TransformMut: Transform {
@@ -117,6 +125,9 @@ impl Transform for VectorData {
 	}
 	fn local_pivot(&self, pivot: DVec2) -> DVec2 {
 		self.local_pivot(pivot)
+	}
+	fn pivot_mut(&mut self) -> Option<&mut Option<DVec2>> {
+		Some(&mut self.pivot)
 	}
 }
 impl TransformMut for VectorData {
@@ -258,6 +269,8 @@ where
 	let modification = pivot_transform * transform * pivot_transform.inverse();
 	let data_transform = data.transform_mut();
 	*data_transform = modification * (*data_transform);
+
+	data.set_pivot(pivot);
 
 	data
 }

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -19,6 +19,7 @@ pub struct VectorData {
 	/// A list of all manipulator groups (referenced in `subpaths`) that have smooth handles (where their handles are colinear, or locked to 180° angles from one another)
 	/// This gets read in `graph_operation_message_handler.rs` by calling `inputs.as_mut_slice()` (search for the string `"Shape does not have subpath and mirror angle inputs"` to find it).
 	pub mirror_angle: Vec<ManipulatorGroupId>,
+	pub pivot: Option<DVec2>,
 }
 
 impl core::hash::Hash for VectorData {
@@ -40,6 +41,7 @@ impl VectorData {
 			style: PathStyle::new(Some(Stroke::new(Some(Color::BLACK), 0.)), super::style::Fill::None),
 			alpha_blending: AlphaBlending::new(),
 			mirror_angle: Vec::new(),
+			pivot: None,
 		}
 	}
 

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -465,3 +465,19 @@ async fn morph<SourceFuture: Future<Output = VectorData>, TargetFuture: Future<O
 
 	current
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct MirrorNode<MirrorX, MirrorY> {
+	mirror_x: MirrorX,
+	mirror_y: MirrorY,
+}
+
+#[node_macro::node_fn(MirrorNode)]
+fn mirror_node(mut vector_data: VectorData, mirror_x: bool, mirror_y: bool) -> VectorData {
+	log::debug!("{:#?}", &vector_data);
+	let pivot_absolute = vector_data.local_pivot(DVec2::splat(0.5));
+	let pivot_relative = vector_data.layerspace_pivot(DVec2::splat(0.5));
+	log::debug!("{:#?}", pivot_absolute);
+	log::debug!("{:#?}", pivot_relative);
+	vector_data
+}

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -705,6 +705,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::vector::RepeatNode<_, _>, input: VectorData, params: [DVec2, u32]),
 		register_node!(graphene_core::vector::BoundingBoxNode, input: VectorData, params: []),
 		register_node!(graphene_core::vector::CircularRepeatNode<_, _, _>, input: VectorData, params: [f64, f64, u32]),
+		register_node!(graphene_core::vector::MirrorNode<_, _>, input: VectorData, params: [bool, bool]),
 		vec![(
 			ProtoNodeIdentifier::new("graphene_core::transform::CullNode<_>"),
 			|args| {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

This will add the Mirror node:
- [x] Define a new node that just outputs the vector data that has been input (to ensure nodes are set up properly). 
- [x] Compute the pivot position of the vector data using the appropriate function.
- [x] Clone the subpaths in the vector data and mirror all of the positions around the computed pivot.

This will close #1453 when finished.
