### PR TITLE
Improve layer positioning in graph upon reordering; improve history system; add selection history

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
 		// Rust
 		"rust-lang.rust-analyzer",
 		"tamasfe.even-better-toml",
-		"serayuzgur.crates",
 		// Web
 		"dbaeumer.vscode-eslint",
 		"svelte.svelte-vscode",
@@ -16,6 +15,6 @@
 		"mhutchie.git-graph",
 		"waderyan.gitblame",
 		"qezhu.gitlink",
-		"wmaurer.change-case",
+		"wmaurer.change-case"
 	]
 }

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -306,8 +306,8 @@ pub fn input_mappings() -> Mapping {
 		// DocumentMessage
 		entry!(KeyDown(Space); modifiers=[Control], action_dispatch=DocumentMessage::GraphViewOverlayToggle),
 		entry!(KeyUp(Escape); action_dispatch=DocumentMessage::Escape),
-		entry!(KeyDown(Delete); action_dispatch=DocumentMessage::DeleteSelectedLayers),
-		entry!(KeyDown(Backspace); action_dispatch=DocumentMessage::DeleteSelectedLayers),
+		entry!(KeyDown(Delete); action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: true }),
+		entry!(KeyDown(Backspace); action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: true }),
 		entry!(KeyDown(KeyP); modifiers=[Alt], action_dispatch=DocumentMessage::DebugPrintDocument),
 		entry!(KeyDown(KeyO); modifiers=[Alt], action_dispatch=DocumentMessage::ToggleOverlaysVisibility),
 		entry!(KeyDown(KeyS); modifiers=[Alt], action_dispatch=DocumentMessage::ToggleSnapping),

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -306,8 +306,8 @@ pub fn input_mappings() -> Mapping {
 		// DocumentMessage
 		entry!(KeyDown(Space); modifiers=[Control], action_dispatch=DocumentMessage::GraphViewOverlayToggle),
 		entry!(KeyUp(Escape); action_dispatch=DocumentMessage::Escape),
-		entry!(KeyDown(Delete); action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: true }),
-		entry!(KeyDown(Backspace); action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: true }),
+		entry!(KeyDown(Delete); action_dispatch=DocumentMessage::DeleteSelectedLayers),
+		entry!(KeyDown(Backspace); action_dispatch=DocumentMessage::DeleteSelectedLayers),
 		entry!(KeyDown(KeyP); modifiers=[Alt], action_dispatch=DocumentMessage::DebugPrintDocument),
 		entry!(KeyDown(KeyO); modifiers=[Alt], action_dispatch=DocumentMessage::ToggleOverlaysVisibility),
 		entry!(KeyDown(KeyS); modifiers=[Alt], action_dispatch=DocumentMessage::ToggleSnapping),

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -323,6 +323,8 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(KeyG); modifiers=[Accel], action_dispatch=DocumentMessage::GroupSelectedLayers),
 		entry!(KeyDown(KeyG); modifiers=[Accel, Shift], action_dispatch=DocumentMessage::UngroupSelectedLayers),
 		entry!(KeyDown(KeyN); modifiers=[Accel, Shift], action_dispatch=DocumentMessage::CreateEmptyFolder),
+		entry!(KeyDown(BracketRight); modifiers=[Alt], action_dispatch=DocumentMessage::SelectionStepForward),
+		entry!(KeyDown(BracketLeft); modifiers=[Alt], action_dispatch=DocumentMessage::SelectionStepBack),
 		entry!(KeyDown(Digit0); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasToFitAll),
 		entry!(KeyDown(Digit1); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasTo100Percent),
 		entry!(KeyDown(Digit2); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasTo200Percent),

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -37,31 +37,31 @@ pub fn input_mappings() -> Mapping {
 		//
 		// NavigationMessage
 		entry!(PointerMove; refresh_keys=[Control], action_dispatch=NavigationMessage::PointerMove { snap: Control }),
-		entry!(KeyUp(Lmb); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
-		entry!(KeyUp(Mmb); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
-		entry!(KeyUp(Rmb); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
-		entry!(KeyDown(Rmb); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: true }),
+		entry!(KeyUp(MouseLeft); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
+		entry!(KeyUp(MouseMiddle); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
+		entry!(KeyUp(MouseRight); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: false }),
+		entry!(KeyDown(MouseRight); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: true }),
 		entry!(KeyDown(Escape); action_dispatch=NavigationMessage::EndCanvasPTZ { abort_transform: true }),
-		entry!(KeyDown(Lmb); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: Lmb }),
-		entry!(KeyDown(Mmb); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: Mmb }),
-		entry!(KeyDown(Rmb); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: Rmb }),
+		entry!(KeyDown(MouseLeft); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: MouseLeft }),
+		entry!(KeyDown(MouseMiddle); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: MouseMiddle }),
+		entry!(KeyDown(MouseRight); action_dispatch=NavigationMessage::EndCanvasPTZWithClick { commit_key: MouseRight }),
 		//
 		// ===============
 		// NORMAL PRIORITY
 		// ===============
 		//
-		// Hack to prevent LMB + CTRL (OPTION) + Z combo (this effectively blocks you from making a double undo with AbortTransaction)
-		entry!(KeyDown(KeyZ); modifiers=[Accel, Lmb], action_dispatch=DocumentMessage::Noop),
+		// Hack to prevent Left Click + Accel + Z combo (this effectively blocks you from making a double undo with AbortTransaction)
+		entry!(KeyDown(KeyZ); modifiers=[Accel, MouseLeft], action_dispatch=DocumentMessage::Noop),
 		// NodeGraphMessage
-		entry!(KeyDown(Lmb); action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: false, right_click: false}),
-		entry!(KeyDown(Lmb); modifiers=[Shift], action_dispatch=NodeGraphMessage::PointerDown {shift_click: true, control_click: false, alt_click: false, right_click: false}),
-		entry!(KeyDown(Lmb); modifiers=[Accel], action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: true, alt_click: false, right_click: false}),
-		entry!(KeyDown(Lmb); modifiers=[Shift, Accel], action_dispatch=NodeGraphMessage::PointerDown {shift_click: true, control_click: true, alt_click: false, right_click: false}),
-		entry!(KeyDown(Lmb); modifiers=[Alt], action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: true, right_click: false}),
-		entry!(KeyDown(Rmb); action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: false, right_click: true}),
+		entry!(KeyDown(MouseLeft); action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: false, right_click: false}),
+		entry!(KeyDown(MouseLeft); modifiers=[Shift], action_dispatch=NodeGraphMessage::PointerDown {shift_click: true, control_click: false, alt_click: false, right_click: false}),
+		entry!(KeyDown(MouseLeft); modifiers=[Accel], action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: true, alt_click: false, right_click: false}),
+		entry!(KeyDown(MouseLeft); modifiers=[Shift, Accel], action_dispatch=NodeGraphMessage::PointerDown {shift_click: true, control_click: true, alt_click: false, right_click: false}),
+		entry!(KeyDown(MouseLeft); modifiers=[Alt], action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: true, right_click: false}),
+		entry!(KeyDown(MouseRight); action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: false, right_click: true}),
 		entry!(DoubleClick(MouseButton::Left); action_dispatch=NodeGraphMessage::EnterNestedNetwork),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=NodeGraphMessage::PointerMove {shift: Shift}),
-		entry!(KeyUp(Lmb); action_dispatch=NodeGraphMessage::PointerUp),
+		entry!(KeyUp(MouseLeft); action_dispatch=NodeGraphMessage::PointerUp),
 		entry!(KeyDown(Delete); modifiers=[Accel], action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: false }),
 		entry!(KeyDown(Backspace); modifiers=[Accel], action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: false }),
 		entry!(KeyDown(Delete); action_dispatch=NodeGraphMessage::DeleteSelectedNodes { delete_children: true }),
