### PR TITLE
Replace self-hosted runner with GH-provided runner

### DIFF
--- a/.github/workflows/build-dev-and-ci.yml
+++ b/.github/workflows/build-dev-and-ci.yml
@@ -13,22 +13,15 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       deployments: write
       pull-requests: write
-    env:
-      RUSTC_WRAPPER: /usr/bin/sccache
-      CARGO_INCREMENTAL: 0
-      SCCACHE_DIR: /var/lib/github-actions/.cache
 
     steps:
       - name: 📥 Clone and checkout repository
         uses: actions/checkout@v3
-
-      - name: 🗑 Clear wasm-bindgen cache
-        run: rm -r ~/.cache/.wasm-pack || true
 
       - name: 🟢 Install the latest Node.js
         uses: actions/setup-node@v4
@@ -48,6 +41,17 @@ jobs:
           echo "Latest updated version:"
           rustc --version
 
+      - name: 📜 Install Rust dependencies
+        run: |
+          cargo install cargo-about
+          cargo install cargo-watch
+          cargo install wasm-pack
+          cargo install -f wasm-bindgen-cli@0.2.92
+
+      - name: 📦 Install system dependencies
+        run: |
+          sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
+
       - name: ✂ Replace template in <head> of index.html
         run: |
           # Remove the INDEX_HTML_HEAD_REPLACEMENT environment variable for build links (not master deploys)
@@ -59,7 +63,7 @@ jobs:
           NODE_ENV: production
         run: |
           cd frontend
-          mold -run npm run build
+          npm run build
 
       - name: 📤 Publish to Cloudflare Pages
         id: cloudflare
@@ -81,25 +85,15 @@ jobs:
 
       - name: 🔬 Check Rust formatting
         run: |
-          mold -run cargo fmt --all -- --check
+          cargo fmt --all -- --check
 
       - name: 🦀 Build Rust code
         run: |
-          mold -run cargo build --all-features
+          cargo build --all-features
 
       - name: 🧪 Run Rust tests
         run: |
-          mold -run cargo test --all-features
-
-  # miri:
-  #   runs-on: self-hosted
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-
-  #     - name: 🧪 Run Rust miri
-  #       run: |
-  #         mold -run cargo +nightly miri nextest run -j32 --all-features
+          cargo test --all-features
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -7,25 +7,18 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  INDEX_HTML_HEAD_REPLACEMENT: <script defer data-domain="editor.graphite.rs" data-api="https://graphite.rs/visit/event" src="https://graphite.rs/visit/script.hash.js"></script>
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       deployments: write
-    env:
-      RUSTC_WRAPPER: /usr/bin/sccache
-      CARGO_INCREMENTAL: 0
-      SCCACHE_DIR: /var/lib/github-actions/.cache
-      INDEX_HTML_HEAD_REPLACEMENT: <script defer data-domain="editor.graphite.rs" data-api="https://graphite.rs/visit/event" src="https://graphite.rs/visit/script.hash.js"></script>
 
     steps:
       - name: 📥 Clone and checkout repository
         uses: actions/checkout@v3
-
-      - name: 🗑 Clear wasm-bindgen cache
-        run: rm -r ~/.cache/.wasm-pack
 
       - name: 🟢 Install the latest Node.js
         uses: actions/setup-node@v4
@@ -45,6 +38,17 @@ jobs:
           echo "Latest updated version:"
           rustc --version
 
+      - name: 📜 Install Rust dependencies
+        run: |
+          cargo install cargo-about
+          cargo install cargo-watch
+          cargo install wasm-pack
+          cargo install -f wasm-bindgen-cli@0.2.92
+
+      - name: 📦 Install system dependencies
+        run: |
+          sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
+
       - name: ✂ Replace template in <head> of index.html
         run: |
           sed -i "s|<!-- INDEX_HTML_HEAD_REPLACEMENT -->|$INDEX_HTML_HEAD_REPLACEMENT|" frontend/index.html
@@ -54,7 +58,7 @@ jobs:
           NODE_ENV: production
         run: |
           cd frontend
-          mold -run npm run build
+          npm run build
 
       - name: 📤 Publish to Cloudflare Pages
         id: cloudflare

--- a/.github/workflows/comment-!build-commands.yml
+++ b/.github/workflows/comment-!build-commands.yml
@@ -22,15 +22,11 @@ jobs:
       github.event.issue.pull_request &&
       github.event.comment.author_association == 'MEMBER' &&
       (github.event.comment.body == '!build-dev' || github.event.comment.body == '!build-profiling' || github.event.comment.body == '!build')
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       deployments: write
       pull-requests: write
-    env:
-      RUSTC_WRAPPER: /usr/bin/sccache
-      CARGO_INCREMENTAL: 0
-      SCCACHE_DIR: /var/lib/github-actions/.cache
 
     steps:
       - name: 🔎 Find branch for this PR
@@ -50,10 +46,6 @@ jobs:
           repository: ${{ steps.commit_info.outputs.repo }}
           ref: ${{ steps.commit_info.outputs.ref }}
 
-      - name: 🗑 Clear wasm-bindgen cache
-        continue-on-error: true
-        run: rm -r ~/.cache/.wasm-pack
-
       - name: 🟢 Install the latest Node.js
         uses: actions/setup-node@v4
         with:
@@ -71,6 +63,17 @@ jobs:
           rustup update stable
           echo "Latest updated version:"
           rustc --version
+
+      - name: 📜 Install Rust dependencies
+        run: |
+          cargo install cargo-about
+          cargo install cargo-watch
+          cargo install wasm-pack
+          cargo install -f wasm-bindgen-cli@0.2.92
+
+      - name: 📦 Install system dependencies
+        run: |
+          sudo apt install libgtk-3-dev libsoup2.4-dev libjavascriptcoregtk-4.0-dev libwebkit2gtk-4.0-dev
 
       - name: ✂ Replace template in <head> of index.html
         run: |
@@ -96,7 +99,7 @@ jobs:
           NODE_ENV: production
         run: |
           cd frontend
-          mold -run npm run ${{ steps.build_command.outputs.command }}
+          npm run ${{ steps.build_command.outputs.command }}
 
       - name: 📤 Publish to Cloudflare Pages
         id: cloudflare


### PR DESCRIPTION
Due to the outage, I'm temporarily reverting use to GH-hosed runners until @TrueDoctor has the time to fix this CI outage.