### PR TITLE
Render output clicktargets

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -13,6 +13,7 @@ use graphene_core::vector::style::ViewMode;
 use graphene_core::Color;
 
 use glam::DAffine2;
+use graphene_std::transform::Footprint;
 
 #[impl_message(Message, PortfolioMessage, Document)]
 #[derive(PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -155,6 +156,9 @@ pub enum DocumentMessage {
 	ToggleGridVisibility,
 	ToggleOverlaysVisibility,
 	ToggleSnapping,
+	UpdateUpstreamTransforms {
+		upstream_transforms: HashMap<NodeId, (Footprint, DAffine2)>,
+	},
 	Undo,
 	UngroupSelectedLayers,
 	UngroupLayer {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1039,6 +1039,9 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				self.snapping_state.snapping_enabled = !self.snapping_state.snapping_enabled;
 				responses.add(PortfolioMessage::UpdateDocumentWidgets);
 			}
+			DocumentMessage::UpdateUpstreamTransforms { upstream_transforms } => {
+				self.network_interface.document_metadata_mut().update_transforms(upstream_transforms);
+			}
 			DocumentMessage::Undo => {
 				if self.network_interface.transaction_status() != TransactionStatus::Finished {
 					return;

--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -253,8 +253,8 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 							},
 							DocumentNode {
 								manual_composition: Some(concrete!(Footprint)),
-								inputs: vec![NodeInput::node(NodeId(1), 0), NodeInput::node(NodeId(2), 0)],
-								implementation: DocumentNodeImplementation::proto("graphene_core::ConstructLayerNode<_, _>"),
+								inputs: vec![NodeInput::node(NodeId(1), 0), NodeInput::node(NodeId(2), 0), NodeInput::value(TaggedValue::OptionalNodeId(None), false)],
+								implementation: DocumentNodeImplementation::proto("graphene_core::ConstructLayerNode<_, _, _>"),
 								..Default::default()
 							},
 						]

--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -359,8 +359,9 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 								inputs: vec![
 									NodeInput::network(graphene_core::Type::Fn(Box::new(concrete!(Footprint)), Box::new(concrete!(ArtboardGroup))), 0),
 									NodeInput::node(NodeId(1), 0),
+									NodeInput::value(TaggedValue::OptionalNodeId(None), false),
 								],
-								implementation: DocumentNodeImplementation::proto("graphene_core::AddArtboardNode<_, _>"),
+								implementation: DocumentNodeImplementation::proto("graphene_core::AddArtboardNode<_, _, _>"),
 								..Default::default()
 							},
 						]

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -528,7 +528,6 @@ impl Fsm for SelectToolFsmState {
 
 					edges
 				});
-
 				let rotating_bounds = tool_data
 					.bounding_box_manager
 					.as_ref()
@@ -634,7 +633,6 @@ impl Fsm for SelectToolFsmState {
 					tool_data.layers_dragging = selected;
 
 					tool_data.get_snap_candidates(document, input);
-
 					SelectToolFsmState::Dragging
 				}
 				// Dragging a selection box
@@ -656,7 +654,6 @@ impl Fsm for SelectToolFsmState {
 							_ => drag_deepest_manipulation(responses, selected, tool_data, document),
 						}
 						tool_data.get_snap_candidates(document, input);
