### PR TITLE
Update Git Attributes for JSON syntax highlighting in `*.graphite` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 # The `eol=lf` sets the conversion to an LF line ending
 # https://git-scm.com/docs/gitattributes
 * text=auto eol=lf
+
+# Adds syntax highlighting to Graphite files on GitHub and minimizes diffs both locally and on GitHub
+*.graphite binary linguist-generated linguist-language=JSON

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 
 # Adds syntax highlighting to Graphite files on GitHub and minimizes diffs both locally and on GitHub
 *.graphite binary linguist-generated linguist-language=JSON
+/node-graph/graphene-cli/test_files/*.graphite text diff -linguist-generated


### PR DESCRIPTION
This is just the type of small PR that I always compulsively do when I encounter a project with a new filetype :laughing:

This will apply the JSON syntax highlighting to *some* `*.graphite` files on GitHub (syntax highlighting is disabled for large minified files). It marks *most* `*.graphite` files as binary and generated, hiding diffs locally and in GitHub PRs. It reverts this for the graphite test files, since they seem to be manually written.

Currently, whether or not syntax highlighting is applied to `test_files/*.graphite` seems to almost be random (linguist's Bayesian classifer timing out perhaps :shrug:), but you can see in my fork that syntax highlighting is always applied.