### PR TITLE
Allow dragging an image into the welcome screen

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -93,6 +93,9 @@ pub enum DocumentMessage {
 		image: Image<Color>,
 		mouse: Option<(f64, f64)>,
 	},
+	PasteImageAsBackground {
+		image: Image<Color>,
+	},
 	PasteSvg {
 		svg: String,
 		mouse: Option<(f64, f64)>,

--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -3,6 +3,7 @@ use crate::messages::frontend::utility_types::{ExportBounds, FileType};
 use crate::messages::portfolio::document::utility_types::clipboards::Clipboard;
 use crate::messages::prelude::*;
 
+use glam::UVec2;
 use graphene_core::text::Font;
 
 #[impl_message(Message, Portfolio)]
@@ -61,6 +62,10 @@ pub enum PortfolioMessage {
 	LoadFont {
 		font: Font,
 		is_default: bool,
+	},
+	NewDocument {
+		name: String,
+		dimensions: UVec2,
 	},
 	NewDocumentWithName {
 		name: String,

--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -78,6 +78,12 @@ pub enum PortfolioMessage {
 		document_is_saved: bool,
 		document_serialized_content: String,
 	},
+	OpenImageFile {
+		image_name: String,
+		image_width: u32,
+		image_height: u32,
+		image_data: Vec<u8>,
+	},
 	PasteIntoFolder {
 		clipboard: Clipboard,
 		parent: LayerNodeIdentifier,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -345,6 +345,21 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					responses.add_front(FrontendMessage::TriggerFontLoad { font, is_default });
 				}
 			}
+			PortfolioMessage::NewDocument { name, dimensions } => {
+				responses.add(PortfolioMessage::NewDocumentWithName { name });
+				debug!("{dimensions}");
+				let create_artboard = dimensions.x > 0 && dimensions.y > 0;
+				if create_artboard {
+					responses.add(GraphOperationMessage::NewArtboard {
+						id: NodeId(generate_uuid()),
+						artboard: graphene_core::Artboard::new(IVec2::ZERO, dimensions.as_ivec2()),
+					});
+					responses.add(FrontendMessage::TriggerDelayedZoomCanvasToFitAll);
+				}
+
+				responses.add(NodeGraphMessage::RunDocumentGraph);
+				responses.add(NodeGraphMessage::UpdateNewNodeGraph);
+			}
 			PortfolioMessage::NewDocumentWithName { name } => {
 				let new_document = DocumentMessageHandler::with_name(name, ipp, responses);
 				let document_id = DocumentId(generate_uuid());

--- a/frontend/src/components/window/workspace/Panel.svelte
+++ b/frontend/src/components/window/workspace/Panel.svelte
@@ -56,7 +56,9 @@
 		const image = new Image();
 		image.onload = async function () {
 			const imageData = await extractPixelData(image);
-			editor.handle.openImageFile(file.name, image.width, image.height, new Uint8Array(imageData.data));
+			editor.handle.newDocument(file.name, image.width, image.height);
+			editor.handle.pasteImage(new Uint8Array(imageData.data), image.width, image.height);
+			// editor.handle.openImageFile(file.name, image.width, image.height, new Uint8Array(imageData.data));
 		};
 		const url = window.URL || window.webkitURL;
 		image.src = url.createObjectURL(file);

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -289,6 +289,17 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 
+	#[wasm_bindgen(js_name = openImageFile)]
+	pub fn open_image_file(&self, image_name: String, image_width: u32, image_height: u32, image_data: Vec<u8>) {
+		let message = PortfolioMessage::OpenImageFile {
+			image_name,
+			image_width,
+			image_height,
+			image_data,
+		};
+		self.dispatch(message);
+	}
+
 	#[wasm_bindgen(js_name = openDocumentFile)]
 	pub fn open_document_file(&self, document_name: String, document_serialized_content: String) {
 		let message = PortfolioMessage::OpenDocumentFile {

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -271,6 +271,13 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 
+	#[wasm_bindgen(js_name = newDocument)]
+	pub fn new_document(&self, name: String, x: u32, y: u32) {
+		let dimensions = glam::UVec2::from_array([x, y]);
+		let message = PortfolioMessage::NewDocument { name, dimensions };
+		self.dispatch(message);
+	}
+
 	#[wasm_bindgen(js_name = newDocumentDialog)]
 	pub fn new_document_dialog(&self) {
 		let message = DialogMessage::RequestNewDocumentDialog;


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Fixes part of #1140 

So far, this enables the ability to drag an image into the welcome screen to open a new document with the same dimensions and paste the image onto a new layer. 

I think I will add tests soon, but would appreciate some feedback in the meantime. I'm not sure I like how I named the new message `OpenImageAsBackground`. I also reused a lot of the code from `PasteImage`.

Todo:
- [ ] enable dragging into tab bar
- [ ] allow .graphite files to be dropped in
- [ ] allow dropping into layer panel