### PR TITLE
Serialize documents with images in linear space instead of sRGB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rustybuzz 0.17.0",
  "serde",
+ "serde_json",
  "specta",
  "spirv-std",
  "tokio",

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -73,6 +73,7 @@ image = { workspace = true, optional = true, default-features = false, features 
 [dev-dependencies]
 # Workspace dependencies
 tokio = { workspace = true, features = ["rt", "macros"] }
+serde_json = { workspace = true }
 
 [lints.rust]
 # the spirv target is not in the list of common cfgs so must be added manually


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1851 

Breaking: This changes the document format for images and will break existing save files
