### PR TITLE
Add grid snapping to graph imports/exports; improve layer panel drag into/between insertion; better preserve graph space on reordering

### DIFF
--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -1,5 +1,7 @@
 // Graph
 pub const GRID_SIZE: u32 = 24;
+pub const EXPORTS_TO_EDGE_PIXEL_GAP: u32 = 120;
+pub const IMPORTS_TO_EDGE_PIXEL_GAP: u32 = 120;
 
 // Viewport
 pub const VIEWPORT_ZOOM_WHEEL_RATE: f64 = (1. / 600.) * 3.;

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -31,6 +31,7 @@ impl MessageHandler<InputPreprocessorMessage, InputPreprocessorMessageData> for 
 					self.viewport_bounds = bounds;
 
 					responses.add(NavigationMessage::CanvasPan { delta: DVec2::ZERO });
+					responses.add(NodeGraphMessage::SetGridAlignedEdges);
 				}
 			}
 			InputPreprocessorMessage::DoubleClick { editor_mouse_state, modifier_keys } => {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -444,6 +444,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				// Update the tilt menu bar buttons to be disabled when the graph is open
 				responses.add(MenuBarMessage::SendLayout);
 				if open {
+					responses.add(NodeGraphMessage::SetGridAlignedEdges);
 					responses.add(NodeGraphMessage::SendGraph);
 					responses.add(NavigationMessage::CanvasTiltSet { angle_radians: 0. });
 				}

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -415,6 +415,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					self.selection_network_path.clone_from(&self.breadcrumb_network_path);
 				}
 				responses.add(DocumentMessage::PTZUpdate);
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 				responses.add(NodeGraphMessage::SendGraph);
 			}
 			DocumentMessage::FlipSelectedLayers { flip_axis } => {
@@ -1036,11 +1037,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					let transform = self
 						.navigation_handler
 						.calculate_offset_transform(ipp.viewport_bounds.center(), &network_metadata.persistent_metadata.navigation_metadata.node_graph_ptz);
-					self.network_interface.set_transform(
-						transform,
-						DVec2::new(ipp.viewport_bounds.bottom_right.x - ipp.viewport_bounds.top_left.x, 0.),
-						&self.breadcrumb_network_path,
-					);
+					self.network_interface.set_transform(transform, &self.breadcrumb_network_path);
 					let imports = self.network_interface.frontend_imports(&self.breadcrumb_network_path).unwrap_or_default();
 					let exports = self.network_interface.frontend_exports(&self.breadcrumb_network_path).unwrap_or_default();
 					responses.add(DocumentMessage::RenderRulers);

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -585,7 +585,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					return;
 				}
 
