### PR TITLE
Allow cancellation of pivot drag in Select tool

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -484,7 +484,7 @@ impl Fsm for SelectToolFsmState {
 				// Dragging the pivot
 				if tool_data.pivot.is_over(input.mouse.position) {
 					responses.add(DocumentMessage::StartTransaction);
-					
+
 					//tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(), true, true);
 					//tool_data.snap_manager.add_all_document_handles(document, input, &[], &[], &[]);
 

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -484,7 +484,7 @@ impl Fsm for SelectToolFsmState {
 				// Dragging the pivot
 				if tool_data.pivot.is_over(input.mouse.position) {
 					responses.add(DocumentMessage::StartTransaction);
-
+					
 					//tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(), true, true);
 					//tool_data.snap_manager.add_all_document_handles(document, input, &[], &[], &[]);
 
@@ -590,6 +590,11 @@ impl Fsm for SelectToolFsmState {
 				tool_data.non_duplicated_layers = None;
 
 				state
+			}
+			(SelectToolFsmState::DraggingPivot, SelectToolMessage::Abort) => {
+				responses.add(DocumentMessage::AbortTransaction);
+
+				SelectToolFsmState::Ready
 			}
 			(SelectToolFsmState::Dragging, SelectToolMessage::PointerMove(modifier_keys)) => {
 				tool_data.has_dragged = true;


### PR DESCRIPTION
Added Abort - tested in multiple scenarios:
- ESC/RMB when DraggingPivot
- Change tool when DraggingPivot
- Tested other actions such as resizing that might be affected by the change
- Tested if rotations around pivot match after aborting

