### PR TITLE
Change devcontainer image to Debian to support ARM platforms

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"image": "mcr.microsoft.com/devcontainers/base:debian",
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
 			"profile": "default"


### PR DESCRIPTION
This pull request aims to facilitate running the development container on ARM-based processors by switching the base image to Debian. Previously, the image was specified as "mcr.microsoft.com/devcontainers/universal:2", which might not be compatible with ARM architectures based on this information (https://github.com/devcontainers/images/blob/main/src/universal/README.md). 

The decision to opt for the Debian base image is grounded in the documentation of the Graphite, which suggests compatibility with Debian distributions. Although there are two options available (base:ubuntu and base:debian), choosing Debian aligns better with the documented requirements, ensuring a smoother development experience. And I've confirmed it runs fine on the Github Codespace and of course ARM-based machine.

more information about the images : https://github.com/devcontainers/images/blob/main/src/base-debian/README.md