### PR TITLE
Update Polygon tool to draw stars/ngons so they're tilted upright

### DIFF
--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -240,8 +240,9 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 	/// Constructs a regular polygon (ngon). Based on `sides` and `radius`, which is the distance from the center to any vertex.
 	pub fn new_regular_polygon(center: DVec2, sides: u64, radius: f64) -> Self {
+		let angle_increment = std::f64::consts::TAU / (sides as f64);
 		let anchor_positions = (0..sides).map(|i| {
-			let angle = (i as f64) * std::f64::consts::TAU / (sides as f64);
+			let angle = -(std::f64::consts::PI / 2.0) + (i as f64) * angle_increment;
 			let center = center + DVec2::ONE * radius;
 			DVec2::new(center.x + radius * f64::cos(angle), center.y + radius * f64::sin(angle)) * 0.5
 		});
@@ -250,8 +251,9 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 
 	/// Constructs a star polygon (n-star). See [new_regular_polygon], but with interspersed vertices at an `inner_radius`.
 	pub fn new_star_polygon(center: DVec2, sides: u64, radius: f64, inner_radius: f64) -> Self {
+		let angle_increment = 0.5 * std::f64::consts::TAU / (sides as f64);
 		let anchor_positions = (0..sides * 2).map(|i| {
-			let angle = (i as f64) * 0.5 * std::f64::consts::TAU / (sides as f64);
+			let angle = -(std::f64::consts::PI / 2.0) + (i as f64) * angle_increment;
 			let center = center + DVec2::ONE * radius;
 			let r = if i % 2 == 0 { radius } else { inner_radius };
 			DVec2::new(center.x + r * f64::cos(angle), center.y + r * f64::sin(angle)) * 0.5

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -242,7 +242,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	pub fn new_regular_polygon(center: DVec2, sides: u64, radius: f64) -> Self {
 		let angle_increment = std::f64::consts::TAU / (sides as f64);
 		let anchor_positions = (0..sides).map(|i| {
-			let angle = -(std::f64::consts::PI / 2.0) + (i as f64) * angle_increment;
+			let angle = (i as f64) * angle_increment - std::f64::consts::FRAC_PI_2;
 			let center = center + DVec2::ONE * radius;
 			DVec2::new(center.x + radius * f64::cos(angle), center.y + radius * f64::sin(angle)) * 0.5
 		});
@@ -253,7 +253,7 @@ impl<ManipulatorGroupId: crate::Identifier> Subpath<ManipulatorGroupId> {
 	pub fn new_star_polygon(center: DVec2, sides: u64, radius: f64, inner_radius: f64) -> Self {
 		let angle_increment = 0.5 * std::f64::consts::TAU / (sides as f64);
 		let anchor_positions = (0..sides * 2).map(|i| {
-			let angle = -(std::f64::consts::PI / 2.0) + (i as f64) * angle_increment;
+			let angle = (i as f64) * angle_increment - std::f64::consts::FRAC_PI_2;
 			let center = center + DVec2::ONE * radius;
 			let r = if i % 2 == 0 { radius } else { inner_radius };
 			DVec2::new(center.x + r * f64::cos(angle), center.y + r * f64::sin(angle)) * 0.5


### PR DESCRIPTION
I found out that polygon and star polygon is not facing upwards, which is not inline from the icon in the toolbar that the polygons are facing upwards, so user expected that polygon would be facing it upward, but when I use it, it is facing sideways.

<img width="1479" alt="image" src="https://github.com/GraphiteEditor/Graphite/assets/76188139/c75ffa80-d87c-4606-bd37-172953c72bb8">

So i update the angel of polygon on this PR.