### PR TITLE
Fix internal consistency of layer ordering when grouping

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -170,23 +170,11 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 						.metadata()
 						.shallowest_unique_layers(active_document.selected_nodes.selected_layers(active_document.metadata()));
 
-					let mut get_last_elements: Vec<_> = binding.iter().map(|x| x.last().expect("empty path")).collect();
+					let get_last_elements: Vec<_> = binding.iter().map(|x| x.last().expect("empty path")).collect();
 
-					let selected_to_vector = active_document
-						.selected_nodes
-						.selected_layers(active_document.metadata())
-						.filter(|_x| true)
-						.map(|x| x.clone())
-						.collect::<Vec<_>>();
+					let ordered_last_elements: Vec<_> = active_document.metadata.all_layers().filter(|layer| get_last_elements.contains(&layer)).collect();
 
-					// sort last elements by their appearance in selected vector
-					get_last_elements.sort_by(|a, b| {
-						let index_a = selected_to_vector.iter().position(|x| x == *a).unwrap_or(9999);
-						let index_b = selected_to_vector.iter().position(|x| x == *b).unwrap_or(9999);
-						index_a.cmp(&index_b)
-					});
-
-					for layer in get_last_elements {
+					for layer in ordered_last_elements {
 						let node = layer.to_node();
 						let previous_alias = active_document.network().nodes.get(&node).map(|node| node.alias.clone()).unwrap_or_default();
 
@@ -205,7 +193,7 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 									.collect(),
 							)
 							.collect(),
-							selected: active_document.selected_nodes.selected_layers_contains(*layer, active_document.metadata()),
+							selected: active_document.selected_nodes.selected_layers_contains(layer, active_document.metadata()),
 							collapsed: false,
 							alias: previous_alias,
 						});


### PR DESCRIPTION
Grouping layers preserve the order that they were sorted once those layers end up in the new group

Part of #1633