### PR TITLE
Don't save undo/redo history when aborting transactions

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1074,15 +1074,14 @@ impl DocumentMessageHandler {
 	}
 
 	pub fn undo_with_history(&mut self, responses: &mut VecDeque<Message>) {
-		let Some(network) = undo(responses) else { return };
+		let Some(previous_network) = self.undo(responses) else { return };
 
-		let previous_network = std::mem::replace(&mut self.network, network);
 		self.document_redo_history.push_back(previous_network);
 		if self.document_redo_history.len() > crate::consts::MAX_UNDO_HISTORY_LEN {
 			self.document_redo_history.pop_front();
 		}
 	}
-	pub fn undo(&mut self, responses: &mut VecDeque<Message>) {
+	pub fn undo(&mut self, responses: &mut VecDeque<Message>) -> Option<NodeNetwork> {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		//If there is no history return and don't broadcast SelectionChanged
@@ -1090,22 +1089,24 @@ impl DocumentMessageHandler {
 
 		responses.add(BroadcastEvent::SelectionChanged);
 
-		network
+		let previous_network = std::mem::replace(&mut self.network, network);
+		Some(previous_network)
 	}
-	pub fn redo(&mut self, responses: &mut VecDeque<Message>) {
+	pub fn redo(&mut self, responses: &mut VecDeque<Message>) -> Option<NodeNetwork> {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		//If there is no history return and don't broadcast SelectionChanged
 		let Some(network) = self.document_redo_history.pop_back() else { return None };
 
 		responses.add(BroadcastEvent::SelectionChanged);
-		network
+
+		let previous_network = std::mem::replace(&mut self.network, network);
+		Some(previous_network)
 	}
 	pub fn redo_with_history(&mut self, responses: &mut VecDeque<Message>) {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
-		let Some(network) = redo(responses) else { return };
+		let Some(previous_network) = self.redo(responses) else { return };
 
-		let previous_network = std::mem::replace(&mut self.network, network);
 		self.document_undo_history.push_back(previous_network);
 		if self.document_undo_history.len() > crate::consts::MAX_UNDO_HISTORY_LEN {
 			self.document_undo_history.pop_front();

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -386,8 +386,8 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 				responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![] });
 				self.layer_range_selection_reference = None;
 			}
-			DocumentHistoryBackward => self.undo(responses),
-			DocumentHistoryForward => self.redo(responses),
+			DocumentHistoryBackward => self.undo_with_history(responses),
+			DocumentHistoryForward => self.redo_with_history(responses),
 			DocumentStructureChanged => {
 				self.update_layers_panel_options_bar_widgets(responses);
 
@@ -1073,13 +1073,8 @@ impl DocumentMessageHandler {
 		std::mem::replace(&mut self.network, network)
 	}
 
-	pub fn undo(&mut self, responses: &mut VecDeque<Message>) {
-		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
-		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
-
-		let Some(network) = self.document_undo_history.pop_back() else { return };
-
-		responses.add(BroadcastEvent::SelectionChanged);
+	pub fn undo_with_history(&mut self, responses: &mut VecDeque<Message>) {
+		let Some(network) = undo(responses) else { return };
 
 		let previous_network = std::mem::replace(&mut self.network, network);
 		self.document_redo_history.push_back(previous_network);
@@ -1087,14 +1082,28 @@ impl DocumentMessageHandler {
 			self.document_redo_history.pop_front();
 		}
 	}
+	pub fn undo(&mut self, responses: &mut VecDeque<Message>) {
+		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
+		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
+		//If there is no history return and don't broadcast SelectionChanged
+		let Some(network) = self.document_undo_history.pop_back() else { return None };
 
+		responses.add(BroadcastEvent::SelectionChanged);
+
+		network
+	}
 	pub fn redo(&mut self, responses: &mut VecDeque<Message>) {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
-
-		let Some(network) = self.document_redo_history.pop_back() else { return };
+		//If there is no history return and don't broadcast SelectionChanged
+		let Some(network) = self.document_redo_history.pop_back() else { return None };
 
 		responses.add(BroadcastEvent::SelectionChanged);
+		network
+	}
+	pub fn redo_with_history(&mut self, responses: &mut VecDeque<Message>) {
+		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
+		let Some(network) = redo(responses) else { return };
 
 		let previous_network = std::mem::replace(&mut self.network, network);
 		self.document_undo_history.push_back(previous_network);

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1084,7 +1084,7 @@ impl DocumentMessageHandler {
 	pub fn undo(&mut self, responses: &mut VecDeque<Message>) -> Option<NodeNetwork> {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
-		//If there is no history return and don't broadcast SelectionChanged
+		// If there is no history return and don't broadcast SelectionChanged
 		let Some(network) = self.document_undo_history.pop_back() else { return None };
 
 		responses.add(BroadcastEvent::SelectionChanged);
@@ -1095,7 +1095,7 @@ impl DocumentMessageHandler {
 	pub fn redo(&mut self, responses: &mut VecDeque<Message>) -> Option<NodeNetwork> {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
-		//If there is no history return and don't broadcast SelectionChanged
+		// If there is no history return and don't broadcast SelectionChanged
 		let Some(network) = self.document_redo_history.pop_back() else { return None };
 
 		responses.add(BroadcastEvent::SelectionChanged);


### PR DESCRIPTION
For now solved with a simple split of undo/redo into a "forgettable" version and non-forgettable.  
Fixes #1659 
