### PR TITLE
CSS fix for Preferences Dialog

### DIFF
--- a/frontend/src/components/widgets/WidgetSpan.svelte
+++ b/frontend/src/components/widgets/WidgetSpan.svelte
@@ -198,6 +198,7 @@
 		flex: 0 0 auto;
 		display: flex;
 		min-height: 32px;
+		justify-content: space-between;
 
 		> * {
 			--widget-height: 24px;


### PR DESCRIPTION
This is added in order let the elements fill the space in the widget span row, this is indeed necessary here, because , the width is available in the dialog, but the elements are aligned to the start, and not utilizing the width properly, in order to fix this in a responsive way, I have added the `justify-content` css property, which uses the width available for the `WidgetSpan`.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Fixes #2103

Screen shots after the fix
![image](https://github.com/user-attachments/assets/88cc0611-b451-40bb-a3e7-25d7309a4665)
![image](https://github.com/user-attachments/assets/24d4bfab-152e-4a81-bcfa-7e82f53c8e48)

