### PR TITLE
Improve the node graph with revamped top bar and disabling tools when graph is open

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -199,10 +199,11 @@ impl Dispatcher {
 				Message::Portfolio(message) => {
 					let ipp = &self.message_handlers.input_preprocessor_message_handler;
 					let preferences = &self.message_handlers.preferences_message_handler;
+					let current_tool = &self.message_handlers.tool_message_handler.tool_state.tool_data.active_tool_type;
 
 					self.message_handlers
 						.portfolio_message_handler
-						.process_message(message, &mut queue, PortfolioMessageData { ipp, preferences });
+						.process_message(message, &mut queue, PortfolioMessageData { ipp, preferences, current_tool });
 				}
 				Message::Preferences(message) => {
 					self.message_handlers.preferences_message_handler.process_message(message, &mut queue, ());
@@ -244,8 +245,10 @@ impl Dispatcher {
 		list.extend(self.message_handlers.input_preprocessor_message_handler.actions());
 		list.extend(self.message_handlers.key_mapping_message_handler.actions());
 		list.extend(self.message_handlers.debug_message_handler.actions());
-		if self.message_handlers.portfolio_message_handler.active_document().is_some() {
-			list.extend(self.message_handlers.tool_message_handler.actions());
+		if let Some(document) = self.message_handlers.portfolio_message_handler.active_document() {
+			if !document.graph_view_overlay_open {
+				list.extend(self.message_handlers.tool_message_handler.actions());
+			}
 		}
 		list.extend(self.message_handlers.portfolio_message_handler.actions());
 		list

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -84,9 +84,6 @@ pub enum FrontendMessage {
 		#[serde(rename = "isDefault")]
 		is_default: bool,
 	},
-	TriggerGraphViewOverlay {
-		open: bool,
-	},
 	TriggerImport,
 	TriggerIndexedDbRemoveDocument {
 		#[serde(rename = "documentId")]
@@ -152,6 +149,9 @@ pub enum FrontendMessage {
 	UpdateClickTargets {
 		#[serde(rename = "clickTargets")]
 		click_targets: Option<FrontendClickTargets>,
+	},
+	UpdateGraphViewOverlay {
+		open: bool,
 	},
 	UpdateLayerWidths {
 		#[serde(rename = "layerWidths")]
@@ -220,6 +220,9 @@ pub enum FrontendMessage {
 		secondary_color: String,
 		#[serde(rename = "setColorChoice")]
 		set_color_choice: Option<String>,
+	},
+	UpdateGraphFadeArtwork {
+		percentage: f64,
 	},
 	UpdateInputHints {
 		#[serde(rename = "hintData")]

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -71,6 +71,7 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(KeyC); modifiers=[Accel], action_dispatch=NodeGraphMessage::Copy),
 		entry!(KeyDown(KeyD); modifiers=[Accel], action_dispatch=NodeGraphMessage::DuplicateSelectedNodes),
 		entry!(KeyDown(KeyH); modifiers=[Accel], action_dispatch=NodeGraphMessage::ToggleSelectedVisibility),
+		entry!(KeyDown(KeyL); modifiers=[Accel], action_dispatch=NodeGraphMessage::ToggleSelectedLocked),
 		entry!(KeyDown(KeyL); modifiers=[Alt], action_dispatch=NodeGraphMessage::ToggleSelectedAsLayersOrNodes),
 		entry!(KeyDown(KeyC); modifiers=[Shift], action_dispatch=NodeGraphMessage::PrintSelectedNodeCoordinates),
 		entry!(KeyDown(KeyC); modifiers=[Alt], action_dispatch=NodeGraphMessage::SendClickTargets),

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -52,6 +52,7 @@ pub fn input_mappings() -> Mapping {
 		//
 		// Hack to prevent Left Click + Accel + Z combo (this effectively blocks you from making a double undo with AbortTransaction)
 		entry!(KeyDown(KeyZ); modifiers=[Accel, MouseLeft], action_dispatch=DocumentMessage::Noop),
+		//
 		// NodeGraphMessage
 		entry!(KeyDown(MouseLeft); action_dispatch=NodeGraphMessage::PointerDown {shift_click: false, control_click: false, alt_click: false, right_click: false}),
 		entry!(KeyDown(MouseLeft); modifiers=[Shift], action_dispatch=NodeGraphMessage::PointerDown {shift_click: true, control_click: false, alt_click: false, right_click: false}),
@@ -69,6 +70,7 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(KeyX); modifiers=[Accel], action_dispatch=NodeGraphMessage::Cut),
 		entry!(KeyDown(KeyC); modifiers=[Accel], action_dispatch=NodeGraphMessage::Copy),
 		entry!(KeyDown(KeyD); modifiers=[Accel], action_dispatch=NodeGraphMessage::DuplicateSelectedNodes),
+		entry!(KeyDown(KeyH); modifiers=[Accel], action_dispatch=NodeGraphMessage::ToggleSelectedVisibility),
 		entry!(KeyDown(KeyL); modifiers=[Alt], action_dispatch=NodeGraphMessage::ToggleSelectedAsLayersOrNodes),
 		entry!(KeyDown(KeyC); modifiers=[Shift], action_dispatch=NodeGraphMessage::PrintSelectedNodeCoordinates),
 		entry!(KeyDown(KeyC); modifiers=[Alt], action_dispatch=NodeGraphMessage::SendClickTargets),

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -131,6 +131,9 @@ pub enum DocumentMessage {
 	SetBlendModeForSelectedLayers {
 		blend_mode: BlendMode,
 	},
+	SetGraphFadeArtwork {
+		percentage: f64,
+	},
 	SetNodePinned {
 		node_id: NodeId,
 		pinned: bool,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -215,6 +215,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						ipp,
 						graph_view_overlay_open: self.graph_view_overlay_open,
 						graph_fade_artwork_percentage: self.graph_fade_artwork_percentage,
+						navigation_handler: &self.navigation_handler,
 					},
 				);
 			}
@@ -2043,15 +2044,15 @@ impl DocumentMessageHandler {
 				IconButton::new(if selection_all_locked { "PadlockLocked" } else { "PadlockUnlocked" }, 24)
 					.hover_icon(Some((if selection_all_locked { "PadlockUnlocked" } else { "PadlockLocked" }).into()))
 					.tooltip(if selection_all_locked { "Unlock Selected" } else { "Lock Selected" })
-					.tooltip_shortcut(action_keys!(NodeGraphMessageDiscriminant::ToggleSelectedLocked))
+					.tooltip_shortcut(action_keys!(DocumentMessageDiscriminant::ToggleSelectedLocked))
 					.on_update(|_| NodeGraphMessage::ToggleSelectedLocked.into())
 					.disabled(!has_selection)
 					.widget_holder(),
 				IconButton::new(if selection_all_visible { "EyeVisible" } else { "EyeHidden" }, 24)
 					.hover_icon(Some((if selection_all_visible { "EyeHide" } else { "EyeShow" }).into()))
 					.tooltip(if selection_all_visible { "Hide Selected" } else { "Show Selected" })
-					.tooltip_shortcut(action_keys!(NodeGraphMessageDiscriminant::ToggleSelectedVisibility))
-					.on_update(|_| NodeGraphMessage::ToggleSelectedVisibility.into())
+					.tooltip_shortcut(action_keys!(DocumentMessageDiscriminant::ToggleSelectedVisibility))
+					.on_update(|_| DocumentMessage::ToggleSelectedVisibility.into())
 					.disabled(!has_selection)
 					.widget_holder(),
 			],

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -39,44 +39,7 @@ pub struct DocumentMessageData<'a> {
 	pub ipp: &'a InputPreprocessorMessageHandler,
 	pub persistent_data: &'a PersistentData,
 	pub executor: &'a mut NodeGraphExecutor,
-}
-
-// TODO: Eventually remove this (probably starting late 2024)
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct OldDocumentMessageHandler {
-	// ============================================
-	// Fields that are saved in the document format
-	// ============================================
-	//
-	/// The node graph that generates this document's artwork.
-	/// It recursively stores its sub-graphs, so this root graph is the whole snapshot of the document content.
-	pub network: OldNodeNetwork,
-	/// List of the [`NodeId`]s that are currently selected by the user.
-	pub selected_nodes: SelectedNodes,
-	/// List of the [`LayerNodeIdentifier`]s that are currently collapsed by the user in the Layers panel.
-	/// Collapsed means that the expansion arrow isn't set to show the children of these layers.
-	pub collapsed: CollapsedLayers,
-	/// The name of the document, which is displayed in the tab and title bar of the editor.
-	pub name: String,
-	/// The full Git commit hash of the Graphite repository that was used to build the editor.
-	/// We save this to provide a hint about which version of the editor was used to create the document.
-	pub commit_hash: String,
-	/// The current pan, tilt, and zoom state of the viewport's view of the document canvas.
-	pub document_ptz: PTZ,
-	/// The current mode that the document is in, which starts out as Design Mode. This choice affects the editing behavior of the tools.
-	pub document_mode: DocumentMode,
-	/// The current view mode that the user has set for rendering the document within the viewport.
-	/// This is usually "Normal" but can be set to "Outline" or "Pixels" to see the canvas differently.
-	pub view_mode: ViewMode,
-	/// Sets whether or not all the viewport overlays should be drawn on top of the artwork.
-	/// This includes tool interaction visualizations (like the transform cage and path anchors/handles), the grid, and more.
-	pub overlays_visible: bool,
-	/// Sets whether or not the rulers should be drawn along the top and left edges of the viewport area.
-	pub rulers_visible: bool,
-	/// Sets whether or not the node graph is drawn (as an overlay) on top of the viewport area, or otherwise if it's hidden.
-	pub graph_view_overlay_open: bool,
-	/// The current user choices for snapping behavior, including whether snapping is enabled at all.
-	pub snapping_state: SnappingState,
+	pub current_tool: &'a ToolType,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -121,10 +84,12 @@ pub struct DocumentMessageHandler {
 	pub overlays_visible: bool,
 	/// Sets whether or not the rulers should be drawn along the top and left edges of the viewport area.
 	pub rulers_visible: bool,
-	/// Sets whether or not the node graph is drawn (as an overlay) on top of the viewport area, or otherwise if it's hidden.
-	pub graph_view_overlay_open: bool,
 	/// The current user choices for snapping behavior, including whether snapping is enabled at all.
 	pub snapping_state: SnappingState,
+	/// Sets whether or not the node graph is drawn (as an overlay) on top of the viewport area, or otherwise if it's hidden.
+	pub graph_view_overlay_open: bool,
+	/// The current opacity of the faded node graph background that covers up the artwork.
+	pub graph_fade_artwork_percentage: f64,
 
 	// =============================================
 	// Fields omitted from the saved document format
@@ -178,6 +143,7 @@ impl Default for DocumentMessageHandler {
 			rulers_visible: true,
 			graph_view_overlay_open: false,
 			snapping_state: SnappingState::default(),
+			graph_fade_artwork_percentage: 80.,
 			// =============================================
 			// Fields omitted from the saved document format
 			// =============================================
@@ -199,6 +165,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			ipp,
 			persistent_data,
 			executor,
+			current_tool,
 		} = data;
 
 		let selected_nodes_bounding_box_viewport = self.network_interface.selected_nodes_bounding_box_viewport(&self.breadcrumb_network_path);
@@ -247,6 +214,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						collapsed: &mut self.collapsed,
 						ipp,
 						graph_view_overlay_open: self.graph_view_overlay_open,
+						graph_fade_artwork_percentage: self.graph_fade_artwork_percentage,
 					},
 				);
 			}
@@ -477,15 +445,25 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 			DocumentMessage::GraphViewOverlay { open } => {
 				self.graph_view_overlay_open = open;
 
-				responses.add(FrontendMessage::TriggerGraphViewOverlay { open });
+				responses.add(FrontendMessage::UpdateGraphViewOverlay { open });
+				responses.add(FrontendMessage::UpdateGraphFadeArtwork {
+					percentage: self.graph_fade_artwork_percentage,
+				});
+
 				// Update the tilt menu bar buttons to be disabled when the graph is open
 				responses.add(MenuBarMessage::SendLayout);
+
 				responses.add(DocumentMessage::RenderRulers);
 				responses.add(DocumentMessage::RenderScrollbars);
 				if open {
+					responses.add(ToolMessage::DeactivateTools);
+					responses.add(OverlaysMessage::Draw); // Clear the overlays
 					responses.add(NavigationMessage::CanvasTiltSet { angle_radians: 0. });
 					responses.add(NodeGraphMessage::SetGridAlignedEdges);
+					responses.add(NodeGraphMessage::UpdateGraphBarRight);
 					responses.add(NodeGraphMessage::SendGraph);
+				} else {
+					responses.add(ToolMessage::ActivateTool { tool_type: *current_tool });
 				}
 			}
 			DocumentMessage::GraphViewOverlayToggle => {
@@ -1019,6 +997,10 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					responses.add(GraphOperationMessage::BlendModeSet { layer, blend_mode });
 				}
 			}
+			DocumentMessage::SetGraphFadeArtwork { percentage } => {
+				self.graph_fade_artwork_percentage = percentage;
+				responses.add(FrontendMessage::UpdateGraphFadeArtwork { percentage });
+			}
 			DocumentMessage::SetNodePinned { node_id, pinned } => {
 				responses.add(DocumentMessage::StartTransaction);
 				responses.add(NodeGraphMessage::SetPinned { node_id, pinned });
@@ -1338,11 +1320,13 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 				SelectedLayersRaise,
 				SelectedLayersRaiseToFront,
 				UngroupSelectedLayers,
-				ToggleSelectedVisibility,
 				ToggleSelectedLocked
 			);
 			if !self.graph_view_overlay_open {
-				select.extend(actions!(DocumentMessageDiscriminant; NudgeSelectedLayers));
+				select.extend(actions!(DocumentMessageDiscriminant;
+					NudgeSelectedLayers,
+					ToggleSelectedVisibility,
+				));
 			}
 			common.extend(select);
 		}
@@ -2265,4 +2249,42 @@ impl<'a> Iterator for ClickXRayIter<'a> {
 		assert!(self.parent_targets.is_empty(), "The parent targets should always be empty (since we have left all layers)");
 		None
 	}
+}
+
+// TODO: Eventually remove this (probably starting late 2024)
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct OldDocumentMessageHandler {
+	// ============================================
+	// Fields that are saved in the document format
+	// ============================================
+	//
+	/// The node graph that generates this document's artwork.
+	/// It recursively stores its sub-graphs, so this root graph is the whole snapshot of the document content.
+	pub network: OldNodeNetwork,
+	/// List of the [`NodeId`]s that are currently selected by the user.
+	pub selected_nodes: SelectedNodes,
+	/// List of the [`LayerNodeIdentifier`]s that are currently collapsed by the user in the Layers panel.
+	/// Collapsed means that the expansion arrow isn't set to show the children of these layers.
+	pub collapsed: CollapsedLayers,
+	/// The name of the document, which is displayed in the tab and title bar of the editor.
+	pub name: String,
+	/// The full Git commit hash of the Graphite repository that was used to build the editor.
+	/// We save this to provide a hint about which version of the editor was used to create the document.
+	pub commit_hash: String,
+	/// The current pan, tilt, and zoom state of the viewport's view of the document canvas.
+	pub document_ptz: PTZ,
+	/// The current mode that the document is in, which starts out as Design Mode. This choice affects the editing behavior of the tools.
+	pub document_mode: DocumentMode,
+	/// The current view mode that the user has set for rendering the document within the viewport.
+	/// This is usually "Normal" but can be set to "Outline" or "Pixels" to see the canvas differently.
+	pub view_mode: ViewMode,
+	/// Sets whether or not all the viewport overlays should be drawn on top of the artwork.
+	/// This includes tool interaction visualizations (like the transform cage and path anchors/handles), the grid, and more.
+	pub overlays_visible: bool,
+	/// Sets whether or not the rulers should be drawn along the top and left edges of the viewport area.
+	pub rulers_visible: bool,
+	/// Sets whether or not the node graph is drawn (as an overlay) on top of the viewport area, or otherwise if it's hidden.
+	pub graph_view_overlay_open: bool,
+	/// The current user choices for snapping behavior, including whether snapping is enabled at all.
+	pub snapping_state: SnappingState,
 }

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -30,8 +30,7 @@ pub enum NodeGraphMessage {
 	CreateNodeFromContextMenu {
 		node_id: Option<NodeId>,
 		node_type: String,
-		x: i32,
-		y: i32,
+		xy: Option<(i32, i32)>,
 	},
 	CreateWire {
 		output_connector: OutputConnector,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -182,6 +182,7 @@ pub enum NodeGraphMessage {
 		node_graph_errors: GraphErrors,
 	},
 	UpdateActionButtons,
+	UpdateGraphBarRight,
 	UpdateInSelectedNetwork,
 	SendSelectedNodes,
 }

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -3,6 +3,7 @@ use super::{document_node_definitions, node_properties};
 use crate::consts::GRID_SIZE;
 use crate::messages::input_mapper::utility_types::macros::action_keys;
 use crate::messages::layout::utility_types::widget_prelude::*;
+use crate::messages::portfolio::document::document_message_handler::navigation_controls;
 use crate::messages::portfolio::document::graph_operation::utility_types::ModifyInputsContext;
 use crate::messages::portfolio::document::node_graph::document_node_definitions::NodePropertiesContext;
 use crate::messages::portfolio::document::node_graph::utility_types::{ContextMenuData, Direction, FrontendGraphDataType};
@@ -1613,7 +1614,7 @@ impl NodeGraphMessageHandler {
 			return;
 		};
 
-		let widgets = vec![
+		let mut widgets = vec![
 			NumberInput::new(Some(graph_fade_artwork_percentage))
 				.percentage()
 				.display_decimal_places(0)
@@ -1627,63 +1628,9 @@ impl NodeGraphMessageHandler {
 				})
 				.widget_holder(),
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
-			IconButton::new("ZoomIn", 24)
-				.tooltip("Zoom In")
-				.tooltip_shortcut(action_keys!(NavigationMessageDiscriminant::CanvasZoomIncrease))
-				.on_update(|_| NavigationMessage::CanvasZoomIncrease { center_on_mouse: false }.into())
-				.widget_holder(),
-			IconButton::new("ZoomOut", 24)
-				.tooltip("Zoom Out")
-				.tooltip_shortcut(action_keys!(NavigationMessageDiscriminant::CanvasZoomDecrease))
-				.on_update(|_| NavigationMessage::CanvasZoomDecrease { center_on_mouse: false }.into())
-				.widget_holder(),
-			IconButton::new("ZoomReset", 24)
-				.tooltip("Reset Tilt and Zoom to 100%")
-				.tooltip_shortcut(action_keys!(NavigationMessageDiscriminant::CanvasTiltResetAndZoomTo100Percent))
-				.on_update(|_| NavigationMessage::CanvasTiltResetAndZoomTo100Percent.into())
-				.disabled((node_graph_ptz.zoom() - 1.).abs() < 1e-4)
-				.widget_holder(),
-			PopoverButton::new()
-				.popover_layout(vec![
-					LayoutGroup::Row {
-						widgets: vec![TextLabel::new("Node Graph Navigation").bold(true).widget_holder()],
-					},
-					LayoutGroup::Row {
-						widgets: vec![TextLabel::new(
-							"
-								Interactive controls in this\n\
-								menu are coming soon.\n\
-								\n\
-								Pan:\n\
-								• Middle Click Drag\n\
-								\n\
-								Zoom:\n\
-								• Shift + Middle Click Drag\n\
-								• Ctrl + Scroll Wheel Roll
-							"
-							.trim(),
-						)
-						.multiline(true)
-						.widget_holder()],
-					},
-				])
-				.widget_holder(),
-			Separator::new(SeparatorType::Related).widget_holder(),
-			NumberInput::new(Some(navigation_handler.snapped_zoom(node_graph_ptz.zoom()) * 100.))
-				.unit("%")
-				.min(0.000001)
-				.max(1000000.)
-				.tooltip("Node graph zoom")
-				.on_update(|number_input: &NumberInput| {
-					NavigationMessage::CanvasZoomSet {
-						zoom_factor: number_input.value.unwrap() / 100.,
-					}
-					.into()
-				})
-				.increment_behavior(NumberInputIncrementBehavior::Callback)
-				.increment_callback_decrease(|_| NavigationMessage::CanvasZoomDecrease { center_on_mouse: false }.into())
-				.increment_callback_increase(|_| NavigationMessage::CanvasZoomIncrease { center_on_mouse: false }.into())
-				.widget_holder(),
+		];
+		widgets.extend(navigation_controls(node_graph_ptz, navigation_handler, "Node Graph"));
+		widgets.extend([
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
 			TextButton::new("Node Graph")
 				.icon(Some("GraphViewOpen".into()))
@@ -1692,7 +1639,7 @@ impl NodeGraphMessageHandler {
 				.tooltip_shortcut(action_keys!(DocumentMessageDiscriminant::GraphViewOverlayToggle))
 				.on_update(move |_| DocumentMessage::GraphViewOverlayToggle.into())
 				.widget_holder(),
-		];
+		]);
 
 		self.widgets[1] = LayoutGroup::Row { widgets };
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -2569,6 +2569,14 @@ impl NodeNetworkInterface {
 			&& (input_count <= 2)
 	}
 
+	pub fn node_graph_ptz(&self, network_path: &[NodeId]) -> Option<&PTZ> {
+		let Some(network_metadata) = self.network_metadata(network_path) else {
+			log::error!("Could not get nested network_metadata in node_graph_ptz_mut");
+			return None;
+		};
+		Some(&network_metadata.persistent_metadata.navigation_metadata.node_graph_ptz)
+	}
+
 	pub fn node_graph_ptz_mut(&mut self, network_path: &[NodeId]) -> Option<&mut PTZ> {
 		let Some(network_metadata) = self.network_metadata_mut(network_path) else {
 			log::error!("Could not get nested network_metadata in node_graph_ptz_mut");

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -757,10 +757,14 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				responses.add(OverlaysMessage::Draw);
 				responses.add(BroadcastEvent::ToolAbort);
 				responses.add(BroadcastEvent::SelectionChanged);
-				responses.add(PortfolioMessage::UpdateDocumentWidgets);
 				responses.add(NavigationMessage::CanvasPan { delta: (0., 0.).into() });
 				responses.add(NodeGraphMessage::RunDocumentGraph);
 				responses.add(DocumentMessage::GraphViewOverlay { open: node_graph_open });
+				if node_graph_open {
+					responses.add(NodeGraphMessage::UpdateGraphBarRight);
+				} else {
+					responses.add(PortfolioMessage::UpdateDocumentWidgets);
+				}
 			}
 			PortfolioMessage::SubmitDocumentExport {
 				file_name,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -10,7 +10,7 @@ use crate::messages::portfolio::document::node_graph::document_node_definitions:
 use crate::messages::portfolio::document::utility_types::clipboards::{Clipboard, CopyBufferEntry, INTERNAL_CLIPBOARD_COUNT};
 use crate::messages::portfolio::document::DocumentMessageData;
 use crate::messages::prelude::*;
-use crate::messages::tool::utility_types::{HintData, HintGroup};
+use crate::messages::tool::utility_types::{HintData, HintGroup, ToolType};
 use crate::node_graph_executor::{ExportConfig, NodeGraphExecutor};
 
 use graph_craft::document::value::TaggedValue;
@@ -25,6 +25,7 @@ use std::vec;
 pub struct PortfolioMessageData<'a> {
 	pub ipp: &'a InputPreprocessorMessageHandler,
 	pub preferences: &'a PreferencesMessageHandler,
+	pub current_tool: &'a ToolType,
 }
 
 #[derive(Debug, Default)]
@@ -41,7 +42,7 @@ pub struct PortfolioMessageHandler {
 
 impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMessageHandler {
 	fn process_message(&mut self, message: PortfolioMessage, responses: &mut VecDeque<Message>, data: PortfolioMessageData) {
-		let PortfolioMessageData { ipp, preferences } = data;
+		let PortfolioMessageData { ipp, preferences, current_tool } = data;
 
 		match message {
 			// Sub-messages
@@ -73,6 +74,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 							ipp,
 							persistent_data: &self.persistent_data,
 							executor: &mut self.executor,
+							current_tool,
 						};
 						document.process_message(message, responses, document_inputs)
 					}
@@ -87,6 +89,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 						ipp,
 						persistent_data: &self.persistent_data,
 						executor: &mut self.executor,
+						current_tool,
 					};
 					document.process_message(message, responses, document_inputs)
 				}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -539,7 +539,6 @@ impl Fsm for PenToolFsmState {
 				// Perform extension of an existing path
 				let selected_nodes = document.network_interface.selected_nodes(&[]).unwrap();
 				if let Some((layer, point, position)) = should_extend(document, viewport, crate::consts::SNAP_POINT_TOLERANCE, selected_nodes.selected_layers(document.metadata())) {
-					log::debug!("Should extend: {:?}", layer);
 					tool_data.add_point(LastPoint {
 						id: point,
 						pos: position,
@@ -550,7 +549,6 @@ impl Fsm for PenToolFsmState {
 					tool_data.next_point = position;
 					tool_data.next_handle_start = position;
 				} else if let (Some(layer), None) = (selected_layers.next(), selected_layers.next()) {
-					log::debug!("Adding to layer: {:?}", layer);
 					// Add the first point to a new layer
 					// Generate first point
 					let id = PointId::generate();
@@ -566,7 +564,6 @@ impl Fsm for PenToolFsmState {
 					tool_data.next_point = pos;
 					tool_data.next_handle_start = pos;
 				} else {
-					log::debug!("Creating new layer");
 					// New path layer
 					let node_type = resolve_document_node_type("Path").expect("Path node does not exist");
 					let nodes = vec![(NodeId(0), node_type.default_node_template())];

--- a/editor/src/messages/tool/utility_types.rs
+++ b/editor/src/messages/tool/utility_types.rs
@@ -477,7 +477,7 @@ pub fn tool_type_to_activate_tool_message(tool_type: ToolType) -> ToolMessageDis
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
 pub struct HintData(pub Vec<HintGroup>);
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]

--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -504,7 +504,7 @@
 						<canvas class="overlays" width={canvasWidthRoundedToEven} height={canvasHeightRoundedToEven} style:width={canvasWidthCSS} style:height={canvasHeightCSS} data-overlays-canvas>
 						</canvas>
 					</div>
-					<div class="graph-view" class:open={$document.graphViewOverlayOpen} style:--fade-artwork="80%" data-graph>
+					<div class="graph-view" class:open={$document.graphViewOverlayOpen} style:--fade-artwork={`${$document.fadeArtwork}%`} data-graph>
 						<Graph />
 					</div>
 				</LayoutCol>

--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -989,7 +989,7 @@
 			}
 
 			&.disabled {
-				background: var(--color-3-darkgray);
+				background: rgba(var(--color-4-dimgray-rgb), 0.33);
 				color: var(--color-a-softgray);
 
 				.icon-label {
@@ -1041,10 +1041,10 @@
 			}
 
 			&.selected {
-				background: rgba(var(--color-5-dullgray-rgb), 0.5);
+				background: rgba(var(--color-5-dullgray-rgb), 0.33);
 
 				&.in-selected-network {
-					background: rgba(var(--color-6-lowergray-rgb), 0.5);
+					background: rgba(var(--color-6-lowergray-rgb), 0.33);
 				}
 			}
 

--- a/frontend/src/components/widgets/WidgetSection.svelte
+++ b/frontend/src/components/widgets/WidgetSection.svelte
@@ -27,18 +27,16 @@
 	<button class="header" class:expanded on:click|stopPropagation={() => (expanded = !expanded)} tabindex="0">
 		<div class="expand-arrow" />
 		<TextLabel bold={true}>{widgetData.name}</TextLabel>
-		{#if widgetData.pinned}
-			<IconButton
-				icon={"CheckboxChecked"}
-				tooltip={"Unpin this node so it's no longer shown here without a selection"}
-				size={24}
-				action={(e) => {
-					editor.handle.unpinNode(widgetData.id);
-					e?.stopPropagation();
-				}}
-				class={"show-only-on-hover"}
-			/>
-		{/if}
+		<IconButton
+			icon={widgetData.pinned ? "CheckboxChecked" : "CheckboxUnchecked"}
+			tooltip={widgetData.pinned ? "Unpin this node so it's no longer shown here when nothing is selected" : "Pin this node so it's shown here when nothing is selected"}
+			size={24}
+			action={(e) => {
+				editor.handle.setNodePinned(widgetData.id, !widgetData.pinned);
+				e?.stopPropagation();
+			}}
+			class={"show-only-on-hover"}
+		/>
 		<IconButton
 			icon={"Trash"}
 			tooltip={"Delete this node from the layer chain"}

--- a/frontend/src/state-providers/document.ts
+++ b/frontend/src/state-providers/document.ts
@@ -11,8 +11,9 @@ import {
 	UpdateToolShelfLayout,
 	UpdateWorkingColorsLayout,
 	UpdateNodeGraphBarLayout,
-	TriggerGraphViewOverlay,
+	UpdateGraphViewOverlay,
 	TriggerDelayedZoomCanvasToFitAll,
+	UpdateGraphFadeArtwork,
 } from "@graphite/wasm-communication/messages";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -27,10 +28,17 @@ export function createDocumentState(editor: Editor) {
 		nodeGraphBarLayout: defaultWidgetLayout(),
 		// Graph view overlay
 		graphViewOverlayOpen: false,
+		fadeArtwork: 100,
 	});
 	const { subscribe, update } = state;
 
 	// Update layouts
+	editor.subscriptions.subscribeJsMessage(UpdateGraphFadeArtwork, (updateGraphFadeArtwork) => {
+		update((state) => {
+			state.fadeArtwork = updateGraphFadeArtwork.percentage;
+			return state;
+		});
+	});
 	editor.subscriptions.subscribeJsMessage(UpdateDocumentModeLayout, async (updateDocumentModeLayout) => {
 		await tick();
 
@@ -84,9 +92,9 @@ export function createDocumentState(editor: Editor) {
 	});
 
 	// Show or hide the graph view overlay
-	editor.subscriptions.subscribeJsMessage(TriggerGraphViewOverlay, (triggerGraphViewOverlay) => {
+	editor.subscriptions.subscribeJsMessage(UpdateGraphViewOverlay, (updateGraphViewOverlay) => {
 		update((state) => {
-			state.graphViewOverlayOpen = triggerGraphViewOverlay.open;
+			state.graphViewOverlayOpen = updateGraphViewOverlay.open;
 			return state;
 		});
 	});

--- a/frontend/src/wasm-communication/messages.ts
+++ b/frontend/src/wasm-communication/messages.ts
@@ -742,6 +742,14 @@ const mouseCursorIconCSSNames = {
 export type MouseCursor = keyof typeof mouseCursorIconCSSNames;
 export type MouseCursorIcon = (typeof mouseCursorIconCSSNames)[MouseCursor];
 
+export class UpdateGraphViewOverlay extends JsMessage {
+	open!: boolean;
+}
+
+export class UpdateGraphFadeArtwork extends JsMessage {
+	readonly percentage!: number;
+}
+
 export class UpdateMouseCursor extends JsMessage {
 	@Transform(({ value }: { value: MouseCursor }) => mouseCursorIconCSSNames[value] || "alias")
 	readonly cursor!: MouseCursorIcon;
@@ -886,10 +894,6 @@ export class TriggerFontLoad extends JsMessage {
 	font!: Font;
 
 	isDefault!: boolean;
-}
-
-export class TriggerGraphViewOverlay extends JsMessage {
-	open!: boolean;
 }
 
 export class TriggerVisitLink extends JsMessage {
@@ -1561,12 +1565,11 @@ export const messageMakers: Record<string, MessageMaker> = {
 	TriggerAboutGraphiteLocalizedCommitDate,
 	TriggerCopyToClipboardBlobUrl,
 	TriggerDelayedZoomCanvasToFitAll,
-	TriggerFetchAndOpenDocument,
 	TriggerDownloadBlobUrl,
 	TriggerDownloadImage,
 	TriggerDownloadTextFile,
+	TriggerFetchAndOpenDocument,
 	TriggerFontLoad,
-	TriggerGraphViewOverlay,
 	TriggerImport,
 	TriggerIndexedDbRemoveDocument,
 	TriggerIndexedDbWriteDocument,
@@ -1584,9 +1587,6 @@ export const messageMakers: Record<string, MessageMaker> = {
 	UpdateBox,
 	UpdateClickTargets,
 	UpdateContextMenuInformation,
-	UpdateInSelectedNetwork,
-	UpdateImportsExports,
-	UpdateLayerWidths,
 	UpdateDialogButtons,
 	UpdateDialogColumn1,
 	UpdateDialogColumn2,
@@ -1598,8 +1598,13 @@ export const messageMakers: Record<string, MessageMaker> = {
 	UpdateDocumentRulers,
 	UpdateDocumentScrollbars,
 	UpdateEyedropperSamplingState,
+	UpdateGraphFadeArtwork,
+	UpdateGraphViewOverlay,
+	UpdateImportsExports,
 	UpdateInputHints,
+	UpdateInSelectedNetwork,
 	UpdateLayersPanelOptionsLayout,
+	UpdateLayerWidths,
 	UpdateMenuBarLayout,
 	UpdateMouseCursor,
 	UpdateNodeGraph,
@@ -1611,8 +1616,8 @@ export const messageMakers: Record<string, MessageMaker> = {
 	UpdatePropertyPanelSectionsLayout,
 	UpdateToolOptionsLayout,
 	UpdateToolShelfLayout,
-	UpdateWorkingColorsLayout,
 	UpdateWirePathInProgress,
+	UpdateWorkingColorsLayout,
 	UpdateZoomWithScroll,
 } as const;
 export type JsMessageType = keyof typeof messageMakers;

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -577,8 +577,7 @@ impl EditorHandle {
 		let message = NodeGraphMessage::CreateNodeFromContextMenu {
 			node_id: Some(id),
 			node_type,
-			x: x / 24,
-			y: y / 24,
+			xy: Some((x / 24, y / 24)),
 		};
 		self.dispatch(message);
 	}
@@ -652,10 +651,10 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 
-	/// Unpin a node given its node ID
-	#[wasm_bindgen(js_name = unpinNode)]
-	pub fn unpin_node(&self, id: u64) {
-		self.dispatch(DocumentMessage::SetNodePinned { node_id: NodeId(id), pinned: false });
+	/// Pin or unpin a node given its node ID
+	#[wasm_bindgen(js_name = setNodePinned)]
+	pub fn set_node_pinned(&self, id: u64, pinned: bool) {
+		self.dispatch(DocumentMessage::SetNodePinned { node_id: NodeId(id), pinned });
 	}
 
 	/// Delete a layer or node given its node ID


### PR DESCRIPTION
Implements these layer/node management and graph view features:

![capture](https://github.com/user-attachments/assets/1fc89ed6-8d52-44b2-bf54-c3ab4d2c0516)

Also disables tools while the graph is open and restores them upon closing the graph.