### PR TITLE
Attempt to fix the segfault in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: 🧪 Run Rust tests
         run: |
-          mold -run cargo nextest run --all-features
+          mold -run cargo nextest run --all-features -j 1
 
   # miri:
   #   runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: 🧪 Run Rust tests
         run: |
-          mold -run cargo nextest run --all-features -j 1
+          mold -run cargo test --all-features -j 1
 
   # miri:
   #   runs-on: self-hosted

--- a/node-graph/graph-craft/src/proto.rs
+++ b/node-graph/graph-craft/src/proto.rs
@@ -29,33 +29,33 @@ pub type NodeConstructor = fn(Vec<SharedNodeContainer>) -> DynFuture<'static, Ty
 
 #[derive(Clone)]
 pub struct NodeContainer {
-	#[cfg(feature = "dealloc_nodes")]
-	pub node: *mut TypeErasedNode<'static>,
-	#[cfg(not(feature = "dealloc_nodes"))]
+	// #[cfg(feature = "dealloc_nodes")]
+	// pub node: *mut TypeErasedNode<'static>,
+	// #[cfg(not(feature = "dealloc_nodes"))]
 	pub node: TypeErasedRef<'static>,
 }
 
 impl Deref for NodeContainer {
 	type Target = TypeErasedNode<'static>;
 
-	#[cfg(feature = "dealloc_nodes")]
-	fn deref(&self) -> &Self::Target {
-		unsafe { &*(self.node as *const TypeErasedNode) }
-		#[cfg(not(feature = "dealloc_nodes"))]
-		self.node
-	}
-	#[cfg(not(feature = "dealloc_nodes"))]
+	// #[cfg(feature = "dealloc_nodes")]
+	// fn deref(&self) -> &Self::Target {
+	// 	unsafe { &*(self.node as *const TypeErasedNode) }
+	// 	#[cfg(not(feature = "dealloc_nodes"))]
+	// 	self.node
+	// }
+	// #[cfg(not(feature = "dealloc_nodes"))]
 	fn deref(&self) -> &Self::Target {
 		self.node
 	}
 }
 
-#[cfg(feature = "dealloc_nodes")]
-impl Drop for NodeContainer {
-	fn drop(&mut self) {
-		unsafe { self.dealloc_unchecked() }
-	}
-}
+// #[cfg(feature = "dealloc_nodes")]
+// impl Drop for NodeContainer {
+// 	fn drop(&mut self) {
+// 		unsafe { self.dealloc_unchecked() }
+// 	}
+// }
 
 impl core::fmt::Debug for NodeContainer {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -69,10 +69,10 @@ impl NodeContainer {
 		Self { node }.into()
 	}
 
-	#[cfg(feature = "dealloc_nodes")]
-	unsafe fn dealloc_unchecked(&mut self) {
-		std::mem::drop(Box::from_raw(self.node));
-	}
+	// #[cfg(feature = "dealloc_nodes")]
+	// unsafe fn dealloc_unchecked(&mut self) {
+	// 	std::mem::drop(Box::from_raw(self.node));
+	// }
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/website/other/bezier-rs-demos/wasm/src/lib.rs
+++ b/website/other/bezier-rs-demos/wasm/src/lib.rs
@@ -15,15 +15,13 @@ pub fn init() {
 	log::set_logger(&LOGGER).expect("Failed to set logger");
 	log::set_max_level(log::LevelFilter::Trace);
 
-	fn panic_hook(info: &core::panic::PanicInfo) {
+	std::panic::set_hook(Box::new(|info| {
 		// Skip if we have already panicked
 		if HAS_CRASHED.with(|cell| cell.replace(true)) {
 			return;
 		}
 		log::error!("{}", info);
-	}
-
-	std::panic::set_hook(Box::new(panic_hook));
+	}));
 }
 
 /// Logging to the JS console


### PR DESCRIPTION
We have been getting segfaults in the testing [e.g. in this PR](https://github.com/GraphiteEditor/Graphite/actions/runs/9819112631/job/27112356540#step:13:5126). I think it is probably related to how we now run the node graph to test that the demo artwork renders. It appears that the demo art test returns ok `test dispatcher::test::check_if_demo_art_opens ... ok` before a segfault `SIGSEGV [   1.771s] graphite-editor dispatcher::test::check_if_demo_art_opens`.

The `NodeContainer` has a raw pointer that is freed on drop, yet can be cloned. This means that if the cloned instance is dropped then the original may still contain a dangling pointer.