### PR TITLE
Fix orphaned child layers left behind when a group is ungrouped or deleted

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -680,8 +680,6 @@ impl MessageHandler<GraphOperationMessage, GraphOperationHandlerData<'_>> for Gr
 				alias,
 			} => {
 				trace!("Inserting new layer {id} as a child of {parent:?} at index {insert_index}");
-				debug!("Inserting new layer {id} as a child of {parent:?} at index {insert_index}");
-				// debug!("The Node is {:#?}", nodes);
 
 				let mut modify_inputs = ModifyInputsContext::new(document_network, document_metadata, node_graph, responses);
 
@@ -753,8 +751,6 @@ impl MessageHandler<GraphOperationMessage, GraphOperationHandlerData<'_>> for Gr
 				}
 			}
 			GraphOperationMessage::DeleteLayer { id } => {
-				debug!("Deleting layer {id}");
-				debug!("Selected nodes: {selected_nodes:?}");
 				let mut modify_inputs = ModifyInputsContext::new(document_network, document_metadata, node_graph, responses);
 				modify_inputs.delete_layer(id, selected_nodes);
 				load_network_structure(document_network, document_metadata, selected_nodes, collapsed);

--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -517,7 +517,7 @@ impl<'a> ModifyInputsContext<'a> {
 		};
 
 		let layer_node = LayerNodeIdentifier::new(id, self.document_network);
-		let child_layers = layer_node.decendants(self.document_metadata).map(|id| id.to_node()).collect::<Vec<_>>();
+		let child_layers = layer_node.decendants(self.document_metadata).map(|layer| layer.to_node()).collect::<Vec<_>>();
 		layer_node.delete(self.document_metadata);
 
 		let new_input = node.inputs[1].clone();


### PR DESCRIPTION
this is resolve `delete_layer` function that failing to fully remove all child nodes associated with the parent layer.

Closes #1654
