### PR TITLE
Fix 'Zoom with Scroll' not working after a page refresh

### DIFF
--- a/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message_handler.rs
@@ -75,6 +75,7 @@ impl PreferencesDialogMessageHandler {
 			LayoutGroup::Row { widgets: imaginate_refresh_frequency },
 		]))
 	}
+
 	pub fn send_layout(&self, responses: &mut VecDeque<Message>, layout_target: LayoutTarget, preferences: &PreferencesMessageHandler) {
 		responses.add(LayoutMessage::SendLayout {
 			layout: self.layout(preferences),
@@ -85,6 +86,7 @@ impl PreferencesDialogMessageHandler {
 	fn layout_column_2(&self) -> Layout {
 		Layout::default()
 	}
+
 	fn send_layout_column_2(&self, responses: &mut VecDeque<Message>, layout_target: LayoutTarget) {
 		responses.add(LayoutMessage::SendLayout {
 			layout: self.layout_column_2(),
@@ -108,6 +110,7 @@ impl PreferencesDialogMessageHandler {
 
 		Layout::WidgetLayout(WidgetLayout::new(vec![LayoutGroup::Row { widgets }]))
 	}
+
 	fn send_layout_buttons(&self, responses: &mut VecDeque<Message>, layout_target: LayoutTarget) {
 		responses.add(LayoutMessage::SendLayout {
 			layout: self.layout_buttons(),

--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -40,7 +40,7 @@ impl MessageHandler<PreferencesMessage, ()> for PreferencesMessageHandler {
 					responses.add(PortfolioMessage::ImaginatePreferences);
 					responses.add(PreferencesMessage::ModifyLayout {
 						zoom_with_scroll: self.zoom_with_scroll,
-					})
+					});
 				}
 			}
 			PreferencesMessage::ResetToDefaults => {

--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -38,6 +38,9 @@ impl MessageHandler<PreferencesMessage, ()> for PreferencesMessageHandler {
 					responses.add(PortfolioMessage::ImaginateServerHostname);
 					responses.add(PortfolioMessage::ImaginateCheckServerStatus);
 					responses.add(PortfolioMessage::ImaginatePreferences);
+					responses.add(PreferencesMessage::ModifyLayout {
+						zoom_with_scroll: self.zoom_with_scroll,
+					})
 				}
 			}
 			PreferencesMessage::ResetToDefaults => {


### PR DESCRIPTION
This fixes a bug in which the preferences dialog's _Zoom with Scroll_ option reverted to the default behavior after a page refresh. 

Steps to reproduce:

1. Open File -> Preferences and select _Zoom with Scroll_.
2. Open a document and try zooming with the mouse scroll wheel without pressing the Ctrl key and observe that the zoom works.
3. Refresh the page.
4. Open a document (if the document you opened the last time was empty, you'd need to open a new document, otherwise the old document will open itself, in which case you don't need to open another document).
5. Try zooming with the mouse scroll wheel again and observe that the zoom doesn't work (it pans instead). Try with pressing the Ctrl key and observe that it works.
6. Open File -> Preferences and observe that the Zoom with Scroll option is still selected.

The bug is due to the _Zoom with Scroll_ option not affecting the key mapping when deserialized preferences are first loaded. Sending a `PreferencesMessage::ModifyLayout { ... }` fixes this.