### PR TITLE
Sandbox node graph execution on native targets and attempt recovery from panics on Wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "spin",
  "thiserror",
  "tokio",
  "usvg",
@@ -5775,6 +5776,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spirv"

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -69,6 +69,7 @@ gpu-executor = { path = "../node-graph/gpu-executor", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 async-mutex = "1.4.0"
+spin = "0.9.8"
 
 [dev-dependencies]
 # Workspace dependencies

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -61,6 +61,10 @@ web-sys = { workspace = true, features = [
 	"TextMetrics",
 ] }
 
+# Required dependencies
+async-mutex = "1.4.0"
+spin = "0.9.8"
+
 # Optional local dependencies
 wgpu-executor = { path = "../node-graph/wgpu-executor", optional = true }
 gpu-executor = { path = "../node-graph/gpu-executor", optional = true }
@@ -68,8 +72,6 @@ gpu-executor = { path = "../node-graph/gpu-executor", optional = true }
 # Optional workspace dependencies
 wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
-async-mutex = "1.4.0"
-spin = "0.9.8"
 
 [dev-dependencies]
 # Workspace dependencies

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -22,10 +22,10 @@ use graphene_core::vector::VectorData;
 use graphene_core::{Color, GraphicElement, SurfaceFrame};
 use graphene_std::wasm_application_io::{WasmApplicationIo, WasmEditorApi};
 use interpreted_executor::dynamic_executor::{DynamicExecutor, ResolvedDocumentNodeTypes};
-use spin::Mutex;
 
 use glam::{DAffine2, DVec2, UVec2};
 use once_cell::sync::Lazy;
+use spin::Mutex;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -4,7 +4,6 @@ use crate::messages::portfolio::document::node_graph::document_node_types::wrap_
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::prelude::*;
 
-use futures::lock::Mutex;
 use graph_craft::concrete;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{generate_uuid, DocumentNodeImplementation, NodeId, NodeNetwork};
@@ -23,6 +22,7 @@ use graphene_core::vector::VectorData;
 use graphene_core::{Color, GraphicElement, SurfaceFrame};
 use graphene_std::wasm_application_io::{WasmApplicationIo, WasmEditorApi};
 use interpreted_executor::dynamic_executor::{DynamicExecutor, ResolvedDocumentNodeTypes};
+use spin::Mutex;
 
 use glam::{DAffine2, DVec2, UVec2};
 use once_cell::sync::Lazy;
@@ -120,7 +120,7 @@ impl NodeGraphUpdateSender for InternalNodeGraphUpdateSender {
 	}
 }
 
