### PR TITLE
Fix artboards not being included in Export menu's bounds list

### DIFF
--- a/editor/src/messages/dialog/dialog_message_handler.rs
+++ b/editor/src/messages/dialog/dialog_message_handler.rs
@@ -74,7 +74,7 @@ impl MessageHandler<DialogMessage, DialogMessageData<'_>> for DialogMessageHandl
 					let artboards = document
 						.metadata
 						.all_layers()
-						.filter(|&layer| is_layer_fed_by_node_of_name(layer, &document.network, "Artboard"))
+						.filter(|&layer| document.metadata.is_artboard(layer))
 						.map(|layer| {
 							(
 								layer,


### PR DESCRIPTION
Adds artboards to export bound options when exporting image