### PR TITLE
Code cleanup and refactor for generalized layers

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -280,11 +280,12 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			DocumentMessage::DuplicateSelectedLayers => {
 				let parent = self.new_layer_parent(false);
 				let calculated_insert_index = self.get_calculated_insert_index(parent);
+
 				responses.add(DocumentMessage::StartTransaction);
 				responses.add(PortfolioMessage::Copy { clipboard: Clipboard::Internal });
 				responses.add(PortfolioMessage::PasteIntoFolder {
 					clipboard: Clipboard::Internal,
-					parent: parent,
+					parent,
 					insert_index: calculated_insert_index,
 				});
 			}
@@ -877,11 +878,13 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						shift: offset,
 						shift_self: true,
 					});
+
 					// Set the primary input for the node downstream of folder to the first layer node
 					let Some((downstream_node_id, downstream_input_index)) = DocumentMessageHandler::get_downstream_node(&self.network, &self.metadata, folder) else {
 						log::error!("Downstream node should always exist when moving layer");
 						continue;
 					};
+
 					// Output_index must be 0 since layers only have 1 output
 					let downstream_input = NodeInput::node(child_layer_node_id, 0);
 					responses.add(NodeGraphMessage::SetNodeInput {

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message.rs
@@ -24,9 +24,18 @@ pub enum GraphOperationMessage {
 		parent: LayerNodeIdentifier,
 		insert_index: isize,
 	},
+	DisconnectInput {
+		node_id: NodeId,
+		input_index: usize,
+	},
 	FillSet {
 		layer: LayerNodeIdentifier,
 		fill: Fill,
+	},
+	InsertLayerAtStackIndex {
+		layer_id: NodeId,
+		parent: NodeId,
+		insert_index: usize,
 	},
 	InsertNodeBetween {
 		post_node_id: NodeId,
@@ -36,6 +45,9 @@ pub enum GraphOperationMessage {
 		insert_node_input_index: usize,
 		pre_node_output_index: usize,
 		pre_node_id: NodeId,
+	},
+	MoveSelectedSiblingsToChild {
+		new_parent: NodeId,
 	},
 	OpacitySet {
 		layer: LayerNodeIdentifier,
@@ -77,10 +89,6 @@ pub enum GraphOperationMessage {
 	Brush {
 		layer: LayerNodeIdentifier,
 		strokes: Vec<BrushStroke>,
-	},
-	MoveUpstreamSiblingsToChild {
-		new_parent: NodeId,
-		upstream_sibling_ids: Vec<NodeId>,
 	},
 	NewArtboard {
 		id: NodeId,

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message.rs
@@ -19,9 +19,23 @@ use glam::{DAffine2, DVec2, IVec2};
 #[impl_message(Message, DocumentMessage, GraphOperation)]
 #[derive(PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum GraphOperationMessage {
+	AddNodesAsChild {
+		nodes: HashMap<NodeId, DocumentNode>,
+		parent: LayerNodeIdentifier,
+		insert_index: isize,
+	},
 	FillSet {
 		layer: LayerNodeIdentifier,
 		fill: Fill,
+	},
+	InsertNodeBetween {
+		post_node_id: NodeId,
+		post_node_input_index: usize,
+		insert_node_output_index: usize,
+		insert_node_id: NodeId,
+		insert_node_input_index: usize,
+		pre_node_output_index: usize,
+		pre_node_id: NodeId,
 	},
 	OpacitySet {
 		layer: LayerNodeIdentifier,

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -50,11 +50,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 					})
 					.unwrap_or_default();
 
-				let mut is_visible = true;
 				for (old_id, mut document_node) in nodes {
-					if !document_node.visible {
-						is_visible = false;
-					}
 					// Shift copied node
 					document_node.metadata.position += shift;
 
@@ -71,12 +67,6 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 					return;
 				};
 				responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![*new_layer_id] });
-				if !is_visible {
-					responses.add(NodeGraphMessage::SetVisibility {
-						node_id: *new_layer_id,
-						visible: false,
-					});
-				}
 				let insert_index = if insert_index < 0 { 0 } else { insert_index as usize };
 				let (downstream_node, upstream_node, input_index) = ModifyInputsContext::get_post_node_with_index(document_network, parent.to_node(), insert_index);
 				if let Some(upstream_node) = upstream_node {

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -1,5 +1,6 @@
 use super::transform_utils::{self, LayerBounds};
 use super::utility_types::ModifyInputsContext;
+use crate::messages::portfolio::document::node_graph::document_node_types::resolve_document_node_type;
 use crate::messages::portfolio::document::utility_types::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
 use crate::messages::portfolio::document::utility_types::nodes::{CollapsedLayers, SelectedNodes};
 use crate::messages::prelude::*;
@@ -103,12 +104,84 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 				});
 
 				responses.add(NodeGraphMessage::RunDocumentGraph);
-				responses.add(DocumentMessage::DocumentStructureChanged);
+			}
+			GraphOperationMessage::DisconnectInput { node_id, input_index } => {
+				let Some(node_to_disconnect) = document_network.nodes.get(&node_id) else {
+					warn!("Node {} not found in DisconnectInput", node_id);
+					return;
+				};
+				let Some(node_type) = resolve_document_node_type(&node_to_disconnect.name) else {
+					warn!("Node {} not in library", node_to_disconnect.name);
+					return;
+				};
+				let Some(existing_input) = node_to_disconnect.inputs.get(input_index) else {
+					warn!("Node does not have an input at the selected index");
+					return;
+				};
+
+				let mut input = node_type.inputs[input_index].default.clone();
+				if let NodeInput::Value { exposed, .. } = &mut input {
+					*exposed = existing_input.is_exposed();
+				}
+				responses.add(NodeGraphMessage::SetNodeInput { node_id, input_index, input });
 			}
 			GraphOperationMessage::FillSet { layer, fill } => {
 				if let Some(mut modify_inputs) = ModifyInputsContext::new_with_layer(layer.to_node(), document_network, document_metadata, node_graph, responses) {
 					modify_inputs.fill_set(fill);
 				}
+			}
+			GraphOperationMessage::InsertLayerAtStackIndex { layer_id, parent, insert_index } => {
+				let (post_node_id, pre_node_id, post_node_input_index) = ModifyInputsContext::get_post_node_with_index(&document_network, parent, insert_index);
+				// Layer_to_move should always correspond to a node.
+				let Some(layer_to_move_node) = document_network.nodes.get(&layer_id) else {
+					log::error!("Layer node not found when inserting node {} at index {}", layer_id, insert_index);
+					return;
+				};
+				// Move current layer to post node.
+				let post_node = document_network.nodes.get(&post_node_id).expect("Post node id should always refer to a node");
+				let current_position = layer_to_move_node.metadata.position;
+				let new_position = post_node.metadata.position;
+
+				// If moved to top of a layer stack, move to the left of the post node. If moved within a stack, move directly on the post node. The stack will be shifted down later.
+				let offset_to_post_node = if insert_index == 0 {
+					new_position - current_position - IVec2::new(8, 0)
+				} else {
+					new_position - current_position
+				};
+
+				responses.add(NodeGraphMessage::ShiftUpstream {
+					node_id: layer_id,
+					shift: offset_to_post_node,
+					shift_self: true,
+				});
+
+				// Update post_node input to layer_to_move.
+				if let Some(upstream_node) = pre_node_id {
+					responses.add(GraphOperationMessage::InsertNodeBetween {
+						post_node_id: post_node_id,
+						post_node_input_index: post_node_input_index,
+						insert_node_output_index: 0,
+						insert_node_id: layer_id,
+						insert_node_input_index: 0,
+						pre_node_output_index: 0,
+						pre_node_id: upstream_node,
+					})
+				} else {
+					let downstream_input = NodeInput::node(layer_id, 0);
+
+					responses.add(NodeGraphMessage::SetNodeInput {
+						node_id: post_node_id,
+						input_index: post_node_input_index,
+						input: downstream_input,
+					})
+				}
+
+				// Shift stack down, starting at the moved node.
+				responses.add(NodeGraphMessage::ShiftUpstream {
+					node_id: layer_id,
+					shift: IVec2::new(0, 3),
+					shift_self: true,
+				});
 			}
 			GraphOperationMessage::InsertNodeBetween {
 				post_node_id,
@@ -212,67 +285,77 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 					modify_inputs.brush_modify(strokes);
 				}
 			}
