### PR TITLE
Correctly set the dimensions of the SVG foreignObject container for the Vello canvas

### DIFF
--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -110,6 +110,8 @@ fn render_svg(data: impl GraphicElementRendered, mut render: SvgRender, render_p
 #[cfg(feature = "vello")]
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 async fn render_canvas(render_config: RenderConfig, data: impl GraphicElementRendered, editor: &WasmEditorApi, surface_handle: wgpu_executor::WgpuSurface) -> RenderOutput {
+	use graphene_core::SurfaceFrame;
+
 	if let Some(exec) = editor.application_io.as_ref().unwrap().gpu_executor() {
 		use vello::*;
 
@@ -129,11 +131,12 @@ async fn render_canvas(render_config: RenderConfig, data: impl GraphicElementRen
 	} else {
 		unreachable!("Attempted to render with Vello when no GPU executor is available");
 	}
-	let frame = graphene_core::application_io::SurfaceHandleFrame {
-		surface_handle,
+	let frame = SurfaceFrame {
+		surface_id: surface_handle.window_id,
+		resolution: render_config.viewport.resolution,
 		transform: glam::DAffine2::IDENTITY,
 	};
-	RenderOutput::CanvasFrame(frame.into())
+	RenderOutput::CanvasFrame(frame)
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -523,7 +523,10 @@ impl WgpuExecutor {
 
 		Ok(SurfaceHandle {
 			window_id: window.window_id,
-			surface: Surface { inner: surface, ..Default::default() },
+			surface: Surface {
+				inner: surface,
+				resolution: UVec2::ZERO,
+			},
 		})
 	}
 }

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -510,7 +510,10 @@ impl WgpuExecutor {
 
 		Ok(SurfaceHandle {
 			window_id: canvas.window_id,
-			surface: Surface { inner: surface, ..Default::default() },
+			surface: Surface {
+				inner: surface,
+				resolution: UVec2::ZERO,
+			},
 		})
 	}
 	#[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Closes #1872 

Fixes a remaining bug from the previous PR where enabling Vello before opening a document would make it default to the footprint's 1920x1080 resolution and get stuck with that.