### PR TITLE
Make the Fill tool's fill click operation cancellable

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -253,6 +253,9 @@ pub fn default_mapping() -> Mapping {
 		// FillToolMessage
 		entry!(KeyDown(Lmb); action_dispatch=FillToolMessage::FillPrimaryColor),
 		entry!(KeyDown(Lmb); modifiers=[Shift], action_dispatch=FillToolMessage::FillSecondaryColor),
+		entry!(KeyUp(Lmb); action_dispatch=FillToolMessage::PointerUp),
+		entry!(KeyDown(Escape); action_dispatch=FillToolMessage::Abort),
+		entry!(KeyDown(Rmb); action_dispatch=FillToolMessage::Abort),
 		//
 		// BrushToolMessage
 		entry!(PointerMove; action_dispatch=BrushToolMessage::PointerMove),

--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -254,8 +254,8 @@ pub fn default_mapping() -> Mapping {
 		entry!(KeyDown(Lmb); action_dispatch=FillToolMessage::FillPrimaryColor),
 		entry!(KeyDown(Lmb); modifiers=[Shift], action_dispatch=FillToolMessage::FillSecondaryColor),
 		entry!(KeyUp(Lmb); action_dispatch=FillToolMessage::PointerUp),
-		entry!(KeyDown(Escape); action_dispatch=FillToolMessage::Abort),
 		entry!(KeyDown(Rmb); action_dispatch=FillToolMessage::Abort),
+		entry!(KeyDown(Escape); action_dispatch=FillToolMessage::Abort),
 		//
 		// BrushToolMessage
 		entry!(PointerMove; action_dispatch=BrushToolMessage::PointerMove),

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -59,7 +59,10 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for FillToo
 
 impl ToolTransition for FillTool {
 	fn event_to_message_map(&self) -> EventToMessageMap {
-		EventToMessageMap::default()
+		EventToMessageMap {
+			tool_abort: Some(FillToolMessage::Abort.into()),
+			..Default::default()
+		}
 	}
 }
 
@@ -83,11 +86,12 @@ impl Fsm for FillToolFsmState {
 		let ToolMessage::Fill(event) = event else {
 			return self;
 		};
-		let Some(layer_identifier) = document.click(input.mouse.position, &document.network) else {
-			return self;
-		};
+
 		match (self, event) {
 			(FillToolFsmState::Ready, color_event) => {
+				let Some(layer_identifier) = document.click(input.mouse.position, &document.network) else {
+					return self;
+				};
 				// TODO: Use a match statement here instead of if-else
 				let color = if color_event == FillToolMessage::FillPrimaryColor {
 					global_tool_data.primary_color

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -10,8 +10,9 @@ pub struct FillTool {
 #[impl_message(Message, ToolMessage, Fill)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, Deserialize, specta::Type)]
 pub enum FillToolMessage {
-	// General messages
+	// Standard messages
 	Abort,
+
 	// Tool-specific messages
 	PointerUp,
 	FillPrimaryColor,
@@ -87,6 +88,7 @@ impl Fsm for FillToolFsmState {
 		};
 		match (self, event) {
 			(FillToolFsmState::Ready, color_event) => {
+				// TODO: Use a match statement here instead of if-else
 				let color = if color_event == FillToolMessage::FillPrimaryColor {
 					global_tool_data.primary_color
 				} else {
@@ -117,7 +119,7 @@ impl Fsm for FillToolFsmState {
 			])]),
 			FillToolFsmState::Filling => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::Rmb, ""),
-				HintInfo::keys([Key::Escape], "Cancel Fill").prepend_slash(),
+				HintInfo::keys([Key::Escape], "Cancel").prepend_slash(),
 			])]),
 		};
 

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -117,10 +117,7 @@ impl Fsm for FillToolFsmState {
 				HintInfo::mouse(MouseMotion::Lmb, "Fill with Primary"),
 				HintInfo::keys_and_mouse([Key::Shift], MouseMotion::Lmb, "Fill with Secondary"),
 			])]),
-			FillToolFsmState::Filling => HintData(vec![HintGroup(vec![
-				HintInfo::mouse(MouseMotion::Rmb, ""),
-				HintInfo::keys([Key::Escape], "Cancel").prepend_slash(),
-			])]),
+			FillToolFsmState::Filling => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Rmb, ""), HintInfo::keys([Key::Escape], "Cancel").prepend_slash()])]),
 		};
 
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -115,7 +115,10 @@ impl Fsm for FillToolFsmState {
 				HintInfo::mouse(MouseMotion::Lmb, "Fill with Primary"),
 				HintInfo::keys_and_mouse([Key::Shift], MouseMotion::Lmb, "Fill with Secondary"),
 			])]),
-			FillToolFsmState::Filling => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Rmb, "Cancel fill"), HintInfo::keys([Key::Escape], "Cancel fill")])]),
+			FillToolFsmState::Filling => HintData(vec![HintGroup(vec![
+				HintInfo::mouse(MouseMotion::Rmb, ""),
+				HintInfo::keys([Key::Escape], "Cancel Fill").prepend_slash(),
+			])]),
 		};
 
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });


### PR DESCRIPTION
This is the last tool that needed a cancellable transaction.

It is implemented in a way that it introduces a "Fake drag" the reason for this is simple, emitting `DocumentMessage::AbortTransaction` currently works as an undo step. Thus if the user would not perform an operation before trying to cancel the transaction it would result in undoing his current history.

This could and should be reimplemented once a Document can be in different states such as "Transaction In Progress"

Closes #1657 
