### PR TITLE
Make Artboard tool respond to Abort keys

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -110,6 +110,8 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowUp], action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: -NUDGE_AMOUNT }),
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowDown], action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: NUDGE_AMOUNT }),
 		entry!(KeyDown(ArrowRight); action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: 0. }),
+		entry!(KeyDown(Rmb); action_dispatch=ArtboardToolMessage::Abort),
+		entry!(KeyDown(Escape); action_dispatch=ArtboardToolMessage::Abort),
 		//
 		// NavigateToolMessage
 		entry!(KeyUp(Lmb); modifiers=[Shift], action_dispatch=NavigateToolMessage::ClickZoom { zoom_in: false }),

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -395,11 +395,17 @@ impl Fsm for ArtboardToolFsmState {
 
 				ArtboardToolFsmState::Ready
 			}
-			(_, ArtboardToolMessage::Abort) => {
-				tool_data.snap_manager.cleanup(responses);
+			(ArtboardToolFsmState::Drawing | ArtboardToolFsmState::ResizingBounds | ArtboardToolFsmState::Dragging, ArtboardToolMessage::Abort) => {
+				responses.add(DocumentMessage::AbortTransaction);
+
+				//ArtboardTool currently doesn't implement snapping
+				//tool_data.snap_manager.cleanup(responses);
+
 				responses.add(OverlaysMessage::Draw);
+
 				ArtboardToolFsmState::Ready
 			}
+			(_, ArtboardToolMessage::Abort) => ArtboardToolFsmState::Ready,
 			_ => self,
 		}
 	}


### PR DESCRIPTION
Part of #1657 

This is the last tool that I will do in a separate pull request as most of the logic is easy to implement.

Implemented 3 aborts:
- When resizing
- When drawing
- When moving (I've seen it implemented with other tools)
