### PR TITLE
Nudge only the shallowest selected layers to avoid amplified translation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
 	},
 	// Rust Analyzer config
 	"rust-analyzer.cargo.allTargets": false,
+	"rust-analyzer.check.command": "clippy",
 	// ESLint config
 	"eslint.format.enable": true,
 	"eslint.workingDirectories": ["./frontend", "./website/other/bezier-rs-demos", "./website"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,6 @@
 	},
 	// Rust Analyzer config
 	"rust-analyzer.cargo.allTargets": false,
-	"rust-analyzer.check.command": "clippy",
 	// ESLint config
 	"eslint.format.enable": true,
 	"eslint.workingDirectories": ["./frontend", "./website/other/bezier-rs-demos", "./website"],


### PR DESCRIPTION
Fixes the issue reported by @moOsama76 on discord whereby if a layer and its parent are selected and nudged, the nudge is applied twice.