### PR TITLE
Refactor collection of snap targets

### DIFF
--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -30,6 +30,9 @@ pub const DRAG_BEYOND_VIEWPORT_SPEED_FACTOR: f64 = 20.;
 
 // Snapping point
 pub const SNAP_POINT_TOLERANCE: f64 = 5.;
+pub const MAX_ALIGNMENT_CANDIDATES: usize = 100; // These are layers whose bounding boxes are used for alignment.
+pub const MAX_SNAP_CANDIDATES: usize = 10; // These are layers that are used for the layer snapper
+pub const MAX_LAYER_SNAP_POINTS: usize = 100; // These are points (anchors and bounding box corners etc.) in the layer snapper
 
 pub const DRAG_THRESHOLD: f64 = 1.;
 

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -4,6 +4,7 @@ use crate::messages::portfolio::document::utility_types::document_metadata::{Doc
 use crate::messages::portfolio::document::utility_types::misc::{GeometrySnapSource, SnapSource};
 use crate::messages::portfolio::document::utility_types::network_interface::NodeNetworkInterface;
 use crate::messages::prelude::*;
+use crate::messages::tool::common_functionality::snapping::SnapTypeConfiguration;
 use crate::messages::tool::tool_messages::path_tool::PointSelectState;
 
 use bezier_rs::{Bezier, BezierHandles, TValue};
@@ -210,7 +211,7 @@ impl ShapeState {
 					}
 				}
 
-				let snapped = snap_manager.free_snap(&snap_data, &point, None, false);
+				let snapped = snap_manager.free_snap(&snap_data, &point, SnapTypeConfiguration::default());
 				if best_snapped.other_snap_better(&snapped) {
 					offset = snapped.snapped_point_document - point.document_point + mouse_delta;
 					best_snapped = snapped;

--- a/editor/src/messages/tool/common_functionality/snapping/alignment_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/alignment_snapper.rs
@@ -50,8 +50,8 @@ impl AlignmentSnapper {
 		}
 	}
 
-	pub fn snap_bbox_points(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
-		self.collect_bounding_box_points(snap_data, point.source_index == 0);
+	pub fn snap_bbox_points(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint, config: SnapTypeConfiguration) {
+		self.collect_bounding_box_points(snap_data, !config.use_existing_candidates);
 		let unselected_geometry = if snap_data.document.snapping_state.target_enabled(SnapTarget::Alignment(AlignmentSnapTarget::Handle)) {
 			snap_data.node_snap_cache.map(|cache| cache.unselected.as_slice()).unwrap_or(&[])
 		} else {
@@ -154,23 +154,23 @@ impl AlignmentSnapper {
 			_ => {}
 		}
 	}
-	pub fn free_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults) {
+	pub fn free_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, config: SnapTypeConfiguration) {
 		let is_bbox = matches!(point.source, SnapSource::BoundingBox(_));
 		let is_geometry = matches!(point.source, SnapSource::Geometry(_));
 		let geometry_selected = snap_data.has_manipulators();
 
 		if is_bbox || (is_geometry && geometry_selected) || (is_geometry && point.alignment) {
-			self.snap_bbox_points(snap_data, point, snap_results, SnapConstraint::None);
+			self.snap_bbox_points(snap_data, point, snap_results, SnapConstraint::None, config);
 		}
 	}
 
-	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint) {
+	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint, config: SnapTypeConfiguration) {
 		let is_bbox = matches!(point.source, SnapSource::BoundingBox(_));
 		let is_geometry = matches!(point.source, SnapSource::Geometry(_));
 		let geometry_selected = snap_data.has_manipulators();
 
 		if is_bbox || (is_geometry && geometry_selected) || (is_geometry && point.alignment) {
-			self.snap_bbox_points(snap_data, point, snap_results, constraint);
+			self.snap_bbox_points(snap_data, point, snap_results, constraint, config);
 		}
 	}
 }

--- a/editor/src/messages/tool/common_functionality/snapping/distribution_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/distribution_snapper.rs
@@ -323,22 +323,23 @@ impl DistributionSnapper {
 		}
 	}
 
