### PR TITLE
Fix crash from gradients with bounds of zero

### DIFF
--- a/node-graph/gcore/src/vector/style.rs
+++ b/node-graph/gcore/src/vector/style.rs
@@ -163,8 +163,12 @@ impl Gradient {
 			stop.push_str(" />")
 		}
 
-		let mod_gradient = transformed_bound_transform.inverse();
-		let mod_points = mod_gradient.inverse() * transformed_bound_transform.inverse() * updated_transform;
+		let mod_gradient = if transformed_bound_transform.matrix2.determinant() != 0. {
+			transformed_bound_transform.inverse()
+		} else {
+			DAffine2::IDENTITY // Ignore if the transform cannot be inverted (the bounds are zero). See issue #1944.
+		};
+		let mod_points = updated_transform;
 
 		let start = mod_points.transform_point2(self.start);
 		let end = mod_points.transform_point2(self.end);


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #1944

Seeing as the bounds are zero this won't make any difference to the visual output anyway.