### PR TITLE
Fix shallow/deep selection

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -900,26 +900,25 @@ impl DocumentMessageHandler {
 			.map(|(layer, _)| layer)
 	}
 
-	/// Find any layers sorted by index that are under the given viewport space location.
+	/// Find the deepest layer given in the sorted array (by returning the one which is not a folder from the list of layers under the click location).
+	pub fn find_deepest(&self, node_list: &[LayerNodeIdentifier], network: &NodeNetwork) -> Option<LayerNodeIdentifier> {
+		node_list.iter().find(|&&layer| !is_folder(layer, network)).copied()
+	}
+
+	/// Find any layers sorted by index that are under the given location in viewport space.
 	pub fn click_list_any(&self, viewport_location: DVec2, network: &NodeNetwork) -> Vec<LayerNodeIdentifier> {
 		self.click_xray(viewport_location).filter(|&layer| !is_artboard(layer, network)).collect::<Vec<_>>()
 	}
 
-	/// Find layers sorted by tree architecture that has been truly clicked.
+	/// Find layers under the location in viewport space that was clicked, listed by their depth in the layer tree hierarchy.
 	pub fn click_list(&self, viewport_location: DVec2, network: &NodeNetwork) -> Vec<LayerNodeIdentifier> {
 		let mut node_list = self.click_list_any(viewport_location, network);
 		node_list.truncate(node_list.iter().position(|&layer| !is_folder(layer, network)).unwrap_or(0) + 1);
 		node_list
 	}
 
-	/// Find the deepest layer given in the sorted array, by simply omitting the folder layer.
-	pub fn find_deepest(&self, node_list: &[LayerNodeIdentifier], network: &NodeNetwork) -> Option<LayerNodeIdentifier> {
-		node_list.iter().find(|&&layer| !is_folder(layer, network)).copied()
-	}
-
-	/// Find the deepest layer that has been clicked on from a viewport space location
+	/// Find the deepest layer that has been clicked on from a location in viewport space.
 	pub fn click(&self, viewport_location: DVec2, network: &NodeNetwork) -> Option<LayerNodeIdentifier> {
-		//self.find_deepest(&self.click_list(viewport_location, network), network)
 		self.click_list(viewport_location, network).last().copied()
 	}
 

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -494,7 +494,8 @@ impl Fsm for SelectToolFsmState {
 					.unwrap_or_default();
 
 				let mut selected: Vec<_> = document.selected_nodes.selected_visible_and_unlocked_layers(document.metadata()).collect();
-				let intersection = document.click(input.mouse.position, &document.network);
+				let intersection_list = document.click_list(input.mouse.position, &document.network);
+				let intersection = document.find_deepest(&intersection_list, &document.network);
 
 				// If the user is dragging the bounding box bounds, go into ResizingBounds mode.
 				// If the user is dragging the rotate trigger, go into RotatingBounds mode.
@@ -591,11 +592,11 @@ impl Fsm for SelectToolFsmState {
 						responses.add(DocumentMessage::StartTransaction);
 
 						tool_data.layer_selected_on_start = Some(intersection);
-						selected = vec![intersection];
+						selected = intersection_list;
 
 						match tool_data.nested_selection_behavior {
 							NestedSelectionBehavior::Shallowest if !input.keyboard.key(select_deepest) => drag_shallowest_manipulation(responses, selected, tool_data, document),
-							_ => drag_deepest_manipulation(responses, selected, tool_data),
+							_ => drag_deepest_manipulation(responses, selected, tool_data, document),
 						}
 						tool_data.get_snap_candidates(document, input);
 						SelectToolFsmState::Dragging
@@ -1115,8 +1116,8 @@ fn drag_shallowest_manipulation(responses: &mut VecDeque<Message>, selected: Vec
 	});
 }
 
-fn drag_deepest_manipulation(responses: &mut VecDeque<Message>, mut selected: Vec<LayerNodeIdentifier>, tool_data: &mut SelectToolData) {
-	tool_data.layers_dragging.append(&mut selected);
+fn drag_deepest_manipulation(responses: &mut VecDeque<Message>, selected: Vec<LayerNodeIdentifier>, tool_data: &mut SelectToolData, document: &DocumentMessageHandler) {
+	tool_data.layers_dragging.append(&mut vec![document.find_deepest(&selected, &document.network).unwrap_or_default()]);
 	responses.add(NodeGraphMessage::SelectedNodesSet {
 		nodes: tool_data.layers_dragging.iter().map(|layer| layer.to_node()).collect(),
 	});


### PR DESCRIPTION
Fix: remove folder (introduced in #1595, `GraphicElementRendered::add_click_targets`, thanks to @0HyperCube ) when clicked (`DocumentMessageHandler::click`), except for shallow select.

This should also fix other tools, like Fill tool which hook Lmb hints.

Todos:

* ~shallow select is not working when long-interval clicks. (Should be same as <https://71e86a06.graphite.pages.dev/>)~

  * This is caused by the detection of double click. ALL double click works fine, except for one state:
  
    Only double click at the first shallow selection will also deepen one level (one -> shallow select, one -> deepen one level). This behavior is reproduced in the previous fine PR(71e86a06), so won't fix in this PR.

* shallow hover is showed same as deep hover. (*Whether to implemented?*)

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1723