-				let layers_to_move = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
+				let layers_to_move = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
 
 				for layer_to_move in layers_to_move.into_iter().rev() {
 					responses.add(NodeGraphMessage::MoveLayerToStack {
@@ -600,15 +600,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			}
 			DocumentMessage::MoveSelectedLayersToGroup { parent } => {
 				// Group all shallowest unique selected layers in order
-				let all_layers_to_group = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
-
-				// Ensure nodes are grouped in the correct order
-				let mut all_layers_to_group_sorted = Vec::new();
-				for descendant in LayerNodeIdentifier::ROOT_PARENT.descendants(self.metadata()) {
-					if all_layers_to_group.contains(&descendant) {
-						all_layers_to_group_sorted.push(descendant);
-					};
-				}
+				let all_layers_to_group_sorted = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
 
 				for layer_to_group in all_layers_to_group_sorted.into_iter().rev() {
 					responses.add(NodeGraphMessage::MoveLayerToStack {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2,7 +2,7 @@ use super::node_graph::utility_types::Transform;
 use super::utility_types::clipboards::Clipboard;
 use super::utility_types::error::EditorError;
 use super::utility_types::misc::{SnappingOptions, SnappingState, GET_SNAP_BOX_FUNCTIONS, GET_SNAP_GEOMETRY_FUNCTIONS};
-use super::utility_types::network_interface::{self, NodeNetworkInterface};
+use super::utility_types::network_interface::NodeNetworkInterface;
 use super::utility_types::nodes::{CollapsedLayers, SelectedNodes};
 use crate::application::{generate_uuid, GRAPHITE_GIT_COMMIT_HASH};
 use crate::consts::{ASYMPTOTIC_EFFECT, DEFAULT_DOCUMENT_NAME, FILE_SAVE_SUFFIX, SCALE_EFFECT, SCROLLBAR_SPACING, VIEWPORT_ROTATE_SNAP_INTERVAL};

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -172,6 +172,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 					true => (-ipp.mouse.scroll_delta.y, 0.).into(),
 				} * VIEWPORT_SCROLL_RATE;
 				responses.add(NavigationMessage::CanvasPan { delta });
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 			}
 			NavigationMessage::CanvasTiltResetAndZoomTo100Percent => {
 				let Some(ptz) = get_ptz_mut(document_ptz, network_interface, graph_view_overlay_open, breadcrumb_network_path) else {
@@ -182,9 +183,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 				ptz.set_zoom(1.);
 				responses.add(PortfolioMessage::UpdateDocumentWidgets);
 				responses.add(DocumentMessage::PTZUpdate);
-				if graph_view_overlay_open {
-					responses.add(NodeGraphMessage::SetGridAlignedEdges);
-				}
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 			}
 			NavigationMessage::CanvasTiltSet { angle_radians } => {
 				let Some(ptz) = get_ptz_mut(document_ptz, network_interface, graph_view_overlay_open, breadcrumb_network_path) else {
@@ -255,9 +254,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 				ptz.set_zoom(zoom);
 				responses.add(PortfolioMessage::UpdateDocumentWidgets);
 				responses.add(DocumentMessage::PTZUpdate);
-				if graph_view_overlay_open {
-					responses.add(NodeGraphMessage::SetGridAlignedEdges);
-				}
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 			}
 			NavigationMessage::EndCanvasPTZ { abort_transform } => {
 				let Some(ptz) = get_ptz_mut(document_ptz, network_interface, graph_view_overlay_open, breadcrumb_network_path) else {
@@ -284,9 +281,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 				ptz.tilt = self.snapped_tilt(ptz.tilt);
 				ptz.set_zoom(self.snapped_zoom(ptz.zoom()));
 				responses.add(DocumentMessage::PTZUpdate);
-				if graph_view_overlay_open {
-					responses.add(NodeGraphMessage::SetGridAlignedEdges);
-				}
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 				// Reset the navigation operation now that it's done
 				self.navigation_operation = NavigationOperation::None;
 
@@ -343,9 +338,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 
 				responses.add(PortfolioMessage::UpdateDocumentWidgets);
 				responses.add(DocumentMessage::PTZUpdate);
-				if graph_view_overlay_open {
-					responses.add(NodeGraphMessage::SetGridAlignedEdges);
-				}
+				responses.add(NodeGraphMessage::SetGridAlignedEdges);
 			}
 			NavigationMessage::FitViewportToSelection => {
 				if let Some(bounds) = selection_bounds {
@@ -430,9 +423,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 						};
 
 						responses.add(NavigationMessage::CanvasZoomSet { zoom_factor: ptz.zoom() });
-						if graph_view_overlay_open {
-							responses.add(NodeGraphMessage::SetGridAlignedEdges);
-						}
+						responses.add(NodeGraphMessage::SetGridAlignedEdges);
 					}
 				}
 

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -40,6 +40,7 @@ pub enum NodeGraphMessage {
 	DisconnectInput {
 		input_connector: InputConnector,
 	},
+	DisconnectRootNode,
 	EnterNestedNetwork,
 	DuplicateSelectedNodes,
 	ExposeInput {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -93,6 +93,7 @@ pub enum NodeGraphMessage {
 	SendClickTargets,
 	EndSendClickTargets,
 	SendGraph,
+	SetGridAlignedEdges,
 	SetInputValue {
 		node_id: NodeId,
 		input_index: usize,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -965,6 +965,13 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					responses.add(NodeGraphMessage::SendSelectedNodes);
 				}
 			}
+			NodeGraphMessage::SetGridAlignedEdges => {
+				network_interface.set_grid_aligned_edges(DVec2::new(ipp.viewport_bounds.bottom_right.x - ipp.viewport_bounds.top_left.x, 0.), breadcrumb_network_path);
+				// Send the new edges to the frontend
+				let imports = network_interface.frontend_imports(breadcrumb_network_path).unwrap_or_default();
+				let exports = network_interface.frontend_exports(breadcrumb_network_path).unwrap_or_default();
+				responses.add(FrontendMessage::UpdateImportsExports { imports, exports });
+			}
 			NodeGraphMessage::SetInputValue { node_id, input_index, value } => {
 				let input = NodeInput::value(value, false);
 				responses.add(NodeGraphMessage::SetInput {
@@ -1071,7 +1078,6 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				if is_layer && !network_interface.is_eligible_to_be_layer(&node_id, selection_network_path) {
 					return;
 				}
-
 				network_interface.set_to_node_or_layer(&node_id, selection_network_path, is_layer);
 
 				self.context_menu = None;

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -963,11 +963,13 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				}
 			}
 			NodeGraphMessage::SetGridAlignedEdges => {
-				network_interface.set_grid_aligned_edges(DVec2::new(ipp.viewport_bounds.bottom_right.x - ipp.viewport_bounds.top_left.x, 0.), breadcrumb_network_path);
-				// Send the new edges to the frontend
-				let imports = network_interface.frontend_imports(breadcrumb_network_path).unwrap_or_default();
-				let exports = network_interface.frontend_exports(breadcrumb_network_path).unwrap_or_default();
-				responses.add(FrontendMessage::UpdateImportsExports { imports, exports });
+				if graph_view_overlay_open {
+					network_interface.set_grid_aligned_edges(DVec2::new(ipp.viewport_bounds.bottom_right.x - ipp.viewport_bounds.top_left.x, 0.), breadcrumb_network_path);
+					// Send the new edges to the frontend
+					let imports = network_interface.frontend_imports(breadcrumb_network_path).unwrap_or_default();
+					let exports = network_interface.frontend_exports(breadcrumb_network_path).unwrap_or_default();
+					responses.add(FrontendMessage::UpdateImportsExports { imports, exports });
+				}
 			}
 			NodeGraphMessage::SetInputValue { node_id, input_index, value } => {
 				let input = NodeInput::value(value, false);

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -444,9 +444,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					} else {
 						network_interface.upstream_output_connector(clicked_input, selection_network_path)
 					};
-					let Some(output_connector) = output_connector else {
-						return;
-					};
+					let Some(output_connector) = output_connector else { return };
 					self.wire_in_progress_from_connector = network_interface.output_position(&output_connector, selection_network_path);
 					return;
 				}

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -563,11 +563,8 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 						if let Some(disconnecting) = &self.disconnecting {
 							responses.add(DocumentMessage::StartTransaction);
 							let mut disconnect_root_node = false;
-							if let Previewing::Yes {
-								root_node_to_restore: Some(root_node_to_restore),
-							} = network_interface.previewing(selection_network_path)
-							{
-								if *disconnecting == InputConnector::Export(0) {
+							if let Previewing::Yes { root_node_to_restore } = network_interface.previewing(selection_network_path) {
+								if root_node_to_restore.is_some() && *disconnecting == InputConnector::Export(0) {
 									disconnect_root_node = true;
 								}
 							}

--- a/editor/src/messages/portfolio/document/node_graph/utility_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/utility_types.rs
@@ -178,4 +178,6 @@ pub struct FrontendClickTargets {
 	pub visibility_click_targets: Vec<String>,
 	#[serde(rename = "allNodesBoundingBox")]
 	pub all_nodes_bounding_box: String,
+	#[serde(rename = "importExportsBoundingBox")]
+	pub import_exports_bounding_box: String,
 }

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -284,10 +284,10 @@ impl LayerNodeIdentifier {
 		}
 	}
 
-	pub fn upstream_siblings(self, metadata: &DocumentMetadata) -> AxisIter {
+	pub fn downstream_siblings(self, metadata: &DocumentMetadata) -> AxisIter {
 		AxisIter {
 			layer_node: Some(self),
-			next_node: Self::next_sibling,
+			next_node: Self::previous_sibling,
 			metadata,
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -2466,21 +2466,7 @@ impl NodeNetworkInterface {
 
 		let value_input = NodeInput::value(tagged_value, true);
 
-		if matches!(input_connector, InputConnector::Node { .. }) {
-			self.set_input(input_connector, value_input, network_path);
-		} else {
-			// TODO: Allow the user to drag the solid line when previewing
-			// This causes a crash since when ending preview the NodeInput::Node to the previewed node needs to be disconnected.
-			// Since it is only possible to drag the solid line, if previewing then there must be a dashed connection, which becomes the new export
-			// if matches!(self.previewing(network_path), Previewing::Yes { .. }) {
-			// 	self.start_previewing_without_restore(network_path);
-			// }
-			// // If there is no preview, then disconnect
-			// else {
-			// 	self.set_input(input_connector, value_input, network_path);
-			// }
-			self.set_input(input_connector, value_input, network_path);
-		}
+		self.set_input(input_connector, value_input, network_path);
 	}
 
 	pub fn create_wire(&mut self, output_connector: &OutputConnector, input_connector: &InputConnector, network_path: &[NodeId]) {
@@ -2714,7 +2700,7 @@ impl NodeNetworkInterface {
 		true
 	}
 
-	fn start_previewing_without_restore(&mut self, network_path: &[NodeId]) {
+	pub fn start_previewing_without_restore(&mut self, network_path: &[NodeId]) {
 		// Some logic will have to be performed to prevent the graph positions from being completely changed when the export changes to some previewed node
 		let Some(network_metadata) = self.network_metadata_mut(network_path) else {
 			log::error!("Could not get nested network_metadata in start_previewing_without_restore");

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -856,6 +856,18 @@ impl NodeNetworkInterface {
 		})
 	}
 
+	pub fn shallowest_unique_layers_sorted(&self, network_path: &[NodeId]) -> Vec<LayerNodeIdentifier> {
+		let all_layers_to_group = self.shallowest_unique_layers(network_path).collect::<Vec<_>>();
+		// Ensure nodes are grouped in the correct order
+		let mut all_layers_to_group_sorted = Vec::new();
+		for descendant in LayerNodeIdentifier::ROOT_PARENT.descendants(self.document_metadata()) {
+			if all_layers_to_group.contains(&descendant) {
+				all_layers_to_group_sorted.push(descendant);
+			};
+		}
+		all_layers_to_group_sorted
+	}
+
 	/// Ancestor that is shared by all layers and that is deepest (more nested). Default may be the root. Skips selected non-folder, non-artboard layers
 	pub fn deepest_common_ancestor(&self, network_path: &[NodeId], include_self: bool) -> Option<LayerNodeIdentifier> {
 		if !network_path.is_empty() {
@@ -3256,8 +3268,6 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		log::debug!("moved layer position: {position:?}");
-		log::debug!("Previous upstream layer: {previous_upstream_layer:?}");
 		match &position {
 			LayerPosition::Stack(offset) => {
 				if let Some(previous_upstream_layer) = previous_upstream_layer {
@@ -3267,7 +3277,6 @@ impl NodeNetworkInterface {
 			}
 			LayerPosition::Absolute(stack_top_position) => {
 				if let Some(previous_upstream_layer) = previous_upstream_layer {
-					log::debug!("Setting previous upstream layer to stack top position");
 					self.set_absolute_position(&previous_upstream_layer, *stack_top_position, network_path);
 					self.unload_upstream_node_click_targets(vec![previous_upstream_layer], network_path);
 				}

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -553,7 +553,16 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					};
 					// If the downstream node is a layer and the input is the first input and the current layer is not in a stack
 					if input_index == 0 && document.network_interface.is_layer(&downstream_node, &[]) && document.network_interface.is_absolute(&layer.to_node(), &[]) {
-						document.network_interface.set_stack_position_calculated_offset(&layer.to_node(), &downstream_node, &[]);
+						// Ensure the layer is horizontally aligned with the downstream layer to prevent changing the layout of old files
+						let (Some(layer_position), Some(downstream_position)) =
+							(document.network_interface.position(&layer.to_node(), &[]), document.network_interface.position(&downstream_node, &[]))
+						else {
+							log::error!("Could not get position for layer {:?} or downstream node {} when opening file", layer.to_node(), downstream_node);
+							continue;
+						};
+						if layer_position.x == downstream_position.x {
+							document.network_interface.set_stack_position_calculated_offset(&layer.to_node(), &downstream_node, &[]);
+						}
 					}
 				}
 

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -380,7 +380,11 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				let upgrade_vector_manipulation_format = document_serialized_content.contains("ManipulatorGroupIds") && !document_name.contains("__DO_NOT_UPGRADE__");
 				let document_name = document_name.replace("__DO_NOT_UPGRADE__", "");
 
-				let document = DocumentMessageHandler::with_name_and_content(document_name.clone(), document_serialized_content);
+				let document = DocumentMessageHandler::deserialize_document(&document_serialized_content).map(|mut document| {
+					document.name = document_name.clone();
+					document
+				});
+
 				let mut document = match document {
 					Ok(document) => document,
 					Err(e) => {

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -549,15 +549,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					};
 					// If the downstream node is a layer and the input is the first input and the current layer is not in a stack
 					if input_index == 0 && document.network_interface.is_layer(&downstream_node, &[]) && document.network_interface.is_absolute(&layer.to_node(), &[]) {
-						let (Some(layer_position), Some(downstream_position)) =
-							(document.network_interface.position(&layer.to_node(), &[]), document.network_interface.position(&downstream_node, &[]))
-						else {
-							log::error!("Could not get downstream node position in PortfolioMessage::OpenDocumentFileWithId");
-							return;
-						};
-						document
-							.network_interface
-							.set_stack_position(&layer.to_node(), (layer_position.y - downstream_position.y - 3).max(0) as u32, &[]);
+						document.network_interface.set_stack_position_calculated_offset(&layer.to_node(), &downstream_node, &[]);
 					}
 				}
 

--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -514,6 +514,7 @@
 					handlePosition={scrollbarPos.x}
 					on:handlePosition={({ detail }) => panCanvasX(detail)}
 					on:pressTrack={({ detail }) => pageX(detail)}
+					on:pointerup={() => editor.handle.setGridAlignedEdges()}
 				/>
 			</LayoutRow>
 		</LayoutCol>

--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -449,6 +449,7 @@
 					<path class="visibility" d={pathString} />
 				{/each}
 				<path class="all-nodes-bounding-box" d={$nodeGraph.clickTargets.allNodesBoundingBox} />
+				<path class="all-nodes-bounding-box" d={$nodeGraph.clickTargets.importExportsBoundingBox} />
 			</svg>
 		</div>
 	{/if}

--- a/frontend/src/components/widgets/inputs/ScrollbarInput.svelte
+++ b/frontend/src/components/widgets/inputs/ScrollbarInput.svelte
@@ -14,7 +14,7 @@
 
 	const pointerPosition = (direction: ScrollbarDirection, e: PointerEvent): number => (direction === "Vertical" ? e.clientY : e.clientX);
 
-	const dispatch = createEventDispatcher<{ handlePosition: number; pressTrack: number }>();
+	const dispatch = createEventDispatcher<{ handlePosition: number; pressTrack: number; pointerup }>();
 
 	export let direction: ScrollbarDirection = "Vertical";
 	export let handlePosition = 0.5;
@@ -102,7 +102,7 @@
 	});
 </script>
 
-<div class={`scrollbar-input ${direction.toLowerCase()}`}>
+<div class={`scrollbar-input ${direction.toLowerCase()}`} on:pointerup={() => dispatch("pointerup")}>
 	<button class="arrow decrease" on:pointerdown={() => changePosition(-50)} tabindex="-1" />
 	<div class="scroll-track" bind:this={scrollTrack} on:pointerdown={grabArea}>
 		<div class="scroll-thumb" on:pointerdown={grabHandle} class:dragging style:top={thumbTop} style:bottom={thumbBottom} style:left={thumbLeft} style:right={thumbRight} />

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -172,6 +172,7 @@ export type FrontendClickTargets = {
 	readonly portClickTargets: string[];
 	readonly visibilityClickTargets: string[];
 	readonly allNodesBoundingBox: string;
+	readonly importExportsBoundingBox: string;
 };
 
 export type ContextMenuInformation = {

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -564,6 +564,13 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 
+	/// Snaps the import/export edges to a grid space when the scroll bar is released
+	#[wasm_bindgen(js_name = setGridAlignedEdges)]
+	pub fn set_grid_aligned_edges(&self) {
+		let message = NodeGraphMessage::SetGridAlignedEdges;
+		self.dispatch(message);
+	}
+
 	/// Creates a new document node in the node graph
 	#[wasm_bindgen(js_name = createNode)]
 	pub fn create_node(&self, node_type: String, x: i32, y: i32) {


### PR DESCRIPTION
Reworks the default positioning system when moving nodes in the layer panel, mostly by ensuring that node gap positioning is correctly maintained. Each layer is the height of that layer plus the height to the next layer below. Fixes all edge cases when moving layers or different groups of selected layers to any other location. Also improves the previewing system and import/export edges

Todo:
- Fix crash when deleting all nodes inside a network
- Create space when moving layers to different stacks