### PR TITLE
Fix Text tool clearing text when hitting Escape by changing it to commit the edit instead

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -151,7 +151,7 @@ pub fn input_mappings() -> Mapping {
 		//
 		// TextToolMessage
 		entry!(KeyUp(MouseLeft); action_dispatch=TextToolMessage::Interact),
-		entry!(KeyDown(Escape); action_dispatch=TextToolMessage::Abort),
+		entry!(KeyDown(Escape); action_dispatch=TextToolMessage::CommitText),
 		entry!(KeyDown(Enter); modifiers=[Accel], action_dispatch=TextToolMessage::CommitText),
 		//
 		// GradientToolMessage

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -497,7 +497,7 @@ impl Fsm for TextToolFsmState {
 				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Edit Text")]),
 			]),
 			TextToolFsmState::Editing => HintData(vec![
-				HintGroup(vec![HintInfo::keys([Key::Escape], "Discard Changes")]),
+				HintGroup(vec![HintInfo::keys([Key::Escape], "Commit Changes")]),
 				HintGroup(vec![HintInfo::keys([Key::Control, Key::Enter], "Commit Changes").add_mac_keys([Key::Command, Key::Enter])]),
 			]),
 		};

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -496,10 +496,10 @@ impl Fsm for TextToolFsmState {
 				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Place Text")]),
 				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Edit Text")]),
 			]),
-			TextToolFsmState::Editing => HintData(vec![
-				HintGroup(vec![HintInfo::keys([Key::Escape], "Commit Changes")]),
-				HintGroup(vec![HintInfo::keys([Key::Control, Key::Enter], "Commit Changes").add_mac_keys([Key::Command, Key::Enter])]),
-			]),
+			TextToolFsmState::Editing => HintData(vec![HintGroup(vec![
+				HintInfo::keys([Key::Control, Key::Enter], "").add_mac_keys([Key::Command, Key::Enter]),
+				HintInfo::keys([Key::Escape], "Commit Changes").prepend_slash(),
+			])]),
 		};
 
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });


### PR DESCRIPTION
Closes #2051 

Text tool escape input now sends CommitText instead of abort.
