### PR TITLE
Add auto-panning to all remaining tools

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -41,6 +41,12 @@ const SIDE_EFFECT_FREE_MESSAGES: &[MessageDiscriminant] = &[
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::TriggerFontLoad),
 ];
 
+const DEBUG_MESSAGE_BLOCKLIST: &[&str] = &[
+	"AnimationFrame",
+	"PointerMove",
+	"PointerOutsideViewport",
+];
+
 impl Dispatcher {
 	pub fn new() -> Self {
 		Self::default()
@@ -224,7 +230,7 @@ impl Dispatcher {
 	fn log_message(&self, message: &Message, queues: &[VecDeque<Message>], message_logging_verbosity: MessageLoggingVerbosity) {
 		let message_name = MessageDiscriminant::from(message).local_name();
 
-		if !(message_name.ends_with("PointerMove") || message_name.ends_with("AnimationFrame")) {
+		if !DEBUG_MESSAGE_BLOCKLIST.iter().any(|blocked_name| message_name.ends_with(blocked_name)) {
 			match message_logging_verbosity {
 				MessageLoggingVerbosity::Off => {}
 				MessageLoggingVerbosity::Names => {

--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -40,8 +40,7 @@ const SIDE_EFFECT_FREE_MESSAGES: &[MessageDiscriminant] = &[
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::UpdateDocumentLayerStructure),
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::TriggerFontLoad),
 ];
-
-const DEBUG_MESSAGE_BLOCKLIST: &[&str] = &["AnimationFrame", "PointerMove", "PointerOutsideViewport"];
+const DEBUG_MESSAGE_BLOCK_LIST: &[&str] = &["AnimationFrame", "PointerMove", "PointerOutsideViewport"];
 
 impl Dispatcher {
 	pub fn new() -> Self {
@@ -226,7 +225,7 @@ impl Dispatcher {
 	fn log_message(&self, message: &Message, queues: &[VecDeque<Message>], message_logging_verbosity: MessageLoggingVerbosity) {
 		let message_name = MessageDiscriminant::from(message).local_name();
 
-		if !DEBUG_MESSAGE_BLOCKLIST.iter().any(|blocked_name| message_name.ends_with(blocked_name)) {
+		if !DEBUG_MESSAGE_BLOCK_LIST.iter().any(|blocked_name| message_name.ends_with(blocked_name)) {
 			match message_logging_verbosity {
 				MessageLoggingVerbosity::Off => {}
 				MessageLoggingVerbosity::Names => {

--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -41,11 +41,7 @@ const SIDE_EFFECT_FREE_MESSAGES: &[MessageDiscriminant] = &[
 	MessageDiscriminant::Frontend(FrontendMessageDiscriminant::TriggerFontLoad),
 ];
 
-const DEBUG_MESSAGE_BLOCKLIST: &[&str] = &[
-	"AnimationFrame",
-	"PointerMove",
-	"PointerOutsideViewport",
-];
+const DEBUG_MESSAGE_BLOCKLIST: &[&str] = &["AnimationFrame", "PointerMove", "PointerOutsideViewport"];
 
 impl Dispatcher {
 	pub fn new() -> Self {

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -1,10 +1,10 @@
 use super::tool_prelude::*;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -226,15 +226,12 @@ impl Fsm for EllipseToolFsmState {
 					responses.add(message);
 				}
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						EllipseToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						EllipseToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					EllipseToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					EllipseToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				self
 			}
@@ -244,18 +241,18 @@ impl Fsm for EllipseToolFsmState {
 				self
 			}
 			(EllipseToolFsmState::Drawing, EllipseToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				EllipseToolFsmState::Drawing
 			}
 			(state, EllipseToolMessage::PointerOutsideViewport { center, lock_ratio }) => {
-				tool_data.auto_panning.stop(
-					&[
-						EllipseToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						EllipseToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					EllipseToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					EllipseToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -435,19 +435,17 @@ impl Fsm for GradientToolFsmState {
 					selected_gradient.update_gradient(mouse, responses, input.keyboard.get(constrain_axis as usize), selected_gradient.gradient.gradient_type);
 				}
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
-						GradientToolMessage::PointerMove { constrain_axis }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
+					GradientToolMessage::PointerMove { constrain_axis }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				GradientToolFsmState::Drawing
 			}
 			(GradientToolFsmState::Drawing, GradientToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				if let Some(shift) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
 					if let Some(selected_gradient) = &mut tool_data.selected_gradient {
 						selected_gradient.transform.translation += shift;
@@ -457,13 +455,12 @@ impl Fsm for GradientToolFsmState {
 				GradientToolFsmState::Drawing
 			}
 			(state, GradientToolMessage::PointerOutsideViewport { constrain_axis }) => {
-				tool_data.auto_panning.stop(
-					&[
-						GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
-						GradientToolMessage::PointerMove { constrain_axis }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
+					GradientToolMessage::PointerMove { constrain_axis }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -2,9 +2,9 @@ use super::tool_prelude::*;
 use crate::consts::{LINE_ROTATE_SNAP_ANGLE, MANIPULATOR_GROUP_MARKER_SIZE, SELECTION_THRESHOLD};
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::graph_modification_utils::get_gradient;
 use crate::messages::tool::common_functionality::snapping::SnapManager;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graphene_core::vector::style::{Fill, Gradient, GradientType};
 

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -4,6 +4,7 @@ use crate::messages::portfolio::document::overlays::utility_types::OverlayContex
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::tool::common_functionality::graph_modification_utils::get_gradient;
 use crate::messages::tool::common_functionality::snapping::SnapManager;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graphene_core::vector::style::{Fill, Gradient, GradientType};
 
@@ -31,6 +32,7 @@ pub enum GradientToolMessage {
 	InsertStop,
 	PointerDown,
 	PointerMove { constrain_axis: Key },
+	PointerOutsideViewport { constrain_axis: Key },
 	PointerUp,
 	UpdateOptions(GradientOptionsUpdate),
 }
@@ -225,6 +227,7 @@ struct GradientToolData {
 	selected_gradient: Option<SelectedGradient>,
 	snap_manager: SnapManager,
 	drag_start: DVec2,
+	auto_panning: AutoPanning,
 }
 
 impl Fsm for GradientToolFsmState {
@@ -431,9 +434,39 @@ impl Fsm for GradientToolFsmState {
 					let mouse = input.mouse.position; // tool_data.snap_manager.snap_position(responses, document, input.mouse.position);
 					selected_gradient.update_gradient(mouse, responses, input.keyboard.get(constrain_axis as usize), selected_gradient.gradient.gradient_type);
 				}
+
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
+						GradientToolMessage::PointerMove { constrain_axis }.into(),
+					],
+					responses,
+				);
+
 				GradientToolFsmState::Drawing
 			}
+			(GradientToolFsmState::Drawing, GradientToolMessage::PointerOutsideViewport { .. }) => {
+				if let Some(shift) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
+					if let Some(selected_gradient) = &mut tool_data.selected_gradient {
+						selected_gradient.transform.translation += shift;
+					}
+				}
 
+				GradientToolFsmState::Drawing
+			}
+			(state, GradientToolMessage::PointerOutsideViewport { constrain_axis }) => {
+				tool_data.auto_panning.stop(
+					&[
+						GradientToolMessage::PointerOutsideViewport { constrain_axis }.into(),
+						GradientToolMessage::PointerMove { constrain_axis }.into(),
+					],
+					responses,
+				);
+
+				state
+			}
 			(GradientToolFsmState::Drawing, GradientToolMessage::PointerUp) => {
 				input.mouse.finish_transaction(tool_data.drag_start, responses);
 				tool_data.snap_manager.cleanup(responses);

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -5,6 +5,7 @@ use crate::messages::portfolio::document::utility_types::document_metadata::Laye
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;
@@ -44,6 +45,7 @@ pub enum LineToolMessage {
 	DragStart,
 	DragStop,
 	PointerMove { center: Key, lock_angle: Key, snap_angle: Key },
+	PointerOutsideViewport { center: Key, lock_angle: Key, snap_angle: Key },
 	UpdateOptions(LineOptionsUpdate),
 }
 
@@ -149,6 +151,7 @@ struct LineToolData {
 	weight: f64,
 	layer: Option<LayerNodeIdentifier>,
 	snap_manager: SnapManager,
+	auto_panning: AutoPanning,
 }
 
 impl Fsm for LineToolFsmState {
@@ -196,12 +199,38 @@ impl Fsm for LineToolFsmState {
 				let snap_data = SnapData::ignore(document, input, &ignore);
 				responses.add(generate_transform(tool_data, snap_data, keyboard.key(lock_angle), keyboard.key(snap_angle), keyboard.key(center)));
 
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						LineToolMessage::PointerOutsideViewport { center, snap_angle, lock_angle }.into(),
+						LineToolMessage::PointerMove { center, snap_angle, lock_angle }.into(),
+					],
+					responses,
+				);
+
 				LineToolFsmState::Drawing
 			}
 			(_, LineToolMessage::PointerMove { .. }) => {
 				tool_data.snap_manager.preview_draw(&SnapData::new(document, input), input.mouse.position);
 				responses.add(OverlaysMessage::Draw);
 				self
+			}
+			(LineToolFsmState::Drawing, LineToolMessage::PointerOutsideViewport { .. }) => {
+				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
+
+				LineToolFsmState::Drawing
+			}
+			(state, LineToolMessage::PointerOutsideViewport { center, lock_angle, snap_angle }) => {
+				tool_data.auto_panning.stop(
+					&[
+						LineToolMessage::PointerOutsideViewport { center, lock_angle, snap_angle }.into(),
+						LineToolMessage::PointerMove { center, lock_angle, snap_angle }.into(),
+					],
+					responses,
+				);
+
+				state
 			}
 			(LineToolFsmState::Drawing, LineToolMessage::DragStop) => {
 				tool_data.snap_manager.cleanup(responses);

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -2,10 +2,10 @@ use super::tool_prelude::*;
 use crate::consts::LINE_ROTATE_SNAP_ANGLE;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -199,15 +199,12 @@ impl Fsm for LineToolFsmState {
 				let snap_data = SnapData::ignore(document, input, &ignore);
 				responses.add(generate_transform(tool_data, snap_data, keyboard.key(lock_angle), keyboard.key(snap_angle), keyboard.key(center)));
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						LineToolMessage::PointerOutsideViewport { center, snap_angle, lock_angle }.into(),
-						LineToolMessage::PointerMove { center, snap_angle, lock_angle }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					LineToolMessage::PointerOutsideViewport { center, snap_angle, lock_angle }.into(),
+					LineToolMessage::PointerMove { center, snap_angle, lock_angle }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				LineToolFsmState::Drawing
 			}
@@ -217,18 +214,18 @@ impl Fsm for LineToolFsmState {
 				self
 			}
 			(LineToolFsmState::Drawing, LineToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				LineToolFsmState::Drawing
 			}
 			(state, LineToolMessage::PointerOutsideViewport { center, lock_angle, snap_angle }) => {
-				tool_data.auto_panning.stop(
-					&[
-						LineToolMessage::PointerOutsideViewport { center, lock_angle, snap_angle }.into(),
-						LineToolMessage::PointerMove { center, lock_angle, snap_angle }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					LineToolMessage::PointerOutsideViewport { center, lock_angle, snap_angle }.into(),
+					LineToolMessage::PointerMove { center, lock_angle, snap_angle }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -480,12 +480,9 @@ impl Fsm for PathToolFsmState {
 				tool_data.previous_mouse_position = input.mouse.position;
 				responses.add(OverlaysMessage::Draw);
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
-					responses,
-				);
+				// Auto-panning
+				let messages = [PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				PathToolFsmState::DrawingBox
 			}
@@ -494,16 +491,14 @@ impl Fsm for PathToolFsmState {
 				let shift_state = input.keyboard.get(shift as usize);
 				tool_data.drag(shift_state, alt_state, shape_editor, document, input, responses);
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
-					responses,
-				);
+				// Auto-panning
+				let messages = [PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				PathToolFsmState::Dragging
 			}
 			(PathToolFsmState::DrawingBox, PathToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				if let Some(shift) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
 					tool_data.drag_start_pos += shift;
 				}
@@ -511,6 +506,7 @@ impl Fsm for PathToolFsmState {
 				PathToolFsmState::DrawingBox
 			}
 			(PathToolFsmState::Dragging, PathToolMessage::PointerOutsideViewport { shift, .. }) => {
+				// Auto-panning
 				if let Some(delta) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
 					let shift_state = input.keyboard.get(shift as usize);
 					shape_editor.move_selected_points(&document.network, &document.metadata, -delta, shift_state, responses);
@@ -519,10 +515,9 @@ impl Fsm for PathToolFsmState {
 				PathToolFsmState::Dragging
 			}
 			(state, PathToolMessage::PointerOutsideViewport { alt, shift }) => {
-				tool_data.auto_panning.stop(
-					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
-					responses,
-				);
+				// Auto-panning
+				let messages = [PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -6,6 +6,7 @@ use crate::messages::portfolio::document::utility_types::document_metadata::{Doc
 use crate::messages::tool::common_functionality::graph_modification_utils::{get_manipulator_from_id, get_mirror_handles, get_subpaths};
 use crate::messages::tool::common_functionality::shape_editor::{ClosestSegment, ManipulatorAngle, ManipulatorPointInfo, OpposingHandleLengths, SelectedPointsInfo, ShapeState};
 use crate::messages::tool::common_functionality::snapping::{SnapData, SnapManager};
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeNetwork;
 use graphene_core::renderer::Quad;
@@ -55,6 +56,10 @@ pub enum PathToolMessage {
 		delta_y: f64,
 	},
 	PointerMove {
+		alt: Key,
+		shift: Key,
+	},
+	PointerOutsideViewport {
 		alt: Key,
 		shift: Key,
 	},
@@ -240,6 +245,7 @@ struct PathToolData {
 	selection_status: SelectionStatus,
 	segment: Option<ClosestSegment>,
 	double_click_handled: bool,
+	auto_panning: AutoPanning,
 }
 
 impl PathToolData {
@@ -470,20 +476,65 @@ impl Fsm for PathToolFsmState {
 				let direct_insert_without_sliding = input.keyboard.get(ctrl as usize);
 				tool_data.mouse_down(shape_editor, document, input, responses, add_to_selection, direct_insert_without_sliding)
 			}
-			(PathToolFsmState::DrawingBox, PathToolMessage::PointerMove { .. }) => {
+			(PathToolFsmState::DrawingBox, PathToolMessage::PointerMove { alt, shift }) => {
 				tool_data.previous_mouse_position = input.mouse.position;
 				responses.add(OverlaysMessage::Draw);
+
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
+						PathToolMessage::PointerMove { alt, shift }.into(),
+					],
+					responses,
+				);
 
 				PathToolFsmState::DrawingBox
 			}
 			(PathToolFsmState::Dragging, PathToolMessage::PointerMove { alt, shift }) => {
-				let alt = input.keyboard.get(alt as usize);
-				let shift = input.keyboard.get(shift as usize);
-				tool_data.drag(shift, alt, shape_editor, document, input, responses);
+				let alt_state = input.keyboard.get(alt as usize);
+				let shift_state = input.keyboard.get(shift as usize);
+				tool_data.drag(shift_state, alt_state, shape_editor, document, input, responses);
+
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
+						PathToolMessage::PointerMove { alt, shift }.into(),
+					],
+					responses,
+				);
 
 				PathToolFsmState::Dragging
 			}
+			(PathToolFsmState::DrawingBox, PathToolMessage::PointerOutsideViewport { .. }) => {
+				if let Some(shift) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
+					tool_data.drag_start_pos += shift;
+				}
 
+				PathToolFsmState::DrawingBox
+			}
+			(PathToolFsmState::Dragging, PathToolMessage::PointerOutsideViewport { shift, .. }) => {
+				if let Some(delta) = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses) {
+					let shift_state = input.keyboard.get(shift as usize);
+					shape_editor.move_selected_points(&document.network, &document.metadata, -delta, shift_state, responses);
+				}
+
+				PathToolFsmState::Dragging
+			}
+			(state, PathToolMessage::PointerOutsideViewport { alt, shift }) => {
+				tool_data.auto_panning.stop(
+					&[
+						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
+						PathToolMessage::PointerMove { alt, shift }.into(),
+					],
+					responses,
+				);
+
+				state
+			}
 			(PathToolFsmState::DrawingBox, PathToolMessage::Enter { add_to_selection }) => {
 				let shift_pressed = input.keyboard.get(add_to_selection as usize);
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -3,10 +3,10 @@ use crate::consts::{COLOR_OVERLAY_YELLOW, DRAG_THRESHOLD, INSERT_POINT_ON_SEGMEN
 use crate::messages::portfolio::document::overlays::utility_functions::path_overlays;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::graph_modification_utils::{get_manipulator_from_id, get_mirror_handles, get_subpaths};
 use crate::messages::tool::common_functionality::shape_editor::{ClosestSegment, ManipulatorAngle, ManipulatorPointInfo, OpposingHandleLengths, SelectedPointsInfo, ShapeState};
 use crate::messages::tool::common_functionality::snapping::{SnapData, SnapManager};
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeNetwork;
 use graphene_core::renderer::Quad;
@@ -483,10 +483,7 @@ impl Fsm for PathToolFsmState {
 				tool_data.auto_panning.setup_by_mouse_position(
 					input.mouse.position,
 					input.viewport_bounds.size(),
-					&[
-						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
-						PathToolMessage::PointerMove { alt, shift }.into(),
-					],
+					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
 					responses,
 				);
 
@@ -500,10 +497,7 @@ impl Fsm for PathToolFsmState {
 				tool_data.auto_panning.setup_by_mouse_position(
 					input.mouse.position,
 					input.viewport_bounds.size(),
-					&[
-						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
-						PathToolMessage::PointerMove { alt, shift }.into(),
-					],
+					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
 					responses,
 				);
 
@@ -526,10 +520,7 @@ impl Fsm for PathToolFsmState {
 			}
 			(state, PathToolMessage::PointerOutsideViewport { alt, shift }) => {
 				tool_data.auto_panning.stop(
-					&[
-						PathToolMessage::PointerOutsideViewport { alt, shift }.into(),
-						PathToolMessage::PointerMove { alt, shift }.into(),
-					],
+					&[PathToolMessage::PointerOutsideViewport { alt, shift }.into(), PathToolMessage::PointerMove { alt, shift }.into()],
 					responses,
 				);
 

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -681,15 +681,12 @@ impl Fsm for PenToolFsmState {
 					.drag_handle(snap_data, transform, input.mouse.position, modifiers, responses)
 					.unwrap_or(PenToolFsmState::Ready);
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
-						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+					PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				state
 			}
@@ -703,15 +700,12 @@ impl Fsm for PenToolFsmState {
 					.place_anchor(SnapData::new(document, input), transform, input.mouse.position, modifiers, responses)
 					.unwrap_or(PenToolFsmState::Ready);
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
-						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+					PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				state
 			}
@@ -721,23 +715,24 @@ impl Fsm for PenToolFsmState {
 				self
 			}
 			(PenToolFsmState::DraggingHandle, PenToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				PenToolFsmState::DraggingHandle
 			}
 			(PenToolFsmState::PlacingAnchor, PenToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				PenToolFsmState::PlacingAnchor
 			}
 			(state, PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }) => {
-				tool_data.auto_panning.stop(
-					&[
-						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
-						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+					PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -4,12 +4,12 @@ use crate::messages::portfolio::document::node_graph::VectorDataModification;
 use crate::messages::portfolio::document::overlays::utility_functions::path_overlays;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::graph_modification_utils::get_subpaths;
 use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
 use crate::messages::tool::common_functionality::utility_functions::should_extend;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::{generate_uuid, ManipulatorGroupId};

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -9,6 +9,7 @@ use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::graph_modification_utils::get_subpaths;
 use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
 use crate::messages::tool::common_functionality::utility_functions::should_extend;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::{generate_uuid, ManipulatorGroupId};
@@ -53,6 +54,7 @@ pub enum PenToolMessage {
 	DragStart,
 	DragStop,
 	PointerMove { snap_angle: Key, break_handle: Key, lock_angle: Key },
+	PointerOutsideViewport { snap_angle: Key, break_handle: Key, lock_angle: Key },
 	Redo,
 	Undo,
 	UpdateOptions(PenOptionsUpdate),
@@ -202,6 +204,7 @@ struct PenToolData {
 	// Indicates that curve extension is occurring from the first point, rather than (more commonly) the last point
 	from_start: bool,
 	angle: f64,
+	auto_panning: AutoPanning,
 }
 impl PenToolData {
 	fn extend_subpath(&mut self, layer: LayerNodeIdentifier, subpath_index: usize, from_start: bool, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
@@ -674,9 +677,21 @@ impl Fsm for PenToolFsmState {
 					break_handle: input.keyboard.key(break_handle),
 				};
 				let snap_data = SnapData::new(document, input);
-				tool_data
+				let state = tool_data
 					.drag_handle(snap_data, transform, input.mouse.position, modifiers, responses)
-					.unwrap_or(PenToolFsmState::Ready)
+					.unwrap_or(PenToolFsmState::Ready);
+
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+					],
+					responses,
+				);
+
+				state
 			}
 			(PenToolFsmState::PlacingAnchor, PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }) => {
 				let modifiers = ModifierState {
@@ -684,14 +699,47 @@ impl Fsm for PenToolFsmState {
 					lock_angle: input.keyboard.key(lock_angle),
 					break_handle: input.keyboard.key(break_handle),
 				};
-				tool_data
+				let state = tool_data
 					.place_anchor(SnapData::new(document, input), transform, input.mouse.position, modifiers, responses)
-					.unwrap_or(PenToolFsmState::Ready)
+					.unwrap_or(PenToolFsmState::Ready);
+
+				tool_data.auto_panning.setup_by_mouse_position(
+					input.mouse.position,
+					input.viewport_bounds.size(),
+					&[
+						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+					],
+					responses,
+				);
+
+				state
 			}
 			(PenToolFsmState::Ready, PenToolMessage::PointerMove { .. }) => {
 				tool_data.snap_manager.preview_draw(&SnapData::new(document, input), input.mouse.position);
 				responses.add(OverlaysMessage::Draw);
 				self
+			}
+			(PenToolFsmState::DraggingHandle, PenToolMessage::PointerOutsideViewport { .. }) => {
+				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
+
+				PenToolFsmState::DraggingHandle
+			}
+			(PenToolFsmState::PlacingAnchor, PenToolMessage::PointerOutsideViewport { .. }) => {
+				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
+
+				PenToolFsmState::PlacingAnchor
+			}
+			(state, PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }) => {
+				tool_data.auto_panning.stop(
+					&[
+						PenToolMessage::PointerOutsideViewport { snap_angle, break_handle, lock_angle }.into(),
+						PenToolMessage::PointerMove { snap_angle, break_handle, lock_angle }.into(),
+					],
+					responses,
+				);
+
+				state
 			}
 			(PenToolFsmState::DraggingHandle | PenToolFsmState::PlacingAnchor, PenToolMessage::Abort | PenToolMessage::Confirm) => {
 				// Abort or commit the transaction to the undo history

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -1,10 +1,10 @@
 use super::tool_prelude::*;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -270,15 +270,12 @@ impl Fsm for PolygonToolFsmState {
 					responses.add(message);
 				}
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						PolygonToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						PolygonToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					PolygonToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					PolygonToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				self
 			}
@@ -288,18 +285,18 @@ impl Fsm for PolygonToolFsmState {
 				self
 			}
 			(PolygonToolFsmState::Drawing, PolygonToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				PolygonToolFsmState::Drawing
 			}
 			(state, PolygonToolMessage::PointerOutsideViewport { center, lock_ratio }) => {
-				tool_data.auto_panning.stop(
-					&[
-						PolygonToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						PolygonToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					PolygonToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					PolygonToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -1,10 +1,10 @@
 use super::tool_prelude::*;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -232,15 +232,12 @@ impl Fsm for RectangleToolFsmState {
 					responses.add(message);
 				}
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[
-						RectangleToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						RectangleToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					RectangleToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					RectangleToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				self
 			}
@@ -250,18 +247,18 @@ impl Fsm for RectangleToolFsmState {
 				self
 			}
 			(RectangleToolFsmState::Drawing, RectangleToolMessage::PointerOutsideViewport { .. }) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				RectangleToolFsmState::Drawing
 			}
 			(state, RectangleToolMessage::PointerOutsideViewport { center, lock_ratio }) => {
-				tool_data.auto_panning.stop(
-					&[
-						RectangleToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
-						RectangleToolMessage::PointerMove { center, lock_ratio }.into(),
-					],
-					responses,
-				);
+				// Auto-panning
+				let messages = [
+					RectangleToolMessage::PointerOutsideViewport { center, lock_ratio }.into(),
+					RectangleToolMessage::PointerMove { center, lock_ratio }.into(),
+				];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -269,24 +269,22 @@ impl Fsm for SplineToolFsmState {
 
 				update_spline(tool_data, true, responses);
 
-				tool_data.auto_panning.setup_by_mouse_position(
-					input.mouse.position,
-					input.viewport_bounds.size(),
-					&[SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()],
-					responses,
-				);
+				// Auto-panning
+				let messages = [SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()];
+				tool_data.auto_panning.setup_by_mouse_position(input.mouse.position, input.viewport_bounds.size(), &messages, responses);
 
 				SplineToolFsmState::Drawing
 			}
 			(SplineToolFsmState::Drawing, SplineToolMessage::PointerOutsideViewport) => {
+				// Auto-panning
 				let _ = AutoPanning::shift_viewport(input.mouse.position, input.viewport_bounds.size(), responses);
 
 				SplineToolFsmState::Drawing
 			}
 			(state, SplineToolMessage::PointerOutsideViewport) => {
-				tool_data
-					.auto_panning
-					.stop(&[SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()], responses);
+				// Auto-panning
+				let messages = [SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()];
+				tool_data.auto_panning.stop(&messages, responses);
 
 				state
 			}

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -2,10 +2,10 @@ use super::tool_prelude::*;
 use crate::consts::DRAG_THRESHOLD;
 use crate::messages::portfolio::document::node_graph::VectorDataModification;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::snapping::SnapManager;
-use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 
 use graph_craft::document::NodeId;
 use graphene_core::uuid::generate_uuid;
@@ -272,10 +272,7 @@ impl Fsm for SplineToolFsmState {
 				tool_data.auto_panning.setup_by_mouse_position(
 					input.mouse.position,
 					input.viewport_bounds.size(),
-					&[
-						SplineToolMessage::PointerOutsideViewport.into(),
-						SplineToolMessage::PointerMove.into(),
-					],
+					&[SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()],
 					responses,
 				);
 
@@ -287,13 +284,9 @@ impl Fsm for SplineToolFsmState {
 				SplineToolFsmState::Drawing
 			}
 			(state, SplineToolMessage::PointerOutsideViewport) => {
-				tool_data.auto_panning.stop(
-					&[
-						SplineToolMessage::PointerOutsideViewport.into(),
-						SplineToolMessage::PointerMove.into(),
-					],
-					responses,
-				);
+				tool_data
+					.auto_panning
+					.stop(&[SplineToolMessage::PointerOutsideViewport.into(), SplineToolMessage::PointerMove.into()], responses);
 
 				state
 			}


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1527

- Add auto-panning to the following tools:
  - Gradient tool
  - Path tool
  - Pen tool
  - Spline tool
  - Line tool
  - Rectangle tool
  - Ellipse tool
  - Polygon tool
- Hide debug messages containing `PointerOutsideViewport`