### PR TITLE
Fix hidden state missing from copy/paste, causing hidden layers to reappear when pasted or grouped

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/clipboards.rs
+++ b/editor/src/messages/portfolio/document/utility_types/clipboards.rs
@@ -19,6 +19,7 @@ pub const INTERNAL_CLIPBOARD_COUNT: u8 = Clipboard::_InternalClipboardCount as u
 pub struct CopyBufferEntry {
 	pub nodes: HashMap<NodeId, DocumentNode>,
 	pub selected: bool,
+	pub disabled: bool,
 	pub collapsed: bool,
 	pub alias: String,
 }

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -202,6 +202,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 							)
 							.collect(),
 							selected: active_document.selected_nodes.selected_layers_contains(layer, active_document.metadata()),
+							disabled: !active_document.selected_nodes.layer_visible(layer, active_document.network(), active_document.metadata()),
 							collapsed: false,
 							alias: previous_alias,
 						});
@@ -387,6 +388,9 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 						if entry.selected {
 							responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![id] });
 						}
+						if entry.disabled {
+							responses.add(NodeGraphMessage::SetHidden { node_id: id, hidden: entry.disabled });
+						}
 					}
 				};
 
@@ -414,6 +418,9 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 							});
 							if entry.selected {
 								responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![id] });
+							}
+							if entry.disabled {
+								responses.add(NodeGraphMessage::SetHidden { node_id: id, hidden: entry.disabled });
 							}
 						}
 


### PR DESCRIPTION
This is related to [this](https://discord.com/channels/731730685944922173/881073965047636018/1219836949750218762)

This change makes copy-and-paste bring the node's visible state to the copy buffer. This way, when you paste, the state stays the same.