### PR TITLE
Refactor navigation metadata

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1435,7 +1435,7 @@ impl DocumentMessageHandler {
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		responses.add(NodeGraphMessage::SelectedNodesUpdated);
 		responses.add(NodeGraphMessage::ForceRunDocumentGraph);
-
+		responses.add(NodeGraphMessage::SetGridAlignedEdges);
 		Some(previous_network)
 	}
 	pub fn redo_with_history(&mut self, ipp: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1435,6 +1435,7 @@ impl DocumentMessageHandler {
 		responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 		responses.add(NodeGraphMessage::SelectedNodesUpdated);
 		responses.add(NodeGraphMessage::ForceRunDocumentGraph);
+		// TODO: Remove once the footprint is used to load the imports/export distances from the edge
 		responses.add(NodeGraphMessage::SetGridAlignedEdges);
 		Some(previous_network)
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -2476,11 +2476,11 @@ impl NodeNetworkInterface {
 		let _ = rect.subpath_to_svg(&mut all_nodes_bounding_box, DAffine2::IDENTITY);
 
 		let Some(rounded_network_edge_distance) = self.rounded_network_edge_distance(network_path).cloned() else {
-			log::error!("Could not get rounded_network_edge_distance in collect_front_end_click_targets");
+			log::error!("Could not get rounded_network_edge_distance in collect_frontend_click_targets");
 			return FrontendClickTargets::default();
 		};
 		let Some(network_metadata) = self.network_metadata(network_path) else {
-			log::error!("Could not get nested network_metadata in collect_front_end_click_targets");
+			log::error!("Could not get nested network_metadata in collect_frontend_click_targets");
 			return FrontendClickTargets::default();
 		};
 		let import_exports_viewport_top_left = rounded_network_edge_distance.imports_to_edge_distance;
@@ -5135,7 +5135,7 @@ pub struct NodeNetworkTransientMetadata {
 
 #[derive(Debug, Clone)]
 pub struct NetworkEdgeDistance {
-	/// The viewport pixel distance distance between the left edge of the node graph and the exports.
+	/// The viewport pixel distance between the left edge of the node graph and the exports.
 	pub exports_to_edge_distance: DVec2,
 	/// The viewport pixel distance between the left edge of the node graph and the imports.
 	pub imports_to_edge_distance: DVec2,
@@ -5367,7 +5367,7 @@ pub struct NavigationMetadata {
 
 impl Default for NavigationMetadata {
 	fn default() -> NavigationMetadata {
-		//Default PTZ and transform
+		// Default PTZ and transform
 		NavigationMetadata {
 			node_graph_ptz: PTZ::default(),
 			node_graph_to_viewport: DAffine2::IDENTITY,

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -5361,6 +5361,7 @@ pub struct NavigationMetadata {
 	/// Transform from node graph space to viewport space.
 	pub node_graph_to_viewport: DAffine2,
 	/// Top right of the node graph in viewport space
+	#[serde(default)]
 	pub node_graph_top_right: DVec2,
 }
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -349,7 +349,6 @@ impl PathToolData {
 		}
 		// We didn't find a segment path, so consider selecting the nearest shape instead
 		else if let Some(layer) = document.click(input) {
-			responses.add(DocumentMessage::StartTransaction);
 			if add_to_selection {
 				responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![layer.to_node()] });
 			} else {
@@ -359,6 +358,7 @@ impl PathToolData {
 			self.previous_mouse_position = document.metadata().document_to_viewport.inverse().transform_point2(input.mouse.position);
 			shape_editor.select_connected_anchors(document, layer, input.mouse.position);
 
+			responses.add(DocumentMessage::StartTransaction);
 			PathToolFsmState::Dragging
 		}
 		// Start drawing a box


### PR DESCRIPTION
Fixes selection bug when selecting a shape with the path tool.
Moves rounded edge distance into transient metadata. This will eventually allow loading the rounded edge distance using the footprint rather than directly using the viewport dimensions to load the rounded widths.
