### PR TITLE
Exclude hidden layers from Ctrl+A selection; prevent G/R/S/nudging hidden layers

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -614,11 +614,10 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			}
 			DocumentMessage::SelectAllLayers => {
 				let metadata = self.metadata();
-				let network = self.network();
 				let all_layers_except_artboards_and_invisible = metadata
 					.all_layers()
 					.filter(move |&layer| !metadata.is_artboard(layer))
-					.filter(|&layer| self.selected_nodes.layer_visible(layer, network, metadata));
+					.filter(|&layer| self.selected_nodes.layer_visible(layer, metadata));
 				let nodes = all_layers_except_artboards_and_invisible.map(|layer| layer.to_node()).collect();
 				responses.add(NodeGraphMessage::SelectedNodesSet { nodes });
 			}

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -614,8 +614,12 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			}
 			DocumentMessage::SelectAllLayers => {
 				let metadata = self.metadata();
-				let all_layers_except_artboards = metadata.all_layers().filter(move |&layer| !metadata.is_artboard(layer));
-				let nodes = all_layers_except_artboards.map(|layer| layer.to_node()).collect();
+				let network = self.network();
+				let all_layers_except_artboards_and_invisible = metadata
+					.all_layers()
+					.filter(move |&layer| !metadata.is_artboard(layer))
+					.filter(|&layer| self.selected_nodes.layer_visible(layer, network, metadata));
+				let nodes = all_layers_except_artboards_and_invisible.map(|layer| layer.to_node()).collect();
 				responses.add(NodeGraphMessage::SelectedNodesSet { nodes });
 			}
 			DocumentMessage::SelectedLayersLower => {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -460,7 +460,11 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				match ipp.keyboard.key(resize) {
 					// Nudge translation
 					false => {
-						for layer in self.selected_nodes.selected_layers(self.metadata()) {
+						for layer in self
+							.selected_nodes
+							.selected_layers(self.metadata())
+							.filter(|&layer| self.selected_nodes.layer_visible(layer, self.metadata()))
+						{
 							responses.add(GraphOperationMessage::TransformChange {
 								layer,
 								transform: DAffine2::from_translation(delta),
@@ -491,7 +495,11 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						let pivot = DAffine2::from_translation(pivot);
 						let transformation = pivot * scale * pivot.inverse();
 
-						for layer in self.selected_nodes.selected_layers(self.metadata()) {
+						for layer in self
+							.selected_nodes
+							.selected_layers(self.metadata())
+							.filter(|&layer| self.selected_nodes.layer_visible(layer, self.metadata()))
+						{
 							let to = self.metadata().document_to_viewport.inverse() * self.metadata().downstream_transform_to_viewport(layer);
 							let original_transform = self.metadata().upstream_transform(layer.to_node());
 							let new = to.inverse() * transformation * to * original_transform;

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -458,6 +458,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				}
 			}
 			NodeGraphMessage::ToggleHidden { node_id } => {
+				responses.add(DocumentMessage::StartTransaction);
 				if let Some(network) = document_network.nested_network(&self.network) {
 					let new_hidden = !network.disabled.contains(&node_id);
 					responses.add(NodeGraphMessage::SetHidden { node_id, hidden: new_hidden });

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -459,6 +459,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				}
 			}
 			NodeGraphMessage::ToggleVisibility { node_id } => {
+				responses.add(DocumentMessage::StartTransaction);
 				let visible = document_metadata.node_is_visible(node_id);
 				let visible = !visible;
 

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -45,7 +45,11 @@ impl<'a> MessageHandler<TransformLayerMessage, TransformData<'a>> for TransformL
 	fn process_message(&mut self, message: TransformLayerMessage, responses: &mut VecDeque<Message>, (document, input, tool_data, shape_editor): TransformData) {
 		let using_path_tool = tool_data.active_tool_type == ToolType::Path;
 
-		let selected_layers = document.selected_nodes.selected_layers(document.metadata()).collect::<Vec<_>>();
+		let selected_layers = document
+			.selected_nodes
+			.selected_layers(document.metadata())
+			.filter(|&layer| document.metadata().node_is_visible(layer.to_node()))
+			.collect::<Vec<_>>();
 
 		let mut selected = Selected::new(
 			&mut self.original_transforms,


### PR DESCRIPTION
This related to this [todo](https://discord.com/channels/731730685944922173/881073965047636018/1219837006113275977)

This will Exclude hidden layer when select all layer and make action hiding layer to history