-	pub fn free_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, bounds: Option<Rect>) {
-		let Some(bounds) = bounds else { return };
+	pub fn free_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, config: SnapTypeConfiguration) {
+		let Some(bounds) = config.bbox else { return };
 		if point.source != SnapSource::BoundingBox(BoundingBoxSnapSource::Center) || !snap_data.document.snapping_state.bounds.distribute {
 			return;
 		}
 
-		self.collect_bounding_box_points(snap_data, point.source_index == 0, bounds);
+		self.collect_bounding_box_points(snap_data, config.accept_distribution, bounds);
 		self.snap_bbox_points(snap_tolerance(snap_data.document), point, snap_results, SnapConstraint::None, bounds);
 	}
 
-	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint, bounds: Option<Rect>) {
-		let Some(bounds) = bounds else { return };
+	pub fn constrained_snap(&mut self, snap_data: &mut SnapData, point: &SnapCandidatePoint, snap_results: &mut SnapResults, constraint: SnapConstraint, config: SnapTypeConfiguration) {
+		let Some(bounds) = config.bbox else { return };
 		if point.source != SnapSource::BoundingBox(BoundingBoxSnapSource::Center) || !snap_data.document.snapping_state.bounds.distribute {
 			return;
 		}
-		self.collect_bounding_box_points(snap_data, point.source_index == 0, bounds);
+
+		self.collect_bounding_box_points(snap_data, config.accept_distribution, bounds);
 		self.snap_bbox_points(snap_tolerance(snap_data.document), point, snap_results, constraint, bounds);
 	}
 }

--- a/editor/src/messages/tool/common_functionality/transformation_cage.rs
+++ b/editor/src/messages/tool/common_functionality/transformation_cage.rs
@@ -227,7 +227,7 @@ pub fn axis_align_drag(axis_align: bool, position: DVec2, start: DVec2) -> DVec2
 }
 
 /// Snaps a dragging event from the artboard or select tool
-pub fn snap_drag(start: DVec2, current: DVec2, axis_align: bool, snap_data: SnapData, snap_manager: &mut SnapManager, candidates: &Vec<SnapCandidatePoint>) -> DVec2 {
+pub fn snap_drag(start: DVec2, current: DVec2, axis_align: bool, snap_data: SnapData, snap_manager: &mut SnapManager, candidates: &[SnapCandidatePoint]) -> DVec2 {
 	let mouse_position = axis_align_drag(axis_align, snap_data.input.mouse.position, start);
 	let document = snap_data.document;
 	let total_mouse_delta_document = document.metadata().document_to_viewport.inverse().transform_vector2(mouse_position - start);

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -6,6 +6,7 @@ use crate::messages::tool::common_functionality::snapping;
 use crate::messages::tool::common_functionality::snapping::SnapCandidatePoint;
 use crate::messages::tool::common_functionality::snapping::SnapData;
 use crate::messages::tool::common_functionality::snapping::SnapManager;
+use crate::messages::tool::common_functionality::snapping::SnapTypeConfiguration;
 use crate::messages::tool::common_functionality::transformation_cage::*;
 
 use graph_craft::document::NodeId;
@@ -260,7 +261,7 @@ impl Fsm for ArtboardToolFsmState {
 
 					let point = SnapCandidatePoint::handle(to_document.transform_point2(input.mouse.position));
 
-					let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, None, false);
+					let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, SnapTypeConfiguration::default());
 
 					tool_data.drag_start = snapped.snapped_point_document;
 					tool_data.drag_current = snapped.snapped_point_document;
@@ -330,7 +331,8 @@ impl Fsm for ArtboardToolFsmState {
 
 				let document_mouse = to_viewport.inverse().transform_point2(input.mouse.position);
 
-				let snapped = tool_data.snap_manager.free_snap(&snap_data, &SnapCandidatePoint::handle(document_mouse), None, false);
+				let config = SnapTypeConfiguration::default();
+				let snapped = tool_data.snap_manager.free_snap(&snap_data, &SnapCandidatePoint::handle(document_mouse), config);
 				let snapped_mouse_position = to_viewport.transform_point2(snapped.snapped_point_document);
 
 				tool_data.snap_manager.update_indicator(snapped);

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -7,7 +7,7 @@ use crate::messages::portfolio::document::utility_types::document_metadata::Laye
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
-use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
+use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager, SnapTypeConfiguration};
 
 use graph_craft::document::{value::TaggedValue, NodeId, NodeInput};
 use graphene_core::Color;
@@ -173,7 +173,7 @@ impl Fsm for LineToolFsmState {
 			}
 			(LineToolFsmState::Ready, LineToolMessage::DragStart) => {
 				let point = SnapCandidatePoint::handle(document.metadata().document_to_viewport.inverse().transform_point2(input.mouse.position));
-				let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, None, false);
+				let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, SnapTypeConfiguration::default());
 				tool_data.drag_start = snapped.snapped_point_document;
 
 				responses.add(DocumentMessage::StartTransaction);