-pub(crate) static NODE_RUNTIME: Lazy<Mutex<Option<NodeRuntime>>> = Lazy::new(|| Mutex::new(None));
+pub static NODE_RUNTIME: Lazy<Mutex<Option<NodeRuntime>>> = Lazy::new(|| Mutex::new(None));
 
 impl NodeRuntime {
 	pub fn new(receiver: Receiver<NodeRuntimeMessage>, sender: Sender<NodeGraphUpdate>) -> Self {
@@ -377,7 +377,7 @@ impl NodeRuntime {
 }
 
 pub async fn introspect_node(path: &[NodeId]) -> Option<Arc<dyn std::any::Any>> {
-	let runtime = NODE_RUNTIME.lock().await;
+	let runtime = NODE_RUNTIME.lock();
 	if let Some(ref mut runtime) = runtime.as_ref() {
 		return runtime.executor.introspect(path).flatten();
 	}
@@ -385,14 +385,14 @@ pub async fn introspect_node(path: &[NodeId]) -> Option<Arc<dyn std::any::Any>> 
 }
 
 pub async fn run_node_graph() {
-	let mut runtime = NODE_RUNTIME.lock().await;
+	let Some(mut runtime) = NODE_RUNTIME.try_lock() else { return };
 	if let Some(ref mut runtime) = runtime.as_mut() {
 		runtime.run().await;
 	}
 }
 
 pub async fn replace_node_runtime(runtime: NodeRuntime) -> Option<NodeRuntime> {
-	let mut node_runtime = NODE_RUNTIME.lock().await;
+	let mut node_runtime = NODE_RUNTIME.lock();
 	node_runtime.replace(runtime)
 }
 

--- a/frontend/wasm/.cargo/config.toml
+++ b/frontend/wasm/.cargo/config.toml
@@ -5,11 +5,18 @@ rustflags = [
 	#"-C",
 	#"target-feature=+simd128",
 	"-C",
+	"panic=unwind",
+	"-C",
+	"llvm-args=-wasm-enable-eh",
+	"-C",
 	"target-feature=+bulk-memory",
+	"-C",
+	"target-feature=+exception-handling",
 	"-C",
 	"link-arg=--max-memory=4294967296",
 	"--cfg=web_sys_unstable_apis",
 ]
 
 [unstable]
-build-std = ["panic_abort", "std"]
+unstable-options = true
+build-std = [ "std"]

--- a/frontend/wasm/.cargo/config.toml
+++ b/frontend/wasm/.cargo/config.toml
@@ -5,18 +5,11 @@ rustflags = [
 	#"-C",
 	#"target-feature=+simd128",
 	"-C",
-	"panic=unwind",
-	"-C",
-	"llvm-args=-wasm-enable-eh",
-	"-C",
 	"target-feature=+bulk-memory",
-	"-C",
-	"target-feature=+exception-handling",
 	"-C",
 	"link-arg=--max-memory=4294967296",
 	"--cfg=web_sys_unstable_apis",
 ]
 
 [unstable]
-unstable-options = true
-build-std = [ "std"]
+build-std = ["std"]

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -52,6 +52,9 @@ web-sys = { workspace = true, features = [
 # Optional workspace dependencies
 ron = { workspace = true, optional = true }
 
+[profile.release]
+debug = true
+
 [package.metadata.wasm-pack.profile.dev]
 wasm-opt = false
 panic = "unwind"
@@ -62,7 +65,7 @@ demangle-name-section = true
 dwarf-debug-info = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os"]
+wasm-opt = ["-Os", "-g"]
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -54,6 +54,7 @@ ron = { workspace = true, optional = true }
 
 [package.metadata.wasm-pack.profile.dev]
 wasm-opt = false
+panic = "unwind"
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 debug-js-glue = true

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -57,7 +57,6 @@ debug = true
 
 [package.metadata.wasm-pack.profile.dev]
 wasm-opt = false
-panic = "unwind"
 
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 debug-js-glue = true

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -898,9 +898,7 @@ fn set_timeout(f: &Closure<dyn FnMut()>, delay: Duration) {
 fn editor<T>(callback: impl FnOnce(&mut editor::application::Editor) -> T) -> T {
 	EDITOR.with(|editor| {
 		let mut guard = editor.lock();
-		let Ok(Some(ref mut editor)) = guard.as_deref_mut() else {
-			panic!("Failed to borrow the editor");
-		};
+		let Ok(Some(ref mut editor)) = guard.as_deref_mut() else { panic!("Failed to borrow the editor") };
 
 		callback(editor)
 	})

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -71,10 +71,10 @@ impl EditorHandle {
 	pub fn new(frontend_message_handler_callback: js_sys::Function) -> Self {
 		let editor = Editor::new();
 		let editor_handle = EditorHandle { frontend_message_handler_callback };
-		if EDITOR.with(|editor_cell| editor_cell.set(RefCell::new(editor))).is_err() {
+		if EDITOR.with(|handle| handle.lock().ok().map(|mut guard| *guard = Some(editor))).is_none() {
 			log::error!("Attempted to initialize the editor more than once");
 		}
-		if EDITOR_HANDLE.with(|handle_cell| handle_cell.set(RefCell::new(editor_handle.clone()))).is_err() {
+		if EDITOR_HANDLE.with(|handle| handle.lock().ok().map(|mut guard| *guard = Some(editor_handle.clone()))).is_none() {
 			log::error!("Attempted to initialize the editor handle more than once");
 		}
 		editor_handle
@@ -895,29 +895,29 @@ fn set_timeout(f: &Closure<dyn FnMut()>, delay: Duration) {
 }
 
 /// Provides access to the `Editor` by calling the given closure with it as an argument.
-fn editor<T: Default>(callback: impl FnOnce(&mut editor::application::Editor) -> T) -> T {
+fn editor<T>(callback: impl FnOnce(&mut editor::application::Editor) -> T) -> T {
 	EDITOR.with(|editor| {
-		let Some(Ok(mut editor)) = editor.get().map(RefCell::try_borrow_mut) else {
-			// TODO: Investigate if this should just panic instead, and if not doing so right now may be the cause of silent crashes that don't inform the user that the app has panicked
-			log::error!("Failed to borrow the editor");
-			return T::default();
+		let mut guard = editor.lock();
+		let Ok(Some(ref mut editor)) = guard.as_deref_mut() else {
+			panic!("Failed to borrow the editor");
 		};
 
-		callback(&mut editor)
+		callback(editor)
 	})
 }
 
 /// Provides access to the `Editor` and its `EditorHandle` by calling the given closure with them as arguments.
 pub(crate) fn editor_and_handle(mut callback: impl FnMut(&mut Editor, &mut EditorHandle)) {
-	editor(|editor| {
-		EDITOR_HANDLE.with(|editor_handle| {
-			let Some(Ok(mut handle)) = editor_handle.get().map(RefCell::try_borrow_mut) else {
+	EDITOR_HANDLE.with(|editor_handle| {
+		editor(|editor| {
+			let mut guard = editor_handle.lock();
+			let Ok(Some(ref mut editor_handle)) = guard.as_deref_mut() else {
 				log::error!("Failed to borrow editor handle");
 				return;
 			};
 
 			// Call the closure with the editor and its handle
-			callback(editor, &mut handle);
+			callback(editor, editor_handle);
 		})
 	});
 }

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -38,11 +38,8 @@ pub fn init_graphite() {
 /// When a panic occurs, notify the user and log the error to the JS console before the backend dies
 pub fn panic_hook(info: &panic::PanicInfo) {
 	let info = info.to_string();
-	let e = Error::new("stack");
-	let stack = e.stack();
-	let backtrace = stack.to_string();
-	// error!("{:?}", backtrace);
-	if backtrace.to_string().contains("DynAnyNode") {
+	let backtrace = Error::new("stack").stack().to_string();
+	if backtrace.contains("DynAnyNode") {
 		log::error!("Node graph evaluation panicked {info}");
 
 		// When the graph panics, the node runtime lock may not be released properly
@@ -71,7 +68,7 @@ pub fn panic_hook(info: &panic::PanicInfo) {
 		EDITOR_HAS_CRASHED.store(true, Ordering::SeqCst);
 	}
 
-	error!("{info}");
+	log::error!("{info}");
 
 	EDITOR_HANDLE.with(|editor_handle| {
 		let mut guard = editor_handle.lock();

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -26,7 +26,7 @@ thread_local! {
 #[wasm_bindgen(start)]
 pub fn init_graphite() {
 	// Set up the panic hook
-	panic::set_hook(Box::new(panic_hook));
+	// panic::set_hook(Box::new(panic_hook));
 
 	// Set up the logger with a default level of debug
 	log::set_logger(&LOGGER).expect("Failed to set logger");

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -41,7 +41,7 @@ pub fn panic_hook(info: &panic::PanicInfo) {
 	let stack = e.stack();
 	let backtrace = stack.to_string();
 	// error!("{:?}", backtrace);
-	if backtrace.to_string().contains("AssertUnwindSafe") {
+	if backtrace.to_string().contains("DynAnyNode") {
 		log::error!("Node graph evaluation panicked {info}");
 
 		// When the graph panics, the node runtime lock may not be released properly

--- a/frontend/wasm/src/lib.rs
+++ b/frontend/wasm/src/lib.rs
@@ -54,8 +54,8 @@ pub fn panic_hook(info: &panic::PanicInfo) {
 				<rect x="50%" y="50%" width="600" height="100" transform="translate(-300 -50)" rx="4" fill="var(--color-error-red)" />
 				<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="18" fill="var(--color-2-mildblack)">
 					<tspan x="50%" dy="-24" font-weight="bold">The document crashed while being rendered in its current state.</tspan>
-					<tspan x="50%" dy="24">Undo your last action to restore the artwork. However, the editor is now</tspan>
-					<tspan x="50%" dy="24">unstable! Save your document then restart the editor before continuing.</tspan>
+					<tspan x="50%" dy="24">The editor is now unstable! Undo your last action to restore the artwork,</tspan>
+					<tspan x="50%" dy="24">then save your document and restart the editor before continuing work.</tspan>
 				/text>"#
 				// It's a mystery why the `/text>` tag above needs to be missing its `<`, but when it exists it prints the `<` character in the text. However this works with it removed.
 				.to_string();

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -107,6 +107,7 @@ fn render_svg(data: impl GraphicElementRendered, mut render: SvgRender, render_p
 #[cfg(feature = "vello")]
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 async fn render_canvas(render_config: RenderConfig, data: impl GraphicElementRendered, editor: &WasmEditorApi, surface_handle: wgpu_executor::WgpuSurface) -> RenderOutput {
+	unimplemented!();
 	if let Some(exec) = editor.application_io.as_ref().unwrap().gpu_executor() {
 		use vello::*;
 

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -107,7 +107,6 @@ fn render_svg(data: impl GraphicElementRendered, mut render: SvgRender, render_p
 #[cfg(feature = "vello")]
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 async fn render_canvas(render_config: RenderConfig, data: impl GraphicElementRendered, editor: &WasmEditorApi, surface_handle: wgpu_executor::WgpuSurface) -> RenderOutput {
-	unimplemented!();
 	if let Some(exec) = editor.application_io.as_ref().unwrap().gpu_executor() {
 		use vello::*;
 

--- a/node-graph/interpreted-executor/src/dynamic_executor.rs
+++ b/node-graph/interpreted-executor/src/dynamic_executor.rs
@@ -107,15 +107,17 @@ impl<'a, I: StaticType + 'static + Send + Sync + std::panic::UnwindSafe> Executo
 	fn execute(&self, input: I) -> LocalFuture<Result<TaggedValue, Box<dyn Error>>> {
 		Box::pin(async move {
 			use futures::FutureExt;
+
 			let result = self.tree.eval_tagged_value(self.output, input);
 			let wrapped_result = std::panic::AssertUnwindSafe(result).catch_unwind().await;
+
 			match wrapped_result {
-				Ok(result) => return result.map_err(|e| e.into()),
+				Ok(result) => result.map_err(|e| e.into()),
 				Err(e) => {
 					Box::leak(e);
-					return Err("Node graph execution paniced".into());
+					Err("Node graph execution paniced".into())
 				}
-			};
+			}
 		})
 	}
 }

--- a/node-graph/interpreted-executor/src/dynamic_executor.rs
+++ b/node-graph/interpreted-executor/src/dynamic_executor.rs
@@ -10,6 +10,7 @@ use graph_craft::Type;
 
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::panic::UnwindSafe;
 use std::sync::Arc;
 
 /// An executor of a node graph that does not require an online compilation server, and instead uses `Box<dyn ...>`.
@@ -102,9 +103,20 @@ impl DynamicExecutor {
 	}
 }
 
-impl<'a, I: StaticType + 'static + Send + Sync> Executor<I, TaggedValue> for &'a DynamicExecutor {
+impl<'a, I: StaticType + 'static + Send + Sync + std::panic::UnwindSafe> Executor<I, TaggedValue> for &'a DynamicExecutor {
 	fn execute(&self, input: I) -> LocalFuture<Result<TaggedValue, Box<dyn Error>>> {
-		Box::pin(async move { self.tree.eval_tagged_value(self.output, input).await.map_err(|e| e.into()) })
+		Box::pin(async move {
+			use futures::FutureExt;
+			let result = self.tree.eval_tagged_value(self.output, input);
+			let wrapped_result = std::panic::AssertUnwindSafe(result).catch_unwind().await;
+			match wrapped_result {
+				Ok(result) => return result.map_err(|e| e.into()),
+				Err(e) => {
+					Box::leak(e);
+					return Err("Node graph execution paniced".into());
+				}
+			};
+		})
 	}
 }
 
@@ -176,7 +188,7 @@ impl BorrowTree {
 	}
 	/// Evaluate the output node of the [`BorrowTree`] and cast it to a tagged value.
 	/// This ensures that no borrowed data can escape the node graph.
-	pub async fn eval_tagged_value<I: StaticType + 'static + Send + Sync>(&self, id: NodeId, input: I) -> Result<TaggedValue, String> {
+	pub async fn eval_tagged_value<I: StaticType + 'static + Send + Sync + UnwindSafe>(&self, id: NodeId, input: I) -> Result<TaggedValue, String> {
 		let node = self.nodes.get(&id).cloned().ok_or("Output node not found in executor")?;
 		let output = node.eval(Box::new(input));
 		TaggedValue::try_from_any(output.await)


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
This implements panic catching for native targets using the rust std `catch_unwind` function. As this does not work on wasm yet: https://github.com/rust-lang/rust/issues/118168, I've implemented a hacky workaround which should give the user the ability to still save their work when the editor crashes and recover some of their work