@@ -82,8 +82,8 @@ pub fn input_mappings() -> Mapping {
 		//
 		// TransformLayerMessage
 		entry!(KeyDown(Enter); action_dispatch=TransformLayerMessage::ApplyTransformOperation),
-		entry!(KeyDown(Lmb); action_dispatch=TransformLayerMessage::ApplyTransformOperation),
-		entry!(KeyDown(Rmb); action_dispatch=TransformLayerMessage::CancelTransformOperation),
+		entry!(KeyDown(MouseLeft); action_dispatch=TransformLayerMessage::ApplyTransformOperation),
+		entry!(KeyDown(MouseRight); action_dispatch=TransformLayerMessage::CancelTransformOperation),
 		entry!(KeyDown(Escape); action_dispatch=TransformLayerMessage::CancelTransformOperation),
 		entry!(KeyDown(KeyX); action_dispatch=TransformLayerMessage::ConstrainX),
 		entry!(KeyDown(KeyY); action_dispatch=TransformLayerMessage::ConstrainY),
@@ -95,17 +95,17 @@ pub fn input_mappings() -> Mapping {
 		//
 		// SelectToolMessage
 		entry!(PointerMove; refresh_keys=[Control, Alt, Shift], action_dispatch=SelectToolMessage::PointerMove(SelectToolPointerKeys { axis_align: Shift, snap_angle: Control, center: Alt, duplicate: Alt })),
-		entry!(KeyDown(Lmb); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, select_deepest: Accel }),
-		entry!(KeyUp(Lmb); action_dispatch=SelectToolMessage::DragStop { remove_from_selection: Shift }),
+		entry!(KeyDown(MouseLeft); action_dispatch=SelectToolMessage::DragStart { add_to_selection: Shift, select_deepest: Accel }),
+		entry!(KeyUp(MouseLeft); action_dispatch=SelectToolMessage::DragStop { remove_from_selection: Shift }),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::Enter),
 		entry!(DoubleClick(MouseButton::Left); action_dispatch=SelectToolMessage::EditLayer),
-		entry!(KeyDown(Rmb); action_dispatch=SelectToolMessage::Abort),
+		entry!(KeyDown(MouseRight); action_dispatch=SelectToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=SelectToolMessage::Abort),
 		//
 		// ArtboardToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=ArtboardToolMessage::PointerDown),
+		entry!(KeyDown(MouseLeft); action_dispatch=ArtboardToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift, Alt], action_dispatch=ArtboardToolMessage::PointerMove { constrain_axis_or_aspect: Shift, center: Alt }),
-		entry!(KeyUp(Lmb); action_dispatch=ArtboardToolMessage::PointerUp),
+		entry!(KeyUp(MouseLeft); action_dispatch=ArtboardToolMessage::PointerUp),
 		entry!(KeyDown(Delete); action_dispatch=ArtboardToolMessage::DeleteSelected),
 		entry!(KeyDown(Backspace); action_dispatch=ArtboardToolMessage::DeleteSelected),
 		entry!(KeyDown(ArrowUp); modifiers=[Shift, ArrowLeft], action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: -BIG_NUDGE_AMOUNT, delta_y: -BIG_NUDGE_AMOUNT }),
@@ -132,72 +132,72 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowUp], action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: -NUDGE_AMOUNT }),
 		entry!(KeyDown(ArrowRight); modifiers=[ArrowDown], action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: NUDGE_AMOUNT }),
 		entry!(KeyDown(ArrowRight); action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: 0. }),
-		entry!(KeyDown(Rmb); action_dispatch=ArtboardToolMessage::Abort),
+		entry!(KeyDown(MouseRight); action_dispatch=ArtboardToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=ArtboardToolMessage::Abort),
 		//
 		// NavigateToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=NavigateToolMessage::ZoomCanvasBegin),
-		entry!(KeyDown(Lmb); modifiers=[Alt], action_dispatch=NavigateToolMessage::TiltCanvasBegin),
+		entry!(KeyDown(MouseLeft); action_dispatch=NavigateToolMessage::ZoomCanvasBegin),
+		entry!(KeyDown(MouseLeft); modifiers=[Alt], action_dispatch=NavigateToolMessage::TiltCanvasBegin),
 		entry!(PointerMove; refresh_keys=[Control], action_dispatch=NavigateToolMessage::PointerMove { snap: Control }),
-		entry!(KeyUp(Lmb); action_dispatch=NavigateToolMessage::PointerUp { zoom_in: true }),
-		entry!(KeyUp(Lmb); modifiers=[Shift], action_dispatch=NavigateToolMessage::PointerUp { zoom_in: false }),
+		entry!(KeyUp(MouseLeft); action_dispatch=NavigateToolMessage::PointerUp { zoom_in: true }),
+		entry!(KeyUp(MouseLeft); modifiers=[Shift], action_dispatch=NavigateToolMessage::PointerUp { zoom_in: false }),
 		//
 		// EyedropperToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=EyedropperToolMessage::SamplePrimaryColorBegin),
-		entry!(KeyDown(Lmb); modifiers=[Shift], action_dispatch=EyedropperToolMessage::SampleSecondaryColorBegin),
-		entry!(KeyUp(Lmb); action_dispatch=EyedropperToolMessage::SamplePrimaryColorEnd),
-		entry!(KeyUp(Lmb); modifiers=[Shift], action_dispatch=EyedropperToolMessage::SampleSecondaryColorEnd),
+		entry!(KeyDown(MouseLeft); action_dispatch=EyedropperToolMessage::SamplePrimaryColorBegin),
+		entry!(KeyDown(MouseLeft); modifiers=[Shift], action_dispatch=EyedropperToolMessage::SampleSecondaryColorBegin),
+		entry!(KeyUp(MouseLeft); action_dispatch=EyedropperToolMessage::SamplePrimaryColorEnd),
+		entry!(KeyUp(MouseLeft); modifiers=[Shift], action_dispatch=EyedropperToolMessage::SampleSecondaryColorEnd),
 		entry!(PointerMove; action_dispatch=EyedropperToolMessage::PointerMove),
-		entry!(KeyDown(Rmb); action_dispatch=EyedropperToolMessage::Abort),
+		entry!(KeyDown(MouseRight); action_dispatch=EyedropperToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=EyedropperToolMessage::Abort),
 		//
 		// TextToolMessage
-		entry!(KeyUp(Lmb); action_dispatch=TextToolMessage::Interact),
+		entry!(KeyUp(MouseLeft); action_dispatch=TextToolMessage::Interact),
 		entry!(KeyDown(Escape); action_dispatch=TextToolMessage::Abort),
 		entry!(KeyDown(Enter); modifiers=[Accel], action_dispatch=TextToolMessage::CommitText),
 		//
 		// GradientToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=GradientToolMessage::PointerDown),
+		entry!(KeyDown(MouseLeft); action_dispatch=GradientToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
-		entry!(KeyUp(Lmb); action_dispatch=GradientToolMessage::PointerUp),
+		entry!(KeyUp(MouseLeft); action_dispatch=GradientToolMessage::PointerUp),
 		entry!(DoubleClick(MouseButton::Left); action_dispatch=GradientToolMessage::InsertStop),
 		entry!(KeyDown(Delete); action_dispatch=GradientToolMessage::DeleteStop),
 		entry!(KeyDown(Backspace); action_dispatch=GradientToolMessage::DeleteStop),
-		entry!(KeyDown(Rmb); action_dispatch=GradientToolMessage::Abort),
+		entry!(KeyDown(MouseRight); action_dispatch=GradientToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=GradientToolMessage::Abort),
 		//
 		// RectangleToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=RectangleToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=RectangleToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=RectangleToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=RectangleToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=RectangleToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=RectangleToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=RectangleToolMessage::Abort),
 		entry!(PointerMove; refresh_keys=[Alt, Shift], action_dispatch=RectangleToolMessage::PointerMove { center: Alt, lock_ratio: Shift }),
 		//
 		// ImaginateToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=ImaginateToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=ImaginateToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=ImaginateToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=ImaginateToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=ImaginateToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=ImaginateToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=ImaginateToolMessage::Abort),
 		entry!(PointerMove; refresh_keys=[Alt, Shift], action_dispatch=ImaginateToolMessage::Resize { center: Alt, lock_ratio: Shift }),
 		//
 		// EllipseToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=EllipseToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=EllipseToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=EllipseToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=EllipseToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=EllipseToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=EllipseToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=EllipseToolMessage::Abort),
 		entry!(PointerMove; refresh_keys=[Alt, Shift], action_dispatch=EllipseToolMessage::PointerMove { center: Alt, lock_ratio: Shift }),
 		//
 		// PolygonToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=PolygonToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=PolygonToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=PolygonToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=PolygonToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=PolygonToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=PolygonToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=PolygonToolMessage::Abort),
 		entry!(PointerMove; refresh_keys=[Alt, Shift], action_dispatch=PolygonToolMessage::PointerMove { center: Alt, lock_ratio: Shift }),
 		//
 		// LineToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=LineToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=LineToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=LineToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=LineToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=LineToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=LineToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=LineToolMessage::Abort),
 		entry!(PointerMove; refresh_keys=[Control, Alt, Shift], action_dispatch=LineToolMessage::PointerMove { center: Alt, lock_angle: Control, snap_angle: Shift }),
 		//
@@ -206,8 +206,8 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(Backspace); modifiers=[Accel], action_dispatch=PathToolMessage::DeleteAndBreakPath),
 		entry!(KeyDown(Delete); modifiers=[Accel, Shift], action_dispatch=PathToolMessage::BreakPath),
 		entry!(KeyDown(Backspace); modifiers=[Accel, Shift], action_dispatch=PathToolMessage::BreakPath),