-			GraphOperationMessage::MoveUpstreamSiblingsToChild { new_parent, upstream_sibling_ids } => {
-				// Start with the furthest upstream node, move it as a child of the new folder, and continue downstream for each layer in vec
-				for node_to_move in upstream_sibling_ids.iter().rev() {
-					// Connect pre node to post node, or disconnect pre node if post node doesn't exist
-					let mut pre_node_id = new_parent;
-					loop {
-						let Some(NodeInput::Node { node_id, .. }) = document_network.nodes.get(&pre_node_id).and_then(|node| node.inputs.get(0)) else {
-							log::error!("End of stack should never be reached");
-							return;
-						};
-						if *node_id == *node_to_move {
-							break;
-						}
-						pre_node_id = *node_id;
-					}
-
-					if let Some(NodeInput::Node { node_id, .. }) = document_network.nodes.get(&node_to_move).and_then(|node| node.inputs.get(0)) {
-						let post_node_id = *node_id;
-						let Some(NodeInput::Node { node_id, .. }) = document_network.nodes.get_mut(&pre_node_id).and_then(|node| node.inputs.get_mut(0)) else {
-							log::error!("Pre node should always have primary input");
-							return;
-						};
-						*node_id = post_node_id;
-					} else {
-						DocumentMessageHandler::disconnect_input(document_network.nodes.get_mut(&pre_node_id).expect("Upstream sibling should always exist"), 0);
-					}
-
-					// Connect upstream sibling to the secondary input of the parent
-					let Some(parent_secondary_input) = document_network.nodes.get(&new_parent).and_then(|node| node.inputs.get(1)) else {
-						log::error!("Could not get child node input for current node");
-						return;
-					};
-
-					// Insert upstream_sibling_node at top of group stack
-					if let NodeInput::Node { node_id, .. } = parent_secondary_input {
-						// If there is already a node at the top of the stack, insert upstream_sibling_node in between
-						let current_child = *node_id;
-						let Some(upstream_sibling_input) = document_network.nodes.get_mut(&node_to_move).and_then(|node| node.inputs.get_mut(0)) else {
-							log::error!("Could not get upstream sibling node input");
-							return;
-						};
-						*upstream_sibling_input = NodeInput::node(current_child, 0);
-					}
-
-					let Some(parent_secondary_input_mut) = document_network.nodes.get_mut(&new_parent).and_then(|node| node.inputs.get_mut(1)) else {
-						log::error!("Could not get child node input for current node");
-						return;
-					};
-
-					*parent_secondary_input_mut = NodeInput::node(*node_to_move, 0);
-				}
-
-				let Some(most_upstream_sibling) = upstream_sibling_ids.last() else {
+			GraphOperationMessage::MoveSelectedSiblingsToChild { new_parent } => {
+				let group_layer = LayerNodeIdentifier::new(new_parent, &document_network);
+				let Some(group_parent) = group_layer.parent(&document_metadata) else {
+					log::error!("Could not find parent for layer {:?}", group_layer);
 					return;
 				};
-				DocumentMessageHandler::disconnect_input(document_network.nodes.get_mut(&most_upstream_sibling).expect("Upstream sibling should always exist"), 0);
+				// Create a vec of nodes to move with all selected layers in the parent layer child stack, as well as each non layer sibling directly upstream of the selected layer
+				let mut selected_siblings = Vec::new();
 
-				let top_of_stack = upstream_sibling_ids.first().expect("Upstream nodes to move cannot be empty");
-				let upstream_shift = IVec2::new(-8, 0);
-				let mut modify_inputs = ModifyInputsContext::new(document_network, document_metadata, node_graph, responses);
-				modify_inputs.shift_upstream(*top_of_stack, upstream_shift, true);
+				// Skip over horizontal non layer node chain that feeds into parent
+				let Some(mut current_stack_node_id) = group_parent.first_child(&document_metadata).and_then(|current_stack_node| Some(current_stack_node.to_node())) else {
+					log::error!("Folder should always have child");
+					return;
+				};
+				let current_stack_node_id = &mut current_stack_node_id;
+
+				loop {
+					let mut current_stack_node = document_network.nodes.get(current_stack_node_id).expect("Current stack node id should always be a node");
+
+					// Check if the current stack node is a selected layer
+					if selected_nodes
+						.selected_layers(&document_metadata)
+						.any(|selected_node_id| selected_node_id.to_node() == *current_stack_node_id)
+					{
+						selected_siblings.push(*current_stack_node_id);
+
+						// Push all non layer sibling nodes directly upstream of the selected layer
+						loop {
+							let Some(NodeInput::Node { node_id, .. }) = current_stack_node.inputs.get(0) else { break };
+
+							let next_node = document_network.nodes.get(node_id).expect("Stack node id should always be a node");
+
+							// If the next node is a layer, immediately break and leave current stack node as the non layer node
+							if next_node.is_layer {
+								break;
+							}
+
+							*current_stack_node_id = *node_id;
+							current_stack_node = next_node;
+
+							selected_siblings.push(*current_stack_node_id);
+						}
+					}
+
+					// Get next node
+					let Some(NodeInput::Node { node_id, .. }) = current_stack_node.inputs.get(0) else { break };
+					*current_stack_node_id = *node_id;
+				}
+
+				// Start with the furthest upstream node, move it as a child of the new folder, and continue downstream for each layer in vec
+				for node_to_move in selected_siblings.iter().rev() {
+					// Connect downstream node to upstream node, or disconnect downstream node if upstream node doesn't exist
+					responses.add(NodeGraphMessage::DisconnectLayerFromStack {
+						node_id: *node_to_move,
+						reconnect_to_sibling: true,
+					});
+
+					responses.add(GraphOperationMessage::InsertLayerAtStackIndex {
+						layer_id: *node_to_move,
+						parent: new_parent,
+						insert_index: 0,
+					});
+				}
+
+				let Some(most_upstream_sibling) = selected_siblings.last() else {
+					return;
+				};
+				responses.add(GraphOperationMessage::DisconnectInput {
+					node_id: *most_upstream_sibling,
+					input_index: 0,
+				});
 			}
 			GraphOperationMessage::NewArtboard { id, artboard } => {
 				let mut modify_inputs = ModifyInputsContext::new(document_network, document_metadata, node_graph, responses);

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -1,5 +1,6 @@
 use crate::messages::prelude::*;
 
+use glam::IVec2;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, NodeId, NodeInput};
 use graph_craft::proto::GraphErrors;
@@ -35,6 +36,10 @@ pub enum NodeGraphMessage {
 	DisconnectNodes {
 		node_id: NodeId,
 		input_index: usize,
+	},
+	DisconnectLayerFromStack {
+		node_id: NodeId,
+		reconnect_to_sibling: bool,
 	},
 	EnterNestedNetwork {
 		node: NodeId,
@@ -92,6 +97,10 @@ pub enum NodeGraphMessage {
 		input_index: usize,
 		input: NodeInput,
 	},
+	SetNodePosition {
+		node_id: NodeId,
+		position: IVec2,
+	},
 	SetQualifiedInputValue {
 		node_path: Vec<NodeId>,
 		input_index: usize,
@@ -100,6 +109,11 @@ pub enum NodeGraphMessage {
 	/// Move all the downstream nodes to the right in the graph to allow space for a newly inserted node
 	ShiftNode {
 		node_id: NodeId,
+	},
+	ShiftUpstream {
+		node_id: NodeId,
+		shift: IVec2,
+		shift_self: bool,
 	},
 	SetVisibility {
 		node_id: NodeId,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -163,7 +163,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 
 					for (_, upstream_id) in document_network.upstream_flow_back_from_nodes(vec![*child_id], graph_craft::document::FlowType::UpstreamFlow) {
 						// This does a downstream traversal starting from the current node, and ending at either a node in the delete_nodes set or the output.
-						// If the traversal find a child node of a node in the delete_nodes set, then it is a sole dependent. If the output node is eventually reached, then it is not a sole dependent.
+						// If the traversal find as child node of a node in the delete_nodes set, then it is a sole dependent. If the output node is eventually reached, then it is not a sole dependent.
 						let mut stack = vec![upstream_id];
 						let mut can_delete = true;
 
@@ -253,11 +253,13 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					warn!("No network");
 					return;
 				};
+
 				// Ensure node is a layer and create LayerNodeIdentifier
 				if network.nodes.get(&node_id).is_some_and(|node| !node.is_layer) {
 					log::error!("Non layer node passed to DisconnectLayer");
 					return;
 				}
+
 				let layer_to_disconnect = LayerNodeIdentifier::new(node_id, &network);
 
 				let Some((downstream_node_id, downstream_input_index)) = DocumentMessageHandler::get_downstream_node(&network, &document_metadata, layer_to_disconnect) else {
@@ -272,6 +274,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					if let Some(NodeInput::Node { node_id, .. }) = downstream_node.inputs.get_mut(downstream_input_index) {
 						*node_id = upstream_sibling_id;
 					}
+
 					let upstream_shift = IVec2::new(0, -3);
 					responses.add(NodeGraphMessage::ShiftUpstream {
 						node_id: upstream_sibling_id,
@@ -619,6 +622,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					warn!("No network");
 					return;
 				};
+
 				let mut modify_inputs = ModifyInputsContext::new(network, document_metadata, self, responses);
 				modify_inputs.shift_upstream(node_id, shift, shift_self);
 			}

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -411,37 +411,16 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					error!("No network");
 					return;
 				};
-				let Some(post_node) = network.nodes.get(&post_node_id) else {
-					error!("Post node not found");
-					return;
-				};
-				let Some((post_node_input_index, _)) = post_node.inputs.iter().enumerate().filter(|input| input.1.is_exposed()).nth(post_node_input_index) else {
-					error!("Failed to find input index {post_node_input_index} on node {post_node_id:#?}");
-					return;
-				};
-				let Some(insert_node) = network.nodes.get(&insert_node_id) else {
-					error!("Insert node not found");
-					return;
-				};
-				let Some((insert_node_input_index, _)) = insert_node.inputs.iter().enumerate().filter(|input| input.1.is_exposed()).nth(insert_node_input_index) else {
-					error!("Failed to find input index {insert_node_input_index} on node {insert_node_id:#?}");
-					return;
-				};
-
 				responses.add(DocumentMessage::StartTransaction);
 
-				let post_input = NodeInput::node(insert_node_id, insert_node_output_index);
-				responses.add(NodeGraphMessage::SetNodeInput {
-					node_id: post_node_id,
-					input_index: post_node_input_index,
-					input: post_input,
-				});
-
-				let insert_input = NodeInput::node(pre_node_id, pre_node_output_index);
-				responses.add(NodeGraphMessage::SetNodeInput {
-					node_id: insert_node_id,
-					input_index: insert_node_input_index,
-					input: insert_input,
+				responses.add(GraphOperationMessage::InsertNodeBetween {
+					post_node_id,
+					post_node_input_index,
+					insert_node_output_index,
+					insert_node_id,
+					insert_node_input_index,
+					pre_node_output_index,
+					pre_node_id,
 				});
 
 				if network.connected_to_output(insert_node_id) {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -9,6 +9,7 @@ use crate::application::generate_uuid;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::portfolio::document::graph_operation::load_network_structure;
+use crate::messages::portfolio::document::graph_operation::utility_types::ModifyInputsContext;
 use crate::messages::portfolio::document::node_graph::document_node_types::{resolve_document_node_type, DocumentInputType, NodePropertiesContext};
 use crate::messages::portfolio::document::utility_types::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
 use crate::messages::portfolio::document::utility_types::nodes::{CollapsedLayers, LayerPanelEntry, SelectedNodes};
@@ -161,15 +162,11 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					let outward_links = document_network.collect_outwards_links();
 
 					for (_, upstream_id) in document_network.upstream_flow_back_from_nodes(vec![*child_id], graph_craft::document::FlowType::UpstreamFlow) {
-						// TODO: move into a document_network function .is_sole_dependent. This function does a downstream traversal starting from the current node,
-						// TODO: and only traverses for nodes that are not in the delete_nodes set. If all downstream nodes converge to some node in the delete_nodes set,
-						// TODO: then it is a sole dependent. If the output node is eventually reached, then it is not a sole dependent. This means disconnected branches
-						// TODO: that do not feed into the delete_nodes set or the output node will be deleted.
-
+						// This does a downstream traversal starting from the current node, and ending at either a node in the delete_nodes set or the output.
+						// If the traversal find a child node of a node in the delete_nodes set, then it is a sole dependent. If the output node is eventually reached, then it is not a sole dependent.
 						let mut stack = vec![upstream_id];
 						let mut can_delete = true;
 
-						// TODO: Add iteration limit to force break in case of infinite while loop
 						while let Some(current_node) = stack.pop() {
 							if let Some(downstream_nodes) = outward_links.get(&current_node) {
 								for downstream_node in downstream_nodes {
@@ -266,6 +263,50 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					responses.add(NodeGraphMessage::RunDocumentGraph);
 				}
 				responses.add(NodeGraphMessage::SendGraph);
+			}
+			NodeGraphMessage::DisconnectLayerFromStack { node_id, reconnect_to_sibling } => {
+				let Some(network) = document_network.nested_network(&self.network) else {
+					warn!("No network");
+					return;
+				};
+				// Ensure node is a layer and create LayerNodeIdentifier
+				if network.nodes.get(&node_id).is_some_and(|node| !node.is_layer) {
+					log::error!("Non layer node passed to DisconnectLayer");
+					return;
+				}
+				let layer_to_disconnect = LayerNodeIdentifier::new(node_id, &network);
+
+				let Some((downstream_node_id, downstream_input_index)) = DocumentMessageHandler::get_downstream_node(&network, &document_metadata, layer_to_disconnect) else {
+					log::error!("Downstream node should always exist when moving layer");
+					return;
+				};
+
+				let layer_to_move_sibling_input = network.nodes.get(&layer_to_disconnect.to_node()).and_then(|node| node.inputs.get(0));
+				if let Some(NodeInput::Node { node_id, .. }) = layer_to_move_sibling_input.and_then(|node_input| if reconnect_to_sibling { Some(node_input) } else { None }) {
+					let upstream_sibling_id = *node_id;
+					let Some(downstream_node) = document_network.nodes.get_mut(&downstream_node_id) else { return };
+
+					if let Some(NodeInput::Node { node_id, .. }) = downstream_node.inputs.get_mut(downstream_input_index) {
+						*node_id = upstream_sibling_id;
+					}
+					let upstream_shift = IVec2::new(0, -3);
+					responses.add(NodeGraphMessage::ShiftUpstream {
+						node_id: upstream_sibling_id,
+						shift: upstream_shift,
+						shift_self: true,
+					});
+				} else {
+					// Disconnect node directly downstream if upstream sibling doesn't exist
+					responses.add(NodeGraphMessage::DisconnectNodes {
+						node_id: downstream_node_id,
+						input_index: downstream_input_index,
+					});
+				}
+
+				responses.add(NodeGraphMessage::DisconnectNodes {
+					node_id: layer_to_disconnect.to_node(),
+					input_index: 0,
+				});
 			}
 			NodeGraphMessage::EnterNestedNetwork { node } => {
 				if let Some(network) = document_network.nested_network(&self.network) {
@@ -520,6 +561,26 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					}
 				}
 			}
+			NodeGraphMessage::SetNodePosition { node_id, position } => {
+				let Some(network) = document_network.nested_network_mut(&self.network) else {
+					warn!("No network");
+					return;
+				};
+
+				let Some(node) = network.nodes.get_mut(&node_id) else {
+					log::error!("Failed to find node {node_id} when setting position");
+					return;
+				};
+
+				node.metadata.position = position;
+
+				// Since document structure doesn't change, just update the nodes
+				if graph_view_overlay_open {
+					let links = Self::collect_links(network);
+					let nodes = self.collect_nodes(&links, network);
+					responses.add(FrontendMessage::UpdateNodeGraph { nodes, links });
+				}
+			}
 			NodeGraphMessage::SetQualifiedInputValue { node_path, input_index, value } => {
 				let Some((node_id, node_path)) = node_path.split_last() else {
 					error!("Node path is empty");
@@ -590,6 +651,14 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				}
 
 				self.send_graph(network, graph_view_overlay_open, document_metadata, selected_nodes, collapsed, responses);
+			}
+			NodeGraphMessage::ShiftUpstream { node_id, shift, shift_self } => {
+				let Some(network) = document_network.nested_network_mut(&self.network) else {
+					warn!("No network");
+					return;
+				};
+				let mut modify_inputs = ModifyInputsContext::new(network, document_metadata, self, responses);
+				modify_inputs.shift_upstream(node_id, shift, shift_self);
 			}
 			NodeGraphMessage::ToggleSelectedVisibility => {
 				responses.add(DocumentMessage::StartTransaction);

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -383,26 +383,14 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>| {
 					if self.active_document().is_some() {
 						trace!("Pasting into folder {parent:?} as index: {insert_index}");
-						let id = NodeId(generate_uuid());
-						responses.add(GraphOperationMessage::NewCustomLayer {
-							id,
-							nodes: entry.nodes.clone(),
+						responses.add(GraphOperationMessage::AddNodesAsChild {
+							nodes: entry.clone().nodes,
 							parent,
-							insert_index,
-							alias: entry.alias.clone(),
+							insert_index: insert_index,
 						});
-						if entry.selected {
-							responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![id] });
-						}
-						if !entry.visible {
-							responses.add(NodeGraphMessage::SetVisibility { node_id: id, visible: false });
-						}
-						if entry.locked {
-							responses.add(NodeGraphMessage::SetLocked { node_id: id, locked: true });
-						}
 					}
 				};
-
+				responses.add(DocumentMessage::DeselectAllLayers);
 				for entry in self.copy_buffer[clipboard as usize].iter().rev() {
 					paste(entry, responses)
 				}

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -383,14 +383,17 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>| {
 					if self.active_document().is_some() {
 						trace!("Pasting into folder {parent:?} as index: {insert_index}");
+
 						responses.add(GraphOperationMessage::AddNodesAsChild {
 							nodes: entry.clone().nodes,
 							parent,
-							insert_index: insert_index,
+							insert_index,
 						});
 					}
 				};
+
 				responses.add(DocumentMessage::DeselectAllLayers);
+
 				for entry in self.copy_buffer[clipboard as usize].iter().rev() {
 					paste(entry, responses)
 				}

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -183,30 +183,29 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					let ordered_last_elements: Vec<_> = active_document.metadata.all_layers().filter(|layer| get_last_elements.contains(&layer)).collect();
 
 					for layer in ordered_last_elements {
-						let node = layer.to_node();
-						let previous_alias = active_document.network().nodes.get(&node).map(|node| node.alias.clone()).unwrap_or_default();
+						let layer_node_id = layer.to_node();
+						let previous_alias = active_document.network().nodes.get(&layer_node_id).map(|node| node.alias.clone()).unwrap_or_default();
 
-						let Some(node) = active_document
+						let mut copy_ids = HashMap::new();
+						copy_ids.insert(layer_node_id, NodeId(0 as u64));
+						if let Some(input_node) = active_document
 							.network()
 							.nodes
-							.get(&node)
+							.get(&layer_node_id)
 							.and_then(|node| if node.is_layer { node.inputs.get(1) } else { node.inputs.get(0) })
 							.and_then(|input| input.as_node())
-						else {
-							continue;
+						{
+							active_document
+								.network()
+								.upstream_flow_back_from_nodes(vec![input_node], graph_craft::document::FlowType::UpstreamFlow)
+								.enumerate()
+								.for_each(|(index, (_, node_id))| {
+									copy_ids.insert(node_id, NodeId((index + 1) as u64));
+								});
 						};
 
 						buffer.push(CopyBufferEntry {
-							nodes: NodeGraphMessageHandler::copy_nodes(
-								active_document.network(),
-								&active_document
-									.network()
-									.upstream_flow_back_from_nodes(vec![node], graph_craft::document::FlowType::UpstreamFlow)
-									.enumerate()
-									.map(|(index, (_, node_id))| (node_id, NodeId(index as u64)))
-									.collect(),
-							)
-							.collect(),
+							nodes: NodeGraphMessageHandler::copy_nodes(active_document.network(), &copy_ids).collect(),
 							selected: active_document.selected_nodes.selected_layers_contains(layer, active_document.metadata()),
 							visible: active_document.selected_nodes.layer_visible(layer, active_document.metadata()),
 							locked: active_document.selected_nodes.layer_locked(layer, active_document.metadata()),
@@ -411,30 +410,19 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 			PortfolioMessage::PasteSerializedData { data } => {
 				if let Some(document) = self.active_document() {
 					if let Ok(data) = serde_json::from_str::<Vec<CopyBufferEntry>>(&data) {
-						let parent = document.new_layer_parent();
+						let parent = document.new_layer_parent(false);
 
 						responses.add(DocumentMessage::DeselectAllLayers);
 						responses.add(DocumentMessage::StartTransaction);
 
 						for entry in data.into_iter().rev() {
 							document.load_layer_resources(responses);
-							let id = NodeId(generate_uuid());
-							responses.add(GraphOperationMessage::NewCustomLayer {
-								id,
+							responses.add(GraphOperationMessage::AddNodesAsChild {
 								nodes: entry.nodes,
 								parent,
 								insert_index: -1,
-								alias: entry.alias,
 							});
-							if entry.selected {
-								responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![id] });
-							}
-							if !entry.visible {
-								responses.add(NodeGraphMessage::SetVisibility { node_id: id, visible: false });
-							}
 						}
-
-						responses.add(DocumentMessage::CommitTransaction);
 					}
 				}
 			}

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -420,7 +420,7 @@ fn new_brush_layer(document: &DocumentMessageHandler, responses: &mut VecDeque<M
 	responses.add(GraphOperationMessage::NewCustomLayer {
 		id,
 		nodes: HashMap::from([(NodeId(0), brush_node)]),
-		parent: document.new_layer_parent(),
+		parent: document.new_layer_parent(true),
 		insert_index: -1,
 		alias: String::new(),
 	});

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -202,7 +202,7 @@ impl Fsm for EllipseToolFsmState {
 				// Create a new ellipse vector shape
 				let subpath = bezier_rs::Subpath::new_ellipse(DVec2::ZERO, DVec2::ONE);
 				let manipulator_groups = subpath.manipulator_groups().to_vec();
-				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(), responses);
+				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				graph_modification_utils::set_manipulator_colinear_handles_state(&manipulator_groups, layer, true, responses);
 				shape_data.layer = Some(layer);
 

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -230,7 +230,7 @@ impl Fsm for FreehandToolFsmState {
 				} else {
 					responses.add(DocumentMessage::DeselectAllLayers);
 
-					let parent = document.new_layer_parent();
+					let parent = document.new_layer_parent(true);
 					let transform = document.metadata().transform_to_viewport(parent);
 					let pos = transform.inverse().transform_point2(input.mouse.position);
 					let subpath = bezier_rs::Subpath::from_anchors([pos], false);

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -181,7 +181,7 @@ impl Fsm for LineToolFsmState {
 
 				responses.add(DocumentMessage::StartTransaction);
 
-				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(), responses);
+				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				responses.add(GraphOperationMessage::StrokeSet {
 					layer,
 					stroke: Stroke::new(tool_options.stroke.active_color(), tool_options.line_weight),

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -232,7 +232,7 @@ impl PenToolData {
 		input: &InputPreprocessorMessageHandler,
 		responses: &mut VecDeque<Message>,
 	) {
-		let parent = document.new_layer_parent();
+		let parent = document.new_layer_parent(true);
 		// Deselect layers because we are now creating a new layer
 		responses.add(DocumentMessage::DeselectAllLayers);
 

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -247,7 +247,7 @@ impl Fsm for PolygonToolFsmState {
 					PolygonType::Convex => bezier_rs::Subpath::new_regular_polygon(DVec2::ZERO, tool_options.vertices as u64, 1.),
 					PolygonType::Star => bezier_rs::Subpath::new_star_polygon(DVec2::ZERO, tool_options.vertices as u64, 1., 0.5),
 				};
-				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(), responses);
+				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				polygon_data.layer = Some(layer);
 
 				let fill_color = tool_options.fill.active_color();

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -209,7 +209,7 @@ impl Fsm for RectangleToolFsmState {
 
 				responses.add(DocumentMessage::StartTransaction);
 
-				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(), responses);
+				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				shape_data.layer = Some(layer);
 
 				let fill_color = tool_options.fill.active_color();

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -208,7 +208,7 @@ impl Fsm for SplineToolFsmState {
 				responses.add(DocumentMessage::StartTransaction);
 				responses.add(DocumentMessage::DeselectAllLayers);
 
-				let parent = document.new_layer_parent();
+				let parent = document.new_layer_parent(true);
 				let transform = document.metadata().transform_to_viewport(parent);
 
 				//tool_data.snap_manager.start_snap(document, input, document.bounding_boxes(), true, true);

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -283,7 +283,7 @@ impl TextToolData {
 				text: String::new(),
 				font: editing_text.font.clone(),
 				size: editing_text.font_size,
-				parent: document.new_layer_parent(),
+				parent: document.new_layer_parent(true),
 				insert_index: -1,
 			});
 			responses.add(GraphOperationMessage::FillSet {


### PR DESCRIPTION
Closes #1510, a follow-up to PR #1712.

Fixes undo bugs by extracting functions into messages. Generalized Copy and Paste for any layer node, and mapped duplicate layers (ctrl+D) to copy and paste.

Refactored Messages:
`DocumentMessage::DuplicateSelectedLayers`
`DocumentMessage::GroupSelectedLayers`
`DocumentMessage::MoveSelectedLayersTo`
`DocumentMessage::UngroupSelectedLayers`
`NodeGraphMessage::DisconnectNodes`
`NodeGraphMessage::InsertNodeBetween`
`GraphOperationMessage::MoveSelectedSiblingsToChild`
`PortfolioMessage::Copy`
`PortfolioMessage::PasteSerializedData`

New Messages:
`NodeGraphMessage::DisconnectLayerFromStack`
`NodeGraphMessage::SetNodePosition`
`NodeGraphMessage::ShiftUpstream`
`GraphOperationMessage::AddNodesAsChild`
`GraphOperationMessage::DisconnectInput`
`GraphOperationMessage::InsertLayerAtStackIndex`
`GraphOperationMessage::InsertNodeBetween`
`GraphOperationMessage::MoveSelectedSiblingsToChild`




