### PR TITLE
Fix regression from #1630 for Layers panel blend modes missing labels

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1408,8 +1408,8 @@ impl DocumentMessageHandler {
 				modes
 					.iter()
 					.map(|&blend_mode| {
-						MenuListEntry::new(blend_mode.to_string())
-							.value(blend_mode.to_string())
+						MenuListEntry::new(format!("{blend_mode:?}"))
+							.label(blend_mode.to_string())
 							.on_update(move |_| DocumentMessage::SetBlendModeForSelectedLayers { blend_mode }.into())
 					})
 					.collect()


### PR DESCRIPTION
This PR fixes a missed conversion in #1630
The bug is described in https://github.com/GraphiteEditor/Graphite/pull/1630#issuecomment-1977756289

And I have checked once again that every instance of `MenuListEntry` and `RadioEntryData` is converted in the codebase.

