### PR TITLE
Fix "contrain" typo

### DIFF
--- a/editor/src/messages/tool/common_functionality/snapping.rs
+++ b/editor/src/messages/tool/common_functionality/snapping.rs
@@ -113,7 +113,7 @@ fn get_closest_intersection(snap_to: DVec2, curves: &[SnappedCurve]) -> Option<S
 						curves: [Some(close.document_curve), Some(far.document_curve)],
 						source: close.point.source,
 						at_intersection: true,
-						contrained: true,
+						constrained: true,
 						..Default::default()
 					})
 				}
@@ -136,7 +136,7 @@ fn get_grid_intersection(snap_to: DVec2, lines: &[SnappedLine]) -> Option<Snappe
 						tolerance: line_i.point.tolerance,
 						source: line_i.point.source,
 						at_intersection: true,
-						contrained: true,
+						constrained: true,
 						..Default::default()
 					})
 				}
@@ -189,7 +189,7 @@ impl SnapManager {
 		self.update_indicator(snapped);
 	}
 
-	fn find_best_snap(snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: SnapResults, contrained: bool, off_screen: bool, to_path: bool) -> SnappedPoint {
+	fn find_best_snap(snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: SnapResults, constrained: bool, off_screen: bool, to_path: bool) -> SnappedPoint {
 		let mut snapped_points = Vec::new();
 		let document = snap_data.document;
 
@@ -207,7 +207,7 @@ impl SnapManager {
 			}
 		}
 
-		if !contrained {
+		if !constrained {
 			if document.snapping_state.target_enabled(SnapTarget::Geometry(GeometrySnapTarget::Intersection)) {
 				if let Some(closest_curves_intersection) = get_closest_intersection(point.document_point, &snap_results.curves) {
 					snapped_points.push(closest_curves_intersection);
@@ -316,8 +316,8 @@ impl SnapManager {
 
 		let mut snap_data = snap_data.clone();
 		snap_data.candidates = Some(&*self.candidates.get_or_insert_with(|| Self::find_candidates(&snap_data, point, bbox)));
-		self.layer_snapper.contrained_snap(&mut snap_data, point, &mut snap_results, constraint);
-		self.grid_snapper.contrained_snap(&mut snap_data, point, &mut snap_results, constraint);
+		self.layer_snapper.constrained_snap(&mut snap_data, point, &mut snap_results, constraint);
+		self.grid_snapper.constrained_snap(&mut snap_data, point, &mut snap_results, constraint);
 
 		Self::find_best_snap(&mut snap_data, point, snap_results, true, false, false)
 	}

--- a/editor/src/messages/tool/common_functionality/snapping/grid_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/grid_snapper.rs
@@ -150,7 +150,7 @@ impl GridSnapper {
 		}
 	}
 
-	pub fn contrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
+	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
 		let tolerance = snap_tolerance(snap_data.document);
 		let projected = constraint.projection(point.document_point);
 		let lines = self.get_snap_lines(projected, snap_data);
@@ -170,7 +170,7 @@ impl GridSnapper {
 					source: point.source,
 					target: SnapTarget::Grid(GridSnapTarget::Line),
 					at_intersection: false,
-					contrained: true,
+					constrained: true,
 					source_bounds: point.quad,
 					curves: [
 						Some(Bezier::from_linear_dvec2(projected - constraint_direction * tolerance, projected + constraint_direction * tolerance)),

--- a/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
@@ -227,7 +227,7 @@ impl LayerSnapper {
 					target: candidate.target,
 					distance,
 					tolerance,
-					contrained: true,
+					constrained: true,
 					target_bounds: candidate.quad,
 					..Default::default()
 				});
@@ -242,7 +242,7 @@ impl LayerSnapper {
 		self.free_snap_paths(snap_data, point, snap_results);
 	}
 
-	pub fn contrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
+	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
 		self.snap_anchors(snap_data, point, snap_results, constraint, constraint.projection(point.document_point));
 		self.snap_paths_constrained(snap_data, point, snap_results, constraint);
 	}
@@ -264,7 +264,7 @@ fn normals_and_tangents(path: &SnapCandidatePath, normals: bool, tangents: bool,
 					tolerance,
 					curves: [Some(path.document_curve), None],
 					source: point.source,
-					contrained: true,
+					constrained: true,
 					..Default::default()
 				});
 			}
@@ -285,7 +285,7 @@ fn normals_and_tangents(path: &SnapCandidatePath, normals: bool, tangents: bool,
 					tolerance,
 					curves: [Some(path.document_curve), None],
 					source: point.source,
-					contrained: true,
+					constrained: true,
 					..Default::default()
 				});
 			}

--- a/editor/src/messages/tool/common_functionality/snapping/snap_results.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/snap_results.rs
@@ -17,7 +17,7 @@ pub struct SnappedPoint {
 	pub source: SnapSource,
 	pub target: SnapTarget,
 	pub at_intersection: bool,
-	pub contrained: bool, // Found when looking for contrained
+	pub constrained: bool, // Found when looking for constrained
 	pub target_bounds: Option<Quad>,
 	pub source_bounds: Option<Quad>,
 	pub curves: [Option<Bezier>; 2],
@@ -56,16 +56,16 @@ impl SnappedPoint {
 		// Prefer closest
 		let other_closer = other_dist < my_dist + bias;
 
-		// We should prefer the most contrained option (e.g. intersection > path)
-		let other_more_contrained = other.contrained && !self.contrained;
-		let self_more_contrained = self.contrained && !other.contrained;
+		// We should prefer the most constrained option (e.g. intersection > path)
+		let other_more_constrained = other.constrained && !self.constrained;
+		let self_more_constrained = self.constrained && !other.constrained;
 
 		// Prefer nodes to intersections if both are at the same position
-		let contrained_at_same_pos = other.contrained && self.contrained && self.snapped_point_document.abs_diff_eq(other.snapped_point_document, 1.);
-		let other_better_constraint = contrained_at_same_pos && self.at_intersection && !other.at_intersection;
-		let self_better_constraint = contrained_at_same_pos && other.at_intersection && !self.at_intersection;
+		let constrained_at_same_pos = other.constrained && self.constrained && self.snapped_point_document.abs_diff_eq(other.snapped_point_document, 1.);
+		let other_better_constraint = constrained_at_same_pos && self.at_intersection && !other.at_intersection;
+		let self_better_constraint = constrained_at_same_pos && other.at_intersection && !self.at_intersection;
 
-		(other_closer || other_more_contrained || other_better_constraint) && !self_more_contrained && !self_better_constraint
+		(other_closer || other_more_constrained || other_better_constraint) && !self_more_constrained && !self_better_constraint
 	}
 	pub fn is_snapped(&self) -> bool {
 		self.distance.is_finite()


### PR DESCRIPTION
Fix typo 'contrain' to true 'constrain'

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Found this typo propagated in many places when going through code for snapping.