@@ -314,6 +314,7 @@ fn generate_transform(tool_data: &mut LineToolData, snap_data: SnapData, lock_an
 
 	let near_point = SnapCandidatePoint::handle_neighbors(document_points[1], [tool_data.drag_start]);
 	let far_point = SnapCandidatePoint::handle_neighbors(2. * document_points[0] - document_points[1], [tool_data.drag_start]);
+	let config = SnapTypeConfiguration::default();
 
 	if constrained {
 		let constraint = SnapConstraint::Line {
@@ -321,26 +322,26 @@ fn generate_transform(tool_data: &mut LineToolData, snap_data: SnapData, lock_an
 			direction: document_points[1] - document_points[0],
 		};
 		if center {
-			let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, None);
-			let snapped_far = snap.constrained_snap(&snap_data, &far_point, constraint, None);
+			let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, config);
+			let snapped_far = snap.constrained_snap(&snap_data, &far_point, constraint, config);
 			let best = if snapped_far.other_snap_better(&snapped) { snapped } else { snapped_far };
 			document_points[1] = document_points[0] * 2. - best.snapped_point_document;
 			document_points[0] = best.snapped_point_document;
 			snap.update_indicator(best);
 		} else {
-			let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, None);
+			let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, config);
 			document_points[1] = snapped.snapped_point_document;
 			snap.update_indicator(snapped);
 		}
 	} else if center {
-		let snapped = snap.free_snap(&snap_data, &near_point, None, false);
-		let snapped_far = snap.free_snap(&snap_data, &far_point, None, false);
+		let snapped = snap.free_snap(&snap_data, &near_point, config);
+		let snapped_far = snap.free_snap(&snap_data, &far_point, config);
 		let best = if snapped_far.other_snap_better(&snapped) { snapped } else { snapped_far };
 		document_points[1] = document_points[0] * 2. - best.snapped_point_document;
 		document_points[0] = best.snapped_point_document;
 		snap.update_indicator(best);
 	} else {
-		let snapped = snap.free_snap(&snap_data, &near_point, None, false);
+		let snapped = snap.free_snap(&snap_data, &near_point, config);
 		document_points[1] = snapped.snapped_point_document;
 		snap.update_indicator(snapped);
 	}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -8,7 +8,7 @@ use crate::messages::portfolio::document::utility_types::network_interface::Inpu
 use crate::messages::tool::common_functionality::auto_panning::AutoPanning;
 use crate::messages::tool::common_functionality::color_selector::{ToolColorOptions, ToolColorType};
 use crate::messages::tool::common_functionality::graph_modification_utils;
-use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
+use crate::messages::tool::common_functionality::snapping::{SnapCandidatePoint, SnapConstraint, SnapData, SnapManager, SnapTypeConfiguration};
 use crate::messages::tool::common_functionality::utility_functions::should_extend;
 
 use bezier_rs::{Bezier, BezierHandles};
