### PR TITLE
New node: Solidify Stroke

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -2618,6 +2618,15 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 			..Default::default()
 		},
 		DocumentNodeDefinition {
+			name: "Fill From Stroke",
+			category: "Vector",
+			implementation: DocumentNodeImplementation::proto("graphene_core::vector::FillFromStrokeNode"),
+			inputs: vec![DocumentInputType::value("Vector Data", TaggedValue::VectorData(graphene_core::vector::VectorData::empty()), true)],
+			outputs: vec![DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
+			properties: node_properties::node_no_properties,
+			..Default::default()
+		},
+		DocumentNodeDefinition {
 			name: "Repeat",
 			category: "Vector",
 			implementation: DocumentNodeImplementation::proto("graphene_core::vector::RepeatNode<_, _>"),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler/document_node_types.rs
@@ -2618,9 +2618,9 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 			..Default::default()
 		},
 		DocumentNodeDefinition {
-			name: "Fill From Stroke",
+			name: "Solidify Stroke",
 			category: "Vector",
-			implementation: DocumentNodeImplementation::proto("graphene_core::vector::FillFromStrokeNode"),
+			implementation: DocumentNodeImplementation::proto("graphene_core::vector::SolidifyStrokeNode"),
 			inputs: vec![DocumentInputType::value("Vector Data", TaggedValue::VectorData(graphene_core::vector::VectorData::empty()), true)],
 			outputs: vec![DocumentOutputType::new("Vector", FrontendGraphDataType::Subpath)],
 			properties: node_properties::node_no_properties,

--- a/node-graph/gcore/src/vector/style.rs
+++ b/node-graph/gcore/src/vector/style.rs
@@ -189,9 +189,17 @@ pub enum Fill {
 }
 
 impl Fill {
-	/// Construct a new solid [Fill] from a [Color].
+	/// Construct a new [Fill::Solid] from a [Color].
 	pub fn solid(color: Color) -> Self {
 		Self::Solid(color)
+	}
+
+	/// Construct a new [Fill::Solid] or [Fill::None] from an optional [Color].
+	pub fn solid_or_none(color: Option<Color>) -> Self {
+		match color {
+			Some(color) => Self::Solid(color),
+			None => Self::None,
+		}
 	}
 
 	/// Evaluate the color at some point on the fill. Doesn't currently work for Gradient.

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -166,22 +166,24 @@ fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
 		);
 
 		// This is where we determine whether we have a closed or open path. Ex: Line vs oval
-		match subpath_out.1 {
-			Some(_) => {
-				// Two closed subpaths, closed shape.
-				new_subpaths.push(subpath_out.0);
-				new_subpaths.push(subpath_out.1.unwrap());
-			}
-
-			None => {
-				// One closed subpath, open path.
-				new_subpaths.push(subpath_out.0);
-			}
+		if subpath_out.1.is_some() {
+			// Two closed subpaths, closed shape.
+			new_subpaths.push(subpath_out.0);
+			new_subpaths.push(subpath_out.1.unwrap());
+		} else {
+			// One closed subpath, open path.
+			new_subpaths.push(subpath_out.0);
 		}
 	}
 
 	// Output our new paths and get rid of the stroke since it's been converted.
 	vector_data.subpaths = new_subpaths;
+
+	//
+	if let Some(stroke) = vector_data.style.stroke() {
+		vector_data.style.set_fill(Fill::solid_or_none(stroke.color));
+	}
+
 	vector_data.style.set_stroke(Stroke::default());
 	vector_data
 }

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -167,11 +167,17 @@ fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
 
 		// This is where we determine whether we have a closed or open path. Ex: Line vs oval
 		match subpath_out.1 {
-			Some(_) => subpath = subpath_out.1.unwrap(), // Two closed subpaths
-			None => subpath = subpath_out.0,             // One closed subpath
-		}
+			Some(_) => {
+				// Two closed subpaths, closed shape.
+				new_subpaths.push(subpath_out.0);
+				new_subpaths.push(subpath_out.1.unwrap());
+			}
 
-		new_subpaths.push(subpath);
+			None => {
+				// One closed subpath, open path.
+				new_subpaths.push(subpath_out.0);
+			}
+		}
 	}
 
 	// Output our new paths and get rid of the stroke since it's been converted.

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -136,6 +136,14 @@ fn generate_bounding_box(vector_data: VectorData) -> VectorData {
 	))
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct FillFromStrokeNode;
+
+#[node_macro::node_fn(FillFromStrokeNode)]
+fn generate_fill_from_stroke(vector_data: VectorData) -> VectorData {
+	VectorData::default()
+}
+
 pub trait ConcatElement {
 	fn concat(&mut self, other: &Self, transform: DAffine2);
 }

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -90,7 +90,6 @@ fn repeat_vector_data(vector_data: VectorData, direction: DVec2, count: u32) -> 
 	// Repeat the vector data
 	let mut result = VectorData::empty();
 	let inverse = vector_data.transform.inverse();
