### PR TITLE
Simplify build process by auto-installing npm packages and simplify the contributor guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
 	"onCreateCommand": "cargo install cargo-watch cargo-about",
-	"postCreateCommand": "cd frontend && npm install",
 	"customizations": {
 		"vscode": {
 			// NOTE: Keep this in sync with `.vscode/extensions.json`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,7 @@ spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu.git" }
 wgpu-types = "0.17"
 wgpu = "0.19"
 once_cell = "1.13" # Remove when `core::cell::LazyCell` (<https://doc.rust-lang.org/core/cell/struct.LazyCell.html>) is stabilized in Rust 1.80 and we bump our MSRV
-# Ensure this is synced with the version in website/content/volunteer/guide/getting-started/_index.md
-wasm-bindgen = "=0.2.92" # wasm-bindgen upgrades may break various things so we pin the version
+wasm-bindgen = "=0.2.92" # NOTICE: ensure this stays in sync with the `wasm-bindgen-cli` version in `website/content/volunteer/guide/getting-started/_index.md`. We pin this version because wasm-bindgen upgrades may break various things.
 wasm-bindgen-futures = "0.4"
 js-sys = "=0.3.69"
 web-sys = "=0.3.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ spirv-std = { git = "https://github.com/EmbarkStudios/rust-gpu.git" }
 wgpu-types = "0.17"
 wgpu = "0.19"
 once_cell = "1.13" # Remove when `core::cell::LazyCell` (<https://doc.rust-lang.org/core/cell/struct.LazyCell.html>) is stabilized in Rust 1.80 and we bump our MSRV
+# Ensure this is synced with the version in website/content/volunteer/guide/getting-started/_index.md
 wasm-bindgen = "=0.2.92" # wasm-bindgen upgrades may break various things so we pin the version
 wasm-bindgen-futures = "0.4"
 js-sys = "=0.3.69"

--- a/frontend/package-installer.js
+++ b/frontend/package-installer.js
@@ -1,0 +1,34 @@
+// This script automatically installs the npm packages listed in package-lock.json and runs before `npm start`.
+// It skips the installation if this has already run and neither package.json nor package-lock.json has been modified since.
+
+import { execSync } from "child_process";
+import { existsSync, statSync, writeFileSync } from "fs";
+
+const INSTALL_TIMESTAMP_FILE = "node_modules/.install-timestamp";
+
+// Checks if the install is needed by comparing modification times
+const isInstallNeeded = () => {
+	if (!existsSync(INSTALL_TIMESTAMP_FILE)) return true;
+
+	const timestamp = statSync(INSTALL_TIMESTAMP_FILE).mtime;
+	return ["package.json", "package-lock.json"].some((file) => {
+		return existsSync(file) && statSync(file).mtime > timestamp;
+	});
+};
+
+// Run `npm ci` if needed and update the install timestamp
+if (isInstallNeeded()) {
+	try {
+		// Check if packages are up to date, doing so quickly by using `npm ci`, preferring local cached packages, and skipping the package audit and other checks
+		execSync("npm ci --prefer-offline --no-audit --no-fund", { stdio: "inherit" });
+		// Touch the install timestamp file
+		writeFileSync(INSTALL_TIMESTAMP_FILE, "");
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error("Failed to install npm packages. Please run `npm install` from the `/frontend` directory.");
+		process.exit(1);
+	}
+} else {
+	// eslint-disable-next-line no-console
+	console.log("All npm packages are up-to-date.");
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
 	"browserslist": "> 1.5%, last 2 versions, not dead, not ie 11, not op_mini all, not ios_saf < 13",
 	"type": "module",
 	"scripts": {
+		"prestart": "node package-installer.js",
 		"start": "npm run build-wasm && concurrently -k -n \"VITE,RUST\" \"vite\" \"npm run watch:wasm\" || (npm run print-building-help && exit 1)",
 		"profiling": "npm run build-wasm-profiling && concurrently -k -n \"VITE,RUST\" \"vite\" \"npm run watch:wasm-profiling\" || (npm run print-building-help && exit 1)",
 		"production": "npm run build-wasm-prod && concurrently -k -n \"VITE,RUST\" \"vite\" \"npm run watch:wasm\" || (npm run print-building-help && exit 1)",
@@ -55,9 +56,6 @@
 		"typescript": "^5.4.2",
 		"vite": "^5.1.5",
 		"vite-multiple-assets": "1.2.10"
-	},
-	"optionalDependencies": {
-		"wasm-pack": "0.12.1"
 	},
 	"homepage": "https://graphite.rs",
 	"license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"description": "A convenience package for calling the real package.json in ./frontend",
 	"private": true,
 	"scripts": {
-		"start": "cd frontend && npm start",
-		"serve": "cd frontend && npm start"
+		"start": "cd frontend && npm start"
 	}
 }

--- a/website/content/features.md
+++ b/website/content/features.md
@@ -130,12 +130,12 @@ Always on the bleeding edge and built to last— Graphite is written on a robust
 			<span>Procedurally alterable vector data</span>
 		</div>
 		<div class="feature-icon ongoing" title="Development Ongoing">
-			<img class="atlas" style="--atlas-index: 0" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
-			<span>Imaginate (Stable Diffusion node/tool)</span>
-		</div>
-		<div class="feature-icon ongoing" title="Development Ongoing">
 			<img class="atlas" style="--atlas-index: 13" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
 			<span>New vector 2D renderer (with <a target="_blank" href="https://github.com/linebender/vello">Vello</a>)</span>
+		</div>
+		<div class="feature-icon ongoing" title="Development Ongoing">
+			<img class="atlas" style="--atlas-index: 0" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
+			<span>Imaginate (Stable Diffusion node/tool)</span>
 		</div>
 		<div class="feature-icon ongoing" title="Development Ongoing">
 			<img class="atlas" style="--atlas-index: 12" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
@@ -152,6 +152,10 @@ Always on the bleeding edge and built to last— Graphite is written on a robust
 		<div class="feature-icon ongoing" title="Development Ongoing">
 			<img class="atlas" style="--atlas-index: 14" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
 			<span>Adaptive resolution system</span>
+		</div>
+		<div class="feature-icon">
+			<img class="atlas" style="--atlas-index: 9" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
+			<span>Graph data attribute spreadsheets</span>
 		</div>
 		<div class="feature-icon">
 			<img class="atlas" style="--atlas-index: 41" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
@@ -172,10 +176,6 @@ Always on the bleeding edge and built to last— Graphite is written on a robust
 		<div class="feature-icon">
 			<img class="atlas" style="--atlas-index: 21" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
 			<span>Select mode (marquee masking)</span>
-		</div>
-		<div class="feature-icon">
-			<img class="atlas" style="--atlas-index: 9" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
-			<span>Graph data attribute spreadsheet</span>
 		</div>
 		<div class="feature-icon">
 			<img class="atlas" style="--atlas-index: 17" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
@@ -267,7 +267,7 @@ Always on the bleeding edge and built to last— Graphite is written on a robust
 		</div>
 		<div class="feature-icon">
 			<img class="atlas" style="--atlas-index: 34" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />
-			<span>Node manager and marketplace</span>
+			<span>Asset libraries and marketplace</span>
 		</div>
 		<div class="feature-icon">
 			<img class="atlas" style="--atlas-index: 45" src="https://static.graphite.rs/icons/icon-atlas-roadmap__2.png" alt="" />

--- a/website/content/volunteer/guide/_index.md
+++ b/website/content/volunteer/guide/_index.md
@@ -8,4 +8,8 @@ aliases = ["/contribute"]
 book = true
 +++
 
-We're glad that you are interested in contributing to Graphite! We want to make it as easy and frictionless as possible for you to get started. Here are the basics.
+Welcome, potential contributor! We're excited to have you join the Graphite project and it's our goal to make the process as smooth as possible. This guide will serve as your library of knowledge to help you get started contributing to the project. If you find any information missing or unclear, please let us know [through Discord](https://discord.graphite.rs) or submit a pull request to help document the process for future contributors.
+
+<p>
+<img src="https://static.graphite.rs/content/volunteer/code-contributions.avif" onerror="this.onerror = null; this.src = this.src.replace('.avif', '.jpg')" alt="Flavor graphic depicting a library of knowledge in a digital realm" />
+</p>

--- a/website/content/volunteer/guide/getting-started/_index.md
+++ b/website/content/volunteer/guide/getting-started/_index.md
@@ -7,65 +7,70 @@ page_template = "book.html"
 order = 1 # Chapter number
 +++
 
-Graphite is built with Rust and web technologies. Install the latest LTS version of [Node.js](https://nodejs.org/) and stable release of [Rust](https://www.rust-lang.org/), as well as [Git](https://git-scm.com/).
+To begin working with the Graphite codebase, you will need to set up the project to build and run on your local machine. Development usually involves running the dev server which watches for changes to frontend (web) and backend (Rust) code and automatically recompiles and reloads the Graphite editor in your browser.
 
-## Installing
+## Dependencies
 
-Clone the project:
+Graphite is built with Rust and web technologies, which means you will need to install:
+- [Node.js](https://nodejs.org/) (the latest LTS version)
+- [Rust](https://www.rust-lang.org/) (the latest stable release)
+- [Git](https://git-scm.com/) (any recent version)
 
-```sh
-git clone https://github.com/GraphiteEditor/Graphite.git
-```
+Next, install the dependencies required for development builds:
 
-On Debian-based (Ubuntu, Mint, etc.) Linux distributions, you may need to install the following additional packages (other dependencies above):
-
-```sh
-sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
-```
-
-On Fedora-based (RHEL, CentOS, etc.) Linux distributions, you may need to install the following additional packages (other dependencies above):
-
-```sh
-sudo dnf install libsoup-devel gtk3-devel javascriptcoregtk4.0-devel webkit2gtk4.0-devel
-```
-
-Cargo watch is required for development builds:
 ```sh
 cargo install cargo-watch
-```
-
-You might benefit from manually installing some Rust based utilities for compiling wasm (they are supposed to be installed automatically but it sometimes doesn't work - see the [Discord discussion](https://discord.com/channels/731730685944922173/830518879247007795/1222453349153247252)):
-
-```sh
-cargo install -f wasm-bindgen-cli@0.2.92 # Must be matched with the version in Cargo.toml otherwise it will be re-downloaded each build.
 cargo install wasm-pack
 ```
 
-Then install the required Node.js packages:
+You'll likely get faster build times if you manually install this specific version of `wasm-bindgen-cli`. It is supposed to be installed automatically but a version mismatch causes it to reinstall every single recompilation. It may need to be manually updated periodically to match the version of the `wasm-bindgen` dependency in [`Cargo.toml`](https://github.com/GraphiteEditor/Graphite/blob/master/Cargo.toml):
 
 ```sh
-cd frontend
-npm install
+cargo install -f wasm-bindgen-cli@0.2.92
 ```
 
-You only need to explicitly install Node.js dependencies. Rust's cargo dependencies will be installed automatically on your first build. One dependency in the build chain, `wasm-pack`, will be installed automatically on your system when the Node.js packages are installing. (If you prefer to install this manually, get it from the [wasm-pack website](https://rustwasm.github.io/wasm-pack/), then install your npm dependencies with `npm install --omit=optional` instead.)
+On Linux, you may need to install this set of additional packages if you run into issues:
 
+```sh
+# On Debian-based (Ubuntu, Mint, etc.) distributions:
+sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
 
+# On Fedora-based (RHEL, CentOS, etc.) distributions:
+sudo dnf install gtk3-devel libsoup-devel javascriptcoregtk4.0-devel webkit2gtk4.0-devel
+```
 
-That's it! Now, to run the project while developing, just execute:
+## Repository
+
+Clone the project to a convenient location:
+
+```sh
+git clone https://github.com/GraphiteEditor/Graphite.git
+cd Graphite
+```
+
+## Development builds
+
+From either the `/` (root) or `/frontend` directories, you can run the project by executing:
 
 ```sh
 npm start
 ```
 
-This spins up the dev server at <http://localhost:8080> with a file watcher that performs hot reloading of the web page. You should be able to start the server, edit and save web and Rust code, and rarely have to kill the server (by hitting <kbd>Ctrl</kbd><kbd>C</kbd> twice). You sometimes may need to reload the browser's web page if the hot reloading didn't behave perfectly. This method compiles Graphite code in debug mode which includes debug symbols for viewing function names in stack traces. But be aware, it runs slower and takes more memory.
+This spins up the dev server at <http://localhost:8080> with a file watcher that performs hot reloading of the web page. You should be able to start the server, edit and save web and Rust code, and shut it down by double pressing <kbd>Ctrl</kbd><kbd>C</kbd>. You sometimes may need to reload the browser's page if hot reloading didn't behave right.
+
+This method compiles Graphite code in debug mode which includes debug symbols for viewing function names in stack traces. But be aware, it runs slower and the Wasm binary is much larger. Having your browser's developer tools open will also significantly impact performance in both debug and release builds, so it's best to close that when not in use.
 
 ## Production builds
 
-You'll rarely ever need to do this, but to compile a production build with full optimizations:
+You'll rarely need to compile your own production builds because our CI/CD system takes care of deployments. However, you can compile a production build with full optimizations by first installing the additional `cargo-about` dev dependency:
 
 ```sh
 cargo install cargo-about
+```
+
+And then running:
+
+```sh
 npm run build
 ```
 

--- a/website/content/volunteer/guide/getting-started/_index.md
+++ b/website/content/volunteer/guide/getting-started/_index.md
@@ -17,16 +17,28 @@ Clone the project:
 git clone https://github.com/GraphiteEditor/Graphite.git
 ```
 
-On Debian-based (Ubuntu, Mint, etc.) Linux distributions, you may need to install the following packages:
+On Debian-based (Ubuntu, Mint, etc.) Linux distributions, you may need to install the following additional packages (other dependencies above):
 
 ```sh
 sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
 ```
 
-On Fedora-based (RHEL, CentOS, etc.) Linux distributions, you may need to install the following packages:
+On Fedora-based (RHEL, CentOS, etc.) Linux distributions, you may need to install the following additional packages (other dependencies above):
 
 ```sh
 sudo dnf install libsoup-devel gtk3-devel javascriptcoregtk4.0-devel webkit2gtk4.0-devel
+```
+
+Cargo watch is required for development builds:
+```sh
+cargo install cargo-watch
+```
+
+You might benefit from manually installing some Rust based utilities for compiling wasm (they are supposed to be installed automatically but it sometimes doesn't work - see the [Discord discussion](https://discord.com/channels/731730685944922173/830518879247007795/1222453349153247252)):
+
+```sh
+cargo install -f wasm-bindgen-cli@0.2.91 # Must be matched with the version in Cargo.toml otherwise it will be re-downloaded each build.
+cargo install wasm-pack
 ```
 
 Then install the required Node.js packages:
@@ -38,11 +50,7 @@ npm install
 
 You only need to explicitly install Node.js dependencies. Rust's cargo dependencies will be installed automatically on your first build. One dependency in the build chain, `wasm-pack`, will be installed automatically on your system when the Node.js packages are installing. (If you prefer to install this manually, get it from the [wasm-pack website](https://rustwasm.github.io/wasm-pack/), then install your npm dependencies with `npm install --omit=optional` instead.)
 
-One tool in the Rust ecosystem does need to be installed:
 
-```sh
-cargo install cargo-watch
-```
 
 That's it! Now, to run the project while developing, just execute:
 

--- a/website/content/volunteer/guide/getting-started/_index.md
+++ b/website/content/volunteer/guide/getting-started/_index.md
@@ -37,7 +37,7 @@ cargo install cargo-watch
 You might benefit from manually installing some Rust based utilities for compiling wasm (they are supposed to be installed automatically but it sometimes doesn't work - see the [Discord discussion](https://discord.com/channels/731730685944922173/830518879247007795/1222453349153247252)):
 
 ```sh
-cargo install -f wasm-bindgen-cli@0.2.91 # Must be matched with the version in Cargo.toml otherwise it will be re-downloaded each build.
+cargo install -f wasm-bindgen-cli@0.2.92 # Must be matched with the version in Cargo.toml otherwise it will be re-downloaded each build.
 cargo install wasm-pack
 ```
 

--- a/website/sass/base.scss
+++ b/website/sass/base.scss
@@ -507,12 +507,16 @@ ol {
 }
 
 code {
-	background: var(--color-fog);
 	color: var(--color-black);
+	background: var(--color-fog);
 	padding: 0 4px;
 	overflow-wrap: anywhere;
 	-webkit-hyphens: none;
 	hyphens: none;
+
+	a & {
+		color: var(--color-crimson);
+	}
 }
 
 pre {


### PR DESCRIPTION
- Highlight how manually installing the correct version of wasm-bindgen prevents it from being re-downloaded each build.
- Clarify that the linux packages are in addition to the dependencies listed above them.