### PR TITLE
Remove `remain` alphabetical sorting enforcement macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,7 +2462,6 @@ dependencies = [
  "log",
  "num_enum 0.6.1",
  "once_cell",
- "remain",
  "serde",
  "serde_json",
  "specta",
@@ -4763,17 +4762,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remain"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad5e011230cad274d0532460c5ab69828ea47ae75681b42a841663efffaf794"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "renderdoc-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ reqwest = { version = "0.11", features = ["rustls", "rustls-tls", "json"] }
 futures = "0.3"
 log = { version = "0.4" }
 bitflags = { version = "2.4", features = ["serde"] }
-remain = "0.2.2"
 derivative = "2.2.0"
 tempfile = "3"
 thiserror = "1.0"

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -34,7 +34,6 @@ serde_json = { workspace = true }
 graphite-proc-macros = { path = "../proc-macros" }
 bezier-rs = { workspace = true }
 glam = { workspace = true, features = ["serde", "debug-glam-assert"] }
-remain = { workspace = true }
 derivative = { workspace = true }
 specta.workspace = true
 image = { workspace = true, features = ["bmp", "png"] }

--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -12,7 +12,6 @@ pub struct Dispatcher {
 	pub message_handlers: DispatcherMessageHandlers,
 }
 
-#[remain::sorted]
 #[derive(Debug, Default)]
 pub struct DispatcherMessageHandlers {
 	broadcast_message_handler: BroadcastMessageHandler,
@@ -57,7 +56,6 @@ impl Dispatcher {
 		}
 	}
 
-	#[remain::check]
 	pub fn handle_message<T: Into<Message>>(&mut self, message: T) {
 		use Message::*;
 
@@ -86,11 +84,8 @@ impl Dispatcher {
 			let mut queue = VecDeque::new();
 
 			// Process the action by forwarding it to the relevant message handler, or saving the FrontendMessage to be sent to the frontend
-			#[remain::sorted]
 			match message {
-				#[remain::unsorted]
 				NoOp => {}
-				#[remain::unsorted]
 				Init => {
 					// Load persistent data from the browser database
 					queue.add(FrontendMessage::TriggerLoadAutoSaveDocuments);

--- a/editor/src/messages/broadcast/broadcast_message.rs
+++ b/editor/src/messages/broadcast/broadcast_message.rs
@@ -2,12 +2,10 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Broadcast)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum BroadcastMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	TriggerEvent(BroadcastEvent),
 

--- a/editor/src/messages/broadcast/broadcast_message_handler.rs
+++ b/editor/src/messages/broadcast/broadcast_message_handler.rs
@@ -6,12 +6,9 @@ pub struct BroadcastMessageHandler {
 }
 
 impl MessageHandler<BroadcastMessage, ()> for BroadcastMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: BroadcastMessage, responses: &mut VecDeque<Message>, _data: ()) {
-		#[remain::sorted]
 		match message {
 			// Sub-messages
-			#[remain::unsorted]
 			BroadcastMessage::TriggerEvent(event) => {
 				for message in self.listeners.entry(event).or_default() {
 					responses.add_front(message.clone())

--- a/editor/src/messages/debug/debug_message_handler.rs
+++ b/editor/src/messages/debug/debug_message_handler.rs
@@ -7,7 +7,6 @@ pub struct DebugMessageHandler {
 }
 
 impl MessageHandler<DebugMessage, ()> for DebugMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: DebugMessage, responses: &mut VecDeque<Message>, _data: ()) {
 		match message {
 			DebugMessage::ToggleTraceLogs => {

--- a/editor/src/messages/dialog/dialog_message.rs
+++ b/editor/src/messages/dialog/dialog_message.rs
@@ -2,18 +2,14 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Dialog)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum DialogMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	ExportDialog(ExportDialogMessage),
-	#[remain::unsorted]
 	#[child]
 	NewDocumentDialog(NewDocumentDialogMessage),
-	#[remain::unsorted]
 	#[child]
 	PreferencesDialog(PreferencesDialogMessage),
 

--- a/editor/src/messages/dialog/dialog_message_handler.rs
+++ b/editor/src/messages/dialog/dialog_message_handler.rs
@@ -17,15 +17,10 @@ pub struct DialogData<'a> {
 }
 
 impl MessageHandler<DialogMessage, DialogData<'_>> for DialogMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: DialogMessage, responses: &mut VecDeque<Message>, DialogData { portfolio, preferences }: DialogData) {
-		#[remain::sorted]
 		match message {
-			#[remain::unsorted]
 			DialogMessage::ExportDialog(message) => self.export_dialog.process_message(message, responses, portfolio),
-			#[remain::unsorted]
 			DialogMessage::NewDocumentDialog(message) => self.new_document_dialog.process_message(message, responses, ()),
-			#[remain::unsorted]
 			DialogMessage::PreferencesDialog(message) => self.preferences_dialog.process_message(message, responses, preferences),
 
 			DialogMessage::CloseAllDocumentsWithConfirmation => {

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -11,7 +11,6 @@ use graphene_core::text::Font;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Frontend)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum FrontendMessage {

--- a/editor/src/messages/globals/globals_message_handler.rs
+++ b/editor/src/messages/globals/globals_message_handler.rs
@@ -4,7 +4,6 @@ use crate::messages::prelude::*;
 pub struct GlobalsMessageHandler {}
 
 impl MessageHandler<GlobalsMessage, ()> for GlobalsMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: GlobalsMessage, _responses: &mut VecDeque<Message>, _data: ()) {
 		match message {
 			GlobalsMessage::SetPlatform { platform } => {

--- a/editor/src/messages/input_mapper/input_mapper_message.rs
+++ b/editor/src/messages/input_mapper/input_mapper_message.rs
@@ -3,24 +3,18 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, KeyMappingMessage, Lookup)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize)]
 pub enum InputMapperMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	KeyDown(Key),
-	#[remain::unsorted]
 	#[child]
 	KeyUp(Key),
-	#[remain::unsorted]
 	#[child]
 	KeyDownNoRepeat(Key),
-	#[remain::unsorted]
 	#[child]
 	KeyUpNoRepeat(Key),
-	#[remain::unsorted]
 	#[child]
 	DoubleClick(MouseButton),
 

--- a/editor/src/messages/input_mapper/key_mapping/key_mapping_message.rs
+++ b/editor/src/messages/input_mapper/key_mapping/key_mapping_message.rs
@@ -2,7 +2,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, KeyMapping)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize)]
 pub enum KeyMappingMessage {
@@ -12,11 +11,9 @@ pub enum KeyMappingMessage {
 	ModifyMapping(MappingVariant),
 }
 
-#[remain::sorted]
 #[impl_message(Message, KeyMappingMessage, ModifyMapping)]
 #[derive(PartialEq, Eq, Clone, Debug, Default, Hash, Serialize, Deserialize)]
 pub enum MappingVariant {
-	#[remain::unsorted]
 	#[default]
 	Default,
 

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message.rs
@@ -4,7 +4,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, InputPreprocessor)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum InputPreprocessorMessage {

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -13,9 +13,7 @@ pub struct InputPreprocessorMessageHandler {
 }
 
 impl MessageHandler<InputPreprocessorMessage, KeyboardPlatformLayout> for InputPreprocessorMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: InputPreprocessorMessage, responses: &mut VecDeque<Message>, keyboard_platform: KeyboardPlatformLayout) {
-		#[remain::sorted]
 		match message {
 			InputPreprocessorMessage::BoundsOfViewports { bounds_of_viewports } => {
 				assert_eq!(bounds_of_viewports.len(), 1, "Only one viewport is currently supported");

--- a/editor/src/messages/layout/layout_message.rs
+++ b/editor/src/messages/layout/layout_message.rs
@@ -3,7 +3,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Layout)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum LayoutMessage {

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -271,10 +271,8 @@ impl LayoutMessageHandler {
 }
 
 impl<F: Fn(&MessageDiscriminant) -> Vec<KeysGroup>> MessageHandler<LayoutMessage, F> for LayoutMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: LayoutMessage, responses: &mut std::collections::VecDeque<Message>, action_input_mapping: F) {
 		use LayoutMessage::*;
-		#[remain::sorted]
 		match message {
 			ResendActiveWidget { layout_target, widget_id } => {
 				// Find the updated diff based on the specified layout target
@@ -345,13 +343,11 @@ impl LayoutMessageHandler {
 	}
 
 	/// Send a diff to the frontend based on the layout target.
-	#[remain::check]
 	fn send_diff(&self, mut diff: Vec<WidgetDiff>, layout_target: LayoutTarget, responses: &mut VecDeque<Message>, action_input_mapping: &impl Fn(&MessageDiscriminant) -> Vec<KeysGroup>) {
 		diff.iter_mut().for_each(|diff| diff.new_value.apply_keyboard_shortcut(action_input_mapping));
 
 		trace!("{layout_target:?} diff {diff:#?}");
 
-		#[remain::sorted]
 		let message = match layout_target {
 			LayoutTarget::DialogButtons => FrontendMessage::UpdateDialogButtons { layout_target, diff },
 			LayoutTarget::DialogColumn1 => FrontendMessage::UpdateDialogColumn1 { layout_target, diff },
@@ -367,7 +363,6 @@ impl LayoutMessageHandler {
 			LayoutTarget::ToolShelf => FrontendMessage::UpdateToolShelfLayout { layout_target, diff },
 			LayoutTarget::WorkingColors => FrontendMessage::UpdateWorkingColorsLayout { layout_target, diff },
 
-			#[remain::unsorted]
 			LayoutTarget::LayoutTargetLength => panic!("`LayoutTargetLength` is not a valid Layout Target and is used for array indexing"),
 		};
 		responses.add(message);

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -20,7 +20,6 @@ impl core::fmt::Display for WidgetId {
 	}
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Hash, Eq, Copy, Serialize, Deserialize, specta::Type)]
 #[repr(u8)]
 pub enum LayoutTarget {
@@ -53,7 +52,6 @@ pub enum LayoutTarget {
 
 	// KEEP THIS ENUM LAST
 	// This is a marker that is used to define an array that is used to hold widgets
-	#[remain::unsorted]
 	LayoutTargetLength,
 }
 
@@ -292,7 +290,6 @@ impl<'a> Iterator for WidgetIterMut<'a> {
 
 pub type SubLayout = Vec<LayoutGroup>;
 
-#[remain::sorted]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub enum LayoutGroup {
 	#[serde(rename = "column")]
@@ -475,7 +472,6 @@ impl<T> Default for WidgetCallback<T> {
 	}
 }
 
-#[remain::sorted]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub enum Widget {
 	BreadcrumbTrailButtons(BreadcrumbTrailButtons),

--- a/editor/src/messages/message.rs
+++ b/editor/src/messages/message.rs
@@ -4,13 +4,10 @@ use graphite_proc_macros::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Message {
-	#[remain::unsorted]
 	NoOp,
-	#[remain::unsorted]
 	Init,
 
 	#[child]

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -12,24 +12,18 @@ use graphene_core::Color;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, PortfolioMessage, Document)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum DocumentMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	Navigation(NavigationMessage),
-	#[remain::unsorted]
 	#[child]
 	Overlays(OverlaysMessage),
-	#[remain::unsorted]
 	#[child]
 	PropertiesPanel(PropertiesPanelMessage),
-	#[remain::unsorted]
 	#[child]
 	NodeGraph(NodeGraphMessage),
-	#[remain::unsorted]
 	#[child]
 	GraphOperation(GraphOperationMessage),
 

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -235,7 +235,6 @@ pub struct DocumentInputs<'a> {
 }
 
 impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: DocumentMessage, responses: &mut VecDeque<Message>, document_inputs: DocumentInputs) {
 		let DocumentInputs {
 			document_id,
@@ -245,10 +244,8 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 		} = document_inputs;
 		use DocumentMessage::*;
 
-		#[remain::sorted]
 		match message {
 			// Sub-messages
-			#[remain::unsorted]
 			Navigation(message) => {
 				let document_bounds = self.metadata().document_bounds_viewport_space();
 				self.navigation_handler.process_message(
@@ -257,11 +254,9 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 					(&self.metadata, document_bounds, ipp, self.selected_visible_layers_bounding_box_viewport(), &mut self.navigation),
 				);
 			}
-			#[remain::unsorted]
 			Overlays(message) => {
 				self.overlays_message_handler.process_message(message, responses, (self.overlays_visible, ipp));
 			}
-			#[remain::unsorted]
 			PropertiesPanel(message) => {
 				let properties_panel_message_handler_data = PropertiesPanelMessageHandlerData {
 					node_graph_message_handler: &self.node_graph_handler,
@@ -274,7 +269,6 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 				self.properties_panel_message_handler
 					.process_message(message, responses, (persistent_data, properties_panel_message_handler_data));
 			}
-			#[remain::unsorted]
 			NodeGraph(message) => {
 				self.node_graph_handler.process_message(
 					message,
@@ -291,7 +285,6 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 					},
 				);
 			}
-			#[remain::unsorted]
 			GraphOperation(message) => GraphOperationMessageHandler.process_message(
 				message,
 				responses,

--- a/editor/src/messages/portfolio/document/navigation/navigation_message.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message.rs
@@ -4,7 +4,6 @@ use crate::messages::prelude::*;
 use glam::DVec2;
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, DocumentMessage, Navigation)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum NavigationMessage {

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -49,7 +49,6 @@ impl Default for NavigationMessageHandler {
 }
 
 impl MessageHandler<NavigationMessage, (&DocumentMetadata, Option<[DVec2; 2]>, &InputPreprocessorMessageHandler, Option<[DVec2; 2]>, &mut PTZ)> for NavigationMessageHandler {
-	#[remain::check]
 	fn process_message(
 		&mut self,
 		message: NavigationMessage,
@@ -60,7 +59,6 @@ impl MessageHandler<NavigationMessage, (&DocumentMetadata, Option<[DVec2; 2]>, &
 
 		let old_zoom = ptz.zoom;
 
-		#[remain::sorted]
 		match message {
 			DecreaseCanvasZoom { center_on_mouse } => {
 				let new_scale = *VIEWPORT_ZOOM_LEVELS.iter().rev().find(|scale| **scale < ptz.zoom).unwrap_or(&ptz.zoom);

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message.rs
@@ -2,7 +2,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, DocumentMessage, PropertiesPanel)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum PropertiesPanelMessage {

--- a/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/properties_panel/properties_panel_message_handler.rs
@@ -8,7 +8,6 @@ use crate::messages::prelude::*;
 pub struct PropertiesPanelMessageHandler;
 
 impl<'a> MessageHandler<PropertiesPanelMessage, (&PersistentData, PropertiesPanelMessageHandlerData<'a>)> for PropertiesPanelMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: PropertiesPanelMessage, responses: &mut VecDeque<Message>, (persistent_data, data): (&PersistentData, PropertiesPanelMessageHandlerData)) {
 		use PropertiesPanelMessage::*;
 

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message.rs
@@ -2,7 +2,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, PortfolioMessage, MenuBar)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize)]
 pub enum MenuBarMessage {

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -10,14 +10,12 @@ pub struct MenuBarMessageHandler {
 }
 
 impl MessageHandler<MenuBarMessage, (bool, bool)> for MenuBarMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: MenuBarMessage, responses: &mut VecDeque<Message>, (has_active_document, rulers_visible): (bool, bool)) {
 		use MenuBarMessage::*;
 
 		self.has_active_document = has_active_document;
 		self.rulers_visible = rulers_visible;
 
-		#[remain::sorted]
 		match message {
 			SendLayout => self.send_layout(responses, LayoutTarget::MenuBar),
 		}

--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -7,20 +7,16 @@ use graphene_core::text::Font;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Portfolio)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum PortfolioMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	MenuBar(MenuBarMessage),
-	#[remain::unsorted]
 	#[child]
 	Document(DocumentMessage),
 
 	// Messages
-	#[remain::unsorted]
 	DocumentPassMessage {
 		document_id: DocumentId,
 		message: DocumentMessage,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -27,12 +27,9 @@ pub struct PortfolioMessageHandler {
 }
 
 impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &PreferencesMessageHandler)> for PortfolioMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: PortfolioMessage, responses: &mut VecDeque<Message>, (ipp, preferences): (&InputPreprocessorMessageHandler, &PreferencesMessageHandler)) {
-		#[remain::sorted]
 		match message {
 			// Sub-messages
-			#[remain::unsorted]
 			PortfolioMessage::MenuBar(message) => {
 				let mut has_active_document = false;
 				let mut rulers_visible = false;
@@ -44,7 +41,6 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 
 				self.menu_bar_message_handler.process_message(message, responses, (has_active_document, rulers_visible));
 			}
-			#[remain::unsorted]
 			PortfolioMessage::Document(message) => {
 				if let Some(document_id) = self.active_document_id {
 					if let Some(document) = self.documents.get_mut(&document_id) {
@@ -60,7 +56,6 @@ impl MessageHandler<PortfolioMessage, (&InputPreprocessorMessageHandler, &Prefer
 			}
 
 			// Messages
-			#[remain::unsorted]
 			PortfolioMessage::DocumentPassMessage { document_id, message } => {
 				if let Some(document) = self.documents.get_mut(&document_id) {
 					let document_inputs = DocumentInputs {

--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -31,7 +31,6 @@ impl Default for PreferencesMessageHandler {
 }
 
 impl MessageHandler<PreferencesMessage, ()> for PreferencesMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: PreferencesMessage, responses: &mut VecDeque<Message>, _data: ()) {
 		match message {
 			PreferencesMessage::Load { preferences } => {

--- a/editor/src/messages/tool/tool_message.rs
+++ b/editor/src/messages/tool/tool_message.rs
@@ -5,120 +5,79 @@ use graphene_core::raster::color::Color;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Tool)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum ToolMessage {
 	// Sub-messages
-	#[remain::unsorted]
 	#[child]
 	TransformLayer(TransformLayerMessage),
 
-	#[remain::unsorted]
 	#[child]
 	Select(SelectToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Artboard(ArtboardToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Navigate(NavigateToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Eyedropper(EyedropperToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Fill(FillToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Gradient(GradientToolMessage),
 
-	#[remain::unsorted]
 	#[child]
 	Path(PathToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Pen(PenToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Freehand(FreehandToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Spline(SplineToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Line(LineToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Rectangle(RectangleToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Ellipse(EllipseToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Polygon(PolygonToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Text(TextToolMessage),
 
-	#[remain::unsorted]
 	#[child]
 	Brush(BrushToolMessage),
-	// #[remain::unsorted]
-	// #[child]
+	// 	// #[child]
 	// Heal(HealToolMessage),
-	// #[remain::unsorted]
-	// #[child]
+	// 	// #[child]
 	// Clone(CloneToolMessage),
-	// #[remain::unsorted]
-	// #[child]
+	// 	// #[child]
 	// Patch(PatchToolMessage),
-	// #[remain::unsorted]
-	// #[child]
+	// 	// #[child]
 	// Relight(RelightToolMessage),
-	// #[remain::unsorted]
-	// #[child]
+	// 	// #[child]
 	// Detail(DetailToolMessage),
-	#[remain::unsorted]
 	#[child]
 	Imaginate(ImaginateToolMessage),
 
 	// Messages
-	#[remain::unsorted]
 	ActivateToolSelect,
-	#[remain::unsorted]
 	ActivateToolArtboard,
-	#[remain::unsorted]
 	ActivateToolNavigate,
-	#[remain::unsorted]
 	ActivateToolEyedropper,
-	#[remain::unsorted]
 	ActivateToolText,
-	#[remain::unsorted]
 	ActivateToolFill,
-	#[remain::unsorted]
 	ActivateToolGradient,
 
-	#[remain::unsorted]
 	ActivateToolPath,
-	#[remain::unsorted]
 	ActivateToolPen,
-	#[remain::unsorted]
 	ActivateToolFreehand,
-	#[remain::unsorted]
 	ActivateToolSpline,
-	#[remain::unsorted]
 	ActivateToolLine,
-	#[remain::unsorted]
 	ActivateToolRectangle,
-	#[remain::unsorted]
 	ActivateToolEllipse,
-	#[remain::unsorted]
 	ActivateToolPolygon,
 
-	#[remain::unsorted]
 	ActivateToolBrush,
-	#[remain::unsorted]
 	ActivateToolImaginate,
 
 	ActivateTool {

--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -17,7 +17,6 @@ pub struct ToolMessageHandler {
 }
 
 impl MessageHandler<ToolMessage, (&DocumentMessageHandler, DocumentId, &InputPreprocessorMessageHandler, &PersistentData, &NodeGraphExecutor)> for ToolMessageHandler {
-	#[remain::check]
 	fn process_message(
 		&mut self,
 		message: ToolMessage,
@@ -26,49 +25,30 @@ impl MessageHandler<ToolMessage, (&DocumentMessageHandler, DocumentId, &InputPre
 	) {
 		let font_cache = &persistent_data.font_cache;
 
-		#[remain::sorted]
 		match message {
 			// Messages
-			#[remain::unsorted]
 			ToolMessage::TransformLayer(message) => self
 				.transform_layer_handler
 				.process_message(message, responses, (document, input, &self.tool_state.tool_data, &mut self.shape_editor)),
 
-			#[remain::unsorted]
 			ToolMessage::ActivateToolSelect => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Select }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolArtboard => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Artboard }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolNavigate => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Navigate }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolEyedropper => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Eyedropper }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolText => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Text }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolFill => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Fill }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolGradient => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Gradient }),
 
-			#[remain::unsorted]
 			ToolMessage::ActivateToolPath => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Path }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolPen => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Pen }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolFreehand => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Freehand }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolSpline => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Spline }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolLine => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Line }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolRectangle => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Rectangle }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolEllipse => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Ellipse }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolPolygon => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Polygon }),
 
-			#[remain::unsorted]
 			ToolMessage::ActivateToolBrush => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Brush }),
-			#[remain::unsorted]
 			ToolMessage::ActivateToolImaginate => responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Imaginate }),
 
 			ToolMessage::ActivateTool { tool_type } => {
@@ -241,7 +221,6 @@ impl MessageHandler<ToolMessage, (&DocumentMessageHandler, DocumentId, &InputPre
 			}
 
 			// Sub-messages
-			#[remain::unsorted]
 			tool_message => {
 				let tool_type = match &tool_message {
 					ToolMessage::UpdateCursor | ToolMessage::UpdateHints => self.tool_state.tool_data.active_tool_type,

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -15,27 +15,18 @@ pub struct ArtboardTool {
 	data: ArtboardToolData,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Artboard)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum ArtboardToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
 
 	// Tool-specific messages
 	DeleteSelected,
-	NudgeSelected {
-		delta_x: f64,
-		delta_y: f64,
-	},
+	NudgeSelected { delta_x: f64, delta_y: f64 },
 	PointerDown,
-	PointerMove {
-		constrain_axis_or_aspect: Key,
-		center: Key,
-	},
+	PointerMove { constrain_axis_or_aspect: Key, center: Key },
 	PointerUp,
 }
 

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -51,14 +51,11 @@ impl Default for BrushOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Brush)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum BrushToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
@@ -68,7 +65,6 @@ pub enum BrushToolMessage {
 	UpdateOptions(BrushToolMessageOptionsUpdate),
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum BrushToolMessageOptionsUpdate {
 	BlendMode(BlendMode),

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -33,7 +33,6 @@ impl Default for EllipseToolOptions {
 	}
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum EllipseOptionsUpdate {
 	FillColor(Option<Color>),
@@ -44,25 +43,18 @@ pub enum EllipseOptionsUpdate {
 	WorkingColors(Option<Color>, Option<Color>),
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Ellipse)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum EllipseToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
 	DragStart,
 	DragStop,
-	PointerMove {
-		center: Key,
-		lock_ratio: Key,
-	},
+	PointerMove { center: Key, lock_ratio: Key },
 	UpdateOptions(EllipseOptionsUpdate),
 }
 

--- a/editor/src/messages/tool/tool_messages/eyedropper_tool.rs
+++ b/editor/src/messages/tool/tool_messages/eyedropper_tool.rs
@@ -7,12 +7,10 @@ pub struct EyedropperTool {
 	data: EyedropperToolData,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Eyedropper)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum EyedropperToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
 
 	// Tool-specific messages

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -7,7 +7,6 @@ pub struct FillTool {
 	fsm_state: FillToolFsmState,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Fill)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum FillToolMessage {

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -39,16 +39,12 @@ impl Default for FreehandOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Freehand)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum FreehandToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
@@ -58,7 +54,6 @@ pub enum FreehandToolMessage {
 	UpdateOptions(FreehandOptionsUpdate),
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum FreehandOptionsUpdate {
 	FillColor(Option<Color>),

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -19,28 +19,22 @@ pub struct GradientOptions {
 	gradient_type: GradientType,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Gradient)]
 #[derive(PartialEq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum GradientToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
 
 	// Tool-specific messages
 	DeleteStop,
 	InsertStop,
 	PointerDown,
-	PointerMove {
-		constrain_axis: Key,
-	},
+	PointerMove { constrain_axis: Key },
 	PointerUp,
 	UpdateOptions(GradientOptionsUpdate),
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum GradientOptionsUpdate {
 	Type(GradientType),

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -11,21 +11,16 @@ pub struct ImaginateTool {
 	tool_data: ImaginateToolData,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Imaginate)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum ImaginateToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
 
 	// Tool-specific messages
 	DragStart,
 	DragStop,
-	Resize {
-		center: Key,
-		lock_ratio: Key,
-	},
+	Resize { center: Key, lock_ratio: Key },
 }
 
 impl LayoutHolder for ImaginateTool {

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -32,30 +32,21 @@ impl Default for LineOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Line)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum LineToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
 	DragStart,
 	DragStop,
-	PointerMove {
-		center: Key,
-		lock_angle: Key,
-		snap_angle: Key,
-	},
+	PointerMove { center: Key, lock_angle: Key, snap_angle: Key },
 	UpdateOptions(LineOptionsUpdate),
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum LineOptionsUpdate {
 	LineWeight(f64),

--- a/editor/src/messages/tool/tool_messages/navigate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/navigate_tool.rs
@@ -6,22 +6,15 @@ pub struct NavigateTool {
 	tool_data: NavigateToolData,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Navigate)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum NavigateToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
 
 	// Tool-specific messages
-	ClickZoom {
-		zoom_in: bool,
-	},
-	PointerMove {
-		snap_angle: Key,
-		snap_zoom: Key,
-	},
+	ClickZoom { zoom_in: bool },
+	PointerMove { snap_angle: Key, snap_zoom: Key },
 	RotateCanvasBegin,
 	TransformCanvasEnd,
 	TranslateCanvasBegin,

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -19,16 +19,12 @@ pub struct PathTool {
 	tool_data: PathToolData,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Path)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum PathToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	SelectionChanged,
 
 	// Tool-specific messages

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -39,29 +39,20 @@ impl Default for PenOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Pen)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum PenToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	SelectionChanged,
-	#[remain::unsorted]
 	WorkingColorChanged,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
 
 	// Tool-specific messages
 	Confirm,
 	DragStart,
 	DragStop,
-	PointerMove {
-		snap_angle: Key,
-		break_handle: Key,
-		lock_angle: Key,
-	},
+	PointerMove { snap_angle: Key, break_handle: Key, lock_angle: Key },
 	Redo,
 	Undo,
 	UpdateOptions(PenOptionsUpdate),
@@ -75,7 +66,6 @@ enum PenToolFsmState {
 	PlacingAnchor,
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum PenOptionsUpdate {
 	FillColor(Option<Color>),

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -37,25 +37,18 @@ impl Default for PolygonOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Polygon)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum PolygonToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
 	DragStart,
 	DragStop,
-	PointerMove {
-		center: Key,
-		lock_ratio: Key,
-	},
+	PointerMove { center: Key, lock_ratio: Key },
 	UpdateOptions(PolygonOptionsUpdate),
 }
 
@@ -65,7 +58,6 @@ pub enum PrimitiveShapeType {
 	Star = 1,
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum PolygonOptionsUpdate {
 	FillColor(Option<Color>),

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -33,7 +33,6 @@ impl Default for RectangleToolOptions {
 	}
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum RectangleOptionsUpdate {
 	FillColor(Option<Color>),
@@ -44,25 +43,18 @@ pub enum RectangleOptionsUpdate {
 	WorkingColors(Option<Color>, Option<Color>),
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Rectangle)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum RectangleToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Overlays(OverlayContext),
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
 	DragStart,
 	DragStop,
-	PointerMove {
-		center: Key,
-		lock_ratio: Key,
-	},
+	PointerMove { center: Key, lock_ratio: Key },
 	UpdateOptions(RectangleOptionsUpdate),
 }
 

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -30,7 +30,6 @@ pub struct SelectOptions {
 	nested_selection_behavior: NestedSelectionBehavior,
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum SelectOptionsUpdate {
 	NestedSelectionBehavior(NestedSelectionBehavior),
@@ -60,32 +59,22 @@ pub struct SelectToolPointerKeys {
 	pub duplicate: Key,
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Select)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum SelectToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
 
 	// Tool-specific messages
-	DragStart {
-		add_to_selection: Key,
-		select_deepest: Key,
-	},
-	DragStop {
-		remove_from_selection: Key,
-	},
+	DragStart { add_to_selection: Key, select_deepest: Key },
+	DragStop { remove_from_selection: Key },
 	EditLayer,
 	Enter,
 	PointerMove(SelectToolPointerKeys),
 	PointerOutsideViewport(SelectToolPointerKeys),
 	SelectOptions(SelectOptionsUpdate),
-	SetPivot {
-		position: PivotPosition,
-	},
+	SetPivot { position: PivotPosition },
 	ShiftViewport,
 }
 

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -34,16 +34,12 @@ impl Default for SplineOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Spline)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum SplineToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	CanvasTransformed,
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
 
 	// Tool-specific messages
@@ -62,7 +58,6 @@ enum SplineToolFsmState {
 	Drawing,
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum SplineOptionsUpdate {
 	FillColor(Option<Color>),

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -40,32 +40,23 @@ impl Default for TextOptions {
 	}
 }
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, Text)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum TextToolMessage {
 	// Standard messages
-	#[remain::unsorted]
 	Abort,
-	#[remain::unsorted]
 	WorkingColorChanged,
-	#[remain::unsorted]
 	Overlays(OverlayContext),
 
 	// Tool-specific messages
 	CommitText,
 	EditSelected,
 	Interact,
-	TextChange {
-		new_text: String,
-	},
-	UpdateBounds {
-		new_text: String,
-	},
+	TextChange { new_text: String },
+	UpdateBounds { new_text: String },
 	UpdateOptions(TextOptionsUpdate),
 }
 
-#[remain::sorted]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize, specta::Type)]
 pub enum TextOptionsUpdate {
 	FillColor(Option<Color>),

--- a/editor/src/messages/tool/transform_layer/transform_layer_message.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message.rs
@@ -3,7 +3,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, ToolMessage, TransformLayer)]
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum TransformLayerMessage {

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -42,7 +42,6 @@ impl TransformLayerMessageHandler {
 
 type TransformData<'a> = (&'a DocumentMessageHandler, &'a InputPreprocessorMessageHandler, &'a ToolData, &'a mut ShapeState);
 impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformLayerMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: TransformLayerMessage, responses: &mut VecDeque<Message>, (document, input, tool_data, shape_editor): TransformData) {
 		use TransformLayerMessage::*;
 
@@ -91,7 +90,6 @@ impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformL
 			selected.original_transforms.clear();
 		};
 
-		#[remain::sorted]
 		match message {
 			ApplyTransformOperation => {
 				selected.original_transforms.clear();

--- a/editor/src/messages/workspace/workspace_message.rs
+++ b/editor/src/messages/workspace/workspace_message.rs
@@ -2,7 +2,6 @@ use crate::messages::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
-#[remain::sorted]
 #[impl_message(Message, Workspace)]
 #[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub enum WorkspaceMessage {

--- a/editor/src/messages/workspace/workspace_message_handler.rs
+++ b/editor/src/messages/workspace/workspace_message_handler.rs
@@ -6,11 +6,9 @@ pub struct WorkspaceMessageHandler {
 }
 
 impl MessageHandler<WorkspaceMessage, ()> for WorkspaceMessageHandler {
-	#[remain::check]
 	fn process_message(&mut self, message: WorkspaceMessage, _responses: &mut VecDeque<Message>, _data: ()) {
 		use WorkspaceMessage::*;
 
-		#[remain::sorted]
 		match message {
 			// Messages
 			NodeGraphToggleVisibility => {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

This PR removes the `remain` dependency and all of its procedural macros used in the codebase.

Closes #1515 
