### PR TITLE
Block the undo shortcut while dragging with a tool

### DIFF
--- a/editor/src/messages/input_mapper/default_mapping.rs
+++ b/editor/src/messages/input_mapper/default_mapping.rs
@@ -48,6 +48,8 @@ pub fn default_mapping() -> Mapping {
 		// NORMAL PRIORITY
 		// ===============
 		//
+		// Hack to prevent LMB + CTRL (OPTION) + Z combo (this effectively blocks you from making a double undo with AbortTransaction)
+		entry!(KeyDown(KeyZ); modifiers=[Accel, Lmb], action_dispatch=DocumentMessage::Noop),
 		// NodeGraphMessage
 		entry!(KeyDown(Delete); modifiers=[Accel], action_dispatch=NodeGraphMessage::DeleteSelectedNodes { reconnect: false }),
 		entry!(KeyDown(Backspace); modifiers=[Accel], action_dispatch=NodeGraphMessage::DeleteSelectedNodes { reconnect: false }),

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -110,6 +110,7 @@ impl InputPreprocessorMessageHandler {
 			let new_down = new_state.mouse_keys & bit_flag == bit_flag;
 			if !old_down && new_down {
 				if allow_first_button_down || self.mouse.mouse_keys != MouseKeys::empty() {
+					self.keyboard.set(key as usize);
 					responses.add(InputMapperMessage::KeyDown(key));
 				} else {
 					// Required to stop a keyup being emitted for a keydown outside canvas
@@ -117,6 +118,7 @@ impl InputPreprocessorMessageHandler {
 				}
 			}
 			if old_down && !new_down {
+				self.keyboard.unset(key as usize);
 				responses.add(InputMapperMessage::KeyUp(key));
 			}
 		}

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 #[impl_message(Message, PortfolioMessage, Document)]
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum DocumentMessage {
+	Noop,
 	// Sub-messages
 	#[child]
 	Navigation(NavigationMessage),

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -892,6 +892,7 @@ impl MessageHandler<DocumentMessage, DocumentInputs<'_>> for DocumentMessageHand
 					responses.add(NavigationMessage::FitViewportToBounds { bounds, prevent_zoom_past_100: true });
 				}
 			}
+			Noop => (),
 		}
 	}
 
@@ -1522,6 +1523,7 @@ impl DocumentMessageHandler {
 
 	pub fn actions_with_graph_open(&self) -> ActionList {
 		let mut common = actions!(DocumentMessageDiscriminant;
+			Noop,
 			Undo,
 			Redo,
 			SelectAllLayers,


### PR DESCRIPTION
Big thanks to @0HyperCube

This is a fix that is presented in the issue as 1) i.e. prevent it by sending a NOOP instead of UNDO when CTRL + Z + LMB is pressed.

Closes #1674 