### PR TITLE
Bezier-rs: Make rectangle constructor produce linear segments

### DIFF
--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -227,7 +227,39 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 
 	/// Constructs a rectangle with `corner1` and `corner2` as the two corners.
 	pub fn new_rect(corner1: DVec2, corner2: DVec2) -> Self {
-		Self::from_anchors([corner1, DVec2::new(corner2.x, corner1.y), corner2, DVec2::new(corner1.x, corner2.y)], true)
+		let bottom_left = DVec2::new(corner1.x, corner2.y);
+		let top_right = DVec2::new(corner2.x, corner1.y);
+
+		// Create a new `Subpath` with linear segments for the rectangle
+		Subpath::new(
+			vec![
+				ManipulatorGroup {
+					anchor: corner1,
+					in_handle: None,
+					out_handle: None,
+					id: PointId::new(),
+				},
+				ManipulatorGroup {
+					anchor: top_right,
+					in_handle: None,
+					out_handle: None,
+					id: PointId::new(),
+				},
+				ManipulatorGroup {
+					anchor: corner2,
+					in_handle: None,
+					out_handle: None,
+					id: PointId::new(),
+				},
+				ManipulatorGroup {
+					anchor: bottom_left,
+					in_handle: None,
+					out_handle: None,
+					id: PointId::new(),
+				},
+			],
+			true,
+		)
 	}
 
 	/// Constructs a rounded rectangle with `corner1` and `corner2` as the two corners and `corner_radii` as the radii of the corners: `[top_left, top_right, bottom_right, bottom_left]`.

--- a/libraries/bezier-rs/src/subpath/core.rs
+++ b/libraries/bezier-rs/src/subpath/core.rs
@@ -225,41 +225,13 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 		Self::new(anchor_positions.into_iter().map(|anchor| ManipulatorGroup::new_anchor(anchor)).collect(), closed)
 	}
 
+	pub fn from_anchors_linear(anchor_positions: impl IntoIterator<Item = DVec2>, closed: bool) -> Self {
+		Self::new(anchor_positions.into_iter().map(|anchor| ManipulatorGroup::new_anchor_linear(anchor)).collect(), closed)
+	}
+
 	/// Constructs a rectangle with `corner1` and `corner2` as the two corners.
 	pub fn new_rect(corner1: DVec2, corner2: DVec2) -> Self {
-		let bottom_left = DVec2::new(corner1.x, corner2.y);
-		let top_right = DVec2::new(corner2.x, corner1.y);
-
-		// Create a new `Subpath` with linear segments for the rectangle
-		Subpath::new(
-			vec![
-				ManipulatorGroup {
-					anchor: corner1,
-					in_handle: None,
-					out_handle: None,
-					id: PointId::new(),
-				},
-				ManipulatorGroup {
-					anchor: top_right,
-					in_handle: None,
-					out_handle: None,
-					id: PointId::new(),
-				},
-				ManipulatorGroup {
-					anchor: corner2,
-					in_handle: None,
-					out_handle: None,
-					id: PointId::new(),
-				},
-				ManipulatorGroup {
-					anchor: bottom_left,
-					in_handle: None,
-					out_handle: None,
-					id: PointId::new(),
-				},
-			],
-			true,
-		)
+		Self::from_anchors_linear([corner1, DVec2::new(corner2.x, corner1.y), corner2, DVec2::new(corner1.x, corner2.y)], true)
 	}
 
 	/// Constructs a rounded rectangle with `corner1` and `corner2` as the two corners and `corner_radii` as the radii of the corners: `[top_left, top_right, bottom_right, bottom_left]`.

--- a/libraries/bezier-rs/src/subpath/structs.rs
+++ b/libraries/bezier-rs/src/subpath/structs.rs
@@ -76,6 +76,10 @@ impl<PointId: crate::Identifier> ManipulatorGroup<PointId> {
 		Self::new(anchor, Some(anchor), Some(anchor))
 	}
 
+	pub fn new_anchor_linear(anchor: DVec2) -> Self {
+		Self::new(anchor, None, None)
+	}
+
 	/// Construct a new manipulator group from an anchor, in handle, out handle and an id
 	pub fn new_with_id(anchor: DVec2, in_handle: Option<DVec2>, out_handle: Option<DVec2>, id: PointId) -> Self {
 		Self { anchor, in_handle, out_handle, id }


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Closes #1696 

`new_rec` constructor now should create linear segments instead of cubic segments.

