### PR TITLE
Make the primitive shape tools avoid setting a negative transform scale

### DIFF
--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -224,7 +224,7 @@ impl Fsm for EllipseToolFsmState {
 					if let Some(layer) = shape_data.layer {
 						responses.add(GraphOperationMessage::TransformSet {
 							layer,
-							transform: DAffine2::from_scale_angle_translation(end - start, 0., (start + end) / 2.),
+							transform: DAffine2::from_scale_angle_translation((end - start).abs(), 0., (start + end) / 2.),
 							transform_in: TransformIn::Viewport,
 							skip_rerender: false,
 						});

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -2,6 +2,7 @@ use super::tool_prelude::*;
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
 use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::utility_types::network_interface::InputConnector;
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
@@ -280,9 +281,37 @@ impl Fsm for PolygonToolFsmState {
 				if let Some([start, end]) = tool_data.data.calculate_points(document, input, center, lock_ratio) {
 					if let Some(layer) = tool_data.data.layer {
 						// TODO: make the scale impact the polygon/star node - we need to determine how to allow the polygon node to make irregular shapes
+						let direction = if end[1] > start[1] { 1. } else { -1. };
+						if graph_modification_utils::NodeGraphLayer::new(layer, &document.network_interface)
+							.find_input("Regular Polygon", 1)
+							.unwrap_or(&TaggedValue::U32(0))
+							.to_u32() % 2 == 1
+						{
+							if let Some(polygon_node_id) = graph_modification_utils::NodeGraphLayer::new(layer, &document.network_interface).upstream_node_id_from_name("Regular Polygon") {
+								responses.add(NodeGraphMessage::SetInput {
+									input_connector: InputConnector::node(polygon_node_id, 2),
+									input: NodeInput::value(TaggedValue::F64(direction * 0.5), false),
+								});
+							}
+						} else if graph_modification_utils::NodeGraphLayer::new(layer, &document.network_interface)
+							.find_input("Star", 1)
+							.unwrap_or(&TaggedValue::U32(0))
+							.to_u32() % 2 == 1
+						{
+							if let Some(star_node_id) = graph_modification_utils::NodeGraphLayer::new(layer, &document.network_interface).upstream_node_id_from_name("Star") {
+								responses.add(NodeGraphMessage::SetInput {
+									input_connector: InputConnector::node(star_node_id, 2),
+									input: NodeInput::value(TaggedValue::F64(direction * 0.5), false),
+								});
+								responses.add(NodeGraphMessage::SetInput {
+									input_connector: InputConnector::node(star_node_id, 3),
+									input: NodeInput::value(TaggedValue::F64(direction * 0.25), false),
+								});
+							}
+						}
 						responses.add(GraphOperationMessage::TransformSet {
 							layer,
-							transform: DAffine2::from_scale_angle_translation(end - start, 0., (start + end) / 2.),
+							transform: DAffine2::from_scale_angle_translation((end - start).abs(), 0., (start + end) / 2.),
 							transform_in: TransformIn::Viewport,
 							skip_rerender: false,
 						});

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -231,7 +231,7 @@ impl Fsm for RectangleToolFsmState {
 						// TODO: make the scale impact the rect node
 						responses.add(GraphOperationMessage::TransformSet {
 							layer,
-							transform: DAffine2::from_scale_angle_translation(end - start, 0., (start + end) / 2.),
+							transform: DAffine2::from_scale_angle_translation((end - start).abs(), 0., (start + end) / 2.),
 							transform_in: TransformIn::Viewport,
 							skip_rerender: false,
 						});

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -194,6 +194,7 @@ impl TaggedValue {
 			_ => panic!("Cannot convert to primitive string"),
 		}
 	}
+
 	pub fn to_u32(&self) -> u32 {
 		match self {
 			TaggedValue::U32(x) => *x,

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -194,6 +194,12 @@ impl TaggedValue {
 			_ => panic!("Cannot convert to primitive string"),
 		}
 	}
+	pub fn to_u32(&self) -> u32 {
+		match self {
+			TaggedValue::U32(x) => *x,
+			_ => panic!("Passed value is not of type u32"),
+		}
+	}
 }
 
 impl Display for TaggedValue {


### PR DESCRIPTION
Fix negative height and unnecessary 180° rotation while drawing primitive tools, make odd-sided polygons and start flipped with radius instead of scale or rotation