### PR TITLE
Create a history step when importing SVG files

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -10,8 +10,8 @@ use graphene_core::raster::Image;
 use graphene_core::vector::style::ViewMode;
 use graphene_core::Color;
 
+use glam::DAffine2;
 use serde::{Deserialize, Serialize};
-
 #[impl_message(Message, PortfolioMessage, Document)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum DocumentMessage {
@@ -67,6 +67,13 @@ pub enum DocumentMessage {
 	ImaginateRandom {
 		imaginate_node: Vec<NodeId>,
 		then_generate: bool,
+	},
+	ImportSvg {
+		id: NodeId,
+		svg: String,
+		transform: DAffine2,
+		parent: LayerNodeIdentifier,
+		insert_index: isize,
 	},
 	MoveSelectedLayersTo {
 		parent: LayerNodeIdentifier,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -538,28 +538,14 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 				parent,
 				insert_index,
 			} => {
-				match usvg::Tree::from_str(&svg, &usvg::Options::default()) {
-					Ok(_) => {
-						//Writing serdes deserializer would literally be an implementation of usvg::to_string.
-						//No point in doing that IMHO hence why we just repeat the same process, even though
-						//it technically leads to a dead match branch further down the stack
-						self.backup(responses);
-						responses.add(GraphOperationMessage::NewSvg {
-							id,
-							svg,
-							transform,
-							parent,
-							insert_index,
-						});
-					}
-					Err(e) => {
-						responses.add(DialogMessage::DisplayDialogError {
-							title: "SVG parsing failed".to_string(),
-							description: e.to_string(),
-						});
-						return;
-					}
-				};
+				self.backup(responses);
+				responses.add(GraphOperationMessage::NewSvg {
+					id,
+					svg,
+					transform,
+					parent,
+					insert_index,
+				});
 			}
 			MoveSelectedLayersTo { parent, insert_index } => {
 				let selected_layers = self.selected_nodes.selected_layers(self.metadata()).collect::<Vec<_>>();

--- a/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/graph_operation_message_handler.rs
@@ -773,6 +773,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationHandlerData<'_>> for Gr
 				let tree = match usvg::Tree::from_str(&svg, &usvg::Options::default()) {
 					Ok(t) => t,
 					Err(e) => {
+						responses.add(DocumentMessage::DocumentHistoryBackward);
 						responses.add(DialogMessage::DisplayDialogError {
 							title: "SVG parsing failed".to_string(),
 							description: e.to_string(),

--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -37,7 +37,7 @@ pub fn new_image_layer(image_frame: ImageFrame<Color>, id: NodeId, parent: Layer
 /// Create a new group layer from an svg
 pub fn new_svg_layer(svg: String, transform: glam::DAffine2, id: NodeId, parent: LayerNodeIdentifier, responses: &mut VecDeque<Message>) -> LayerNodeIdentifier {
 	let insert_index = -1;
-	responses.add(GraphOperationMessage::NewSvg {
+	responses.add(DocumentMessage::ImportSvg {
 		id,
 		svg,
 		transform,


### PR DESCRIPTION
Generally the issue is that the actual import and creation of a new SVG is handled through `GraphOperationMessageHandler` which doesn't have a "syncish" way of backuping data (the only way how you could backup the data from there is by rewriting the `DocumentMessage::Backup` message and fixing code around and after that you would call it, but that leads to an async backup of data meaning the "step before the import" will likely not get saved in time).

So my approach was to add a `DocumentMessage::ImportSvg` ... which pretty much tries to create a `usvg::Tree` the same way as `GraphOperationMessage::NewSvg` does... with the exception that it doesn't care about the result... only cares about the succesful unwraping `Ok(_)` of the `Option<Tree>` and then proceeds to send the original message (and calls self.backup(responses) before)

Now ofcourse the idea of just deserializing the tree and sending that crossed my mind but after investigating serde I realized it would just be a reimplementation of their `Tree::to_string` method which seemed pointless.
I'll look into what is your branching strategy and I'll submit a PR so that you can take a look at it
Maybe just to add... of course an option would be to just `self.backup(...) `on every `GraphOperationMessage` received by `DocumentMessageHandler`... but that would lead to undesired behaviour with some of the other tools that work with vector graphics