### PR TITLE
Remove Double-Click Behavior for Switching to Path Tool on Non-Path Layers

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1233,7 +1233,7 @@ fn edit_layer_deepest_manipulation(layer: LayerNodeIdentifier, network_interface
 	if is_layer_fed_by_node_of_name(layer, network_interface, "Text") {
 		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Text });
 		responses.add(TextToolMessage::EditSelected);
-	} else if is_layer_fed_by_node_of_name(layer, network_interface, "Path") {
-		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Path });
+	} else if is_layer_fed_by_node_of_name(layer, network_interface, "Select") {
+		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Select });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1208,11 +1208,6 @@ fn drag_deepest_manipulation(responses: &mut VecDeque<Message>, selected: Vec<La
 }
 
 fn edit_layer_shallowest_manipulation(document: &DocumentMessageHandler, layer: LayerNodeIdentifier, responses: &mut VecDeque<Message>) {
-	if document.network_interface.selected_nodes(&[]).unwrap().selected_layers_contains(layer, document.metadata()) {
-		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Path });
-		return;
-	}
-
 	let Some(new_selected) = layer.ancestors(document.metadata()).filter(not_artboard(document)).find(|ancestor| {
 		ancestor
 			.parent(document.metadata())

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1233,7 +1233,5 @@ fn edit_layer_deepest_manipulation(layer: LayerNodeIdentifier, network_interface
 	if is_layer_fed_by_node_of_name(layer, network_interface, "Text") {
 		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Text });
 		responses.add(TextToolMessage::EditSelected);
-	} else if is_layer_fed_by_node_of_name(layer, network_interface, "Select") {
-		responses.add_front(ToolMessage::ActivateTool { tool_type: ToolType::Select });
 	}
 }


### PR DESCRIPTION
Altered the function `edit_layer_deepest_manipulation` and `edit_layer_shallowest_manipulation` to remove the path tool switching.

Closes #1828
