### PR TITLE
Clean up old usages of `NodeId(generate_uuid())` by replacing it with `NodeId::new()`

### DIFF
--- a/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
@@ -2,7 +2,6 @@ use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::prelude::*;
 
 use graph_craft::document::NodeId;
-use graphene_core::uuid::generate_uuid;
 
 use glam::{IVec2, UVec2};
 
@@ -27,7 +26,7 @@ impl MessageHandler<NewDocumentDialogMessage, ()> for NewDocumentDialogMessageHa
 				let create_artboard = !self.infinite && self.dimensions.x > 0 && self.dimensions.y > 0;
 				if create_artboard {
 					responses.add(GraphOperationMessage::NewArtboard {
-						id: NodeId(generate_uuid()),
+						id: NodeId::new(),
 						artboard: graphene_core::Artboard::new(IVec2::ZERO, self.dimensions.as_ivec2()),
 					});
 				}

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -322,7 +322,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				};
 				let insert_index = DocumentMessageHandler::get_calculated_insert_index(self.metadata(), self.network_interface.selected_nodes(&[]).unwrap(), parent);
 
-				let folder_id = NodeId(generate_uuid());
+				let folder_id = NodeId::new();
 				let boolean_operation_layer = LayerNodeIdentifier::new_unchecked(folder_id);
 				responses.add(GraphOperationMessage::NewBooleanOperationLayer {
 					id: folder_id,
@@ -338,7 +338,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				responses.add(DocumentMessage::MoveSelectedLayersToGroup { parent: boolean_operation_layer });
 			}
 			DocumentMessage::CreateEmptyFolder => {
-				let id = NodeId(generate_uuid());
+				let id = NodeId::new();
 
 				let parent = self
 					.network_interface
@@ -505,7 +505,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				};
 				let insert_index = DocumentMessageHandler::get_calculated_insert_index(self.metadata(), self.network_interface.selected_nodes(&[]).unwrap(), parent);
 
-				let node_id = NodeId(generate_uuid());
+				let node_id = NodeId::new();
 				let new_group_node = document_node_definitions::resolve_document_node_type("Merge")
 					.expect("Failed to create merge node")
 					.default_node_template();
@@ -740,7 +740,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 
 				let transform = center_in_viewport_layerspace * fit_image_size;
 
-				let layer_node_id = NodeId(generate_uuid());
+				let layer_node_id = NodeId::new();
 				let layer_id = LayerNodeIdentifier::new_unchecked(layer_node_id);
 
 				responses.add(DocumentMessage::AddTransaction);
@@ -785,7 +785,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				let viewport_location = mouse.map_or(ipp.viewport_bounds.center() + ipp.viewport_bounds.top_left, |pos| pos.into());
 				let center_in_viewport = DAffine2::from_translation(document_to_viewport.inverse().transform_point2(viewport_location - ipp.viewport_bounds.top_left));
 
-				let layer_node_id = NodeId(generate_uuid());
+				let layer_node_id = NodeId::new();
 				let layer_id = LayerNodeIdentifier::new_unchecked(layer_node_id);
 
 				responses.add(DocumentMessage::AddTransaction);
@@ -1231,7 +1231,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				let bounds_rounded_dimensions = (bounds[1] - bounds[0]).round();
 
 				// Create an artboard and set its dimensions to the bounding box size and location
-				let node_id = NodeId(generate_uuid());
+				let node_id = NodeId::new();
 				let node_layer_id = LayerNodeIdentifier::new_unchecked(node_id);
 				let new_artboard_node = document_node_definitions::resolve_document_node_type("Artboard")
 					.expect("Failed to create artboard node")

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -5,7 +5,7 @@ use crate::messages::portfolio::document::utility_types::network_interface::{Inp
 use crate::messages::portfolio::document::utility_types::nodes::CollapsedLayers;
 use crate::messages::prelude::*;
 
-use graph_craft::document::{generate_uuid, NodeId, NodeInput};
+use graph_craft::document::{NodeId, NodeInput};
 use graphene_core::renderer::Quad;
 use graphene_core::text::Font;
 use graphene_core::vector::style::{Fill, Gradient, GradientStops, GradientType, LineCap, LineJoin, Stroke};
@@ -156,7 +156,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 
 				if !nodes.is_empty() {
 					// Add the nodes to the network
-					let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();
+					let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 					// Since all the new nodes are already connected, just connect the input of the layer to first new node
 					let first_new_node_id = new_ids[&NodeId(0)];
 					responses.add(NodeGraphMessage::AddNodes { nodes, new_ids });
@@ -259,7 +259,7 @@ fn import_usvg_node(modify_inputs: &mut ModifyInputsContext, node: &usvg::Node, 
 	match node {
 		usvg::Node::Group(group) => {
 			for child in group.children() {
-				import_usvg_node(modify_inputs, child, transform, NodeId(generate_uuid()), layer, 0);
+				import_usvg_node(modify_inputs, child, transform, NodeId::new(), layer, 0);
 			}
 			modify_inputs.layer_node = Some(layer);
 		}

--- a/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
@@ -6,7 +6,7 @@ use crate::messages::prelude::*;
 
 use bezier_rs::Subpath;
 use graph_craft::document::value::TaggedValue;
-use graph_craft::document::{generate_uuid, NodeId, NodeInput};
+use graph_craft::document::{NodeId, NodeInput};
 use graphene_core::raster::{BlendMode, ImageFrame};
 use graphene_core::text::Font;
 use graphene_core::vector::brush_stroke::BrushStroke;
@@ -140,7 +140,7 @@ impl<'a> ModifyInputsContext<'a> {
 			Some(NodeInput::value(TaggedValue::BooleanOperation(operation), false)),
 		]);
 
-		let boolean_id = NodeId(generate_uuid());
+		let boolean_id = NodeId::new();
 		self.network_interface.insert_node(boolean_id, boolean, &[]);
 		self.network_interface.move_node_to_chain_start(&boolean_id, layer, &[]);
 	}
@@ -151,27 +151,27 @@ impl<'a> ModifyInputsContext<'a> {
 		let shape = resolve_document_node_type("Path")
 			.expect("Path node does not exist")
 			.node_template_input_override([Some(NodeInput::value(TaggedValue::VectorData(vector_data), false))]);
-		let shape_id = NodeId(generate_uuid());
+		let shape_id = NodeId::new();
 		self.network_interface.insert_node(shape_id, shape, &[]);
 		self.network_interface.move_node_to_chain_start(&shape_id, layer, &[]);
 
 		if include_transform {
 			let transform = resolve_document_node_type("Transform").expect("Transform node does not exist").default_node_template();
-			let transform_id = NodeId(generate_uuid());
+			let transform_id = NodeId::new();
 			self.network_interface.insert_node(transform_id, transform, &[]);
 			self.network_interface.move_node_to_chain_start(&transform_id, layer, &[]);
 		}
 
 		if include_fill {
 			let fill = resolve_document_node_type("Fill").expect("Fill node does not exist").default_node_template();
-			let fill_id = NodeId(generate_uuid());
+			let fill_id = NodeId::new();
 			self.network_interface.insert_node(fill_id, fill, &[]);
 			self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
 		}
 
 		if include_stroke {
 			let stroke = resolve_document_node_type("Stroke").expect("Stroke node does not exist").default_node_template();
-			let stroke_id = NodeId(generate_uuid());
+			let stroke_id = NodeId::new();
 			self.network_interface.insert_node(stroke_id, stroke, &[]);
 			self.network_interface.move_node_to_chain_start(&stroke_id, layer, &[]);
 		}
@@ -190,19 +190,19 @@ impl<'a> ModifyInputsContext<'a> {
 			Some(NodeInput::value(TaggedValue::F64(character_spacing), false)),
 		]);
 
-		let text_id = NodeId(generate_uuid());
+		let text_id = NodeId::new();
 		self.network_interface.insert_node(text_id, text, &[]);
 		self.network_interface.move_node_to_chain_start(&text_id, layer, &[]);
 
-		let transform_id = NodeId(generate_uuid());
+		let transform_id = NodeId::new();
 		self.network_interface.insert_node(transform_id, transform, &[]);
 		self.network_interface.move_node_to_chain_start(&transform_id, layer, &[]);
 
-		let fill_id = NodeId(generate_uuid());
+		let fill_id = NodeId::new();
 		self.network_interface.insert_node(fill_id, fill, &[]);
 		self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
 
-		let stroke_id = NodeId(generate_uuid());
+		let stroke_id = NodeId::new();
 		self.network_interface.insert_node(stroke_id, stroke, &[]);
 		self.network_interface.move_node_to_chain_start(&stroke_id, layer, &[]);
 	}
@@ -213,11 +213,11 @@ impl<'a> ModifyInputsContext<'a> {
 			.expect("Image node does not exist")
 			.node_template_input_override([Some(NodeInput::value(TaggedValue::ImageFrame(image_frame), false))]);
 
-		let image_id = NodeId(generate_uuid());
+		let image_id = NodeId::new();
 		self.network_interface.insert_node(image_id, image, &[]);
 		self.network_interface.move_node_to_chain_start(&image_id, layer, &[]);
 
-		let transform_id = NodeId(generate_uuid());
+		let transform_id = NodeId::new();
 		self.network_interface.insert_node(transform_id, transform, &[]);
 		self.network_interface.move_node_to_chain_start(&transform_id, layer, &[]);
 	}
@@ -274,7 +274,7 @@ impl<'a> ModifyInputsContext<'a> {
 				log::error!("Node type {} does not exist in ModifyInputsContext::existing_node_id", reference);
 				return None;
 			};
-			let node_id = NodeId(generate_uuid());
+			let node_id = NodeId::new();
 			self.network_interface.insert_node(node_id, node_definition.default_node_template(), &[]);
 			self.network_interface.move_node_to_chain_start(&node_id, output_layer, &[]);
 			Some(node_id)

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1,6 +1,5 @@
 use super::utility_types::{BoxSelection, ContextMenuInformation, DragStart, FrontendGraphInput, FrontendGraphOutput, FrontendNode, FrontendNodeWire, WirePath};
 use super::{document_node_definitions, node_properties};
-use crate::application::generate_uuid;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::portfolio::document::node_graph::document_node_definitions::NodePropertiesContext;
@@ -138,7 +137,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				responses.add(FrontendMessage::TriggerTextCopy { copy_text });
 			}
 			NodeGraphMessage::CreateNodeFromContextMenu { node_id, node_type, x, y } => {
-				let node_id = node_id.unwrap_or_else(|| NodeId(generate_uuid()));
+				let node_id = node_id.unwrap_or_else(|| NodeId::new());
 
 				let Some(document_node_type) = document_node_definitions::resolve_document_node_type(&node_type) else {
 					responses.add(DialogMessage::DisplayDialogError {
@@ -235,7 +234,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				// Copy the selected nodes
 				let nodes = network_interface.copy_nodes(&copy_ids, selection_network_path).collect::<Vec<_>>();
 
-				let new_ids = nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect::<HashMap<_, _>>();
+				let new_ids = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect::<HashMap<_, _>>();
 				responses.add(DocumentMessage::AddTransaction);
 				responses.add(NodeGraphMessage::AddNodes { nodes, new_ids: new_ids.clone() });
 				responses.add(NodeGraphMessage::SelectedNodesSet {
@@ -325,7 +324,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 
 				responses.add(DocumentMessage::AddTransaction);
 
-				let new_ids: HashMap<_, _> = data.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();
+				let new_ids: HashMap<_, _> = data.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 				responses.add(NodeGraphMessage::AddNodes {
 					nodes: data,
 					new_ids: new_ids.clone(),
@@ -1020,11 +1019,11 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				// 			.join("\r\n");
 				// 		output += "\r\n";
 				// 		output += &format!(
-				// 			"imports_metadata: (NodeId(generate_uuid()), ({}, {}).into()),\r\n",
+				// 			"imports_metadata: (NodeId::new(), ({}, {}).into()),\r\n",
 				// 			network.imports_metadata.1.x, network.imports_metadata.1.y
 				// 		);
 				// 		output += &format!(
-				// 			"exports_metadata: (NodeId(generate_uuid()), ({}, {}).into()),",
+				// 			"exports_metadata: (NodeId::new(), ({}, {}).into()),",
 				// 			network.exports_metadata.1.x, network.exports_metadata.1.y
 				// 		);
 				// 		output += "\r\n\r\n";

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -618,7 +618,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					if self.active_document().is_some() {
 						trace!("Pasting into folder {parent:?} as index: {insert_index}");
 						let nodes = entry.clone().nodes;
-						let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();
+						let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 						let layer = LayerNodeIdentifier::new_unchecked(new_ids[&NodeId(0)]);
 						responses.add(NodeGraphMessage::AddNodes { nodes, new_ids });
 						responses.add(NodeGraphMessage::MoveLayerToStack { layer, parent, insert_index });
@@ -646,7 +646,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 								added_nodes = true;
 							}
 							document.load_layer_resources(responses);
-							let new_ids: HashMap<_, _> = entry.nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();
+							let new_ids: HashMap<_, _> = entry.nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 							let layer = LayerNodeIdentifier::new_unchecked(new_ids[&NodeId(0)]);
 							responses.add(NodeGraphMessage::AddNodes { nodes: entry.nodes, new_ids });
 							responses.add(NodeGraphMessage::MoveLayerToStack { layer, parent, insert_index: 0 });

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -1,5 +1,4 @@
 use super::tool_prelude::*;
-use crate::application::generate_uuid;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
@@ -365,7 +364,7 @@ impl Fsm for ArtboardToolFsmState {
 						});
 					}
 				} else {
-					let id = NodeId(generate_uuid());
+					let id = NodeId::new();
 
 					tool_data.selected_artboard = Some(LayerNodeIdentifier::new_unchecked(id));
 

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -9,7 +9,6 @@ use crate::messages::tool::common_functionality::color_selector::{ToolColorOptio
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::NodeId;
 use graphene_core::raster::BlendMode;
-use graphene_core::uuid::generate_uuid;
 use graphene_core::vector::brush_stroke::{BrushInputSample, BrushStroke, BrushStyle};
 use graphene_core::Color;
 
@@ -432,7 +431,7 @@ fn new_brush_layer(document: &DocumentMessageHandler, responses: &mut VecDeque<M
 
 	let brush_node = resolve_document_node_type("Brush").expect("Brush node does not exist").default_node_template();
 
-	let id = NodeId(generate_uuid());
+	let id = NodeId::new();
 	responses.add(GraphOperationMessage::NewCustomLayer {
 		id,
 		nodes: vec![(NodeId(0), brush_node)],

--- a/editor/src/messages/tool/tool_messages/ellipse_tool.rs
+++ b/editor/src/messages/tool/tool_messages/ellipse_tool.rs
@@ -10,7 +10,6 @@ use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
-use graphene_core::uuid::generate_uuid;
 use graphene_core::Color;
 
 #[derive(Default)]
@@ -206,7 +205,7 @@ impl Fsm for EllipseToolFsmState {
 				let node = node_type.node_template_input_override([None, Some(NodeInput::value(TaggedValue::F64(0.5), false)), Some(NodeInput::value(TaggedValue::F64(0.5), false))]);
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, document.new_layer_parent(true), responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, document.new_layer_parent(true), responses);
 				responses.add(Message::StartBuffer);
 				responses.add(GraphOperationMessage::TransformSet {
 					layer,

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -9,7 +9,6 @@ use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::utility_functions::should_extend;
 
 use graph_craft::document::NodeId;
-use graphene_core::uuid::generate_uuid;
 use graphene_core::vector::VectorModificationType;
 use graphene_core::Color;
 use graphene_std::vector::{PointId, SegmentId};
@@ -229,7 +228,7 @@ impl Fsm for FreehandToolFsmState {
 				let node = node_type.default_node_template();
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, parent, responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 				responses.add(Message::StartBuffer);
 				tool_options.fill.apply_fill(layer, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);

--- a/editor/src/messages/tool/tool_messages/imaginate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/imaginate_tool.rs
@@ -98,7 +98,7 @@ impl Fsm for ImaginateToolFsmState {
 			(ImaginateToolFsmState::Ready, ImaginateToolMessage::DragStart) => {
 				shape_data.start(document, input);
 				// responses.add(DocumentMessage::AddTransaction);
-				//shape_data.layer = Some(LayerNodeIdentifier::new(NodeId(generate_uuid()), &document.network_interface));
+				//shape_data.layer = Some(LayerNodeIdentifier::new(NodeId::new(), &document.network_interface));
 				responses.add(DocumentMessage::DeselectAllLayers);
 
 				// // Utility function to offset the position of each consecutive node

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -10,7 +10,6 @@ use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
-use graphene_core::uuid::generate_uuid;
 use graphene_core::Color;
 
 #[derive(Default)]
@@ -187,7 +186,7 @@ impl Fsm for LineToolFsmState {
 				]);
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, document.new_layer_parent(false), responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, document.new_layer_parent(false), responses);
 				responses.add(Message::StartBuffer);
 				responses.add(GraphOperationMessage::TransformSet {
 					layer,

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -12,7 +12,6 @@ use crate::messages::tool::common_functionality::utility_functions::should_exten
 
 use bezier_rs::{Bezier, BezierHandles};
 use graph_craft::document::NodeId;
-use graphene_core::uuid::generate_uuid;
 use graphene_core::vector::{PointId, VectorModificationType};
 use graphene_core::Color;
 use graphene_std::vector::{HandleId, SegmentId};
@@ -545,7 +544,7 @@ impl Fsm for PenToolFsmState {
 					let nodes = vec![(NodeId(0), node_type.default_node_template())];
 
 					let parent = document.new_layer_parent(true);
-					let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, parent, responses);
+					let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 					tool_options.fill.apply_fill(layer, responses);
 					tool_options.stroke.apply_stroke(tool_options.line_weight, layer, responses);
 					tool_data.layer = Some(layer);

--- a/editor/src/messages/tool/tool_messages/polygon_tool.rs
+++ b/editor/src/messages/tool/tool_messages/polygon_tool.rs
@@ -12,7 +12,6 @@ use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
-use graphene_core::uuid::generate_uuid;
 use graphene_core::Color;
 
 #[derive(Default)]
@@ -265,7 +264,7 @@ impl Fsm for PolygonToolFsmState {
 
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, document.new_layer_parent(false), responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, document.new_layer_parent(false), responses);
 				responses.add(Message::StartBuffer);
 				responses.add(GraphOperationMessage::TransformSet {
 					layer,

--- a/editor/src/messages/tool/tool_messages/rectangle_tool.rs
+++ b/editor/src/messages/tool/tool_messages/rectangle_tool.rs
@@ -9,7 +9,6 @@ use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::snapping::SnapData;
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
-use graphene_core::uuid::generate_uuid;
 use graphene_core::Color;
 
 #[derive(Default)]
@@ -212,7 +211,7 @@ impl Fsm for RectangleToolFsmState {
 				let node = node_type.node_template_input_override([None, Some(NodeInput::value(TaggedValue::F64(1.), false)), Some(NodeInput::value(TaggedValue::F64(1.), false))]);
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, document.new_layer_parent(true), responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, document.new_layer_parent(true), responses);
 				responses.add(Message::StartBuffer);
 				responses.add(GraphOperationMessage::TransformSet {
 					layer,

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use super::tool_prelude::*;
-use crate::application::generate_uuid;
 use crate::consts::{ROTATE_SNAP_ANGLE, SELECTION_TOLERANCE};
 use crate::messages::input_mapper::utility_types::input_mouse::ViewportPosition;
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
@@ -343,7 +342,7 @@ impl SelectToolData {
 
 			let insert_index = DocumentMessageHandler::get_calculated_insert_index(document.metadata(), document.network_interface.selected_nodes(&[]).unwrap(), parent);
 
-			let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId(generate_uuid()))).collect();
+			let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 
 			let layer_id = *new_ids.get(&NodeId(0)).expect("Node Id 0 should be a layer");
 			let layer = LayerNodeIdentifier::new_unchecked(layer_id);

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -8,7 +8,6 @@ use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::snapping::SnapManager;
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
-use graphene_core::uuid::generate_uuid;
 use graphene_core::Color;
 
 #[derive(Default)]
@@ -212,7 +211,7 @@ impl Fsm for SplineToolFsmState {
 				let node = node_type.node_template_input_override([None, Some(NodeInput::value(TaggedValue::VecDVec2(Vec::new()), false))]);
 				let nodes = vec![(NodeId(0), node)];
 
-				let layer = graph_modification_utils::new_custom(NodeId(generate_uuid()), nodes, parent, responses);
+				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 				tool_options.fill.apply_fill(layer, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);
 				tool_data.layer = Some(layer);

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use super::tool_prelude::*;
-use crate::application::generate_uuid;
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
@@ -320,7 +319,7 @@ impl TextToolData {
 		else if let Some(editing_text) = self.editing_text.as_ref().filter(|_| state == TextToolFsmState::Ready) {
 			responses.add(DocumentMessage::AddTransaction);
 
-			self.layer = LayerNodeIdentifier::new_unchecked(NodeId(generate_uuid()));
+			self.layer = LayerNodeIdentifier::new_unchecked(NodeId::new());
 
 			responses.add(GraphOperationMessage::NewTextLayer {
 				id: self.layer.to_node(),

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -7,7 +7,6 @@
 use crate::helpers::translate_key;
 use crate::{Error, EDITOR, EDITOR_HANDLE, EDITOR_HAS_CRASHED};
 
-use editor::application::generate_uuid;
 use editor::application::Editor;
 use editor::consts::FILE_SAVE_SUFFIX;
 use editor::messages::input_mapper::utility_types::input_keyboard::ModifierKeys;
@@ -574,7 +573,7 @@ impl EditorHandle {
 	/// Creates a new document node in the node graph
 	#[wasm_bindgen(js_name = createNode)]
 	pub fn create_node(&self, node_type: String, x: i32, y: i32) {
-		let id = NodeId(generate_uuid());
+		let id = NodeId::new();
 		let message = NodeGraphMessage::CreateNodeFromContextMenu {
 			node_id: Some(id),
 			node_type,

--- a/node-graph/gcore/src/uuid.rs
+++ b/node-graph/gcore/src/uuid.rs
@@ -73,7 +73,6 @@ mod uuid_generation {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize, specta::Type, DynAny)]
 pub struct NodeId(pub u64);
 
-// TODO: Find and replace all `NodeId(generate_uuid())` with `NodeId::new()`.
 impl NodeId {
 	pub fn new() -> Self {
 		Self(generate_uuid())

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -747,11 +747,11 @@ fn migrate_layer_to_merge<'de, D: serde::Deserializer<'de>>(deserializer: D) -> 
 }
 // TODO: Eventually remove this (probably starting late 2024)
 fn default_import_metadata() -> (NodeId, IVec2) {
-	(NodeId(generate_uuid()), IVec2::new(-25, -4))
+	(NodeId::new(), IVec2::new(-25, -4))
 }
 // TODO: Eventually remove this (probably starting late 2024)
 fn default_export_metadata() -> (NodeId, IVec2) {
-	(NodeId(generate_uuid()), IVec2::new(8, -4))
+	(NodeId::new(), IVec2::new(8, -4))
 }
 
 #[derive(Clone, Default, Debug, DynAny)]
@@ -1016,7 +1016,7 @@ impl NodeNetwork {
 
 	/// Remove all nodes that contain [`DocumentNodeImplementation::Network`] by moving the nested nodes into the parent network.
 	pub fn flatten(&mut self, node_id: NodeId) {
-		self.flatten_with_fns(node_id, merge_ids, || NodeId(generate_uuid()))
+		self.flatten_with_fns(node_id, merge_ids, || NodeId::new())
 	}
 
 	/// Remove all nodes that contain [`DocumentNodeImplementation::Network`] by moving the nested nodes into the parent network.


### PR DESCRIPTION
Solves the todo:

https://github.com/GraphiteEditor/Graphite/blob/20470b566b6b80426887f028000a2c4944a513b2/node-graph/gcore/src/uuid.rs#L76