### PR TITLE
Fix primitive tool shapes appearing at document origin before dragging; fix Ctrl+0 recenter shifting

### DIFF
--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -209,7 +209,13 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 				let size = 1. / size;
 				let new_scale = size.min_element();
 
-				ptz.pan += center;
+				let viewport_change = metadata.document_to_viewport.transform_vector2(center);
+
+				// Don't change the pan if the change won't be visible in the viewport.
+				if viewport_change.x.abs() > 0.5 || viewport_change.y.abs() > 0.5 {
+					ptz.pan += center;
+				}
+
 				ptz.zoom *= new_scale * VIEWPORT_ZOOM_TO_FIT_PADDING_SCALE_FACTOR;
 
 				// Keep the canvas filling less than the full available viewport bounds if requested.

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -204,14 +204,13 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 				let v1 = metadata.document_to_viewport.inverse().transform_point2(DVec2::ZERO);
 				let v2 = metadata.document_to_viewport.inverse().transform_point2(ipp.viewport_bounds.size());
 
-				let center = v1.lerp(v2, 0.5) - pos1.lerp(pos2, 0.5);
-				let size = (pos2 - pos1) / (v2 - v1);
-				let size = 1. / size;
+				let center = ((v1 + v2) - (pos1 + pos2)) / 2.;
+				let size = 1. / ((pos2 - pos1) / (v2 - v1));
 				let new_scale = size.min_element();
 
 				let viewport_change = metadata.document_to_viewport.transform_vector2(center);
 
-				// Don't change the pan if the change won't be visible in the viewport.
+				// Only change the pan if the change will be visible in the viewport
 				if viewport_change.x.abs() > 0.5 || viewport_change.y.abs() > 0.5 {
 					ptz.pan += center;
 				}

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
+use crate::messages::portfolio::document::{graph_operation::utility_types::TransformIn, overlays::utility_types::OverlayContext};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
@@ -205,6 +205,13 @@ impl Fsm for EllipseToolFsmState {
 				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				graph_modification_utils::set_manipulator_colinear_handles_state(&manipulator_groups, layer, true, responses);
 				shape_data.layer = Some(layer);
+
+				responses.add(GraphOperationMessage::TransformSet {
+					layer,
+					transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
+					transform_in: TransformIn::Viewport,
+					skip_rerender: false,
+				});
 
 				let fill_color = tool_options.fill.active_color();
 				responses.add(GraphOperationMessage::FillSet {

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -1,5 +1,6 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::{graph_operation::utility_types::TransformIn, overlays::utility_types::OverlayContext};
+use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
+use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -182,12 +182,20 @@ impl Fsm for LineToolFsmState {
 				responses.add(DocumentMessage::StartTransaction);
 
 				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
+
+				responses.add(GraphOperationMessage::TransformSet {
+					layer,
+					transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
+					transform_in: TransformIn::Viewport,
+					skip_rerender: false,
+				});
+
 				responses.add(GraphOperationMessage::StrokeSet {
 					layer,
 					stroke: Stroke::new(tool_options.stroke.active_color(), tool_options.line_weight),
 				});
-				tool_data.layer = Some(layer);
 
+				tool_data.layer = Some(layer);
 				tool_data.weight = tool_options.line_weight;
 
 				LineToolFsmState::Drawing

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
+use crate::messages::portfolio::document::{graph_operation::utility_types::TransformIn, overlays::utility_types::OverlayContext};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -1,5 +1,6 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::{graph_operation::utility_types::TransformIn, overlays::utility_types::OverlayContext};
+use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
+use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
@@ -249,6 +249,13 @@ impl Fsm for PolygonToolFsmState {
 				};
 				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				polygon_data.layer = Some(layer);
+
+				responses.add(GraphOperationMessage::TransformSet {
+					layer,
+					transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
+					transform_in: TransformIn::Viewport,
+					skip_rerender: false,
+				});
 
 				let fill_color = tool_options.fill.active_color();
 				responses.add(GraphOperationMessage::FillSet {

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
+use crate::messages::portfolio::document::{graph_operation::utility_types::TransformIn, overlays::utility_types::OverlayContext};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -1,5 +1,5 @@
 use super::tool_prelude::*;
-use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, graph_operation::utility_types::TransformIn};
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
@@ -211,6 +211,13 @@ impl Fsm for RectangleToolFsmState {
 
 				let layer = graph_modification_utils::new_vector_layer(vec![subpath], NodeId(generate_uuid()), document.new_layer_parent(true), responses);
 				shape_data.layer = Some(layer);
+
+				responses.add(GraphOperationMessage::TransformSet {
+					layer,
+					transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
+					transform_in: TransformIn::Viewport,
+					skip_rerender: false,
+				});
 
 				let fill_color = tool_options.fill.active_color();
 				responses.add(GraphOperationMessage::FillSet {

--- a/libraries/bezier-rs/src/bezier/solvers.rs
+++ b/libraries/bezier-rs/src/bezier/solvers.rs
@@ -586,7 +586,7 @@ impl Bezier {
 		Bezier::from_cubic_dvec2(self.end, handle1, handle2, other.start)
 	}
 
-	/// Compute the winding order (number of times crossing an infinate line to the left of the point)
+	/// Compute the winding order (number of times crossing an infinite line to the left of the point)
 	///
 	/// Assumes curve is split at the extrema.
 	fn pre_split_winding_number(&self, target_point: DVec2) -> i32 {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

- Fixes the position of zero-sized shape upon mousedown before starting to draw the shape as specified in https://discord.com/channels/731730685944922173/881073965047636018/1111926515853164617.
- Fixes the indeterministic recenter by `Ctrl+0` as specified in https://discord.com/channels/731730685944922173/881073965047636018/1178103299547877426.
- Fix typo in `infinate`