### PR TITLE
Fix SVG `viewBox` capitalization in renderer

### DIFF
--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -153,7 +153,7 @@ impl SvgRender {
 	pub fn wrap_with_transform(&mut self, transform: DAffine2, size: Option<DVec2>) {
 		let defs = &self.svg_defs;
 		let view_box = size
-			.map(|size| format!("viewbox=\"0 0 {} {}\" width=\"{}\" height=\"{}\"", size.x, size.y, size.x, size.y))
+			.map(|size| format!("viewBox=\"0 0 {} {}\" width=\"{}\" height=\"{}\"", size.x, size.y, size.x, size.y))
 			.unwrap_or_default();
 
 		let matrix = format_transform_matrix(transform);


### PR DESCRIPTION
Check issue #2130 for description.

The `viewBox` attribute was erroneously lowercase, but the spec and browser rendering need it to be _"viewBox"_.

Closes #2130