-		entry!(KeyDown(Lmb); action_dispatch=PathToolMessage::MouseDown { ctrl: Control, shift: Shift }),
-		entry!(KeyDown(Rmb); action_dispatch=PathToolMessage::RightClick),
+		entry!(KeyDown(MouseLeft); action_dispatch=PathToolMessage::MouseDown { ctrl: Control, shift: Shift }),
+		entry!(KeyDown(MouseRight); action_dispatch=PathToolMessage::RightClick),
 		entry!(KeyDown(Escape); action_dispatch=PathToolMessage::Escape),
 		entry!(KeyDown(KeyG); action_dispatch=PathToolMessage::GRS { key: KeyG }),
 		entry!(KeyDown(KeyR); action_dispatch=PathToolMessage::GRS { key: KeyR }),
@@ -217,7 +217,7 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(KeyA); modifiers=[Accel], action_dispatch=PathToolMessage::SelectAllAnchors),
 		entry!(KeyDown(KeyA); modifiers=[Accel, Shift], action_dispatch=PathToolMessage::DeselectAllPoints),
 		entry!(KeyDown(Backspace); action_dispatch=PathToolMessage::Delete),
-		entry!(KeyUp(Lmb); action_dispatch=PathToolMessage::DragStop { equidistant: Shift }),
+		entry!(KeyUp(MouseLeft); action_dispatch=PathToolMessage::DragStop { equidistant: Shift }),
 		entry!(KeyDown(Enter); action_dispatch=PathToolMessage::Enter { add_to_selection: Shift }),
 		entry!(DoubleClick(MouseButton::Left); action_dispatch=PathToolMessage::FlipSmoothSharp),
 		entry!(KeyDown(ArrowRight); action_dispatch=PathToolMessage::NudgeSelectedPoints { delta_x: NUDGE_AMOUNT, delta_y: 0. }),
@@ -247,41 +247,41 @@ pub fn input_mappings() -> Mapping {
 		//
 		// PenToolMessage
 		entry!(PointerMove; refresh_keys=[Control, Alt, Shift], action_dispatch=PenToolMessage::PointerMove { snap_angle: Shift, break_handle: Alt, lock_angle: Control}),
-		entry!(KeyDown(Lmb); action_dispatch=PenToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=PenToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=PenToolMessage::Confirm),
+		entry!(KeyDown(MouseLeft); action_dispatch=PenToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=PenToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=PenToolMessage::Confirm),
 		entry!(KeyDown(Escape); action_dispatch=PenToolMessage::Confirm),
 		entry!(KeyDown(Enter); action_dispatch=PenToolMessage::Confirm),
 		//
 		// FreehandToolMessage
 		entry!(PointerMove; action_dispatch=FreehandToolMessage::PointerMove),
-		entry!(KeyDown(Lmb); action_dispatch=FreehandToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=FreehandToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=FreehandToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=FreehandToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=FreehandToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=FreehandToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=FreehandToolMessage::Abort),
 		//
 		// SplineToolMessage
 		entry!(PointerMove; action_dispatch=SplineToolMessage::PointerMove),
-		entry!(KeyDown(Lmb); action_dispatch=SplineToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=SplineToolMessage::DragStop),
-		entry!(KeyDown(Rmb); action_dispatch=SplineToolMessage::Confirm),
+		entry!(KeyDown(MouseLeft); action_dispatch=SplineToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=SplineToolMessage::DragStop),
+		entry!(KeyDown(MouseRight); action_dispatch=SplineToolMessage::Confirm),
 		entry!(KeyDown(Escape); action_dispatch=SplineToolMessage::Confirm),
 		entry!(KeyDown(Enter); action_dispatch=SplineToolMessage::Confirm),
 		//
 		// FillToolMessage
-		entry!(KeyDown(Lmb); action_dispatch=FillToolMessage::FillPrimaryColor),
-		entry!(KeyDown(Lmb); modifiers=[Shift], action_dispatch=FillToolMessage::FillSecondaryColor),
-		entry!(KeyUp(Lmb); action_dispatch=FillToolMessage::PointerUp),
-		entry!(KeyDown(Rmb); action_dispatch=FillToolMessage::Abort),
+		entry!(KeyDown(MouseLeft); action_dispatch=FillToolMessage::FillPrimaryColor),
+		entry!(KeyDown(MouseLeft); modifiers=[Shift], action_dispatch=FillToolMessage::FillSecondaryColor),
+		entry!(KeyUp(MouseLeft); action_dispatch=FillToolMessage::PointerUp),
+		entry!(KeyDown(MouseRight); action_dispatch=FillToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=FillToolMessage::Abort),
 		//
 		// BrushToolMessage
 		entry!(PointerMove; action_dispatch=BrushToolMessage::PointerMove),
-		entry!(KeyDown(Lmb); action_dispatch=BrushToolMessage::DragStart),
-		entry!(KeyUp(Lmb); action_dispatch=BrushToolMessage::DragStop),
+		entry!(KeyDown(MouseLeft); action_dispatch=BrushToolMessage::DragStart),
+		entry!(KeyUp(MouseLeft); action_dispatch=BrushToolMessage::DragStop),
 		entry!(KeyDown(BracketLeft); action_dispatch=BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::ChangeDiameter(-BRUSH_SIZE_CHANGE_KEYBOARD))),
 		entry!(KeyDown(BracketRight); action_dispatch=BrushToolMessage::UpdateOptions(BrushToolMessageOptionsUpdate::ChangeDiameter(BRUSH_SIZE_CHANGE_KEYBOARD))),
-		entry!(KeyDown(Rmb); action_dispatch=BrushToolMessage::Abort),
+		entry!(KeyDown(MouseRight); action_dispatch=BrushToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=BrushToolMessage::Abort),
 		//
 		// ToolMessage
@@ -323,8 +323,10 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(KeyG); modifiers=[Accel], action_dispatch=DocumentMessage::GroupSelectedLayers),
 		entry!(KeyDown(KeyG); modifiers=[Accel, Shift], action_dispatch=DocumentMessage::UngroupSelectedLayers),
 		entry!(KeyDown(KeyN); modifiers=[Accel, Shift], action_dispatch=DocumentMessage::CreateEmptyFolder),
-		entry!(KeyDown(BracketRight); modifiers=[Alt], action_dispatch=DocumentMessage::SelectionStepForward),
 		entry!(KeyDown(BracketLeft); modifiers=[Alt], action_dispatch=DocumentMessage::SelectionStepBack),
+		entry!(KeyDown(BracketRight); modifiers=[Alt], action_dispatch=DocumentMessage::SelectionStepForward),
+		entry!(KeyDown(MouseBack); action_dispatch=DocumentMessage::SelectionStepBack),
+		entry!(KeyDown(MouseForward); action_dispatch=DocumentMessage::SelectionStepForward),
 		entry!(KeyDown(Digit0); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasToFitAll),
 		entry!(KeyDown(Digit1); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasTo100Percent),
 		entry!(KeyDown(Digit2); modifiers=[Accel], action_dispatch=DocumentMessage::ZoomCanvasTo200Percent),
@@ -373,11 +375,11 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(Digit9); action_dispatch=TransformLayerMessage::TypeDigit { digit: 9 }),
 		//
 		// NavigationMessage
