### PR TITLE
Bump MSRV

### DIFF
--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphite-editor"
 publish = false
 version = "0.0.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 edition = "2021"
 readme = "../README.md"

--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -167,7 +167,7 @@ impl Dispatcher {
 					if let Some(document) = self.message_handlers.portfolio_message_handler.active_document() {
 						let data = ToolMessageData {
 							document_id: self.message_handlers.portfolio_message_handler.active_document_id().unwrap(),
-							document: document,
+							document,
 							input: &self.message_handlers.input_preprocessor_message_handler,
 							persistent_data: &self.message_handlers.portfolio_message_handler.persistent_data,
 							node_graph: &self.message_handlers.portfolio_message_handler.executor,

--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -28,7 +28,7 @@ impl LayoutHolder for DemoArtworkDialog {
 	fn layout(&self) -> Layout {
 		let mut rows_of_images_with_buttons: Vec<_> = ARTWORK
 			.chunks(3)
-			.map(|chunk| {
+			.flat_map(|chunk| {
 				let images = chunk.iter().map(|(_, thumbnail, _)| ImageLabel::new(*thumbnail).width(Some("256px".into())).widget_holder()).collect();
 
 				let buttons = chunk
@@ -52,7 +52,6 @@ impl LayoutHolder for DemoArtworkDialog {
 
 				vec![LayoutGroup::Row { widgets: images }, LayoutGroup::Row { widgets: buttons }, LayoutGroup::Row { widgets: vec![] }]
 			})
-			.flatten()
 			.collect();
 		let _ = rows_of_images_with_buttons.pop();
 

--- a/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
+++ b/editor/src/messages/dialog/simple_dialogs/demo_artwork_dialog.rs
@@ -28,15 +28,11 @@ impl LayoutHolder for DemoArtworkDialog {
 	fn layout(&self) -> Layout {
 		let mut rows_of_images_with_buttons: Vec<_> = ARTWORK
 			.chunks(3)
-			.into_iter()
 			.map(|chunk| {
-				let images = chunk
-					.into_iter()
-					.map(|(_, thumbnail, _)| ImageLabel::new(*thumbnail).width(Some("256px".into())).widget_holder())
-					.collect();
+				let images = chunk.iter().map(|(_, thumbnail, _)| ImageLabel::new(*thumbnail).width(Some("256px".into())).widget_holder()).collect();
 
 				let buttons = chunk
-					.into_iter()
+					.iter()
 					.map(|(name, _, filename)| {
 						TextButton::new(*name)
 							.min_width(256)

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -69,12 +69,12 @@ impl ScrollDelta {
 	}
 
 	pub fn as_dvec2(&self) -> DVec2 {
-		DVec2::new(self.x as f64, self.y as f64)
+		DVec2::new(self.x, self.y)
 	}
 
 	pub fn scroll_delta(&self) -> f64 {
 		let (dx, dy) = (self.x, self.y);
-		dy.signum() as f64 * ((dy * dy + f64::min(dy.abs(), dx.abs()).powi(2)) as f64).sqrt()
+		dy.signum() * (dy * dy + f64::min(dy.abs(), dx.abs()).powi(2)).sqrt()
 	}
 }
 

--- a/editor/src/messages/input_mapper/utility_types/misc.rs
+++ b/editor/src/messages/input_mapper/utility_types/misc.rs
@@ -105,6 +105,12 @@ impl KeyMappingEntries {
 	}
 }
 
+impl Default for KeyMappingEntries {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 #[derive(PartialEq, Clone, Debug)]
 pub struct MappingEntry {
 	/// Serves two purposes:

--- a/editor/src/messages/layout/layout_message_handler.rs
+++ b/editor/src/messages/layout/layout_message_handler.rs
@@ -161,11 +161,11 @@ impl LayoutMessageHandler {
 			Widget::DropdownInput(dropdown_input) => {
 				let callback_message = match action {
 					WidgetValueAction::Commit => {
-						let update_value = value.as_u64().expect(&format!("DropdownInput commit was not of type `u64`, found {value:?}"));
+						let update_value = value.as_u64().unwrap_or_else(|| panic!("DropdownInput commit was not of type `u64`, found {value:?}"));
 						(dropdown_input.entries.iter().flatten().nth(update_value as usize).unwrap().on_commit.callback)(&())
 					}
 					WidgetValueAction::Update => {
-						let update_value = value.as_u64().expect(&format!("DropdownInput update was not of type `u64`, found {value:?}"));
+						let update_value = value.as_u64().unwrap_or_else(|| panic!("DropdownInput update was not of type `u64`, found {value:?}"));
 						dropdown_input.selected_index = Some(update_value as u32);
 						(dropdown_input.entries.iter().flatten().nth(update_value as usize).unwrap().on_update.callback)(&())
 					}

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -186,7 +186,7 @@ impl WidgetLayout {
 		// TODO: Diff insersion and deletion of items
 		if self.layout.len() != new.layout.len() {
 			// Update the layout to the new layout
-			self.layout = new.layout.clone();
+			self.layout.clone_from(&new.layout);
 
 			// Push an update sublayout to the diff
 			let new = DiffUpdate::SubLayout(new.layout);
@@ -342,7 +342,7 @@ impl LayoutGroup {
 				Widget::InvisibleStandinInput(_) | Widget::PivotInput(_) | Widget::RadioInput(_) | Widget::Separator(_) | Widget::WorkingColorsInput(_) => continue,
 			};
 			if val.is_empty() {
-				*val = tooltip.clone();
+				val.clone_from(&tooltip);
 			}
 		}
 		if is_col {
@@ -361,7 +361,7 @@ impl LayoutGroup {
 				// TODO: Diff insersion and deletion of items
 				if current_widgets.len() != new_widgets.len() {
 					// Update to the new value
-					*current_widgets = new_widgets.clone();
+					current_widgets.clone_from(&new_widgets);
 
 					// Push back a LayoutGroup update to the diff
 					let new_value = DiffUpdate::LayoutGroup(if is_column { Self::Column { widgets: new_widgets } } else { Self::Row { widgets: new_widgets } });
@@ -394,10 +394,10 @@ impl LayoutGroup {
 				// TODO: Diff insersion and deletion of items
 				if current_layout.len() != new_layout.len() || *current_name != new_name || *current_visible != new_visible || *current_id != new_id {
 					// Update self to reflect new changes
-					*current_name = new_name.clone();
+					current_name.clone_from(&new_name);
 					*current_visible = new_visible;
 					*current_id = new_id;
-					*current_layout = new_layout.clone();
+					current_layout.clone_from(&new_layout);
 
 					// Push an update layout group to the diff
 					let new_value = DiffUpdate::LayoutGroup(Self::Section {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2103,13 +2103,12 @@ impl DocumentMessageHandler {
 
 fn root_network() -> NodeNetwork {
 	{
-		let network = NodeNetwork {
+		NodeNetwork {
 			exports: vec![NodeInput::Value {
 				tagged_value: TaggedValue::ArtboardGroup(graphene_core::ArtboardGroup::EMPTY),
 				exposed: true,
 			}],
 			..Default::default()
-		};
-		network
+		}
 	}
 }

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2103,11 +2103,13 @@ impl DocumentMessageHandler {
 
 fn root_network() -> NodeNetwork {
 	{
-		let mut network = NodeNetwork::default();
-		network.exports = vec![NodeInput::Value {
-			tagged_value: TaggedValue::ArtboardGroup(graphene_core::ArtboardGroup::EMPTY),
-			exposed: true,
-		}];
+		let network = NodeNetwork {
+			exports: vec![NodeInput::Value {
+				tagged_value: TaggedValue::ArtboardGroup(graphene_core::ArtboardGroup::EMPTY),
+				exposed: true,
+			}],
+			..Default::default()
+		};
 		network
 	}
 }

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -187,7 +187,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					node_graph_ptz: &mut self.node_graph_ptz,
 					graph_view_overlay_open: self.graph_view_overlay_open,
 					node_graph_handler: &self.node_graph_handler,
-					node_graph_to_viewport: &self.node_graph_to_viewport.entry(self.node_graph_handler.network.clone()).or_insert(DAffine2::IDENTITY),
+					node_graph_to_viewport: self.node_graph_to_viewport.entry(self.node_graph_handler.network.clone()).or_insert(DAffine2::IDENTITY),
 				};
 
 				self.navigation_handler.process_message(message, responses, data);
@@ -221,7 +221,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						collapsed: &mut self.collapsed,
 						ipp,
 						graph_view_overlay_open: self.graph_view_overlay_open,
-						node_graph_to_viewport: &self.node_graph_to_viewport.entry(self.node_graph_handler.network.clone()).or_insert(DAffine2::IDENTITY),
+						node_graph_to_viewport: self.node_graph_to_viewport.entry(self.node_graph_handler.network.clone()).or_insert(DAffine2::IDENTITY),
 					},
 				);
 			}
@@ -384,7 +384,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 
 				// TODO: Update click targets when node graph is closed so that this is not necessary
 				if self.graph_view_overlay_open {
-					self.node_graph_handler.update_all_click_targets(&mut self.network, self.node_graph_handler.network.clone())
+					self.node_graph_handler.update_all_click_targets(&self.network, self.node_graph_handler.network.clone())
 				}
 
 				responses.add(FrontendMessage::TriggerGraphViewOverlay { open });
@@ -606,7 +606,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					// Reconnect layer_to_move to new parent at insert index.
 					responses.add(GraphOperationMessage::InsertNodeAtStackIndex {
 						node_id: layer_to_move.to_node(),
-						parent: parent,
+						parent,
 						insert_index,
 					});
 				}
@@ -1047,13 +1047,13 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					});
 
 					// Get the node that feeds into the primary input for the folder (if it exists)
-					if let Some(NodeInput::Node { node_id, .. }) = self.network.nodes.get(&folder.to_node()).expect("Folder should always exist").inputs.get(0) {
+					if let Some(NodeInput::Node { node_id, .. }) = self.network.nodes.get(&folder.to_node()).expect("Folder should always exist").inputs.first() {
 						let upstream_sibling_id = *node_id;
 
 						// Get the node at the bottom of the first layer node stack
 						let mut last_child_node_id = child_layer.to_node();
 						loop {
-							let Some(NodeInput::Node { node_id, .. }) = self.network.nodes.get(&last_child_node_id).expect("Child node should always exist").inputs.get(0) else {
+							let Some(NodeInput::Node { node_id, .. }) = self.network.nodes.get(&last_child_node_id).expect("Child node should always exist").inputs.first() else {
 								break;
 							};
 							last_child_node_id = *node_id;
@@ -1276,7 +1276,7 @@ impl DocumentMessageHandler {
 		self.selected_nodes
 			.selected_nodes(network)
 			.filter_map(|node| {
-				let Some(node_metadata) = self.node_graph_handler.node_metadata.get(&node) else {
+				let Some(node_metadata) = self.node_graph_handler.node_metadata.get(node) else {
 					log::debug!("Could not get click target for node {node}");
 					return None;
 				};
@@ -1437,7 +1437,7 @@ impl DocumentMessageHandler {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		// If there is no history return and don't broadcast SelectionChanged
-		let Some(network) = self.document_undo_history.pop_back() else { return None };
+		let network = self.document_undo_history.pop_back()?;
 
 		responses.add(BroadcastEvent::SelectionChanged);
 
@@ -1460,7 +1460,7 @@ impl DocumentMessageHandler {
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		// If there is no history return and don't broadcast SelectionChanged
-		let Some(network) = self.document_redo_history.pop_back() else { return None };
+		let network = self.document_redo_history.pop_back()?;
 
 		responses.add(BroadcastEvent::SelectionChanged);
 
@@ -1480,7 +1480,7 @@ impl DocumentMessageHandler {
 		};
 
 		for (node_id, current_node) in &network.nodes {
-			if let Some(previous_node) = previous_nested_network.nodes.get(&node_id) {
+			if let Some(previous_node) = previous_nested_network.nodes.get(node_id) {
 				if previous_node.alias == current_node.alias
 					&& previous_node.inputs.iter().map(|node_input| node_input.is_exposed()).count() == current_node.inputs.iter().map(|node_input| node_input.is_exposed()).count()
 					&& previous_node.is_layer == current_node.is_layer
@@ -1542,9 +1542,7 @@ impl DocumentMessageHandler {
 		};
 
 		// Downstream layer should always exist
-		let Some((downstream_layer_node_id, downstream_layer_is_parent)) = downstream_layer else {
-			return None;
-		};
+		let (downstream_layer_node_id, downstream_layer_is_parent) = downstream_layer?;
 
 		// Horizontal traversal if layer_to_move is the top of its layer stack, primary traversal if not
 		let flow_type = if downstream_layer_is_parent { FlowType::HorizontalFlow } else { FlowType::PrimaryFlow };

--- a/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
@@ -794,7 +794,7 @@ impl<'a> ModifyInputsContext<'a> {
 		node_id: NodeId,
 		reconnect: bool,
 		responses: &mut VecDeque<Message>,
-		network_path: &Vec<NodeId>,
+		network_path: &[NodeId],
 	) -> bool {
 		if !ModifyInputsContext::remove_references_from_network(node_graph, document_network, node_id, reconnect, network_path) {
 			log::error!("could not remove_references_from_network");
@@ -804,14 +804,14 @@ impl<'a> ModifyInputsContext<'a> {
 
 		network.nodes.remove(&node_id);
 		selected_nodes.retain_selected_nodes(|&id| id != node_id || id == network.exports_metadata.0 || id == network.imports_metadata.0);
-		node_graph.update_click_target(node_id, document_network, network_path.clone());
+		node_graph.update_click_target(node_id, document_network, network_path.to_owned());
 
 		responses.add(BroadcastEvent::SelectionChanged);
 
 		true
 	}
 
-	pub fn remove_references_from_network(node_graph: &mut NodeGraphMessageHandler, document_network: &mut NodeNetwork, deleting_node_id: NodeId, reconnect: bool, network_path: &Vec<NodeId>) -> bool {
+	pub fn remove_references_from_network(node_graph: &mut NodeGraphMessageHandler, document_network: &mut NodeNetwork, deleting_node_id: NodeId, reconnect: bool, network_path: &[NodeId]) -> bool {
 		let Some(network) = document_network.nested_network(network_path) else { return false };
 		let mut reconnect_to_input: Option<NodeInput> = None;
 
@@ -951,7 +951,7 @@ impl<'a> ModifyInputsContext<'a> {
 		};
 
 		// TODO: Store types for all document nodes, not just the compiled proto nodes, which currently skips isolated nodes
-		let node_id_path = &[&network_path[..], &[node_id]].concat();
+		let node_id_path = &[network_path, &[node_id]].concat();
 		let input_type = resolved_types.inputs.get(&graph_craft::document::Source {
 			node: node_id_path.clone(),
 			index: input_index,

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -139,7 +139,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 			NavigationMessage::CanvasPanMouseWheel { use_y_as_x } => {
 				let delta = match use_y_as_x {
 					false => -ipp.mouse.scroll_delta.as_dvec2(),
-					true => (-ipp.mouse.scroll_delta.y as f64, 0.).into(),
+					true => (-ipp.mouse.scroll_delta.y, 0.).into(),
 				} * VIEWPORT_SCROLL_RATE;
 				responses.add(NavigationMessage::CanvasPan { delta });
 			}

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1985,7 +1985,7 @@ impl NodeGraphMessageHandler {
 		// If the selected nodes are in the document network, use the document network. Otherwise, use the nested network
 		let Some(network) = context
 			.document_network
-			.nested_network_for_selected_nodes(&context.nested_path, selected_nodes.selected_nodes(context.document_network))
+			.nested_network_for_selected_nodes(context.nested_path, selected_nodes.selected_nodes(context.document_network))
 		else {
 			warn!("No network in collate_properties");
 			return Vec::new();
@@ -2605,7 +2605,7 @@ impl NodeGraphMessageHandler {
 	/// Returns an iterator of nodes to be copied and their ids, excluding output and input nodes
 	pub fn copy_nodes<'a>(
 		document_network: &'a NodeNetwork,
-		network_path: &'a Vec<NodeId>,
+		network_path: &'a [NodeId],
 		resolved_types: &'a ResolvedDocumentNodeTypes,
 		new_ids: &'a HashMap<NodeId, NodeId>,
 	) -> impl Iterator<Item = (NodeId, DocumentNode)> + 'a {
@@ -2622,7 +2622,7 @@ impl NodeGraphMessageHandler {
 			})
 	}
 
-	pub fn get_default_inputs(document_network: &NodeNetwork, network_path: &Vec<NodeId>, node_id: NodeId, resolved_types: &ResolvedDocumentNodeTypes, node: &DocumentNode) -> Vec<NodeInput> {
+	pub fn get_default_inputs(document_network: &NodeNetwork, network_path: &[NodeId], node_id: NodeId, resolved_types: &ResolvedDocumentNodeTypes, node: &DocumentNode) -> Vec<NodeInput> {
 		let mut default_inputs = Vec::new();
 
 		for (input_index, input) in node.inputs.iter().enumerate() {
@@ -2666,14 +2666,12 @@ impl NodeGraphMessageHandler {
 	}
 
 	fn untitled_layer_label(node: &DocumentNode) -> String {
-		if (!node.alias.is_empty()) {
+		if !node.alias.is_empty() {
 			node.alias.to_string()
+		} else if node.is_layer && node.name == "Merge" {
+			"Untitled Layer".to_string()
 		} else {
-			if node.is_layer && node.name == "Merge" {
-				"Untitled Layer".to_string()
-			} else {
-				node.name.clone()
-			}
+			node.name.clone()
 		}
 	}
 

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -322,7 +322,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 
 					// Select the new nodes
 					selected_nodes.retain_selected_nodes(|selected_node| network.nodes.contains_key(selected_node));
-					selected_nodes.add_selected_nodes(copied_nodes.iter().map(|(node_id, _)| *node_id).collect(), &document_network, &self.network);
+					selected_nodes.add_selected_nodes(copied_nodes.iter().map(|(node_id, _)| *node_id).collect(), document_network, &self.network);
 					responses.add(BroadcastEvent::SelectionChanged);
 
 					for (node_id, mut document_node) in copied_nodes {
@@ -668,7 +668,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 						.or(network.exports.get(input_index))
 					{
 						self.disconnecting = Some((clicked_input.0, clicked_input.1));
-						let Some(output_node) = network.nodes.get(&node_id) else {
+						let Some(output_node) = network.nodes.get(node_id) else {
 							log::error!("Could not find node {}", node_id);
 							return;
 						};
@@ -710,7 +710,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					if let Some(clicked_output_node) = network.nodes.get(&clicked_output.0) {
 						// Disallow creating additional vertical output wires from an already-connected layer
 						if clicked_output_node.is_layer && clicked_output_node.has_primary_output {
-							for (_, node) in &network.nodes {
+							for node in network.nodes.values() {
 								if node
 									.inputs
 									.iter()
@@ -925,15 +925,10 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					// TODO: Only loop through visible nodes
 					let shift = ipp.keyboard.get(shift as usize);
 					let mut nodes = if shift { selected_nodes.selected_nodes_ref().clone() } else { Vec::new() };
-					for node_id in network
-						.nodes
-						.iter()
-						.map(|(node_id, _)| node_id)
-						.chain(vec![network.exports_metadata.0, network.imports_metadata.0].iter())
-					{
+					for node_id in network.nodes.keys().chain([network.exports_metadata.0, network.imports_metadata.0].iter()) {
 						if self
 							.node_metadata
-							.get(&node_id)
+							.get(node_id)
 							.is_some_and(|node_metadata| node_metadata.node_click_target.intersect_rectangle(Quad::from_box([graph_start, point]), DAffine2::IDENTITY))
 						{
 							nodes.push(*node_id);
@@ -992,7 +987,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 							&& (selected_nodes.selected_nodes_ref().len() != 1
 								|| selected_nodes
 									.selected_nodes_ref()
-									.get(0)
+									.first()
 									.is_some_and(|first_selected_node| *first_selected_node != select_if_not_dragged))
 						{
 							responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![select_if_not_dragged] })
@@ -1006,18 +1001,14 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 						let (selected_node_input, selected_node_is_layer) = network
 							.nodes
 							.get(&selected_node_id)
-							.map(|selected_node| (selected_node.inputs.get(0), selected_node.is_layer))
-							.unwrap_or((network.exports.get(0), false));
+							.map(|selected_node| (selected_node.inputs.first(), selected_node.is_layer))
+							.unwrap_or((network.exports.first(), false));
 
 						// Check if primary input is disconnected
 						if selected_node_input.is_some_and(|first_input| first_input.as_value().is_some()) {
 							let has_primary_output_connection = network.nodes.iter().flat_map(|(_, node)| node.inputs.iter()).any(|input| {
 								if let NodeInput::Node { node_id, output_index, .. } = input {
-									if *node_id == selected_node_id && *output_index == 0 {
-										true
-									} else {
-										false
-									}
+									*node_id == selected_node_id && *output_index == 0
 								} else {
 									false
 								}
@@ -1609,7 +1600,7 @@ impl NodeGraphMessageHandler {
 	}
 
 	// Inserts a node into the network and updates the click target
-	pub fn insert_node(&mut self, node_id: NodeId, node: DocumentNode, document_network: &mut NodeNetwork, network_path: &Vec<NodeId>) {
+	pub fn insert_node(&mut self, node_id: NodeId, node: DocumentNode, document_network: &mut NodeNetwork, network_path: &[NodeId]) {
 		let Some(network) = document_network.nested_network_mut(network_path) else {
 			log::error!("Network not found in update_click_target");
 			return;
@@ -1619,7 +1610,7 @@ impl NodeGraphMessageHandler {
 			"Cannot insert import/export node into network.nodes"
 		);
 		network.nodes.insert(node_id, node);
-		self.update_click_target(node_id, document_network, network_path.clone());
+		self.update_click_target(node_id, document_network, network_path.to_owned());
 	}
 
 	/// Update the click targets when a DocumentNode's click target changes. network_path is the path to the encapsulating network
@@ -1901,7 +1892,7 @@ impl NodeGraphMessageHandler {
 			.find_map(|(node_id, click_targets)| {
 				for (index, click_target) in click_targets.iter().enumerate() {
 					if click_target.intersect_point(point, DAffine2::IDENTITY) {
-						return Some((node_id.clone(), index));
+						return Some((*node_id, index));
 					}
 				}
 				None
@@ -1994,7 +1985,7 @@ impl NodeGraphMessageHandler {
 		// If the selected nodes are in the document network, use the document network. Otherwise, use the nested network
 		let Some(network) = context
 			.document_network
-			.nested_network_for_selected_nodes(&context.nested_path.to_vec(), selected_nodes.selected_nodes(context.document_network))
+			.nested_network_for_selected_nodes(&context.nested_path, selected_nodes.selected_nodes(context.document_network))
 		else {
 			warn!("No network in collate_properties");
 			return Vec::new();
@@ -2191,10 +2182,10 @@ impl NodeGraphMessageHandler {
 				.map(|(_, input_type)| input_type)
 				.collect();
 
-			let output_types = Self::get_output_types(node, &self.resolved_types, &node_id_path);
-			let primary_output_type = output_types.get(0).expect("Primary output should always exist");
+			let output_types = Self::get_output_types(node, &self.resolved_types, node_id_path);
+			let primary_output_type = output_types.first().expect("Primary output should always exist");
 			let frontend_data_type = if let Some(output_type) = primary_output_type {
-				FrontendGraphDataType::with_type(&output_type)
+				FrontendGraphDataType::with_type(output_type)
 			} else {
 				FrontendGraphDataType::General
 			};
@@ -2238,7 +2229,7 @@ impl NodeGraphMessageHandler {
 					connected_index,
 				});
 			}
-			let is_export = network.exports.get(0).is_some_and(|export| export.as_node().is_some_and(|export_node_id| node_id == export_node_id));
+			let is_export = network.exports.first().is_some_and(|export| export.as_node().is_some_and(|export_node_id| node_id == export_node_id));
 			let is_root_node = network.get_root_node().is_some_and(|root_node| root_node.id == node_id);
 			let previewed = is_export && !is_root_node;
 
@@ -2326,7 +2317,7 @@ impl NodeGraphMessageHandler {
 			let (frontend_data_type, input_type) = if let NodeInput::Node { node_id, output_index, .. } = export {
 				let node = network.nodes.get(node_id).expect("Node should always exist");
 				let node_id_path = &[&self.network[..], &[*node_id]].concat();
-				let output_types = Self::get_output_types(node, &self.resolved_types, &node_id_path);
+				let output_types = Self::get_output_types(node, &self.resolved_types, node_id_path);
 
 				if let Some(output_type) = output_types.get(*output_index).cloned().flatten() {
 					(FrontendGraphDataType::with_type(&output_type), Some(output_type.clone()))
@@ -2547,10 +2538,16 @@ impl NodeGraphMessageHandler {
 		}
 	}
 
-	pub fn get_output_types(node: &DocumentNode, resolved_types: &ResolvedDocumentNodeTypes, node_id_path: &Vec<NodeId>) -> Vec<Option<Type>> {
+	pub fn get_output_types(node: &DocumentNode, resolved_types: &ResolvedDocumentNodeTypes, node_id_path: &[NodeId]) -> Vec<Option<Type>> {
 		let mut output_types = Vec::new();
 
-		let primary_output_type = resolved_types.outputs.get(&Source { node: node_id_path.clone(), index: 0 }).cloned();
+		let primary_output_type = resolved_types
+			.outputs
+			.get(&Source {
+				node: node_id_path.to_owned(),
+				index: 0,
+			})
+			.cloned();
 		output_types.push(primary_output_type);
 
 		// If the node is not a protonode, get types by traversing across exports until a proto node is reached.
@@ -2558,7 +2555,7 @@ impl NodeGraphMessageHandler {
 			for export in internal_network.exports.iter().skip(1) {
 				let mut current_export = export;
 				let mut current_network = internal_network;
-				let mut current_path = node_id_path.clone();
+				let mut current_path = node_id_path.to_owned();
 
 				while let NodeInput::Node { node_id, output_index, .. } = current_export {
 					current_path.push(*node_id);
@@ -2583,7 +2580,7 @@ impl NodeGraphMessageHandler {
 					resolved_types
 						.outputs
 						.get(&Source {
-							node: node_id_path.clone(),
+							node: node_id_path.to_owned(),
 							index: *import_index,
 						})
 						.cloned()
@@ -2669,9 +2666,15 @@ impl NodeGraphMessageHandler {
 	}
 
 	fn untitled_layer_label(node: &DocumentNode) -> String {
-		(node.alias != "")
-			.then_some(node.alias.to_string())
-			.unwrap_or(if node.is_layer && node.name == "Merge" { "Untitled Layer".to_string() } else { node.name.clone() })
+		if (!node.alias.is_empty()) {
+			node.alias.to_string()
+		} else {
+			if node.is_layer && node.name == "Merge" {
+				"Untitled Layer".to_string()
+			} else {
+				node.name.clone()
+			}
+		}
 	}
 
 	/// Get the actual input index from the visible input index where hidden inputs are skipped
@@ -2745,7 +2748,7 @@ impl NodeGraphMessageHandler {
 		let horizontal_curve = horizontal_curve_amount * curve_length;
 		let vertical_curve = vertical_curve_amount * curve_length;
 
-		return vec![
+		vec![
 			output_position,
 			DVec2::new(
 				if vertical_out { output_position.x } else { output_position.x + horizontal_curve },
@@ -2756,7 +2759,7 @@ impl NodeGraphMessageHandler {
 				if vertical_in { input_position.y + vertical_curve } else { input_position.y },
 			),
 			DVec2::new(input_position.x, input_position.y),
-		];
+		]
 	}
 }
 

--- a/editor/src/messages/portfolio/document/overlays/utility_types.rs
+++ b/editor/src/messages/portfolio/document/overlays/utility_types.rs
@@ -196,7 +196,7 @@ impl OverlayContext {
 		}
 	}
 
-	pub fn outline<'a>(&mut self, subpaths: impl Iterator<Item = impl Borrow<Subpath<PointId>>>, transform: DAffine2) {
+	pub fn outline(&mut self, subpaths: impl Iterator<Item = impl Borrow<Subpath<PointId>>>, transform: DAffine2) {
 		self.render_context.begin_path();
 		for subpath in subpaths {
 			let subpath = subpath.borrow();

--- a/editor/src/messages/portfolio/document/utility_types/misc.rs
+++ b/editor/src/messages/portfolio/document/utility_types/misc.rs
@@ -233,8 +233,8 @@ impl Default for GridSnapping {
 			origin: DVec2::ZERO,
 			grid_type: Default::default(),
 			grid_color: COLOR_OVERLAY_GRAY
-				.strip_prefix("#")
-				.and_then(|value| Color::from_rgb_str(value))
+				.strip_prefix('#')
+				.and_then(Color::from_rgb_str)
 				.expect("Should create Color from prefixed hex string"),
 			dot_display: false,
 		}

--- a/editor/src/messages/portfolio/document/utility_types/nodes.rs
+++ b/editor/src/messages/portfolio/document/utility_types/nodes.rs
@@ -121,7 +121,7 @@ impl SelectedNodes {
 	}
 
 	// TODO: This function is run when a node in the layer panel is currently selected, and a new node is selected in the graph, as well as when a node is currently selected in the graph and a node in the layer panel is selected. These are fundamentally different operations, since different nodes should be selected in each case, but cannot be distinguished. Currently it is not possible to shift+click a node in the node graph while a layer is selected. Instead of set_selected_nodes, add_selected_nodes should be used.
-	pub fn set_selected_nodes(&mut self, new: Vec<NodeId>, document_network: &NodeNetwork, network_path: &Vec<NodeId>) {
+	pub fn set_selected_nodes(&mut self, new: Vec<NodeId>, document_network: &NodeNetwork, network_path: &[NodeId]) {
 		let Some(network) = document_network.nested_network(network_path) else { return };
 
 		let mut new_nodes = new;
@@ -140,7 +140,7 @@ impl SelectedNodes {
 		self.0 = new_nodes;
 	}
 
-	pub fn add_selected_nodes(&mut self, new: Vec<NodeId>, document_network: &NodeNetwork, network_path: &Vec<NodeId>) {
+	pub fn add_selected_nodes(&mut self, new: Vec<NodeId>, document_network: &NodeNetwork, network_path: &[NodeId]) {
 		let Some(network) = document_network.nested_network(network_path) else { return };
 
 		// If the nodes to add are in the document network, clear selected nodes in the current network

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -352,6 +352,7 @@ pub struct Selected<'a> {
 }
 
 impl<'a> Selected<'a> {
+	#[allow(clippy::too_many_arguments)]
 	pub fn new(
 		original_transforms: &'a mut OriginalTransforms,
 		pivot: &'a mut DVec2,

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -507,14 +507,14 @@ impl ShapeState {
 		};
 
 		// Set the manipulator to have colinear handles
-		if let (Some(a), Some(b)) = (handles.get(0), handles.get(1)) {
+		if let (Some(a), Some(b)) = (handles.first(), handles.get(1)) {
 			let handles = [*a, *b];
 			let modification_type = VectorModificationType::SetG1Continuous { handles, enabled: true };
 			responses.add(GraphOperationMessage::Vector { layer, modification_type });
 		}
 
 		// Flip the vector if it is not facing towards the same direction as the anchor
-		let [first, second] = [anchor_positions.get(0).copied().flatten(), anchor_positions.get(1).copied().flatten()];
+		let [first, second] = [anchor_positions.first().copied().flatten(), anchor_positions.get(1).copied().flatten()];
 		if first.is_some_and(|group| (group - anchor_position).normalize_or_zero().dot(handle_direction) < 0.)
 			|| second.is_some_and(|group| (group - anchor_position).normalize_or_zero().dot(handle_direction) > 0.)
 		{
@@ -532,7 +532,7 @@ impl ShapeState {
 			responses.add(GraphOperationMessage::Vector { layer, modification_type });
 
 			// Create the opposite handle if it doesn't exist (if it is not a cubic segment)
-			if handle.opposite().to_manipulator_point().get_position(&vector_data).is_none() {
+			if handle.opposite().to_manipulator_point().get_position(vector_data).is_none() {
 				let modification_type = handle.opposite().set_relative_position(DVec2::ZERO);
 				responses.add(GraphOperationMessage::Vector { layer, modification_type });
 			}
@@ -784,7 +784,7 @@ impl ShapeState {
 
 				let mut handles = handles.map(Some);
 				for handle in &mut handles {
-					while let Some((point, connected)) = handle.clone().and_then(|(_, point)| missing_anchors.remove_entry(&point)) {
+					while let Some((point, connected)) = (*handle).and_then(|(_, point)| missing_anchors.remove_entry(&point)) {
 						visited.push(point);
 
 						*handle = connected.into_iter().find(|(_, point)| !visited.contains(point));

--- a/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
@@ -70,7 +70,7 @@ impl LayerSnapper {
 				for subpath in document.metadata.layer_outline(layer) {
 					for (start_index, curve) in subpath.iter().enumerate() {
 						let document_curve = curve.apply_transformation(|p| transform.transform_point2(p));
-						let start = subpath.manipulator_groups()[start_index].id.into();
+						let start = subpath.manipulator_groups()[start_index].id;
 						if snap_data.ignore_manipulator(layer, start) || snap_data.ignore_manipulator(layer, subpath.manipulator_groups()[(start_index + 1) % subpath.len()].id) {
 							continue;
 						}

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -144,8 +144,7 @@ impl ArtboardToolData {
 	fn hovered_artboard(document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler) -> Option<LayerNodeIdentifier> {
 		document
 			.click_xray(input.mouse.position)
-			.filter(|&layer| document.network.nodes.get(&layer.to_node()).map_or(false, |document_node| document_node.is_artboard()))
-			.next()
+			.find(|&layer| document.network.nodes.get(&layer.to_node()).map_or(false, |document_node| document_node.is_artboard()))
 	}
 
 	fn select_artboard(&mut self, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) -> bool {

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -262,9 +262,7 @@ impl BrushToolData {
 		if document.selected_nodes.selected_layers(document.metadata()).count() != 1 {
 			return None;
 		}
-		let Some(layer) = document.selected_nodes.selected_layers(document.metadata()).next() else {
-			return None;
-		};
+		let layer = document.selected_nodes.selected_layers(document.metadata()).next()?;
 
 		self.layer = Some(layer);
 		for (node, node_id) in document.network().upstream_flow_back_from_nodes(vec![layer.to_node()], graph_craft::document::FlowType::HorizontalFlow) {
@@ -277,7 +275,7 @@ impl BrushToolData {
 				else {
 					continue;
 				};
-				self.strokes = strokes.clone();
+				self.strokes.clone_from(strokes);
 
 				return Some(layer);
 			} else if node.name == "Transform" {

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -417,7 +417,7 @@ impl PathToolData {
 		let previous_mouse = document.metadata.document_to_viewport.transform_point2(self.previous_mouse_position);
 		let snapped_delta = shape_editor.snap(&mut self.snap_manager, document, input, previous_mouse);
 		let handle_lengths = if equidistant { None } else { self.opposing_handle_lengths.take() };
-		shape_editor.move_selected_points(handle_lengths, &document, snapped_delta, equidistant, responses);
+		shape_editor.move_selected_points(handle_lengths, document, snapped_delta, equidistant, responses);
 		self.previous_mouse_position += document.metadata.document_to_viewport.inverse().transform_vector2(snapped_delta);
 	}
 }
@@ -608,7 +608,7 @@ impl Fsm for PathToolFsmState {
 			(_, PathToolMessage::Delete) => {
 				// Delete the selected points and clean up overlays
 				responses.add(DocumentMessage::StartTransaction);
-				shape_editor.delete_selected_points(&document, responses);
+				shape_editor.delete_selected_points(document, responses);
 				responses.add(PathToolMessage::SelectionChanged);
 
 				PathToolFsmState::Ready
@@ -634,7 +634,7 @@ impl Fsm for PathToolFsmState {
 			}
 			(_, PathToolMessage::PointerMove { .. }) => self,
 			(_, PathToolMessage::NudgeSelectedPoints { delta_x, delta_y }) => {
-				shape_editor.move_selected_points(tool_data.opposing_handle_lengths.take(), &document, (delta_x, delta_y).into(), true, responses);
+				shape_editor.move_selected_points(tool_data.opposing_handle_lengths.take(), document, (delta_x, delta_y).into(), true, responses);
 
 				PathToolFsmState::Ready
 			}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -406,10 +406,8 @@ impl PathToolData {
 		}
 		self.alt_debounce = alt;
 
-		if shift {
-			if self.opposing_handle_lengths.is_none() {
-				self.opposing_handle_lengths = Some(shape_editor.opposing_handle_lengths(document));
-			}
+		if shift && self.opposing_handle_lengths.is_none() {
+			self.opposing_handle_lengths = Some(shape_editor.opposing_handle_lengths(document));
 		}
 		false
 	}

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -251,7 +251,7 @@ impl Fsm for PolygonToolFsmState {
 							.to_document_node_default_inputs(
 								[
 									None,
-									Some(NodeInput::value(TaggedValue::U32(tool_options.vertices as u32), false)),
+									Some(NodeInput::value(TaggedValue::U32(tool_options.vertices), false)),
 									Some(NodeInput::value(TaggedValue::F64(0.5), false)),
 								],
 								Default::default(),
@@ -259,7 +259,7 @@ impl Fsm for PolygonToolFsmState {
 						PolygonType::Star => resolve_document_node_type("Star").expect("Star node does not exist").to_document_node_default_inputs(
 							[
 								None,
-								Some(NodeInput::value(TaggedValue::U32(tool_options.vertices as u32), false)),
+								Some(NodeInput::value(TaggedValue::U32(tool_options.vertices), false)),
 								Some(NodeInput::value(TaggedValue::F64(0.5), false)),
 								Some(NodeInput::value(TaggedValue::F64(0.25), false)),
 							],

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -158,7 +158,7 @@ impl SelectTool {
 
 		let operations = BooleanOperation::list();
 		let icons = BooleanOperation::icons();
-		operations.into_iter().zip(icons.into_iter()).map(move |(operation, icon)| {
+		operations.into_iter().zip(icons).map(move |(operation, icon)| {
 			IconButton::new(icon, 24)
 				.tooltip(operation.to_string())
 				.disabled(!enabled(operation))
@@ -344,12 +344,12 @@ impl SelectToolData {
 			// Copy the layer
 			let mut copy_ids = HashMap::new();
 			let node = layer.to_node();
-			copy_ids.insert(node, NodeId(0 as u64));
+			copy_ids.insert(node, NodeId(0_u64));
 			if let Some(input_node) = document
 				.network()
 				.nodes
 				.get(&node)
-				.and_then(|node| if node.is_layer { node.inputs.get(1) } else { node.inputs.get(0) })
+				.and_then(|node| if node.is_layer { node.inputs.get(1) } else { node.inputs.first() })
 				.and_then(|input| input.as_node())
 			{
 				document
@@ -367,7 +367,7 @@ impl SelectToolData {
 
 			let new_ids: HashMap<_, _> = nodes.iter().map(|(&id, _)| (id, NodeId(generate_uuid()))).collect();
 
-			let layer_id = new_ids.get(&NodeId(0)).expect("Node Id 0 should be a layer").clone();
+			let layer_id = *new_ids.get(&NodeId(0)).expect("Node Id 0 should be a layer");
 			responses.add(GraphOperationMessage::AddNodesAsChild { nodes, new_ids, parent, insert_index });
 			new_dragging.push(LayerNodeIdentifier::new_unchecked(layer_id));
 		}

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -243,7 +243,7 @@ impl TextToolData {
 			color: Some(color),
 			transform,
 		});
-		self.new_text = text.clone();
+		self.new_text.clone_from(text);
 		Some(())
 	}
 

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -287,11 +287,11 @@ impl NodeRuntime {
 
 			let introspected_data_output = introspected_data
 				.downcast_ref::<IORecord<Footprint, graphene_core::GraphicElement>>()
-				.and_then(|io_data| Some(IntrospectedData::GraphicElement(&io_data.output)))
+				.map(|io_data| IntrospectedData::GraphicElement(&io_data.output))
 				.or_else(|| {
 					introspected_data
 						.downcast_ref::<IORecord<Footprint, graphene_core::Artboard>>()
-						.and_then(|io_data| Some(IntrospectedData::Artboard(&io_data.output)))
+						.map(|io_data| IntrospectedData::Artboard(&io_data.output))
 				});
 
 			let graphic_element = match introspected_data_output {

--- a/editor/src/test_utils.rs
+++ b/editor/src/test_utils.rs
@@ -73,7 +73,7 @@ impl EditorTestUtils for Editor {
 	}
 
 	fn move_mouse(&mut self, x: f64, y: f64) {
-		let mut editor_mouse_state = EditorMouseState {
+		let editor_mouse_state = EditorMouseState {
 			editor_position: ViewportPosition::new(x, y),
 			..Default::default()
 		};

--- a/editor/src/test_utils.rs
+++ b/editor/src/test_utils.rs
@@ -73,8 +73,10 @@ impl EditorTestUtils for Editor {
 	}
 
 	fn move_mouse(&mut self, x: f64, y: f64) {
-		let mut editor_mouse_state = EditorMouseState::default();
-		editor_mouse_state.editor_position = ViewportPosition::new(x, y);
+		let mut editor_mouse_state = EditorMouseState {
+			editor_position: ViewportPosition::new(x, y),
+			..Default::default()
+		};
 		let modifier_keys = ModifierKeys::default();
 		self.input(InputPreprocessorMessage::PointerMove { editor_mouse_state, modifier_keys });
 	}

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = ""
 default-run = "graphite-desktop"
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 // use std::sync::Mutex;
 
 thread_local! {
-	static EDITOR: RefCell<Option<Editor>> = RefCell::new(None);
+	static EDITOR: RefCell<Option<Editor>> = const { RefCell::new(None) };
 }
 
 // async fn respond_to(id: Path<String>) -> impl IntoResponse {

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphite-wasm"
 publish = false
 version = "0.0.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 edition = "2021"
 readme = "../../README.md"

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -731,9 +731,9 @@ impl EditorHandle {
 						return;
 					}
 
-					let transform = get_current_transform(&inputs);
+					let transform = get_current_transform(inputs);
 					let upstream_transform = metadata.upstream_transform(node_id);
-					let pivot_transform = glam::DAffine2::from_translation(upstream_transform.transform_point2(bounds.local_pivot(get_current_normalized_pivot(&inputs))));
+					let pivot_transform = glam::DAffine2::from_translation(upstream_transform.transform_point2(bounds.local_pivot(get_current_normalized_pivot(inputs))));
 
 					update_transform(inputs, pivot_transform * transform * pivot_transform.inverse());
 				});
@@ -894,7 +894,7 @@ fn editor<T: Default>(callback: impl FnOnce(&mut editor::application::Editor) ->
 			return T::default();
 		};
 
-		callback(&mut *editor)
+		callback(&mut editor)
 	})
 }
 

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -48,9 +48,9 @@ pub fn panic_hook(info: &panic::PanicInfo) {
 	});
 }
 
-/// The JavaScript `Error` type
 #[wasm_bindgen]
 extern "C" {
+	/// The JavaScript `Error` type
 	#[derive(Clone, Debug)]
 	pub type Error;
 

--- a/libraries/bezier-rs/Cargo.toml
+++ b/libraries/bezier-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bezier-rs"
 version = "0.4.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 edition = "2021"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 description = "Computational geometry algorithms for Bézier segments and shapes useful in the context of 2D graphics"

--- a/libraries/dyn-any/Cargo.toml
+++ b/libraries/dyn-any/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dyn-any"
 version = "0.3.1"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 edition = "2021"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 description = "An Any trait that works for arbitrary lifetimes"

--- a/libraries/raw-rs/src/decoder/arw2.rs
+++ b/libraries/raw-rs/src/decoder/arw2.rs
@@ -30,7 +30,7 @@ pub fn decode<R: Read + Seek>(ifd: Ifd, file: &mut TiffRead<R>) -> RawImage {
 
 	let image_width: usize = ifd.image_width.try_into().unwrap();
 	let image_height: usize = ifd.image_height.try_into().unwrap();
-	let bits_per_sample: usize = ifd.bits_per_sample.into();
+	let _bits_per_sample: usize = ifd.bits_per_sample.into();
 	let [cfa_pattern_width, cfa_pattern_height] = ifd.cfa_pattern_dim;
 	assert!(cfa_pattern_width == 2 && cfa_pattern_height == 2);
 
@@ -81,10 +81,11 @@ fn sony_arw2_load_raw<R: Read + Seek>(width: usize, height: usize, curve: CurveL
 			let max_minus_min = max as i32 - min as i32;
 			let shift_by_bits = (0..4).find(|&shift| (0x80 << shift) > max_minus_min).unwrap_or(4);
 
-			let mut pixel = [0_u16; 16];
+			let mut pixels = [0_u16; 16];
 			let mut bit = 30;
-			for i in 0..16 {
-				pixel[i] = match () {
+			// for i in 0..16 {
+			for (i, pixel) in pixels.iter_mut().enumerate() {
+				*pixel = match () {
 					_ if i as u32 == index_to_set_max => max,
 					_ if i as u32 == index_to_set_min => min,
 					_ => {
@@ -98,7 +99,7 @@ fn sony_arw2_load_raw<R: Read + Seek>(width: usize, height: usize, curve: CurveL
 				};
 			}
 
-			for value in pixel {
+			for value in pixels {
 				image[row * width + column] = curve.get((value << 1).into()) >> 2;
 
 				// Skip between interlaced columns

--- a/libraries/raw-rs/src/decoder/uncompressed.rs
+++ b/libraries/raw-rs/src/decoder/uncompressed.rs
@@ -29,7 +29,7 @@ pub fn decode<R: Read + Seek>(ifd: Ifd, file: &mut TiffRead<R>) -> RawImage {
 	let image_width: usize = ifd.image_width.try_into().unwrap();
 	let image_height: usize = ifd.image_height.try_into().unwrap();
 	let rows_per_strip: usize = ifd.rows_per_strip.try_into().unwrap();
-	let bits_per_sample: usize = ifd.bits_per_sample.into();
+	let _bits_per_sample: usize = ifd.bits_per_sample.into();
 	let [cfa_pattern_width, cfa_pattern_height] = ifd.cfa_pattern_dim;
 	assert!(cfa_pattern_width == 2 && cfa_pattern_height == 2);
 

--- a/libraries/raw-rs/src/tiff/mod.rs
+++ b/libraries/raw-rs/src/tiff/mod.rs
@@ -106,7 +106,7 @@ impl Ifd {
 		})
 	}
 
-	fn next_ifd<R: Read + Seek>(&self, file: &mut TiffRead<R>) -> Result<Self, TiffError> {
+	fn _next_ifd<R: Read + Seek>(&self, file: &mut TiffRead<R>) -> Result<Self, TiffError> {
 		Ifd::new_from_offset(file, self.next_ifd_offset.unwrap_or(0))
 	}
 

--- a/libraries/raw-rs/src/tiff/types.rs
+++ b/libraries/raw-rs/src/tiff/types.rs
@@ -270,7 +270,7 @@ impl PrimitiveType for TypeIfd {
 
 	fn read_primitive<R: Read + Seek>(the_type: IfdTagType, file: &mut TiffRead<R>) -> Result<Self::Output, TiffError> {
 		let offset = TypeLong::read_primitive(the_type, file)?;
-		Ok(Ifd::new_from_offset(file, offset)?)
+		Ifd::new_from_offset(file, offset)
 	}
 }
 
@@ -284,7 +284,7 @@ impl<T: PrimitiveType> TagType for T {
 	type Output = T::Output;
 
 	fn read<R: Read + Seek>(file: &mut TiffRead<R>) -> Result<Self::Output, TiffError> {
-		let the_type = IfdTagType::try_from(file.read_u16()?).map_err(|_| TiffError::InvalidType)?;
+		let the_type = IfdTagType::from(file.read_u16()?);
 		let count = file.read_u32()?;
 
 		if count != 1 {
@@ -313,7 +313,7 @@ impl<T: PrimitiveType> TagType for Array<T> {
 	type Output = Vec<T::Output>;
 
 	fn read<R: Read + Seek>(file: &mut TiffRead<R>) -> Result<Self::Output, TiffError> {
-		let the_type = IfdTagType::try_from(file.read_u16()?).map_err(|_| TiffError::InvalidType)?;
+		let the_type = IfdTagType::from(file.read_u16()?);
 		let count = file.read_u32()?;
 
 		let size = T::get_size(the_type).ok_or(TiffError::InvalidType)?;
@@ -334,7 +334,7 @@ impl<T: PrimitiveType, const N: usize> TagType for ConstArray<T, N> {
 	type Output = [T::Output; N];
 
 	fn read<R: Read + Seek>(file: &mut TiffRead<R>) -> Result<Self::Output, TiffError> {
-		let the_type = IfdTagType::try_from(file.read_u16()?).map_err(|_| TiffError::InvalidType)?;
+		let the_type = IfdTagType::from(file.read_u16()?);
 		let count = file.read_u32()?;
 
 		if count != N.try_into()? {

--- a/node-graph/gcore/src/uuid.rs
+++ b/node-graph/gcore/src/uuid.rs
@@ -47,7 +47,7 @@ mod uuid_generation {
 
 	static RNG: Mutex<Option<ChaCha20Rng>> = Mutex::new(None);
 	thread_local! {
-		pub static UUID_SEED: Cell<Option<u64>> = Cell::new(None);
+		pub static UUID_SEED: Cell<Option<u64>> = const { Cell::new(None) };
 	}
 
 	pub fn set_uuid_seed(random_seed: u64) {

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -149,8 +149,7 @@ fn solidify_stroke(vector_data: VectorData) -> VectorData {
 	// Perform operation on all subpaths in this shape.
 	for mut subpath in subpaths {
 		let stroke = style.stroke().unwrap();
-		let transform = transform.clone();
-		subpath.apply_transform(transform);
+		subpath.apply_transform(*transform);
 
 		// Taking the existing stroke data and passing it to Bezier-rs to generate new paths.
 		let subpath_out = subpath.outline(

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -827,7 +827,7 @@ impl NodeNetwork {
 	}
 
 	/// Get the network the selected nodes are part of, which is either self or the nested network from nested_path. Used to get nodes selected in the layer panel when viewing a nested network.
-	pub fn nested_network_for_selected_nodes<'a>(&self, nested_path: &Vec<NodeId>, mut selected_nodes: impl Iterator<Item = &'a NodeId>) -> Option<&Self> {
+	pub fn nested_network_for_selected_nodes<'a>(&self, nested_path: &[NodeId], mut selected_nodes: impl Iterator<Item = &'a NodeId>) -> Option<&Self> {
 		if selected_nodes.any(|node_id| self.nodes.contains_key(node_id) || self.exports_metadata.0 == *node_id || self.imports_metadata.0 == *node_id) {
 			Some(self)
 		} else {
@@ -836,7 +836,7 @@ impl NodeNetwork {
 	}
 
 	/// Get the mutable network the selected nodes are part of, which is either self or the nested network from nested_path. Used to modify nodes selected in the layer panel when viewing a nested network.
-	pub fn nested_network_for_selected_nodes_mut<'a>(&mut self, nested_path: &Vec<NodeId>, mut selected_nodes: impl Iterator<Item = &'a NodeId>) -> Option<&mut Self> {
+	pub fn nested_network_for_selected_nodes_mut<'a>(&mut self, nested_path: &[NodeId], mut selected_nodes: impl Iterator<Item = &'a NodeId>) -> Option<&mut Self> {
 		if selected_nodes.any(|node_id| self.nodes.contains_key(node_id)) {
 			Some(self)
 		} else {
@@ -1215,7 +1215,7 @@ impl NodeNetwork {
 
 				for (nested_input_index, nested_input) in nested_node.clone().inputs.iter().enumerate() {
 					if let NodeInput::Network { import_index, .. } = nested_input {
-						let parent_input = node.inputs.get(*import_index).expect(&format!("Import index {} should always exist", import_index));
+						let parent_input = node.inputs.get(*import_index).unwrap_or_else(|| panic!("Import index {} should always exist", import_index));
 						match *parent_input {
 							// If the input to self is a node, connect the corresponding output of the inner network to it
 							NodeInput::Node { node_id, output_index, lambda } => {

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -173,7 +173,7 @@ tagged_value! {
 	BooleanOperation(graphene_core::vector::misc::BooleanOperation),
 }
 
-impl<'a> TaggedValue {
+impl TaggedValue {
 	pub fn to_string(&self) -> String {
 		match self {
 			TaggedValue::String(x) => x.to_string(),

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -10,6 +10,7 @@ use graphene_core::{Color, Node, Type};
 use dyn_any::DynAny;
 pub use dyn_any::StaticType;
 pub use glam::{DAffine2, DVec2, IVec2, UVec2};
+use std::fmt::Display;
 use std::hash::Hash;
 pub use std::sync::Arc;
 
@@ -174,16 +175,6 @@ tagged_value! {
 }
 
 impl TaggedValue {
-	pub fn to_string(&self) -> String {
-		match self {
-			TaggedValue::String(x) => x.to_string(),
-			TaggedValue::U32(x) => x.to_string(),
-			TaggedValue::U64(x) => x.to_string(),
-			TaggedValue::F64(x) => x.to_string(),
-			TaggedValue::Bool(x) => x.to_string(),
-			_ => panic!("Cannot convert to string"),
-		}
-	}
 	pub fn to_primitive_string(&self) -> String {
 		match self {
 			TaggedValue::None => "()".to_string(),
@@ -195,6 +186,19 @@ impl TaggedValue {
 			TaggedValue::BlendMode(x) => "BlendMode::".to_string() + &x.to_string(),
 			TaggedValue::Color(x) => format!("Color {x:?}"),
 			_ => panic!("Cannot convert to primitive string"),
+		}
+	}
+}
+
+impl Display for TaggedValue {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			TaggedValue::String(x) => f.write_str(x),
+			TaggedValue::U32(x) => f.write_fmt(format_args!("{x}")),
+			TaggedValue::U64(x) => f.write_fmt(format_args!("{x}")),
+			TaggedValue::F64(x) => f.write_fmt(format_args!("{x}")),
+			TaggedValue::Bool(x) => f.write_fmt(format_args!("{x}")),
+			_ => panic!("Cannot convert to string"),
 		}
 	}
 }

--- a/node-graph/graphene-cli/src/main.rs
+++ b/node-graph/graphene-cli/src/main.rs
@@ -90,7 +90,7 @@ fn create_executor(_document_string: String) -> Result<DynamicExecutor, Box<dyn 
 	// Ok(executor)
 }
 
-fn begin_scope() -> DocumentNode {
+fn _begin_scope() -> DocumentNode {
 	DocumentNode {
 		name: "Begin Scope".to_string(),
 		implementation: DocumentNodeImplementation::Network(NodeNetwork {

--- a/node-graph/gstd/src/any.rs
+++ b/node-graph/gstd/src/any.rs
@@ -276,6 +276,12 @@ impl<I, O> PanicNode<I, O> {
 	}
 }
 
+impl<I, O> Default for PanicNode<I, O> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 #[cfg(test)]
 mod test {
 	use super::*;

--- a/node-graph/gstd/src/brush.rs
+++ b/node-graph/gstd/src/brush.rs
@@ -293,8 +293,8 @@ async fn brush(image: ImageFrame<Color>, bounds: ImageFrame<Color>, strokes: Vec
 	let image_bbox = Bbox::from_transform(image.transform).to_axis_aligned_bbox();
 	let bbox = if image_bbox.size().length() < 0.1 { stroke_bbox } else { stroke_bbox.union(&image_bbox) };
 
-	let mut draw_strokes: Vec<_> = strokes.iter().cloned().filter(|s| !matches!(s.style.blend_mode, BlendMode::Erase | BlendMode::Restore)).collect();
-	let erase_restore_strokes: Vec<_> = strokes.iter().cloned().filter(|s| matches!(s.style.blend_mode, BlendMode::Erase | BlendMode::Restore)).collect();
+	let mut draw_strokes: Vec<_> = strokes.iter().filter(|&s| !matches!(s.style.blend_mode, BlendMode::Erase | BlendMode::Restore)).cloned().collect();
+	let erase_restore_strokes: Vec<_> = strokes.iter().filter(|&s| matches!(s.style.blend_mode, BlendMode::Erase | BlendMode::Restore)).cloned().collect();
 
 	let mut brush_plan = cache.compute_brush_plan(image, &draw_strokes);
 

--- a/node-graph/node-macro/Cargo.toml
+++ b/node-graph/node-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "node-macro"
 publish = false
 version = "0.0.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 edition = "2021"
 readme = "../../README.md"

--- a/node-graph/vulkan-executor/src/executor.rs
+++ b/node-graph/vulkan-executor/src/executor.rs
@@ -71,7 +71,7 @@ fn execute_shader<I: Pod + Send + Sync, O: Pod + Send + Sync>(
 	let dest_buffer = create_buffer(dest_data, alloc).expect("failed to create buffer");
 
 	let compute_pipeline = ComputePipeline::new(device.clone(), entry_point, &(), None, |_| {}).expect("failed to create compute pipeline");
-	let layout = compute_pipeline.layout().set_layouts().get(0).unwrap();
+	let layout = compute_pipeline.layout().set_layouts().first().unwrap();
 	let dalloc = StandardDescriptorSetAllocator::new(device.clone());
 	let set = PersistentDescriptorSet::new(
 		&dalloc,

--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphite-proc-macros"
 publish = false
 version = "0.0.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 edition = "2021"
 readme = "../README.md"

--- a/proc-macros/src/helpers.rs
+++ b/proc-macros/src/helpers.rs
@@ -3,6 +3,9 @@ use syn::punctuated::Punctuated;
 use syn::{Path, PathArguments, PathSegment, Token};
 
 /// Returns `Ok(Vec<T>)` if all items are `Ok(T)`, else returns a combination of every error encountered (not just the first one)
+// Allowing this lint because this is a false positive in this case. The fold can only be changed into a `try_fold` if the closure
+// doesn't have an error case. See for details: https://rust-lang.github.io/rust-clippy/master/index.html#/manual_try_fold.
+#[allow(clippy::manual_try_fold)]
 pub fn fold_error_iter<T>(iter: impl Iterator<Item = syn::Result<T>>) -> syn::Result<Vec<T>> {
 	iter.fold(Ok(vec![]), |acc, x| match acc {
 		Ok(mut v) => x.map(|x| {

--- a/website/other/bezier-rs-demos/wasm/Cargo.toml
+++ b/website/other/bezier-rs-demos/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bezier-rs-wasm"
 publish = false
 version = "0.0.0"
-rust-version = "1.66.0"
+rust-version = "1.70.0"
 authors = ["Graphite Authors <contact@graphite.rs>"]
 edition = "2021"
 readme = "../../README.md"

--- a/website/other/bezier-rs-demos/wasm/src/lib.rs
+++ b/website/other/bezier-rs-demos/wasm/src/lib.rs
@@ -6,7 +6,7 @@ mod utils;
 use wasm_bindgen::prelude::*;
 
 pub static LOGGER: WasmLog = WasmLog;
-thread_local! { pub static HAS_CRASHED: std::cell::RefCell<bool> = std::cell::RefCell::new(false); }
+thread_local! { pub static HAS_CRASHED: std::cell::RefCell<bool> = const { std::cell::RefCell::new(false) } }
 
 /// Initialize the backend
 #[wasm_bindgen(start)]


### PR DESCRIPTION
This PR bump MSRV to Rust 1.70.0 to fix warnings shown by `cargo clippy` because many new functions which are stabilized in Rust 1.70.0 are being used, but the current MSRV is at 1.66.0. One example of such a warning is like this:

```
warning: current MSRV (Minimum Supported Rust Version) is `1.66.0` but this item is stable since `1.70.0`
   --> libraries/bezier-rs/src/symmetrical_basis.rs:140:39
    |
140 | ....last().is_some_and(|x| x.abs_diff_eq(DVec2::ZERO, 1e-5)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `#[warn(clippy::incompatible_msrv)]` on by default
```