-
 						responses.add(DocumentMessage::StartTransaction);
 						SelectToolFsmState::Dragging
 					} else {
@@ -1200,9 +1197,12 @@ fn drag_shallowest_manipulation(responses: &mut VecDeque<Message>, selected: Vec
 }
 
 fn drag_deepest_manipulation(responses: &mut VecDeque<Message>, selected: Vec<LayerNodeIdentifier>, tool_data: &mut SelectToolData, document: &DocumentMessageHandler) {
-	tool_data.layers_dragging.append(&mut vec![document
-		.find_deepest(&selected)
-		.unwrap_or(LayerNodeIdentifier::ROOT_PARENT.children(document.metadata()).next().expect("Child should exist when dragging deepest"))]);
+	tool_data.layers_dragging.append(&mut vec![document.find_deepest(&selected).unwrap_or(
+		LayerNodeIdentifier::ROOT_PARENT
+			.children(document.metadata())
+			.next()
+			.expect("ROOT_PARENT should have a layer child when clicking"),
+	)]);
 	responses.add(NodeGraphMessage::SelectedNodesSet {
 		nodes: tool_data
 			.layers_dragging

--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -1,6 +1,7 @@
 use crate::application_io::TextureFrame;
 use crate::raster::{BlendMode, ImageFrame};
 use crate::transform::{Footprint, Transform, TransformMut};
+use crate::uuid::NodeId;
 use crate::vector::VectorData;
 use crate::{Color, Node};
 
@@ -43,7 +44,7 @@ impl AlphaBlending {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GraphicGroup {
 	// TODO:  Separate into multiple Vecs in a spread sheet format.
-	elements: Vec<(GraphicElement, Option<(u64, Footprint)>)>,
+	elements: Vec<(GraphicElement, Option<NodeId>)>,
 	// TODO: Convert to Vec<DAffine2>
 	pub transform: DAffine2,
 	// TODO: Convert to Vec<AlphaBlending>
@@ -219,7 +220,7 @@ impl Artboard {
 #[derive(Clone, Default, Debug, Hash, PartialEq, DynAny)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArtboardGroup {
-	pub artboards: Vec<Artboard>,
+	pub artboards: Vec<(Artboard, Option<NodeId>)>,
 }
 
 impl ArtboardGroup {
@@ -229,8 +230,8 @@ impl ArtboardGroup {
 		Default::default()
 	}
 
-	fn add_artboard(&mut self, artboard: Artboard) {
-		self.artboards.push(artboard);
+	fn add_artboard(&mut self, artboard: Artboard, node_id: Option<NodeId>) {
+		self.artboards.push((artboard, node_id));
 	}
 }
 
@@ -245,15 +246,11 @@ async fn construct_layer<Data: Into<GraphicElement> + Send>(
 	footprint: crate::transform::Footprint,
 	mut stack: impl Node<crate::transform::Footprint, Output = GraphicGroup>,
 	graphic_element: impl Node<crate::transform::Footprint, Output = Data>,
-	node_id: Option<u64>,
+	node_id: Option<NodeId>,
 ) -> GraphicGroup {
 	let graphic_element = self.graphic_element.eval(footprint).await;
 	let mut stack = self.stack.eval(footprint).await;
-	if let Some(node_id) = node_id {
-		stack.push((graphic_element.into(), Some((node_id, footprint))));
-	} else {
-		stack.push((graphic_element.into(), None));
-	}
+	stack.push((graphic_element.into(), node_id));
 	stack
 }
 
@@ -302,17 +299,23 @@ async fn construct_artboard(
 		clip,
 	}
 }
-pub struct AddArtboardNode<ArtboardGroup, Artboard> {
+pub struct AddArtboardNode<ArtboardGroup, Artboard, OptionalNodeId> {
 	artboards: ArtboardGroup,
 	artboard: Artboard,
+	node_id: OptionalNodeId,
 }
 
 #[node_fn(AddArtboardNode)]
-async fn add_artboard<Data: Into<Artboard> + Send>(footprint: Footprint, artboards: impl Node<Footprint, Output = ArtboardGroup>, artboard: impl Node<Footprint, Output = Data>) -> ArtboardGroup {
+async fn add_artboard<Data: Into<Artboard> + Send>(
+	footprint: Footprint,
+	artboards: impl Node<Footprint, Output = ArtboardGroup>,
+	artboard: impl Node<Footprint, Output = Data>,
+	node_id: Option<NodeId>,
+) -> ArtboardGroup {
 	let artboard = self.artboard.eval(footprint).await;
 	let mut artboards = self.artboards.eval(footprint).await;
 
-	artboards.add_artboard(artboard.into());
+	artboards.add_artboard(artboard.into(), node_id);
 
 	artboards
 }
@@ -339,7 +342,7 @@ impl From<GraphicGroup> for GraphicElement {
 }
 
 impl Deref for GraphicGroup {
-	type Target = Vec<(GraphicElement, Option<(u64, Footprint)>)>;
+	type Target = Vec<(GraphicElement, Option<NodeId>)>;
 	fn deref(&self) -> &Self::Target {
 		&self.elements
 	}

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -272,6 +272,7 @@ pub trait GraphicElementRendered {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams);
 	fn bounding_box(&self, transform: DAffine2) -> Option<[DVec2; 2]>;
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>);
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, Footprint>)
 	#[cfg(feature = "vello")]
 	fn to_vello_scene(&self, transform: DAffine2, context: &mut RenderContext) -> Scene {
 		let mut scene = vello::Scene::new();
@@ -305,7 +306,7 @@ impl GraphicElementRendered for GraphicGroup {
 				}
 			},
 			|render| {
-				for element in self.iter() {
+				for (element, _) in self.iter() {
 					element.render_svg(render, render_params);
 				}
 			},
@@ -313,11 +314,11 @@ impl GraphicElementRendered for GraphicGroup {
 	}
 
 	fn bounding_box(&self, transform: DAffine2) -> Option<[DVec2; 2]> {
-		self.iter().filter_map(|element| element.bounding_box(transform * self.transform)).reduce(Quad::combine_bounds)
+		self.iter().filter_map(|(element, _)| element.bounding_box(transform * self.transform)).reduce(Quad::combine_bounds)
 	}
 
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>) {
-		for element in self.elements.iter() {
+		for (element, _) in self.elements.iter() {
 			let mut new_click_targets = Vec::new();
 			element.add_click_targets(&mut new_click_targets);
 			for click_target in new_click_targets.iter_mut() {
@@ -344,7 +345,7 @@ impl GraphicElementRendered for GraphicGroup {
 				&vello::kurbo::Rect::new(bounds[0].x, bounds[0].y, bounds[1].x, bounds[1].y),
 			);
 		}
-		for element in self.iter() {
+		for (element, _) in self.iter() {
 			element.render_to_vello(scene, child_transform, context);
 		}
 		if layer {
@@ -353,7 +354,7 @@ impl GraphicElementRendered for GraphicGroup {
 	}
 
 	fn contains_artboard(&self) -> bool {
-		self.iter().any(|element| element.contains_artboard())
+		self.iter().any(|(element, _)| element.contains_artboard())
 	}
 }
 
@@ -581,7 +582,7 @@ impl GraphicElementRendered for Artboard {
 			},
 			// Artboard contents
 			|render| {
-				for element in self.graphic_group.iter() {
+				for (element, _) in self.graphic_group.iter() {
 					element.render_svg(render, render_params);
 				}
 			},

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -4,8 +4,8 @@ pub use quad::Quad;
 pub use rect::Rect;
 
 use crate::raster::{BlendMode, Image, ImageFrame};
-use crate::transform::Transform;
-use crate::uuid::generate_uuid;
+use crate::transform::{self, Footprint, Transform};
+use crate::uuid::{generate_uuid, NodeId};
 use crate::vector::style::{Fill, Stroke, ViewMode};
 use crate::vector::PointId;
 use crate::Raster;
@@ -16,6 +16,7 @@ use bezier_rs::Subpath;
 use base64::Engine;
 use glam::{DAffine2, DVec2};
 use num_traits::Zero;
+use std::collections::HashMap;
 use std::fmt::Write;
 #[cfg(feature = "vello")]
 use vello::*;
@@ -272,7 +273,7 @@ pub trait GraphicElementRendered {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams);
 	fn bounding_box(&self, transform: DAffine2) -> Option<[DVec2; 2]>;
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>);
-	fn add_footprints(&self, footprints: &mut HashMap<NodeId, Footprint>)
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>);
 	#[cfg(feature = "vello")]
 	fn to_vello_scene(&self, transform: DAffine2, context: &mut RenderContext) -> Scene {
 		let mut scene = vello::Scene::new();
@@ -325,6 +326,19 @@ impl GraphicElementRendered for GraphicGroup {
 				click_target.apply_transform(element.transform())
 			}
 			click_targets.extend(new_click_targets);
+		}
+	}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, mut footprint: Footprint, _: Option<NodeId>) {
+		log::debug!("Transform for graphic group: {:?}", self.transform);
+		footprint.transform *= self.transform;
+		for (element, optional_node_id) in self.elements.iter() {
+			log::debug!("Optional node id: {:?}", optional_node_id);
+			if let Some(element_id) = optional_node_id {
+				let mut new_footprints = HashMap::new();
+				element.add_footprints(&mut new_footprints, footprint, Some(*element_id));
+				footprints.extend(new_footprints);
+			}
 		}
 	}
 
@@ -410,6 +424,8 @@ impl GraphicElementRendered for VectorData {
 		};
 		click_targets.extend(self.stroke_bezier_paths().map(fill).map(|subpath| ClickTarget::new(subpath, stroke_width)));
 	}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, _: Option<NodeId>) {}
 
 	#[cfg(feature = "vello")]
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, _: &mut RenderContext) {
@@ -626,6 +642,17 @@ impl GraphicElementRendered for Artboard {
 		click_targets.push(ClickTarget::new(subpath, 0.));
 	}
 
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, mut footprint: Footprint, node_id: Option<NodeId>) {
+		log::debug!("Adding footprints for artboard");
+		let mut graphic_group_footprint = footprint.clone();
+		graphic_group_footprint.transform *= self.transform();
+		self.graphic_group.add_footprints(footprints, graphic_group_footprint, None);
+		// footprint.transform *= self.transform();
+		if let Some(node_id) = node_id {
+			footprints.insert(node_id, (footprint, DAffine2::from_translation(self.location.as_dvec2())));
+		}
+	}
+
 	fn contains_artboard(&self) -> bool {
 		true
 	}
@@ -633,25 +660,31 @@ impl GraphicElementRendered for Artboard {
 
 impl GraphicElementRendered for crate::ArtboardGroup {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams) {
-		for artboard in &self.artboards {
+		for (artboard, _) in &self.artboards {
 			artboard.render_svg(render, render_params);
 		}
 	}
 
 	fn bounding_box(&self, transform: DAffine2) -> Option<[DVec2; 2]> {
-		self.artboards.iter().filter_map(|element| element.bounding_box(transform)).reduce(Quad::combine_bounds)
+		self.artboards.iter().filter_map(|(element, _)| element.bounding_box(transform)).reduce(Quad::combine_bounds)
 	}
 
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>) {
-		for artboard in &self.artboards {
+		for (artboard, _) in &self.artboards {
 			artboard.add_click_targets(click_targets);
 		}
 	}
 
 	#[cfg(feature = "vello")]
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext) {
-		for artboard in &self.artboards {
+		for (artboard, _) in &self.artboards {
 			artboard.render_to_vello(scene, transform, context)
+		}
+	}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, _: Option<NodeId>) {
+		for (artboard, node_id) in &self.artboards {
+			artboard.add_footprints(footprints, footprint, *node_id)
 		}
 	}
 
@@ -704,6 +737,12 @@ impl GraphicElementRendered for ImageFrame<Color> {
 	fn add_click_targets(&self, click_targets: &mut Vec<ClickTarget>) {
 		let subpath = Subpath::new_rect(DVec2::ZERO, DVec2::ONE);
 		click_targets.push(ClickTarget::new(subpath, 0.));
+	}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {
+		if let Some(element_id) = element_id {
+			footprints.insert(element_id, (footprint, self.transform));
+		}
 	}
 
 	#[cfg(feature = "vello")]
@@ -776,6 +815,10 @@ impl GraphicElementRendered for Raster {
 		click_targets.push(ClickTarget::new(subpath, 0.));
 	}
 
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {
+		//footprints.insert(element_id, (transform, self.transform));
+	}
+
 	#[cfg(feature = "vello")]
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext) {
 		use vello::peniko;
@@ -841,6 +884,17 @@ impl GraphicElementRendered for GraphicElement {
 		}
 	}
 
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {
+		if let Some(element_id) = element_id {
+			footprints.insert(element_id, (footprint, self.transform()));
+		}
+		match self {
+			GraphicElement::VectorData(vector_data) => vector_data.add_footprints(footprints, footprint, None),
+			GraphicElement::Raster(raster) => raster.add_footprints(footprints, footprint, None),
+			GraphicElement::GraphicGroup(graphic_group) => graphic_group.add_footprints(footprints, footprint, None),
+		}
+	}
+
 	#[cfg(feature = "vello")]
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext) {
 		match self {
@@ -883,6 +937,7 @@ impl<T: Primitive> GraphicElementRendered for T {
 	}
 
 	fn add_click_targets(&self, _click_targets: &mut Vec<ClickTarget>) {}
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {}
 }
 
 impl GraphicElementRendered for Option<Color> {
@@ -910,6 +965,8 @@ impl GraphicElementRendered for Option<Color> {
 	}
 
 	fn add_click_targets(&self, _click_targets: &mut Vec<ClickTarget>) {}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {}
 }
 
 impl GraphicElementRendered for Vec<Color> {
@@ -933,6 +990,8 @@ impl GraphicElementRendered for Vec<Color> {
 	}
 
 	fn add_click_targets(&self, _click_targets: &mut Vec<ClickTarget>) {}
+
+	fn add_footprints(&self, footprints: &mut HashMap<NodeId, (Footprint, DAffine2)>, footprint: Footprint, element_id: Option<NodeId>) {}
 }
 
 /// A segment of an svg string to allow for embedding blob urls

--- a/node-graph/gcore/src/uuid.rs
+++ b/node-graph/gcore/src/uuid.rs
@@ -66,4 +66,23 @@ mod uuid_generation {
 	}
 }
 
+use dyn_any::DynAny;
+use dyn_any::StaticType;
 pub use uuid_generation::*;
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize, specta::Type, DynAny)]
+pub struct NodeId(pub u64);
+
+// TODO: Find and replace all `NodeId(generate_uuid())` with `NodeId::new()`.
+impl NodeId {
+	pub fn new() -> Self {
+		Self(generate_uuid())
+	}
+}
+
+impl core::fmt::Display for NodeId {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -23,7 +23,7 @@ pub struct AssignColorsNode<Fill, Stroke, Gradient, Reverse, Randomize, Seed, Re
 #[node_macro::node_fn(AssignColorsNode)]
 fn assign_colors_node(group: GraphicGroup, fill: bool, stroke: bool, gradient: GradientStops, reverse: bool, randomize: bool, seed: u32, repeat_every: u32) -> GraphicGroup {
 	let mut group = group;
-	let vector_data_list: Vec<_> = group.iter_mut().filter_map(|element| element.as_vector_data_mut()).collect();
+	let vector_data_list: Vec<_> = group.iter_mut().filter_map(|(element, _)| element.as_vector_data_mut()).collect();
 	let list = (vector_data_list.len(), vector_data_list.into_iter());
 
 	assign_colors(
@@ -297,9 +297,9 @@ pub trait ConcatElement {
 impl ConcatElement for GraphicGroup {
 	fn concat(&mut self, other: &Self, transform: DAffine2) {
 		// TODO: Decide if we want to keep this behavior whereby the layers are flattened
-		for mut element in other.iter().cloned() {
+		for (mut element, footprint_mapping) in other.iter().cloned() {
 			*element.transform_mut() = transform * element.transform() * other.transform();
-			self.push(element);
+			self.push((element, footprint_mapping));
 		}
 		self.alpha_blending = other.alpha_blending;
 	}

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -1120,7 +1120,12 @@ impl NodeNetwork {
 		for export in inputs {
 			let export: &mut NodeInput = export;
 			let previous_export = std::mem::replace(export, NodeInput::network(concrete!(()), 0));
-			if let NodeInput::Value { tagged_value, exposed } = previous_export {
+			if let NodeInput::Value { mut tagged_value, exposed } = previous_export {
+				if matches!(*tagged_value, TaggedValue::OptionalNodeId(None)) {
+					if let Some(encapsulating_layer) = path.last() {
+						tagged_value = TaggedValue::OptionalNodeId(Some(encapsulating_layer.0)).into();
+					}
+				};
 				let value_node_id = gen_id();
 				let merged_node_id = map_ids(id, value_node_id);
 				let mut original_location = OriginalLocation {

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -175,6 +175,7 @@ tagged_value! {
 	CentroidType(graphene_core::vector::misc::CentroidType),
 	BooleanOperation(graphene_core::vector::misc::BooleanOperation),
 	FontCache(Arc<graphene_core::text::FontCache>),
+	OptionalNodeId(Option<u64>),
 }
 
 impl TaggedValue {

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -5,11 +5,13 @@ use crate::wasm_application_io::WasmEditorApi;
 
 use graphene_core::raster::brush_cache::BrushCache;
 use graphene_core::raster::{BlendMode, LuminanceCalculation};
+use graphene_core::uuid::NodeId;
 use graphene_core::{Color, MemoHash, Node, Type};
 
 use dyn_any::DynAny;
 pub use dyn_any::StaticType;
 pub use glam::{DAffine2, DVec2, IVec2, UVec2};
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -175,7 +177,7 @@ tagged_value! {
 	CentroidType(graphene_core::vector::misc::CentroidType),
 	BooleanOperation(graphene_core::vector::misc::BooleanOperation),
 	FontCache(Arc<graphene_core::text::FontCache>),
-	OptionalNodeId(Option<u64>),
+	OptionalNodeId(Option<NodeId>),
 }
 
 impl TaggedValue {
@@ -239,12 +241,25 @@ impl<T: AsRef<U> + Sync + Send, U: Sync + Send> UpcastAsRefNode<T, U> {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, dyn_any::DynAny, Hash)]
+#[derive(Debug, Clone, PartialEq, dyn_any::DynAny)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RenderOutput {
 	CanvasFrame(graphene_core::SurfaceFrame),
-	Svg(String),
+	Svg((String, HashMap<NodeId, (graphene_core::transform::Footprint, DAffine2)>)),
 	Image(Vec<u8>),
+}
+
+impl Hash for RenderOutput {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		core::mem::discriminant(self).hash(state);
+		match self {
+			Self::CanvasFrame(x) => x.hash(state),
+			Self::Svg((x, _)) => {
+				x.hash(state);
+			}
+			Self::Image(x) => x.hash(state),
+		}
+	}
 }
 
 /// We hash the floats and so-forth despite it not being reproducible because all inputs to the node graph must be hashed otherwise the graph execution breaks (so sorry about this hack)

--- a/node-graph/gstd/src/vector.rs
+++ b/node-graph/gstd/src/vector.rs
@@ -42,7 +42,7 @@ fn boolean_operation_node(group_of_paths: GraphicGroup, operation: BooleanOperat
 
 	fn collect_vector_data(graphic_group: &GraphicGroup) -> Vec<VectorData> {
 		// Ensure all non vector data in the graphic group is converted to vector data
-		let vector_data = graphic_group.iter().map(union_vector_data);
+		let vector_data = graphic_group.iter().map(|(element, _)| union_vector_data(element));
 		// Apply the transform from the parent graphic group
 		let transformed_vector_data = vector_data.map(|mut vector_data| {
 			vector_data.transform = graphic_group.transform * vector_data.transform;

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -16,6 +16,7 @@ use graphene_core::{Color, WasmNotSend};
 use base64::Engine;
 #[cfg(target_arch = "wasm32")]
 use glam::DAffine2;
+use std::collections::HashMap;
 use std::sync::Arc;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::Clamped;
@@ -102,9 +103,11 @@ fn render_svg(data: impl GraphicElementRendered, mut render: SvgRender, render_p
 	}
 
 	data.render_svg(&mut render, &render_params);
+	let mut footprints = HashMap::new();
+	data.add_footprints(&mut footprints, footprint, None);
 	render.wrap_with_transform(footprint.transform, Some(footprint.resolution.as_dvec2()));
 
-	RenderOutput::Svg(render.svg.to_svg_string())
+	RenderOutput::Svg((render.svg.to_svg_string(), footprints))
 }
 
 #[cfg(feature = "vello")]

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -794,7 +794,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::vector::PathModify<_>, input: VectorData, params: [graphene_core::vector::VectorModification]),
 		register_node!(graphene_core::text::TextGeneratorNode<_, _, _>, input: &WasmEditorApi, params: [String, graphene_core::text::Font, f64]),
 		register_node!(graphene_std::brush::VectorPointsNode, input: VectorData, params: []),
-		async_node!(graphene_core::ConstructLayerNode<_, _>, input: Footprint, output: GraphicGroup, fn_params: [Footprint => GraphicGroup, Footprint => graphene_core::GraphicElement]),
+		async_node!(graphene_core::ConstructLayerNode<_, _, _>, input: Footprint, output: GraphicGroup, fn_params: [Footprint => GraphicGroup, Footprint => graphene_core::GraphicElement, () => Option<u64>]),
 		register_node!(graphene_core::ToGraphicElementNode, input: graphene_core::vector::VectorData, params: []),
 		register_node!(graphene_core::ToGraphicElementNode, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_core::ToGraphicElementNode, input: GraphicGroup, params: []),

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -19,6 +19,7 @@ use graphene_core::{Node, NodeIO, NodeIOTypes};
 use graphene_std::any::{ComposeTypeErased, DowncastBothNode, DynAnyNode, FutureWrapperNode, IntoTypeErasedNode};
 use graphene_std::application_io::{RenderConfig, TextureFrame};
 use graphene_std::raster::*;
+use graphene_std::uuid::NodeId;
 use graphene_std::vector::style::GradientStops;
 use graphene_std::wasm_application_io::*;
 use graphene_std::GraphicElement;
@@ -794,7 +795,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::vector::PathModify<_>, input: VectorData, params: [graphene_core::vector::VectorModification]),
 		register_node!(graphene_core::text::TextGeneratorNode<_, _, _>, input: &WasmEditorApi, params: [String, graphene_core::text::Font, f64]),
 		register_node!(graphene_std::brush::VectorPointsNode, input: VectorData, params: []),
-		async_node!(graphene_core::ConstructLayerNode<_, _, _>, input: Footprint, output: GraphicGroup, fn_params: [Footprint => GraphicGroup, Footprint => graphene_core::GraphicElement, () => Option<u64>]),
+		async_node!(graphene_core::ConstructLayerNode<_, _, _>, input: Footprint, output: GraphicGroup, fn_params: [Footprint => GraphicGroup, Footprint => graphene_core::GraphicElement, () => Option<NodeId>]),
 		register_node!(graphene_core::ToGraphicElementNode, input: graphene_core::vector::VectorData, params: []),
 		register_node!(graphene_core::ToGraphicElementNode, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_core::ToGraphicElementNode, input: GraphicGroup, params: []),
@@ -803,7 +804,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		register_node!(graphene_core::ToGraphicGroupNode, input: ImageFrame<Color>, params: []),
 		register_node!(graphene_core::ToGraphicGroupNode, input: GraphicGroup, params: []),
 		async_node!(graphene_core::ConstructArtboardNode<_, _, _, _, _, _>, input: Footprint, output: Artboard, fn_params: [Footprint => GraphicGroup, () => String, () => glam::IVec2, () => glam::IVec2, () => Color, () => bool]),
-		async_node!(graphene_core::AddArtboardNode<_, _>, input: Footprint, output: ArtboardGroup, fn_params: [Footprint => ArtboardGroup, Footprint => Artboard]),
+		async_node!(graphene_core::AddArtboardNode<_, _, _>, input: Footprint, output: ArtboardGroup, fn_params: [Footprint => ArtboardGroup, Footprint => Artboard, () => Option<NodeId>]),
 	];
 	let mut map: HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeConstructor>> = HashMap::new();
 	for (id, c, types) in node_types.into_iter().flatten() {


### PR DESCRIPTION
Closes https://github.com/GraphiteEditor/Graphite/issues/1889

Get footprints from RenderOutput to allow caching for all layers. Caching currently causes click targets to be desynced since the transform from layer space to viewport space is not updated when panning.
 

Frame time for Rust execution in Painted Dreams currently (no caching): 78ms
Frame time with caching: 6.2ms


TODO:
Prevent rendering the entire network when a layer is selected
Fix using select tool on artboard