### PR TITLE
Shift layers in stack as blocks

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -649,10 +649,11 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			} => {
 				self.backup(responses);
 				if self.graph_view_overlay_open {
+					self.node_graph_handler.load_upstream_nodes_below_layers(&mut self.network_interface, &self.selection_network_path);
 					responses.add(NodeGraphMessage::ShiftNodes {
 						node_ids: self.network_interface.selected_nodes(&[]).unwrap().selected_nodes().cloned().collect(),
-						displacement_x: delta_x.signum() as i32,
-						displacement_y: delta_y.signum() as i32,
+						displacement_x: if delta_x == 0. { 0 } else { delta_x.signum() as i32 },
+						displacement_y: if delta_y == 0. { 0 } else { delta_y.signum() as i32 },
 						move_upstream: ipp.keyboard.get(Key::Shift as usize),
 					});
 					return;

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -552,7 +552,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 						continue;
 					};
 					// If the downstream node is a layer and the input is the first input and the current layer is not in a stack
-					if input_index == 0 && document.network_interface.is_layer(&downstream_node, &[]) && document.network_interface.is_absolute(&layer.to_node(), &[]) {
+					if input_index == 0 && document.network_interface.is_layer(&downstream_node, &[]) && !document.network_interface.is_stack(&layer.to_node(), &[]) {
 						// Ensure the layer is horizontally aligned with the downstream layer to prevent changing the layout of old files
 						let (Some(layer_position), Some(downstream_position)) =
 							(document.network_interface.position(&layer.to_node(), &[]), document.network_interface.position(&downstream_node, &[]))


### PR DESCRIPTION
Closes #1932

When shifting layers in a stack, nodes above and below will be pushed in order to prevent overlap.