### PR TITLE
Fix PathStyle::clear_fill() doctest in style.rs

### DIFF
--- a/node-graph/gcore/src/vector/style.rs
+++ b/node-graph/gcore/src/vector/style.rs
@@ -698,11 +698,11 @@ impl PathStyle {
 	/// # use graphene_core::raster::color::Color;
 	/// let mut style = PathStyle::new(None, Fill::Solid(Color::RED));
 	///
-	/// assert!(style.fill().is_some());
+	/// assert_ne!(*style.fill(), Fill::None);
 	///
 	/// style.clear_fill();
 	///
-	/// assert!(!style.fill().is_some());
+	/// assert_eq!(*style.fill(), Fill::None);
 	/// ```
 	pub fn clear_fill(&mut self) {
 		self.fill = Fill::None;


### PR DESCRIPTION
This should allow `cargo test` to pass successfully when run in `graphite/node-graph/gcore` (previously it failed on `is_some()` because `clear_fill()` doesn't return an `Option`).
