### PR TITLE
Set integer ruler intervals when zoomed in

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -797,10 +797,14 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				let ruler_origin = document_to_viewport.transform_point2(DVec2::ZERO);
 				let log = ruler_scale.log2();
 				let mut ruler_interval: f64 = if log < 0. { 100. * 2_f64.powf(-log.ceil()) } else { 100. / 2_f64.powf(log.ceil()) };
-				// when the interval becomes too small, force it to be a whole number.
-				// progression of intervals is: ...200,100,50,25,12.5,7(6.25),4(3.125),2(1.5625),1
-				if ruler_interval < 12.5 {
-					ruler_interval = ruler_interval.ceil();
+
+				// when the interval becomes too small, force it to be a whole number, then to powers of 10.
+				// progression of intervals is: ...,100,50,25,12.5,6(6.25),4(3.125),2(1.5625),1.0,0.1,0.01,...
+				if ruler_interval < 1.0 {
+					ruler_interval = 10.0_f64.powf(ruler_interval.log10().ceil());
+				} else if ruler_interval < 12.5 {
+					// round to nearest even number
+					ruler_interval = 2.0 * (ruler_interval / 2.0).round();
 				}
 				let ruler_spacing = ruler_interval * ruler_scale;
 

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -798,13 +798,14 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				let log = ruler_scale.log2();
 				let mut ruler_interval: f64 = if log < 0. { 100. * 2_f64.powf(-log.ceil()) } else { 100. / 2_f64.powf(log.ceil()) };
 
-				// when the interval becomes too small, force it to be a whole number, then to powers of 10.
-				// progression of intervals is: ...,100,50,25,12.5,6(6.25),4(3.125),2(1.5625),1.0,0.1,0.01,...
-				if ruler_interval < 1.0 {
-					ruler_interval = 10.0_f64.powf(ruler_interval.log10().ceil());
+				// When the interval becomes too small, force it to be a whole number, then to powers of 10.
+				// The progression of intervals is:
+				// ..., 100, 50, 25, 12.5, 6 (6.25), 4 (3.125), 2 (1.5625), 1, 0.1, 0.01, ...
+				if ruler_interval < 1. {
+					ruler_interval = 10_f64.powf(ruler_interval.log10().ceil());
 				} else if ruler_interval < 12.5 {
-					// round to nearest even number
-					ruler_interval = 2.0 * (ruler_interval / 2.0).round();
+					// Round to nearest even number
+					ruler_interval = 2. * (ruler_interval / 2.).round();
 				}
 				let ruler_spacing = ruler_interval * ruler_scale;
 

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -796,7 +796,12 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 
 				let ruler_origin = document_to_viewport.transform_point2(DVec2::ZERO);
 				let log = ruler_scale.log2();
-				let ruler_interval: f64 = if log < 0. { 100. * 2_f64.powf(-log.ceil()) } else { 100. / 2_f64.powf(log.ceil()) };
+				let mut ruler_interval: f64 = if log < 0. { 100. * 2_f64.powf(-log.ceil()) } else { 100. / 2_f64.powf(log.ceil()) };
+				// when the interval becomes too small, force it to be a whole number.
+				// progression of intervals is: ...200,100,50,25,12.5,7(6.25),4(3.125),2(1.5625),1
+				if ruler_interval < 12.5 {
+					ruler_interval = ruler_interval.ceil();
+				}
 				let ruler_spacing = ruler_interval * ruler_scale;
 
 				responses.add(FrontendMessage::UpdateDocumentRulers {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -807,6 +807,11 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					// Round to nearest even number
 					ruler_interval = 2. * (ruler_interval / 2.).round();
 				}
+
+				if self.graph_view_overlay_open {
+					ruler_interval = ruler_interval.max(1.);
+				}
+
 				let ruler_spacing = ruler_interval * ruler_scale;
 
 				responses.add(FrontendMessage::UpdateDocumentRulers {

--- a/frontend/src/components/widgets/inputs/RulerInput.svelte
+++ b/frontend/src/components/widgets/inputs/RulerInput.svelte
@@ -51,7 +51,7 @@
 		return dPathAttribute;
 	}
 
-	function computeSvgTexts(direction: RulerDirection, origin: number, majorMarkSpacing: number, numberInterval: number, rulerLength: number): { transform: string; text: number }[] {
+	function computeSvgTexts(direction: RulerDirection, origin: number, majorMarkSpacing: number, numberInterval: number, rulerLength: number): { transform: string; text: string }[] {
 		const isVertical = direction === "Vertical";
 
 		const offsetStart = mod(origin, majorMarkSpacing);
@@ -69,7 +69,14 @@
 			let transform = `translate(${x} ${y})`;
 			if (isVertical) transform += " rotate(270)";
 
-			svgTextCoordinates.push({ transform, text });
+			let addText: string;
+			if (numberInterval < 1.0) {
+				addText = text.toFixed(Math.abs(Math.log10(numberInterval)));
+			} else {
+				addText = text.toString();
+			}
+
+			svgTextCoordinates.push({ transform, text: addText });
 
 			text += numberInterval;
 		}

--- a/frontend/src/components/widgets/inputs/RulerInput.svelte
+++ b/frontend/src/components/widgets/inputs/RulerInput.svelte
@@ -7,40 +7,40 @@
 
 	const RULER_THICKNESS = 16;
 	const MAJOR_MARK_THICKNESS = 16;
-	const MEDIUM_MARK_THICKNESS = 6;
-	const MINOR_MARK_THICKNESS = 3;
+	const MINOR_MARK_THICKNESS = 6;
+	const MICRO_MARK_THICKNESS = 3;
 
 	export let direction: RulerDirection = "Vertical";
 	export let origin: number;
 	export let numberInterval: number;
 	export let majorMarkSpacing: number;
-	export let mediumDivisions = 5;
-	export let minorDivisions = 2;
+	export let minorDivisions = 5;
+	export let microDivisions = 2;
 
 	let rulerInput: HTMLDivElement | undefined;
 	let rulerLength = 0;
 	let svgBounds = { width: "0px", height: "0px" };
 
-	$: svgPath = computeSvgPath(direction, origin, majorMarkSpacing, mediumDivisions, minorDivisions, rulerLength);
+	$: svgPath = computeSvgPath(direction, origin, majorMarkSpacing, minorDivisions, microDivisions, rulerLength);
 	$: svgTexts = computeSvgTexts(direction, origin, majorMarkSpacing, numberInterval, rulerLength);
 
-	function computeSvgPath(direction: RulerDirection, origin: number, majorMarkSpacing: number, mediumDivisions: number, minorDivisions: number, rulerLength: number): string {
+	function computeSvgPath(direction: RulerDirection, origin: number, majorMarkSpacing: number, minorDivisions: number, microDivisions: number, rulerLength: number): string {
 		const isVertical = direction === "Vertical";
 		const lineDirection = isVertical ? "H" : "V";
 
 		const offsetStart = mod(origin, majorMarkSpacing);
 		const shiftedOffsetStart = offsetStart - majorMarkSpacing;
 
-		const divisions = majorMarkSpacing / mediumDivisions / minorDivisions;
-		const majorMarksFrequency = mediumDivisions * minorDivisions;
+		const divisions = majorMarkSpacing / minorDivisions / microDivisions;
+		const majorMarksFrequency = minorDivisions * microDivisions;
 
 		let dPathAttribute = "";
 		let i = 0;
 		for (let location = shiftedOffsetStart; location < rulerLength; location += divisions) {
 			let length;
 			if (i % majorMarksFrequency === 0) length = MAJOR_MARK_THICKNESS;
-			else if (i % minorDivisions === 0) length = MEDIUM_MARK_THICKNESS;
-			else length = MINOR_MARK_THICKNESS;
+			else if (i % microDivisions === 0) length = MINOR_MARK_THICKNESS;
+			else length = MICRO_MARK_THICKNESS;
 			i += 1;
 
 			const destination = Math.round(location) + 0.5;
@@ -59,7 +59,7 @@
 
 		const svgTextCoordinates = [];
 
-		let text = (Math.ceil(-origin / majorMarkSpacing) - 1) * numberInterval;
+		let labelNumber = (Math.ceil(-origin / majorMarkSpacing) - 1) * numberInterval;
 
 		for (let location = shiftedOffsetStart; location < rulerLength; location += majorMarkSpacing) {
 			const destination = Math.round(location);
@@ -69,16 +69,11 @@
 			let transform = `translate(${x} ${y})`;
 			if (isVertical) transform += " rotate(270)";
 
-			let addText: string;
-			if (numberInterval < 1.0) {
-				addText = text.toFixed(Math.abs(Math.log10(numberInterval)));
-			} else {
-				addText = text.toString();
-			}
+			const text = numberInterval >= 1 ? `${labelNumber}` : labelNumber.toFixed(Math.abs(Math.log10(numberInterval))).replace(/\.0+$/, "");
 
-			svgTextCoordinates.push({ transform, text: addText });
+			svgTextCoordinates.push({ transform, text });
 
-			text += numberInterval;
+			labelNumber += numberInterval;
 		}
 
 		return svgTextCoordinates;


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

## Summary

Closes #1927 

Adds a check for when the interval would be too small and then applies `.ceil()` to make it a whole number. Now, the progression of intervals is:

...200, 100, 50, 25, 12.5,7(6.25), 4(3.125), 2(...),1

## Discussion

I chose to start rounding at 12.5 since 12.5 is a fairly legible number. It only started looking weird below that. A slight issue is that 7 is used when 6.25 is rounded up, which isn't a clean number for the ruler :shrug:. I couldn't think of a clean way to get it to 8 or 6 without messing up the other numbers (i thought about something like: `ruler_interval += ruler_interval % 2` to force evenness, but then `ruler_interval` bottoms out at 2, which felt too big). 

## Results

When toggling the node graph display, the ruler now looks like this:
![image](https://github.com/user-attachments/assets/2f0d903b-d2e6-41fb-a43c-669683da1727)

And for very high zoom percentages (> 60000%), the ruler tops out at an interval of 1. 
![image](https://github.com/user-attachments/assets/99b75cf7-7861-4706-947f-fbd775d22dec)

Previously, the long decimals would overlap each other and look bad:
![image](https://github.com/user-attachments/assets/f0300704-614a-437d-b9a8-dbef1a8e0740)

 