-		entry!(KeyDown(Mmb); modifiers=[Alt], action_dispatch=NavigationMessage::BeginCanvasTilt { was_dispatched_from_menu: false }),
-		entry!(KeyDown(Mmb); modifiers=[Shift], action_dispatch=NavigationMessage::BeginCanvasZoom),
-		entry!(KeyDown(Lmb); modifiers=[Shift, Space], action_dispatch=NavigationMessage::BeginCanvasZoom),
-		entry!(KeyDown(Mmb); action_dispatch=NavigationMessage::BeginCanvasPan),
-		entry!(KeyDown(Lmb); modifiers=[Space], action_dispatch=NavigationMessage::BeginCanvasPan),
+		entry!(KeyDown(MouseMiddle); modifiers=[Alt], action_dispatch=NavigationMessage::BeginCanvasTilt { was_dispatched_from_menu: false }),
+		entry!(KeyDown(MouseMiddle); modifiers=[Shift], action_dispatch=NavigationMessage::BeginCanvasZoom),
+		entry!(KeyDown(MouseLeft); modifiers=[Shift, Space], action_dispatch=NavigationMessage::BeginCanvasZoom),
+		entry!(KeyDown(MouseMiddle); action_dispatch=NavigationMessage::BeginCanvasPan),
+		entry!(KeyDown(MouseLeft); modifiers=[Space], action_dispatch=NavigationMessage::BeginCanvasPan),
 		entry!(KeyDown(NumpadAdd); modifiers=[Accel], action_dispatch=NavigationMessage::CanvasZoomIncrease { center_on_mouse: false }),
 		entry!(KeyDown(Equal); modifiers=[Accel], action_dispatch=NavigationMessage::CanvasZoomIncrease { center_on_mouse: false }),
 		entry!(KeyDown(Minus); modifiers=[Accel], action_dispatch=NavigationMessage::CanvasZoomDecrease { center_on_mouse: false }),

--- a/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
@@ -202,9 +202,11 @@ pub enum Key {
 	Command,
 	/// "Ctrl" on Windows/Linux, "Cmd" on Mac
 	Accel,
-	Lmb,
-	Rmb,
-	Mmb,
+	MouseLeft,
+	MouseRight,
+	MouseMiddle,
+	MouseBack,
+	MouseForward,
 
 	// This has to be the last element in the enum
 	NumKeys,

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -90,7 +90,7 @@ impl MouseState {
 	pub fn finish_transaction(&self, drag_start: DVec2, responses: &mut VecDeque<Message>) {
 		match drag_start.distance(self.position) <= DRAG_THRESHOLD {
 			true => responses.add(DocumentMessage::AbortTransaction),
-			false => responses.add(DocumentMessage::CommitTransaction),
+			false => responses.add(DocumentMessage::EndTransaction),
 		}
 	}
 }

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -144,6 +144,8 @@ pub enum MouseButton {
 	Left,
 	Right,
 	Middle,
+	Back,
+	Forward,
 }
 
 pub const NUMBER_OF_MOUSE_BUTTONS: usize = 3;

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -148,4 +148,4 @@ pub enum MouseButton {
 	Forward,
 }
 
-pub const NUMBER_OF_MOUSE_BUTTONS: usize = 3;
+pub const NUMBER_OF_MOUSE_BUTTONS: usize = 5; // Should be the number of variants in MouseButton

--- a/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
+++ b/editor/src/messages/input_preprocessor/input_preprocessor_message_handler.rs
@@ -45,6 +45,8 @@ impl MessageHandler<InputPreprocessorMessage, InputPreprocessorMessageData> for 
 						MouseKeys::LEFT => MouseButton::Left,
 						MouseKeys::RIGHT => MouseButton::Right,
 						MouseKeys::MIDDLE => MouseButton::Middle,
+						MouseKeys::BACK => MouseButton::Back,
+						MouseKeys::FORWARD => MouseButton::Forward,
 						_ => unimplemented!(),
 					}));
 				}