@@ -395,6 +395,7 @@ impl PenToolData {
 
 		let neighbors = relative.filter(|_| neighbor).map_or(Vec::new(), |neighbor| vec![neighbor]);
 
+		let config = SnapTypeConfiguration::default();
 		if let Some(relative) = relative
 			.map(|layer| transform.transform_point2(layer))
 			.filter(|&relative| (snap_angle || lock_angle) && (relative - document_pos).length_squared() > f64::EPSILON * 100.)
@@ -417,8 +418,8 @@ impl PenToolData {
 			let near_point = SnapCandidatePoint::handle_neighbors(document_pos, neighbors.clone());
 			let far_point = SnapCandidatePoint::handle_neighbors(2. * relative - document_pos, neighbors);
 			if colinear {
-				let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, None);
-				let snapped_far = snap.constrained_snap(&snap_data, &far_point, constraint, None);
+				let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, config);
+				let snapped_far = snap.constrained_snap(&snap_data, &far_point, constraint, config);
 				document_pos = if snapped_far.other_snap_better(&snapped) {
 					snapped.snapped_point_document
 				} else {
@@ -426,13 +427,13 @@ impl PenToolData {
 				};
 				snap.update_indicator(if snapped_far.other_snap_better(&snapped) { snapped } else { snapped_far });
 			} else {
-				let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, None);
+				let snapped = snap.constrained_snap(&snap_data, &near_point, constraint, config);
 				document_pos = snapped.snapped_point_document;
 				snap.update_indicator(snapped);
 			}
 		} else if let Some(relative) = relative.map(|layer| transform.transform_point2(layer)).filter(|_| colinear) {
-			let snapped = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(document_pos, neighbors.clone()), None, false);
-			let snapped_far = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(2. * relative - document_pos, neighbors), None, false);
+			let snapped = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(document_pos, neighbors.clone()), config);
+			let snapped_far = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(2. * relative - document_pos, neighbors), config);
 			document_pos = if snapped_far.other_snap_better(&snapped) {
 				snapped.snapped_point_document
 			} else {
@@ -440,7 +441,7 @@ impl PenToolData {
 			};
 			snap.update_indicator(if snapped_far.other_snap_better(&snapped) { snapped } else { snapped_far });
 		} else {
-			let snapped = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(document_pos, neighbors), None, false);
+			let snapped = snap.free_snap(&snap_data, &SnapCandidatePoint::handle_neighbors(document_pos, neighbors), config);
 			document_pos = snapped.snapped_point_document;
 			snap.update_indicator(snapped);
 		}
@@ -456,7 +457,7 @@ impl PenToolData {
 
 	fn create_initial_point(&mut self, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>, tool_options: &PenOptions, append: bool) {
 		let point = SnapCandidatePoint::handle(document.metadata().document_to_viewport.inverse().transform_point2(input.mouse.position));
-		let snapped = self.snap_manager.free_snap(&SnapData::new(document, input), &point, None, false);
+		let snapped = self.snap_manager.free_snap(&SnapData::new(document, input), &point, SnapTypeConfiguration::default());
 		let viewport = document.metadata().document_to_viewport.transform_point2(snapped.snapped_point_document);
 
 		let selected_nodes = document.network_interface.selected_nodes(&[]).unwrap();
@@ -632,7 +633,7 @@ impl Fsm for PenToolFsmState {
 			}
 			(PenToolFsmState::PlacingAnchor, PenToolMessage::DragStart { append_to_selected }) => {
 				let point = SnapCandidatePoint::handle(document.metadata().document_to_viewport.inverse().transform_point2(input.mouse.position));
-				let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, None, false);
+				let snapped = tool_data.snap_manager.free_snap(&SnapData::new(document, input), &point, SnapTypeConfiguration::default());
 				let viewport = document.metadata().document_to_viewport.transform_point2(snapped.snapped_point_document);
 				// Early return if the buffer was started and this message is being run again after the buffer (so that place_anchor updates the state with the newly merged vector)
 				if tool_data.buffering_merged_vector {


### PR DESCRIPTION
Collecting snap targets is only done once, cleaning up the control flow and possibly leading to some minor performance improvements in certain scenarios with too many snap points.