### PR TITLE
Remove type from NodeInput::Network

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -3421,10 +3421,7 @@ impl NodeNetworkInterface {
 	pub fn create_wire(&mut self, output_connector: &OutputConnector, input_connector: &InputConnector, network_path: &[NodeId]) {
 		let input = match output_connector {
 			OutputConnector::Node { node_id, output_index } => NodeInput::node(*node_id, *output_index),
-			OutputConnector::Import(import_index) => NodeInput::Network {
-				import_type: graph_craft::generic!(T),
-				import_index: *import_index,
-			},
+			OutputConnector::Import(import_index) => NodeInput::Network { import_index: *import_index },
 		};
 
 		self.set_input(input_connector, input, network_path);

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -229,7 +229,7 @@ impl NodeRuntime {
 		// We assume only one output
 		assert_eq!(scoped_network.exports.len(), 1, "Graph with multiple outputs not yet handled");
 		let c = Compiler {};
-		let proto_network = match c.compile_single(scoped_network) {
+		let proto_network = match c.compile_single(scoped_network, &[concrete!(RenderConfig)]) {
 			Ok(network) => network,
 			Err(e) => return Err(e),
 		};

--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -30,6 +30,7 @@
 	// Number presentation
 	export let displayDecimalPlaces = 2;
 	export let unit = "";
+	$: console.info("new unit", unit);
 	export let unitIsHiddenWhenEditing = true;
 
 	// Mode behavior

--- a/node-graph/compilation-client/src/main.rs
+++ b/node-graph/compilation-client/src/main.rs
@@ -13,7 +13,8 @@ fn main() {
 
 	let network = add_network();
 	let compiler = graph_craft::graphene_compiler::Compiler {};
-	let proto_network = compiler.compile_single(network).unwrap();
+	let input_types = vec![concrete!(Color), concrete!(Color), concrete!(u32)];
+	let proto_network = compiler.compile_single(network, &input_types).unwrap();
 
 	let io = ShaderIO {
 		inputs: vec![
@@ -25,7 +26,7 @@ fn main() {
 		output: ShaderInput::OutputBuffer((), concrete!(Color)),
 	};
 
-	let compile_request = CompileRequest::new(vec![proto_network], vec![concrete!(Color), concrete!(Color), concrete!(u32)], vec![concrete!(Color)], io);
+	let compile_request = CompileRequest::new(vec![proto_network], input_types, vec![concrete!(Color)], io);
 	let response = client
 		.post("http://localhost:3000/compile/spirv")
 		.timeout(Duration::from_secs(30))

--- a/node-graph/graph-craft/benches/compile_demo_art_criterion.rs
+++ b/node-graph/graph-craft/benches/compile_demo_art_criterion.rs
@@ -1,12 +1,14 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use graph_craft::util::DEMO_ART;
 fn compile_to_proto(c: &mut Criterion) {
-	use graph_craft::util::{compile, load_from_name};
+	use graph_craft::util::{compile_with_render_config, load_from_name};
 	let mut c = c.benchmark_group("Compile Network cold");
 
 	for name in DEMO_ART {
 		let network = load_from_name(name);
-		c.bench_function(name, |b| b.iter_batched(|| network.clone(), |network| compile(black_box(network)), criterion::BatchSize::SmallInput));
+		c.bench_function(name, |b| {
+			b.iter_batched(|| network.clone(), |network| compile_with_render_config(black_box(network)), criterion::BatchSize::SmallInput)
+		});
 	}
 }
 

--- a/node-graph/graph-craft/benches/compile_demo_art_iai.rs
+++ b/node-graph/graph-craft/benches/compile_demo_art_iai.rs
@@ -5,7 +5,7 @@ use iai_callgrind::{black_box, library_benchmark, library_benchmark_group, main}
 #[library_benchmark]
 #[benches::with_setup(args = ["isometric-fountain", "painted-dreams", "procedural-string-lights", "red-dress", "valley-of-spires"], setup = load_from_name)]
 pub fn compile_to_proto(_input: NodeNetwork) {
-	black_box(compile(_input));
+	black_box(compile_with_render_config(_input));
 }
 
 library_benchmark_group!(name = compile_group; benchmarks = compile_to_proto);

--- a/node-graph/graph-craft/src/graphene_compiler.rs
+++ b/node-graph/graph-craft/src/graphene_compiler.rs
@@ -6,7 +6,7 @@ use crate::proto::{LocalFuture, ProtoNetwork};
 pub struct Compiler {}
 
 impl Compiler {
-	pub fn compile(&self, mut network: NodeNetwork) -> impl Iterator<Item = Result<ProtoNetwork, String>> {
+	pub fn compile(&self, mut network: NodeNetwork, global_import_types: &[crate::Type]) -> impl Iterator<Item = Result<ProtoNetwork, String>> {
 		let node_ids = network.nodes.keys().copied().collect::<Vec<_>>();
 		network.populate_dependants();
 		for id in node_ids {
@@ -15,7 +15,7 @@ impl Compiler {
 		network.resolve_scope_inputs();
 		network.remove_redundant_id_nodes();
 		// network.remove_dead_nodes(0);
-		let proto_networks = network.into_proto_networks();
+		let proto_networks = network.into_proto_networks(global_import_types);
 
 		proto_networks.map(move |mut proto_network| {
 			proto_network.resolve_inputs()?;
@@ -23,9 +23,9 @@ impl Compiler {
 			Ok(proto_network)
 		})
 	}
-	pub fn compile_single(&self, network: NodeNetwork) -> Result<ProtoNetwork, String> {
+	pub fn compile_single(&self, network: NodeNetwork, global_import_types: &[crate::Type]) -> Result<ProtoNetwork, String> {
 		assert_eq!(network.exports.len(), 1, "Graph with multiple outputs not yet handled");
-		let Some(proto_network) = self.compile(network).next() else {
+		let Some(proto_network) = self.compile(network, global_import_types).next() else {
 			return Err("Failed to convert graph into proto graph".to_string());
 		};
 		proto_network

--- a/node-graph/graph-craft/src/util.rs
+++ b/node-graph/graph-craft/src/util.rs
@@ -7,9 +7,9 @@ pub fn load_network(document_string: &str) -> NodeNetwork {
 	serde_json::from_value::<NodeNetwork>(document["network_interface"]["network"].clone()).expect("Failed to parse document")
 }
 
-pub fn compile(network: NodeNetwork) -> ProtoNetwork {
+pub fn compile_with_render_config(network: NodeNetwork) -> ProtoNetwork {
 	let compiler = Compiler {};
-	compiler.compile_single(network).unwrap()
+	compiler.compile_single(network, &[concrete!(graphene_core::application_io::RenderConfig)]).unwrap()
 }
 
 pub fn load_from_name(name: &str) -> NodeNetwork {

--- a/node-graph/graphene-cli/src/main.rs
+++ b/node-graph/graphene-cli/src/main.rs
@@ -1,7 +1,7 @@
-use graph_craft::document::*;
 use graph_craft::graphene_compiler::{Compiler, Executor};
 use graph_craft::util::load_network;
 use graph_craft::wasm_application_io::EditorPreferences;
+use graph_craft::{concrete, document::*};
 use graphene_core::application_io::{ApplicationIo, NodeGraphUpdateSender};
 use graphene_core::text::FontCache;
 use graphene_std::wasm_application_io::{WasmApplicationIo, WasmEditorApi};
@@ -105,7 +105,7 @@ fn create_executor(document_string: String, editor_api: Arc<WasmEditorApi>) -> R
 
 	let wrapped_network = wrap_network_in_scope(network.clone(), editor_api);
 	let compiler = Compiler {};
-	let protograph = compiler.compile_single(wrapped_network)?;
+	let protograph = compiler.compile_single(wrapped_network, &[concrete!(graphene_core::application_io::RenderConfig)])?;
 	let executor = block_on(DynamicExecutor::new(protograph)).unwrap();
 	Ok(executor)
 }

--- a/node-graph/interpreted-executor/benches/benchmark_util.rs
+++ b/node-graph/interpreted-executor/benches/benchmark_util.rs
@@ -2,13 +2,13 @@ use criterion::{measurement::Measurement, BenchmarkGroup};
 use futures::executor::block_on;
 use graph_craft::{
 	proto::ProtoNetwork,
-	util::{compile, load_from_name, DEMO_ART},
+	util::{compile_with_render_config, load_from_name, DEMO_ART},
 };
 use interpreted_executor::dynamic_executor::DynamicExecutor;
 
 pub fn setup_network(name: &str) -> (DynamicExecutor, ProtoNetwork) {
 	let network = load_from_name(name);
-	let proto_network = compile(network);
+	let proto_network = compile_with_render_config(network);
 	let executor = block_on(DynamicExecutor::new(proto_network.clone())).unwrap();
 	(executor, proto_network)
 }

--- a/node-graph/interpreted-executor/benches/run_demo_art_criterion.rs
+++ b/node-graph/interpreted-executor/benches/run_demo_art_criterion.rs
@@ -2,14 +2,14 @@ use criterion::{black_box, criterion_group, criterion_main, measurement::Measure
 use graph_craft::{
 	graphene_compiler::Executor,
 	proto::ProtoNetwork,
-	util::{compile, load_from_name, DEMO_ART},
+	util::{compile_with_render_config, load_from_name, DEMO_ART},
 };
 use graphene_std::transform::Footprint;
 use interpreted_executor::dynamic_executor::DynamicExecutor;
 
 fn update_executor<M: Measurement>(name: &str, c: &mut BenchmarkGroup<M>) {
 	let network = load_from_name(name);
-	let proto_network = compile(network);
+	let proto_network = compile_with_render_config(network);
 	let empty = ProtoNetwork::default();
 
 	let executor = futures::executor::block_on(DynamicExecutor::new(empty)).unwrap();
@@ -32,7 +32,7 @@ fn update_executor_demo(c: &mut Criterion) {
 
 fn run_once<M: Measurement>(name: &str, c: &mut BenchmarkGroup<M>) {
 	let network = load_from_name(name);
-	let proto_network = compile(network);
+	let proto_network = compile_with_render_config(network);
 
 	let executor = futures::executor::block_on(DynamicExecutor::new(proto_network)).unwrap();
 	let footprint = Footprint::default();

--- a/node-graph/interpreted-executor/src/lib.rs
+++ b/node-graph/interpreted-executor/src/lib.rs
@@ -44,7 +44,7 @@ mod tests {
 		use graph_craft::graphene_compiler::Compiler;
 
 		let compiler = Compiler {};
-		let protograph = compiler.compile_single(network).expect("Graph should be generated");
+		let protograph = compiler.compile_single(network, &[concrete!(u32)]).expect("Graph should be generated");
 
 		let _exec = block_on(DynamicExecutor::new(protograph)).map(|_e| panic!("The network should not type check ")).unwrap_err();
 	}


### PR DESCRIPTION
Partially addresses #2042 (this removes the type from NodeNetwork::Input).

In the issue it mentions that it is necessary to store input types in the `NodeNetwork` struct for the into system. I am unsure of how exactly the into insertion system would be implemented. However I don't believe the proposed change would help at all.
In order to insert an into node, you need to resolve the type of the input. Types are only resolved after flattening. After flattening the nested network inputs are no longer accessible. This makes storing a list of input types in the `NodeNetwork` entirely redundant.

This change necessitated passing the types to the top level network to the compile function. This is only required for the inputs to the TOP LEVEL node network. This doesn't impact copy pasting or in any other way limit the flexibility of the graph. When you compile a network and then call it, you already know what types you are going to call it with (for the editor this is `concrete!(RenderConfig)`).

Even if further work is required for this issue, I think this PR represents an improvement as it avoids storing redundant and unused data within the complex network data structures.