### PR TITLE
Fix tool drawing start point offset when an artboard has a transform

### DIFF
--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -157,7 +157,11 @@ impl ArtboardToolData {
 		};
 
 		let center = from_center.then_some(bounds.center_of_transformation);
-		let (position, size) = movement.new_size(mouse_position, bounds.transform, center, constrain_square, None);
+		let (min, size) = movement.new_size(mouse_position, bounds.transform, center, constrain_square, None);
+		let max = min + size;
+		let position = min.min(max);
+		let size = (max - min).abs();
+
 		responses.add(GraphOperationMessage::ResizeArtboard {
 			id: self.selected_artboard.unwrap().to_node(),
 			location: position.round().as_ivec2(),
@@ -271,6 +275,9 @@ impl Fsm for ArtboardToolFsmState {
 
 				let start = root_transform.transform_point2(start);
 				let size = root_transform.transform_vector2(size);
+				let end = start + size;
+				let size = (start - end).abs();
+				let start = start.min(end);
 
 				if let Some(artboard) = tool_data.selected_artboard {
 					responses.add(GraphOperationMessage::ResizeArtboard {

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -318,7 +318,7 @@ impl Fsm for BrushToolFsmState {
 				let layer = loaded_layer.unwrap_or_else(|| new_brush_layer(document, responses));
 				tool_data.layer = Some(layer);
 
-				let parent = layer.parent(document.metadata()).unwrap_or_default();
+				let parent = layer.parent(document.metadata()).unwrap_or_else(|| document.new_layer_parent(true));
 				let parent_transform = document.metadata().transform_to_viewport(parent).inverse().transform_point2(input.mouse.position);
 				let layer_position = tool_data.transform.inverse().transform_point2(parent_transform);
 

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -339,6 +339,7 @@ impl NodeRuntime {
 				None.or_else(|| try_downcast::<VectorData>(introspected_data.as_ref()))
 					.or_else(|| try_downcast::<ImageFrame<Color>>(introspected_data.as_ref()))
 					.or_else(|| try_downcast::<GraphicElement>(introspected_data.as_ref()))
+					.or_else(|| try_downcast::<graphene_core::Artboard>(introspected_data.as_ref()))
 			} {
 				self.upstream_transforms.insert(parent_network_node_id, transform);
 			}

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -447,7 +447,8 @@ impl GraphicElementRendered for Artboard {
 	}
 
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>) {
-		let subpath = Subpath::new_rect(DVec2::ZERO, self.dimensions.as_dvec2());
+		let mut subpath = Subpath::new_rect(DVec2::ZERO, self.dimensions.as_dvec2());
+		subpath.apply_transform(self.graphic_group.transform.inverse());
 		click_targets.push(ClickTarget { stroke_width: 0., subpath });
 	}
 

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -447,7 +447,7 @@ impl GraphicElementRendered for Artboard {
 	}
 
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>) {
-		let subpath = Subpath::new_rect(self.location.as_dvec2(), self.location.as_dvec2() + self.dimensions.as_dvec2());
+		let subpath = Subpath::new_rect(DVec2::ZERO, self.dimensions.as_dvec2());
 		click_targets.push(ClickTarget { stroke_width: 0., subpath });
 	}
 

--- a/node-graph/gcore/src/transform.rs
+++ b/node-graph/gcore/src/transform.rs
@@ -127,7 +127,7 @@ impl TransformMut for VectorData {
 
 impl Transform for Artboard {
 	fn transform(&self) -> DAffine2 {
-		DAffine2::from_translation(self.location.as_dvec2())
+		DAffine2::from_translation(self.location.as_dvec2()) * self.graphic_group.transform
 	}
 	fn local_pivot(&self, pivot: DVec2) -> DVec2 {
 		self.location.as_dvec2() + self.dimensions.as_dvec2() * pivot


### PR DESCRIPTION
Removes offset to the initial point when drawing with a tool, especially the Freehand tool, as reproduced with these steps:
- Move the artboard away from the origin by dragging with artboard tool
- Draw with the Freehand tool and notice how the first point has the artboard transform offset

A regression introduced by #1712.