### PR TITLE
Fix layer name text input

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1631,7 +1631,7 @@ impl NodeGraphMessageHandler {
 						Separator::new(SeparatorType::Related).widget_holder(),
 						IconLabel::new("Layer").tooltip("Name of the selected layer").widget_holder(),
 						Separator::new(SeparatorType::Related).widget_holder(),
-						TextInput::new(context.document_name)
+						TextInput::new(context.network_interface.frontend_display_name(&layer, context.selection_network_path))
 							.on_update(move |text_input| {
 								NodeGraphMessage::SetDisplayName {
 									node_id: layer,


### PR DESCRIPTION
Fixes an issue created & reported by Keavon.

It appears that the text input value for the layer name should have been the layer name instead of the document name.