### PR TITLE
Allow the Fill and Stroke nodes to work on groups

### DIFF
--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -71,6 +71,16 @@ impl GraphicGroup {
 	}
 }
 
+impl crate::vector::ApplyStyle for GraphicGroup {
+	fn apply(&mut self, mut modify_fn: impl FnMut(&mut crate::vector::PathStyle, DAffine2)) {
+		// The style is applied only to direct children (a bit unintuitive perhaps)
+		for (direct_child, _) in self.elements.iter_mut() {
+			let GraphicElement::VectorData(direct_child) = direct_child else { continue };
+			modify_fn(&mut direct_child.style, self.transform * direct_child.transform);
+		}
+	}
+}
+
 /// The possible forms of graphical content held in a Vec by the `elements` field of [`GraphicElement`].
 /// Can be another recursively nested [`GraphicGroup`], a [`VectorData`] shape, an [`ImageFrame`], or an [`Artboard`].
 #[derive(Clone, Debug, Hash, PartialEq, DynAny)]

--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -71,16 +71,6 @@ impl GraphicGroup {
 	}
 }
 
-impl crate::vector::ApplyStyle for GraphicGroup {
-	fn apply(&mut self, mut modify_fn: impl FnMut(&mut crate::vector::PathStyle, DAffine2)) {
-		// The style is applied only to direct children (a bit unintuitive perhaps)
-		for (direct_child, _) in self.elements.iter_mut() {
-			let GraphicElement::VectorData(direct_child) = direct_child else { continue };
-			modify_fn(&mut direct_child.style, self.transform * direct_child.transform);
-		}
-	}
-}
-
 /// The possible forms of graphical content held in a Vec by the `elements` field of [`GraphicElement`].
 /// Can be another recursively nested [`GraphicGroup`], a [`VectorData`] shape, an [`ImageFrame`], or an [`Artboard`].
 #[derive(Clone, Debug, Hash, PartialEq, DynAny)]

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -14,11 +14,11 @@ use rand::{Rng, SeedableRng};
 /// Implemented for types that can be converted to an iterator of vector data.
 /// Used for the fill and stroke node so they can be used on VectorData or GraphicGroup
 trait VectorIterMut {
-	fn vector_iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (&'a mut VectorData, DAffine2)> + 'a;
+	fn vector_iter_mut(&mut self) -> impl Iterator<Item = (&mut VectorData, DAffine2)>;
 }
 
 impl VectorIterMut for GraphicGroup {
-	fn vector_iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (&'a mut VectorData, DAffine2)> + 'a {
+	fn vector_iter_mut(&mut self) -> impl Iterator<Item = (&mut VectorData, DAffine2)> {
 		let parent_transform = self.transform;
 		// Grab only the direct children (perhaps unintuitive?)
 		self.iter_mut().filter_map(|(element, _)| element.as_vector_data_mut()).map(move |vector| {
@@ -29,7 +29,7 @@ impl VectorIterMut for GraphicGroup {
 }
 
 impl VectorIterMut for VectorData {
-	fn vector_iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (&'a mut VectorData, DAffine2)> + 'a {
+	fn vector_iter_mut(&mut self) -> impl Iterator<Item = (&mut VectorData, DAffine2)> {
 		let transform = self.transform;
 		std::iter::once((self, transform))
 	}

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -83,7 +83,9 @@ async fn assign_colors<F: 'n + Send, T: VectorIterMut>(
 
 /// A trait to allow the application of the path style (which allows the fill and stroke node to support either GraphicGroup or VectorData)
 pub trait ApplyStyle {
-	fn apply(&mut self, modify_fn: impl FnMut(&mut crate::vector::PathStyle, DAffine2)) {}
+	fn apply(&mut self, modify_fn: impl FnMut(&mut crate::vector::PathStyle, DAffine2)) {
+		let _ = modify_fn;
+	}
 }
 
 impl ApplyStyle for VectorData {


### PR DESCRIPTION
As requested by Keavon, it rather unintuitive works only on the direct children of a graphic group. Also the generics are a mess, I'm not really sure how they work.