@@ -115,7 +117,15 @@ impl MessageHandler<InputPreprocessorMessage, InputPreprocessorMessageData> for 
 
 impl InputPreprocessorMessageHandler {
 	fn translate_mouse_event(&mut self, mut new_state: MouseState, allow_first_button_down: bool, responses: &mut VecDeque<Message>) {
-		for (bit_flag, key) in [(MouseKeys::LEFT, Key::Lmb), (MouseKeys::RIGHT, Key::Rmb), (MouseKeys::MIDDLE, Key::Mmb)] {
+		let click_mappings = [
+			(MouseKeys::LEFT, Key::MouseLeft),
+			(MouseKeys::RIGHT, Key::MouseRight),
+			(MouseKeys::MIDDLE, Key::MouseMiddle),
+			(MouseKeys::BACK, Key::MouseBack),
+			(MouseKeys::FORWARD, Key::MouseForward),
+		];
+
+		for (bit_flag, key) in click_mappings {
 			// Calculate the intersection between the two key states
 			let old_down = self.mouse.mouse_keys & bit_flag == bit_flag;
 			let new_down = new_state.mouse_keys & bit_flag == bit_flag;

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -32,23 +32,17 @@ pub enum DocumentMessage {
 	PropertiesPanel(PropertiesPanelMessage),
 
 	// Messages
-	AbortTransaction,
 	AlignSelectedLayers {
 		axis: AlignAxis,
 		aggregate: AlignAggregate,
 	},
-	BackupDocument {
-		network_interface: NodeNetworkInterface,
-	},
 	ClearArtboards,
 	ClearLayersPanel,
-	CommitTransaction,
 	InsertBooleanOperation {
 		operation: graphene_core::vector::misc::BooleanOperation,
 	},
 	CreateEmptyFolder,
 	DebugPrintDocument,
-	DeleteSelectedLayers,
 	DeselectAllLayers,
 	DocumentHistoryBackward,
 	DocumentHistoryForward,
@@ -151,6 +145,10 @@ pub enum DocumentMessage {
 		view_mode: ViewMode,
 	},
 	StartTransaction,
+	EndTransaction,
+	CommitTransaction,
+	AbortTransaction,
+	AddTransaction,
 	ToggleLayerExpansion {
 		id: NodeId,
 	},
@@ -158,7 +156,6 @@ pub enum DocumentMessage {
 	ToggleOverlaysVisibility,
 	ToggleSnapping,
 	Undo,
-	UndoFinished,
 	UngroupSelectedLayers,
 	UngroupLayer {
 		layer: LayerNodeIdentifier,

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -1,5 +1,4 @@
 use super::utility_types::misc::SnappingState;
-use super::utility_types::network_interface::NodeNetworkInterface;
 use crate::messages::input_mapper::utility_types::input_keyboard::Key;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
@@ -43,6 +42,7 @@ pub enum DocumentMessage {
 	},
 	CreateEmptyFolder,
 	DebugPrintDocument,
+	DeleteSelectedLayers,
 	DeselectAllLayers,
 	DocumentHistoryBackward,
 	DocumentHistoryForward,

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -161,6 +161,8 @@ pub enum DocumentMessage {
 		layer: LayerNodeIdentifier,
 	},
 	PTZUpdate,
+	SelectionStepBack,
+	SelectionStepForward,
 	ZoomCanvasTo100Percent,
 	ZoomCanvasTo200Percent,
 	ZoomCanvasToFitAll,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1426,6 +1426,9 @@ impl DocumentMessageHandler {
 		let transform = self.navigation_handler.calculate_offset_transform(ipp.viewport_bounds.center(), &self.document_ptz);
 		network_interface.set_document_to_viewport_transform(transform);
 
+		// Ensure document structure is loaded so that updating the selected nodes has the correct metadata
+		network_interface.load_structure();
+
 		let previous_network = std::mem::replace(&mut self.network_interface, network_interface);
 
 		// Push the UpdateOpenDocumentsList message to the bus in order to update the save status of the open documents

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -256,7 +256,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				graph_operation_message_handler.process_message(message, responses, data);
 			}
 			DocumentMessage::AlignSelectedLayers { axis, aggregate } => {
-				let axis: DVec2 = match axis {
+				let axis = match axis {
 					AlignAxis::X => DVec2::X,
 					AlignAxis::Y => DVec2::Y,
 				};

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -217,7 +217,6 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 				let tree = match usvg::Tree::from_str(&svg, &usvg::Options::default()) {
 					Ok(t) => t,
 					Err(e) => {
-						responses.add(DocumentMessage::DocumentHistoryBackward);
 						responses.add(DialogMessage::DisplayDialogError {
 							title: "SVG parsing failed".to_string(),
 							description: e.to_string(),

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -294,7 +294,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageData<'_>> for Navigation
 			NavigationMessage::EndCanvasPTZWithClick { commit_key } => {
 				self.finish_operation_with_click = false;
 
-				let abort_transform = commit_key == Key::Rmb;
+				let abort_transform = commit_key == Key::MouseRight;
 				responses.add(NavigationMessage::EndCanvasPTZ { abort_transform });
 			}
 			NavigationMessage::FitViewportToBounds {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -354,8 +354,9 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 					}
 					// Abort a box selection
 					if self.box_selection_start.is_some() {
-						responses.add(NodeGraphMessage::SelectedNodesSet { nodes: Vec::new() });
 						self.box_selection_start = None;
+						responses.add(NodeGraphMessage::SelectedNodesSet { nodes: Vec::new() });
+						responses.add(FrontendMessage::UpdateBox { box_selection: None });
 						return;
 					}
 					// Abort dragging a wire

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -484,7 +484,6 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				}
 
 				if let Some(clicked_id) = clicked_id {
-					responses.add(DocumentMessage::StartTransaction);
 					let Some(selected_nodes) = network_interface.selected_nodes(selection_network_path) else {
 						log::error!("Could not get selected nodes in PointerDown");
 						return;
@@ -533,6 +532,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 						responses.add(NodeGraphMessage::SelectedNodesSet { nodes: updated_selected })
 					}
 
+					responses.add(DocumentMessage::StartTransaction);
 					return;
 				}
 

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -42,7 +42,7 @@ fn update_value<T>(value: impl Fn(&T) -> TaggedValue + 'static + Send + Sync, no
 }
 
 fn commit_value<T>(_: &T) -> Message {
-	DocumentMessage::StartTransaction.into()
+	DocumentMessage::AddTransaction.into()
 }
 
 fn expose_widget(node_id: NodeId, index: usize, data_type: FrontendGraphDataType, exposed: bool) -> WidgetHolder {

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1503,11 +1503,13 @@ impl NodeNetworkInterface {
 	pub fn start_transaction(&mut self) {
 		self.transaction_status = TransactionStatus::Started;
 	}
+
 	pub fn transaction_modified(&mut self) {
 		if self.transaction_status == TransactionStatus::Started {
 			self.transaction_status = TransactionStatus::Modified;
 		}
 	}
+
 	pub fn finish_transaction(&mut self) {
 		self.transaction_status = TransactionStatus::Finished;
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -3103,7 +3103,6 @@ impl NodeNetworkInterface {
 		};
 
 		if old_input == new_input {
-			log::debug!("old input: {old_input:?} is the same as new input: {new_input:?}");
 			return;
 		};
 
@@ -3444,7 +3443,7 @@ impl NodeNetworkInterface {
 				continue;
 			}
 
-			for input_index in 1..self.number_of_inputs(delete_node_id, network_path) {
+			for input_index in 0..self.number_of_inputs(delete_node_id, network_path) {
 				self.disconnect_input(&InputConnector::node(*delete_node_id, input_index), network_path);
 			}
 

--- a/editor/src/messages/portfolio/document/utility_types/nodes.rs
+++ b/editor/src/messages/portfolio/document/utility_types/nodes.rs
@@ -140,6 +140,10 @@ impl SelectedNodes {
 	pub fn clear_selected_nodes(&mut self) {
 		self.0 = Vec::new();
 	}
+
+	pub fn replace_with(&mut self, new: Vec<NodeId>) -> Vec<NodeId> {
+		std::mem::replace(&mut self.0, new)
+	}
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, PartialEq, Eq, specta::Type)]

--- a/editor/src/messages/portfolio/document/utility_types/nodes.rs
+++ b/editor/src/messages/portfolio/document/utility_types/nodes.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use super::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
 use super::network_interface::NodeNetworkInterface;
 
@@ -147,7 +145,7 @@ impl SelectedNodes {
 		std::mem::replace(&mut self.0, new)
 	}
 
-	pub fn filtered_selected_nodes(&self, node_ids: HashSet<NodeId>) -> SelectedNodes {
+	pub fn filtered_selected_nodes(&self, node_ids: std::collections::HashSet<NodeId>) -> SelectedNodes {
 		SelectedNodes(self.0.iter().filter(|node_id| node_ids.contains(node_id)).cloned().collect())
 	}
 }

--- a/editor/src/messages/portfolio/document/utility_types/nodes.rs
+++ b/editor/src/messages/portfolio/document/utility_types/nodes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
 use super::network_interface::NodeNetworkInterface;
 
@@ -143,6 +145,10 @@ impl SelectedNodes {
 
 	pub fn replace_with(&mut self, new: Vec<NodeId>) -> Vec<NodeId> {
 		std::mem::replace(&mut self.0, new)
+	}
+
+	pub fn filtered_selected_nodes(&self, node_ids: HashSet<NodeId>) -> SelectedNodes {
+		SelectedNodes(self.0.iter().filter(|node_id| node_ids.contains(node_id)).cloned().collect())
 	}
 }
 

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -189,6 +189,18 @@ impl LayoutHolder for MenuBarMessageHandler {
 							disabled: no_active_document,
 							..MenuBarEntry::default()
 						},
+						MenuBarEntry {
+							label: "Previous Selection".into(),
+							shortcut: action_keys!(DocumentMessageDiscriminant::SelectionStepBack),
+							action: MenuBarEntry::create_action(|_| DocumentMessage::SelectionStepBack.into()),
+							..MenuBarEntry::default()
+						},
+						MenuBarEntry {
+							label: "Next Selection".into(),
+							shortcut: action_keys!(DocumentMessageDiscriminant::SelectionStepForward),
+							action: MenuBarEntry::create_action(|_| DocumentMessage::SelectionStepForward.into()),
+							..MenuBarEntry::default()
+						},
 					],
 					vec![MenuBarEntry {
 						label: "Delete Selected".into(),

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -189,6 +189,8 @@ impl LayoutHolder for MenuBarMessageHandler {
 							disabled: no_active_document,
 							..MenuBarEntry::default()
 						},
+					],
+					vec![
 						MenuBarEntry {
 							label: "Previous Selection".into(),
 							shortcut: action_keys!(DocumentMessageDiscriminant::SelectionStepBack),

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -193,8 +193,8 @@ impl LayoutHolder for MenuBarMessageHandler {
 					vec![MenuBarEntry {
 						label: "Delete Selected".into(),
 						icon: Some("Trash".into()),
-						shortcut: action_keys!(DocumentMessageDiscriminant::DeleteSelectedLayers),
-						action: MenuBarEntry::create_action(|_| DocumentMessage::DeleteSelectedLayers.into()),
+						shortcut: action_keys!(NodeGraphMessageDiscriminant::DeleteSelectedNodes),
+						action: MenuBarEntry::create_action(|_| NodeGraphMessage::DeleteSelectedNodes { delete_children: true }.into()),
 						disabled: no_active_document,
 						..MenuBarEntry::default()
 					}],

--- a/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/portfolio/menu_bar/menu_bar_message_handler.rs
@@ -193,8 +193,8 @@ impl LayoutHolder for MenuBarMessageHandler {
 					vec![MenuBarEntry {
 						label: "Delete Selected".into(),
 						icon: Some("Trash".into()),
-						shortcut: action_keys!(NodeGraphMessageDiscriminant::DeleteSelectedNodes),
-						action: MenuBarEntry::create_action(|_| NodeGraphMessage::DeleteSelectedNodes { delete_children: true }.into()),
+						shortcut: action_keys!(DocumentMessageDiscriminant::DeleteSelectedLayers),
+						action: MenuBarEntry::create_action(|_| DocumentMessage::DeleteSelectedLayers.into()),
 						disabled: no_active_document,
 						..MenuBarEntry::default()
 					}],

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -234,7 +234,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 			}
 			PortfolioMessage::Cut { clipboard } => {
 				responses.add(PortfolioMessage::Copy { clipboard });
-				responses.add(NodeGraphMessage::DeleteSelectedNodes { delete_children: true });
+				responses.add(DocumentMessage::DeleteSelectedLayers);
 			}
 			PortfolioMessage::DeleteDocument { document_id } => {
 				let document_index = self.document_index(document_id);
@@ -601,6 +601,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 							if !added_nodes {
 								responses.add(DocumentMessage::DeselectAllLayers);
 								responses.add(DocumentMessage::AddTransaction);
+								added_nodes = true;
 							}
 							document.load_layer_resources(responses);
 							let new_ids: HashMap<_, _> = entry.nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -45,11 +45,8 @@ impl Pivot {
 
 	/// Recomputes the pivot position and transform.
 	fn recalculate_pivot(&mut self, document: &DocumentMessageHandler) {
-		let mut layers = document
-			.network_interface
-			.selected_nodes(&[])
-			.unwrap()
-			.selected_visible_and_unlocked_layers(&document.network_interface);
+		let selected_nodes = document.network_interface.selected_nodes(&[]).unwrap();
+		let mut layers = selected_nodes.selected_visible_and_unlocked_layers(&document.network_interface);
 		let Some(first) = layers.next() else {
 			// If no layers are selected then we revert things back to default
 			self.normalized_pivot = DVec2::splat(0.5);

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -236,9 +236,7 @@ impl Fsm for ArtboardToolFsmState {
 				tool_data.drag_start = to_document.transform_point2(input.mouse.position);
 				tool_data.drag_current = to_document.transform_point2(input.mouse.position);
 
-				responses.add(DocumentMessage::StartTransaction);
-
-				if let Some(selected_edges) = tool_data.check_dragging_bounds(input.mouse.position) {
+				let state = if let Some(selected_edges) = tool_data.check_dragging_bounds(input.mouse.position) {
 					tool_data.start_resizing(selected_edges, document, input);
 					tool_data.get_snap_candidates(document, input);
 					ArtboardToolFsmState::ResizingBounds
@@ -256,7 +254,9 @@ impl Fsm for ArtboardToolFsmState {
 					tool_data.drag_current = snapped.snapped_point_document;
 
 					ArtboardToolFsmState::Drawing
-				}
+				};
+				responses.add(DocumentMessage::StartTransaction);
+				state
 			}
 			(ArtboardToolFsmState::ResizingBounds, ArtboardToolMessage::PointerMove { constrain_axis_or_aspect, center }) => {
 				let from_center = input.keyboard.get(center as usize);

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -449,7 +449,7 @@ impl Fsm for ArtboardToolFsmState {
 			}
 			(_, ArtboardToolMessage::DeleteSelected) => {
 				tool_data.selected_artboard.take();
-				responses.add(NodeGraphMessage::DeleteSelectedNodes { delete_children: true });
+				responses.add(DocumentMessage::DeleteSelectedLayers);
 
 				ArtboardToolFsmState::Ready { hovered }
 			}

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -146,8 +146,6 @@ impl ArtboardToolData {
 	}
 
 	fn select_artboard(&mut self, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) -> bool {
-		responses.add(DocumentMessage::StartTransaction);
-
 		if let Some(intersection) = Self::hovered_artboard(document, input) {
 			self.selected_artboard = Some(intersection);
 
@@ -238,9 +236,9 @@ impl Fsm for ArtboardToolFsmState {
 				tool_data.drag_start = to_document.transform_point2(input.mouse.position);
 				tool_data.drag_current = to_document.transform_point2(input.mouse.position);
 
-				if let Some(selected_edges) = tool_data.check_dragging_bounds(input.mouse.position) {
-					responses.add(DocumentMessage::StartTransaction);
+				responses.add(DocumentMessage::StartTransaction);
 
+				if let Some(selected_edges) = tool_data.check_dragging_bounds(input.mouse.position) {
 					tool_data.start_resizing(selected_edges, document, input);
 					tool_data.get_snap_candidates(document, input);
 					ArtboardToolFsmState::ResizingBounds
@@ -427,32 +425,15 @@ impl Fsm for ArtboardToolFsmState {
 
 				state
 			}
-			(ArtboardToolFsmState::ResizingBounds, ArtboardToolMessage::PointerUp) => {
+			(ArtboardToolFsmState::Drawing | ArtboardToolFsmState::ResizingBounds | ArtboardToolFsmState::Dragging, ArtboardToolMessage::PointerUp) => {
+				responses.add(DocumentMessage::EndTransaction);
+
 				tool_data.snap_manager.cleanup(responses);
 
 				if let Some(bounds) = &mut tool_data.bounding_box_manager {
 					bounds.original_transforms.clear();
 				}
 
-				ArtboardToolFsmState::Ready { hovered }
-			}
-			(ArtboardToolFsmState::Drawing, ArtboardToolMessage::PointerUp) => {
-				tool_data.snap_manager.cleanup(responses);
-
-				if let Some(bounds) = &mut tool_data.bounding_box_manager {
-					bounds.original_transforms.clear();
-				}
-
-				responses.add(OverlaysMessage::Draw);
-
-				ArtboardToolFsmState::Ready { hovered }
-			}
-			(ArtboardToolFsmState::Dragging, ArtboardToolMessage::PointerUp) => {
-				tool_data.snap_manager.cleanup(responses);
-
-				if let Some(bounds) = &mut tool_data.bounding_box_manager {
-					bounds.original_transforms.clear();
-				}
 				responses.add(OverlaysMessage::Draw);
 
 				ArtboardToolFsmState::Ready { hovered }
@@ -468,7 +449,7 @@ impl Fsm for ArtboardToolFsmState {
 			}
 			(_, ArtboardToolMessage::DeleteSelected) => {
 				tool_data.selected_artboard.take();
-				responses.add(DocumentMessage::DeleteSelectedLayers);
+				responses.add(NodeGraphMessage::DeleteSelectedNodes { delete_children: true });
 
 				ArtboardToolFsmState::Ready { hovered }
 			}

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -381,7 +381,9 @@ impl Fsm for BrushToolFsmState {
 
 			(BrushToolFsmState::Drawing, BrushToolMessage::DragStop) => {
 				if !tool_data.strokes.is_empty() {
-					responses.add(DocumentMessage::CommitTransaction);
+					responses.add(DocumentMessage::EndTransaction);
+				} else {
+					responses.add(DocumentMessage::AbortTransaction);
 				}
 				tool_data.strokes.clear();
 

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -96,9 +96,8 @@ impl Fsm for FillToolFsmState {
 					_ => return self,
 				};
 
-				responses.add(DocumentMessage::StartTransaction);
+				responses.add(DocumentMessage::AddTransaction);
 				responses.add(GraphOperationMessage::FillSet { layer: layer_identifier, fill });
-				responses.add(DocumentMessage::CommitTransaction);
 
 				FillToolFsmState::Filling
 			}

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -254,7 +254,7 @@ impl Fsm for FreehandToolFsmState {
 				if tool_data.dragged {
 					responses.add(DocumentMessage::CommitTransaction);
 				} else {
-					responses.add(DocumentMessage::DocumentHistoryBackward);
+					responses.add(DocumentMessage::EndTransaction);
 				}
 
 				tool_data.end_point = None;

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -111,7 +111,9 @@ enum GradientToolFsmState {
 fn gradient_space_transform(layer: LayerNodeIdentifier, document: &DocumentMessageHandler) -> DAffine2 {
 	let bounds = document.metadata().nonzero_bounding_box(layer);
 	let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+
 	let multiplied = document.metadata().transform_to_viewport(layer);
+
 	multiplied * bound_transform
 }
 

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -97,7 +97,7 @@ impl Fsm for ImaginateToolFsmState {
 		match (self, event) {
 			(ImaginateToolFsmState::Ready, ImaginateToolMessage::DragStart) => {
 				shape_data.start(document, input);
-				responses.add(DocumentMessage::StartTransaction);
+				// responses.add(DocumentMessage::AddTransaction);
 				//shape_data.layer = Some(LayerNodeIdentifier::new(NodeId(generate_uuid()), &document.network_interface));
 				responses.add(DocumentMessage::DeselectAllLayers);
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -619,6 +619,7 @@ impl Fsm for PathToolFsmState {
 						}
 					}
 				}
+
 				responses.add(DocumentMessage::EndTransaction);
 				responses.add(PathToolMessage::SelectedPointUpdated);
 				tool_data.snap_manager.cleanup(responses);

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -332,7 +332,7 @@ impl PathToolData {
 
 			if let Some(selected_points) = selected_points {
 				self.drag_start_pos = input.mouse.position;
-				self.start_dragging_point(selected_points, input, document, shape_editor, responses);
+				self.start_dragging_point(selected_points, input, document, shape_editor);
 				responses.add(OverlaysMessage::Draw);
 			}
 			PathToolFsmState::Dragging
@@ -370,14 +370,7 @@ impl PathToolData {
 		}
 	}
 
-	fn start_dragging_point(
-		&mut self,
-		selected_points: SelectedPointsInfo,
-		input: &InputPreprocessorMessageHandler,
-		document: &DocumentMessageHandler,
-		shape_editor: &mut ShapeState,
-		responses: &mut VecDeque<Message>,
-	) {
+	fn start_dragging_point(&mut self, selected_points: SelectedPointsInfo, input: &InputPreprocessorMessageHandler, document: &DocumentMessageHandler, shape_editor: &mut ShapeState) {
 		let mut manipulators = HashMap::with_hasher(NoHashBuilder);
 		let mut unselected = Vec::new();
 		for (&layer, state) in &shape_editor.selected_shape_state {

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -630,6 +630,7 @@ impl Fsm for PenToolFsmState {
 				state
 			}
 			(PenToolFsmState::DraggingHandle | PenToolFsmState::PlacingAnchor, PenToolMessage::Abort | PenToolMessage::Confirm) => {
+				responses.add(DocumentMessage::EndTransaction);
 				tool_data.layer = None;
 				tool_data.handle_end = None;
 				tool_data.latest_points.clear();
@@ -639,6 +640,8 @@ impl Fsm for PenToolFsmState {
 				PenToolFsmState::Ready
 			}
 			(_, PenToolMessage::Abort) => {
+				responses.add(DocumentMessage::AbortTransaction);
+
 				responses.add(OverlaysMessage::Draw);
 
 				self

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -647,10 +647,10 @@ impl Fsm for SelectToolFsmState {
 					}
 
 					if let Some(intersection) = intersection {
-						
+
 						tool_data.layer_selected_on_start = Some(intersection);
 						selected = intersection_list;
-						
+
 						match tool_data.nested_selection_behavior {
 							NestedSelectionBehavior::Shallowest if !input.keyboard.key(select_deepest) => drag_shallowest_manipulation(responses, selected, tool_data, document),
 							_ => drag_deepest_manipulation(responses, selected, tool_data, document),
@@ -906,7 +906,6 @@ impl Fsm for SelectToolFsmState {
 				// Deselect layer if not snap dragging
 				responses.add(DocumentMessage::EndTransaction);
 
-				log::debug!("self.select_single_layer: {:?}", tool_data.select_single_layer);
 				if !tool_data.has_dragged && input.keyboard.key(remove_from_selection) && tool_data.layer_selected_on_start.is_none() {
 					let quad = tool_data.selection_quad();
 					let intersection = document.intersect_quad(quad, input);
@@ -1045,7 +1044,6 @@ impl Fsm for SelectToolFsmState {
 			(SelectToolFsmState::Dragging, SelectToolMessage::Abort) => {
 				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
-				responses.add(DocumentMessage::Undo);
 				responses.add(OverlaysMessage::Draw);
 
 				let selection = tool_data.nested_selection_behavior;

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -656,7 +656,7 @@ impl Fsm for SelectToolFsmState {
 							_ => drag_deepest_manipulation(responses, selected, tool_data, document),
 						}
 						tool_data.get_snap_candidates(document, input);
-						log::debug!("starting transaction");
+
 						responses.add(DocumentMessage::StartTransaction);
 						SelectToolFsmState::Dragging
 					} else {
@@ -1028,7 +1028,8 @@ impl Fsm for SelectToolFsmState {
 				SelectToolFsmState::Ready { selection }
 			}
 			(SelectToolFsmState::Ready { .. }, SelectToolMessage::Enter) => {
-				let mut selected_layers = document.network_interface.selected_nodes(&[]).unwrap().selected_layers(document.metadata());
+				let selected_nodes = document.network_interface.selected_nodes(&[]).unwrap();
+				let mut selected_layers = selected_nodes.selected_layers(document.metadata());
 
 				if let Some(layer) = selected_layers.next() {
 					// Check that only one layer is selected
@@ -1042,6 +1043,7 @@ impl Fsm for SelectToolFsmState {
 				SelectToolFsmState::Ready { selection }
 			}
 			(SelectToolFsmState::Dragging, SelectToolMessage::Abort) => {
+				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
 				responses.add(DocumentMessage::Undo);
 				responses.add(OverlaysMessage::Draw);

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -479,7 +479,7 @@ impl Fsm for SelectToolFsmState {
 				}
 				// Only highlight layers if the viewport is not being panned (middle mouse button is pressed)
 				// TODO: Don't use `Key::Mmb` directly, instead take it as a variable from the input mappings list like in all other places
-				else if !input.keyboard.get(Key::Mmb as usize) {
+				else if !input.keyboard.get(Key::MouseMiddle as usize) {
 					// Get the layer the user is hovering over
 					let click = document.click(input);
 					let not_selected_click = click.filter(|&hovered_layer| !document.network_interface.selected_nodes(&[]).unwrap().selected_layers_contains(hovered_layer, document.metadata()));

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -543,6 +543,7 @@ impl Fsm for SelectToolFsmState {
 					.collect();
 				let intersection_list = document.click_list(input).collect::<Vec<_>>();
 				let intersection = document.find_deepest(&intersection_list);
+
 				// If the user is dragging the bounding box bounds, go into ResizingBounds mode.
 				// If the user is dragging the rotate trigger, go into RotatingBounds mode.
 				// If the user clicks on a layer that is in their current selection, go into the dragging mode.
@@ -631,6 +632,7 @@ impl Fsm for SelectToolFsmState {
 					} else {
 						tool_data.select_single_layer = intersection.and_then(|intersection| intersection.ancestors(document.metadata()).find(|ancestor| selected.contains(ancestor)));
 					}
+
 					tool_data.layers_dragging = selected;
 
 					tool_data.get_snap_candidates(document, input);

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -941,7 +941,6 @@ impl Fsm for SelectToolFsmState {
 						if selecting_layer == LayerNodeIdentifier::ROOT_PARENT {
 							log::error!("selecting_layer should not be ROOT_PARENT");
 						} else {
-							log::info!("Selecting layer {:?}", selecting_layer);
 							responses.add(NodeGraphMessage::SelectedNodesSet {
 								nodes: vec![selecting_layer.to_node()],
 							});
@@ -1201,11 +1200,9 @@ fn drag_shallowest_manipulation(responses: &mut VecDeque<Message>, selected: Vec
 }
 
 fn drag_deepest_manipulation(responses: &mut VecDeque<Message>, selected: Vec<LayerNodeIdentifier>, tool_data: &mut SelectToolData, document: &DocumentMessageHandler) {
-	tool_data.layers_dragging.append(&mut vec![document.find_deepest(&selected).unwrap_or(LayerNodeIdentifier::new(
-		document.network_interface.root_node(&[]).expect("Root node should exist when dragging layers").node_id,
-		&document.network_interface,
-		&[],
-	))]);
+	tool_data.layers_dragging.append(&mut vec![document
+		.find_deepest(&selected)
+		.unwrap_or(LayerNodeIdentifier::ROOT_PARENT.children(document.metadata()).next().expect("Child should exist when dragging deepest"))]);
 	responses.add(NodeGraphMessage::SelectedNodesSet {
 		nodes: tool_data
 			.layers_dragging

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -229,6 +229,7 @@ impl Fsm for SplineToolFsmState {
 			}
 			(SplineToolFsmState::Drawing, SplineToolMessage::DragStop) => {
 				responses.add(DocumentMessage::EndTransaction);
+
 				let Some(layer) = tool_data.layer else {
 					return SplineToolFsmState::Ready;
 				};

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -228,6 +228,7 @@ impl Fsm for SplineToolFsmState {
 				SplineToolFsmState::Drawing
 			}
 			(SplineToolFsmState::Drawing, SplineToolMessage::DragStop) => {
+				responses.add(DocumentMessage::EndTransaction);
 				let Some(layer) = tool_data.layer else {
 					return SplineToolFsmState::Ready;
 				};
@@ -279,7 +280,7 @@ impl Fsm for SplineToolFsmState {
 			(SplineToolFsmState::Drawing, SplineToolMessage::Confirm | SplineToolMessage::Abort) => {
 				if tool_data.points.len() >= 2 {
 					update_spline(document, tool_data, false, responses);
-					responses.add(DocumentMessage::CommitTransaction);
+					responses.add(DocumentMessage::EndTransaction);
 				} else {
 					responses.add(DocumentMessage::AbortTransaction);
 				}

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -320,7 +320,8 @@ impl TextToolData {
 }
 
 fn can_edit_selected(document: &DocumentMessageHandler) -> Option<LayerNodeIdentifier> {
-	let mut selected_layers = document.network_interface.selected_nodes(&[]).unwrap().selected_layers(document.metadata());
+	let selected_nodes = document.network_interface.selected_nodes(&[]).unwrap();
+	let mut selected_layers = selected_nodes.selected_layers(document.metadata());
 	let layer = selected_layers.next()?;
 
 	// Check that only one layer is selected

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -259,7 +259,7 @@ impl TextToolData {
 		self.layer = layer;
 		self.load_layer_text_node(document);
 
-		responses.add(DocumentMessage::StartTransaction);
+		responses.add(DocumentMessage::AddTransaction);
 
 		self.set_editing(true, font_cache, document, responses);
 
@@ -282,7 +282,7 @@ impl TextToolData {
 		}
 		// Create new text
 		else if let Some(editing_text) = self.editing_text.as_ref().filter(|_| state == TextToolFsmState::Ready) {
-			responses.add(DocumentMessage::StartTransaction);
+			responses.add(DocumentMessage::AddTransaction);
 
 			self.layer = LayerNodeIdentifier::new_unchecked(NodeId(generate_uuid()));
 

--- a/editor/src/test_utils.rs
+++ b/editor/src/test_utils.rs
@@ -23,7 +23,7 @@ pub trait EditorTestUtils {
 	fn move_mouse(&mut self, x: f64, y: f64);
 	fn mousedown(&mut self, state: EditorMouseState);
 	fn mouseup(&mut self, state: EditorMouseState);
-	fn lmb_mousedown(&mut self, x: f64, y: f64);
+	fn left_mousedown(&mut self, x: f64, y: f64);
 	fn input(&mut self, message: InputPreprocessorMessage);
 	fn select_tool(&mut self, typ: ToolType);
 	fn select_primary_color(&mut self, color: Color);
@@ -63,7 +63,7 @@ impl EditorTestUtils for Editor {
 	fn drag_tool(&mut self, typ: ToolType, x1: f64, y1: f64, x2: f64, y2: f64) {
 		self.select_tool(typ);
 		self.move_mouse(x1, y1);
-		self.lmb_mousedown(x1, y1);
+		self.left_mousedown(x1, y1);
 		self.move_mouse(x2, y2);
 		self.mouseup(EditorMouseState {
 			editor_position: (x2, y2).into(),
@@ -91,7 +91,7 @@ impl EditorTestUtils for Editor {
 		self.handle_message(InputPreprocessorMessage::PointerUp { editor_mouse_state, modifier_keys });
 	}
 
-	fn lmb_mousedown(&mut self, x: f64, y: f64) {
+	fn left_mousedown(&mut self, x: f64, y: f64) {
 		self.mousedown(EditorMouseState {
 			editor_position: (x, y).into(),
 			mouse_keys: MouseKeys::LEFT,

--- a/frontend/src/io-managers/input.ts
+++ b/frontend/src/io-managers/input.ts
@@ -182,6 +182,12 @@ export function createInputManager(editor: Editor, dialog: DialogState, portfoli
 	}
 
 	function onPointerUp(e: PointerEvent) {
+		// Don't let the browser navigate back or forward when using the buttons on some mice
+		// TODO: This works in Chrome but not in Firefox
+		// TODO: Possible workaround: use the browser's history API to block navigation:
+		// TODO: <https://stackoverflow.com/questions/57102502/preventing-mouse-fourth-and-fifth-buttons-from-navigating-back-forward-in-browse>
+		if (e.button === 3 || e.button === 4) e.preventDefault();
+
 		if (!e.buttons) viewportPointerInteractionOngoing = false;
 
 		if (textToolInteractiveInputElement) return;
@@ -198,9 +204,11 @@ export function createInputManager(editor: Editor, dialog: DialogState, portfoli
 
 		// `e.buttons` is always 0 in the `mouseup` event, so we have to convert from `e.button` instead
 		let buttons = 1;
-		if (e.button === 0) buttons = 1; // LMB
-		if (e.button === 1) buttons = 4; // MMB
-		if (e.button === 2) buttons = 2; // RMB
+		if (e.button === 0) buttons = 1; // Left
+		if (e.button === 2) buttons = 2; // Right
+		if (e.button === 1) buttons = 4; // Middle
+		if (e.button === 3) buttons = 8; // Back
+		if (e.button === 4) buttons = 16; // Forward
 
 		const modifiers = makeKeyboardModifiersBitfield(e);
 		editor.handle.onDoubleClick(e.clientX, e.clientY, buttons, modifiers);

--- a/website/content/volunteer/guide/codebase-overview/code-structure.md
+++ b/website/content/volunteer/guide/codebase-overview/code-structure.md
@@ -29,7 +29,6 @@ Backend (Rust) -> frontend (TS) communication happens by sending a queue of mess
 
 The Graphite editor backend is organized into a hierarchy of systems, called *message handlers*, which talk to one another through message passing. Messages are pushed to the front or back of a queue and each one is processed sequentially by the backend's dispatcher. The dispatcher lives at the root of the application hierarchy and it owns its message handlers. Thus, Rust's restrictions on mutable borrowing are satisfied because only the dispatcher mutably borrows its message handlers, one at a time, while each message is processed.
 
-//TODO: Rewrite this since DeleteSelectedLayers was removed in favor of NodeGraphMessage::DeleteSelectedNodes { delete_children: true }
 ### Messages
 
 Messages are enum variants that are dispatched to perform some intended activity within their respective message handlers. Here are two `DocumentMessage` definitions:

--- a/website/content/volunteer/guide/codebase-overview/code-structure.md
+++ b/website/content/volunteer/guide/codebase-overview/code-structure.md
@@ -29,6 +29,7 @@ Backend (Rust) -> frontend (TS) communication happens by sending a queue of mess
 
 The Graphite editor backend is organized into a hierarchy of systems, called *message handlers*, which talk to one another through message passing. Messages are pushed to the front or back of a queue and each one is processed sequentially by the backend's dispatcher. The dispatcher lives at the root of the application hierarchy and it owns its message handlers. Thus, Rust's restrictions on mutable borrowing are satisfied because only the dispatcher mutably borrows its message handlers, one at a time, while each message is processed.
 
+//TODO: Rewrite this since DeleteSelectedLayers was removed in favor of NodeGraphMessage::DeleteSelectedNodes { delete_children: true }
 ### Messages
 
 Messages are enum variants that are dispatched to perform some intended activity within their respective message handlers. Here are two `DocumentMessage` definitions:


### PR DESCRIPTION
- Improves the automatic positioning of nodes in the graph when layers are reordered.
- Reworks transactions with start/end points to ensure redo history is maintained when aborting. Closes #1943
- Adds selection history alongside document undo/redo history (<kbd>Alt</kbd><kbd>[</kbd> and <kbd>Alt</kbd><kbd>]</kbd>, also the mouse forward/back buttons in Chrome). Closes #706

Also closes #1910.

Todo:
- [x] Alt+click and drag to duplicate selection
- [x] Improve the undo/redo system to fix <https://github.com/GraphiteEditor/Graphite/issues/1943>
- [x] Deleting should shift all nodes up by replacing single node selection with all upstream nodes
- [x] Adding a layer should create space first
- [x] Grouping artboard crashes
- [x] Cannot select with artboard tool
- [x] Selecting layer with non layer node between layer and export crashes

Deferred:
- Get footprints from RenderOutput to allow caching for any layer. Caching currently causes click targets to be desynced since the transform is not updated when panning.
- Prevent rendering the entire network when a layer is selected
- Solve #1889