-	//let direction = inverse.transform_vector2(direction);
 	for i in 0..count {
 		let transform = DAffine2::from_translation(direction * i as f64);
 		result.concat(&vector_data, transform);

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -90,7 +90,7 @@ fn repeat_vector_data(vector_data: VectorData, direction: DVec2, count: u32) -> 
 	// Repeat the vector data
 	let mut result = VectorData::empty();
 	let inverse = vector_data.transform.inverse();
-	let direction = inverse.transform_vector2(direction);
+	//let direction = inverse.transform_vector2(direction);
 	for i in 0..count {
 		let transform = DAffine2::from_translation(direction * i as f64);
 		result.concat(&vector_data, transform);
@@ -141,10 +141,10 @@ fn generate_bounding_box(vector_data: VectorData) -> VectorData {
 pub struct SolidifyStrokeNode;
 
 #[node_macro::node_fn(SolidifyStrokeNode)]
-fn solidify_stroke(mut vector_data: VectorData) -> VectorData {
+fn solidify_stroke(vector_data: VectorData) -> VectorData {
 	// Grab what we need from original data.
 	let VectorData { transform, style, .. } = &vector_data;
-	let mut subpaths = vector_data.stroke_bezier_paths();
+	let subpaths = vector_data.stroke_bezier_paths();
 	let mut result = VectorData::empty();
 
 	// Perform operation on all subpaths in this shape.

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -138,21 +138,24 @@ fn generate_bounding_box(vector_data: VectorData) -> VectorData {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct FillFromStrokeNode;
+pub struct SolidifyStrokeNode;
 
-#[node_macro::node_fn(FillFromStrokeNode)]
-fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
+#[node_macro::node_fn(SolidifyStrokeNode)]
+fn solidify_stroke(mut vector_data: VectorData) -> VectorData {
 	// Grab what we need from original data.
-	let VectorData { subpaths, style, .. } = &vector_data;
+	let VectorData { subpaths, transform, style, .. } = &vector_data;
 	let mut new_subpaths: Vec<Subpath<ManipulatorGroupId>> = Vec::with_capacity(subpaths.len()); // Our output
 
 	// Perform operation on all subpaths in this shape.
 	for mut subpath in subpaths.clone() {
 		let stroke = style.stroke().unwrap();
+		let transform = transform.clone();
+		subpath.apply_transform(transform);
+		debug!("The transform we are applying is: translate: {}, matrix2: {}", transform.translation, transform.matrix2);
 
 		// Taking the existing stroke data and passing it to Bezier-rs to generate new paths.
 		let subpath_out = subpath.outline(
-			stroke.weight,
+			stroke.weight / 2.0, // Diameter to radius.
 			match stroke.line_join {
 				crate::vector::style::LineJoin::Miter => Join::Miter(Some(stroke.line_join_miter_limit)),
 				crate::vector::style::LineJoin::Bevel => Join::Bevel,
@@ -165,9 +168,9 @@ fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
 			},
 		);
 
-		// This is where we determine whether we have a closed or open path. Ex: Line vs oval
+		// This is where we determine whether we have a closed or open path. Ex: Oval vs line segment.
 		if subpath_out.1.is_some() {
-			// Two closed subpaths, closed shape.
+			// Two closed subpaths, closed shape. Add both subpaths.
 			new_subpaths.push(subpath_out.0);
 			new_subpaths.push(subpath_out.1.unwrap());
 		} else {
@@ -176,15 +179,15 @@ fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
 		}
 	}
 
-	// Output our new paths and get rid of the stroke since it's been converted.
+	// Output our new paths.
 	vector_data.subpaths = new_subpaths;
 
-	//
+	// We set our fill to our stroke's color, then clear our stroke.
 	if let Some(stroke) = vector_data.style.stroke() {
 		vector_data.style.set_fill(Fill::solid_or_none(stroke.color));
+		vector_data.style.set_stroke(Stroke::default());
 	}
 
-	vector_data.style.set_stroke(Stroke::default());
 	vector_data
 }
 

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -6,7 +6,7 @@ use crate::uuid::ManipulatorGroupId;
 use crate::{Color, GraphicGroup, Node};
 use core::future::Future;
 
-use bezier_rs::{Subpath, SubpathTValue, TValue, utils};
+use bezier_rs::{Cap, Join, Subpath, SubpathTValue, TValue};
 use glam::{DAffine2, DVec2};
 use rand::{Rng, SeedableRng};
 
@@ -154,7 +154,7 @@ fn generate_fill_from_stroke(mut vector_data: VectorData) -> VectorData {
 		let subpath_out = subpath.outline(
 			stroke.weight,
 			match stroke.line_join {
-				crate::vector::style::LineJoin::Miter => Join::Miter(None),
+				crate::vector::style::LineJoin::Miter => Join::Miter(Some(stroke.line_join_miter_limit)),
 				crate::vector::style::LineJoin::Bevel => Join::Bevel,
 				crate::vector::style::LineJoin::Round => Join::Round,
 			},

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -704,6 +704,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::vector::SetStrokeNode<_, _, _, _, _, _, _>, input: VectorData, params: [Option<graphene_core::Color>, f64, Vec<f64>, f64, graphene_core::vector::style::LineCap, graphene_core::vector::style::LineJoin, f64]),
 		register_node!(graphene_core::vector::RepeatNode<_, _>, input: VectorData, params: [DVec2, u32]),
 		register_node!(graphene_core::vector::BoundingBoxNode, input: VectorData, params: []),
+		register_node!(graphene_core::vector::FillFromStrokeNode, input: VectorData, params: []),
 		register_node!(graphene_core::vector::CircularRepeatNode<_, _, _>, input: VectorData, params: [f64, f64, u32]),
 		vec![(
 			ProtoNodeIdentifier::new("graphene_core::transform::CullNode<_>"),

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -704,7 +704,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::vector::SetStrokeNode<_, _, _, _, _, _, _>, input: VectorData, params: [Option<graphene_core::Color>, f64, Vec<f64>, f64, graphene_core::vector::style::LineCap, graphene_core::vector::style::LineJoin, f64]),
 		register_node!(graphene_core::vector::RepeatNode<_, _>, input: VectorData, params: [DVec2, u32]),
 		register_node!(graphene_core::vector::BoundingBoxNode, input: VectorData, params: []),
-		register_node!(graphene_core::vector::FillFromStrokeNode, input: VectorData, params: []),
+		register_node!(graphene_core::vector::SolidifyStrokeNode, input: VectorData, params: []),
 		register_node!(graphene_core::vector::CircularRepeatNode<_, _, _>, input: VectorData, params: [f64, f64, u32]),
 		vec![(
 			ProtoNodeIdentifier::new("graphene_core::transform::CullNode<_>"),


### PR DESCRIPTION
This node can be added after a stroke node in a set of vector data. Upon doing so, it will account for the stroke's shape and add it to the vector data. The stroke will be treated as a solid part of the shape or line segment. Both closed shapes and line segments are supported.

Closes #1092