### PR TITLE
Fix tool options bar number inputs not being applied before starting a drag with the tool

### DIFF
--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -165,6 +165,9 @@
 		const onEditbox = e.target instanceof HTMLDivElement && e.target.contentEditable;
 
 		if (!onEditbox) viewport?.setPointerCapture(e.pointerId);
+		if (window.document.activeElement instanceof HTMLElement) {
+			window.document.activeElement.blur();
+		}
 	}
 
 	// Update rendered SVGs


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1443 

This also fixes similar behaviour in other input boxes, such as weight.