### PR TITLE
Selection history navigation with Alt+[ and Alt+] keys should filter out empty selections

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1209,13 +1209,15 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphHandlerData<'a>> for NodeGrap
 				responses.add(BroadcastEvent::SelectionChanged);
 			}
 			NodeGraphMessage::SelectedNodesSet { nodes } => {
-				let Some(selected_nodes) = network_interface.selected_nodes_mut(selection_network_path) else {
-					log::error!("Could not get selected nodes in NodeGraphMessage::SelectedNodesSet");
-					return;
-				};
-				selected_nodes.set_selected_nodes(nodes);
-				responses.add(BroadcastEvent::SelectionChanged);
-				responses.add(PropertiesPanelMessage::Refresh);
+				if !nodes.is_empty() {
+					let Some(selected_nodes) = network_interface.selected_nodes_mut(selection_network_path) else {
+						log::error!("Could not get selected nodes in NodeGraphMessage::SelectedNodesSet");
+						return;
+					};
+					selected_nodes.set_selected_nodes(nodes);
+					responses.add(BroadcastEvent::SelectionChanged);
+					responses.add(PropertiesPanelMessage::Refresh);
+				}
 			}
 			NodeGraphMessage::SendClickTargets => responses.add(FrontendMessage::UpdateClickTargets {
 				click_targets: Some(network_interface.collect_frontend_click_targets(breadcrumb_network_path)),

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1608,12 +1608,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		let mut non_empty_selections:VecDeque<SelectedNodes>  = network_metadata.persistent_metadata.selection_redo_history.iter().
-		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
-		cloned().
-		collect();
+		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = non_empty_selections.pop_back() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}
@@ -1624,12 +1621,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		let mut non_empty_selections:VecDeque<SelectedNodes> = network_metadata.persistent_metadata.selection_redo_history.iter().
-		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
-		cloned().
-		collect();
+		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = non_empty_selections.pop_front() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1608,7 +1608,12 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
+		let mut non_empty_selections:VecDeque<SelectedNodes>  = network_metadata.persistent_metadata.selection_redo_history.iter().
+		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
+		cloned().
+		collect();
+
+		if let Some(selection_state) = non_empty_selections.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}
@@ -1619,7 +1624,12 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
+		let mut non_empty_selections:VecDeque<SelectedNodes> = network_metadata.persistent_metadata.selection_redo_history.iter().
+		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
+		cloned().
+		collect();
+
+		if let Some(selection_state) = non_empty_selections.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1608,8 +1608,6 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		network_metadata.persistent_metadata.selection_undo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
-
 		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
@@ -1620,8 +1618,6 @@ impl NodeNetworkInterface {
 			log::error!("Could not get nested network_metadata in selection_step_forward");
 			return;
 		};
-
-		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
 		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1607,9 +1607,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
+		network_metadata.persistent_metadata.selection_undo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_back() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1607,12 +1607,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		let mut non_empty_selections:VecDeque<SelectedNodes>  = network_metadata.persistent_metadata.selection_redo_history.iter().
-		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
-		cloned().
-		collect();
+		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = non_empty_selections.pop_back() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}
@@ -1623,12 +1620,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		let mut non_empty_selections:VecDeque<SelectedNodes> = network_metadata.persistent_metadata.selection_redo_history.iter().
-		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
-		cloned().
-		collect();
+		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = non_empty_selections.pop_front() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1607,8 +1607,6 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		network_metadata.persistent_metadata.selection_undo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
-
 		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
@@ -1619,8 +1617,6 @@ impl NodeNetworkInterface {
 			log::error!("Could not get nested network_metadata in selection_step_forward");
 			return;
 		};
-
-		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
 		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1607,7 +1607,12 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
+		let mut non_empty_selections:VecDeque<SelectedNodes>  = network_metadata.persistent_metadata.selection_redo_history.iter().
+		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
+		cloned().
+		collect();
+
+		if let Some(selection_state) = non_empty_selections.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}
@@ -1618,7 +1623,12 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_front() {
+		let mut non_empty_selections:VecDeque<SelectedNodes> = network_metadata.persistent_metadata.selection_redo_history.iter().
+		filter(|selected_nodes| selected_nodes.has_selected_nodes()).
+		cloned().
+		collect();
+
+		if let Some(selection_state) = non_empty_selections.pop_front() {
 			network_metadata.persistent_metadata.selection_undo_history.push_back(selection_state);
 		}
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1599,9 +1599,9 @@ impl NodeNetworkInterface {
 		if network_metadata.persistent_metadata.selection_undo_history.len() > crate::consts::MAX_UNDO_HISTORY_LEN {
 			network_metadata.persistent_metadata.selection_undo_history.pop_front();
 		}
-
 		network_metadata.persistent_metadata.selection_undo_history.back_mut()
 	}
+
 	pub fn selection_step_back(&mut self, network_path: &[NodeId]) {
 		let Some(network_metadata) = self.network_metadata_mut(network_path) else {
 			log::error!("Could not get nested network_metadata in selection_step_back");

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1586,31 +1586,12 @@ impl NodeNetworkInterface {
 	pub fn selected_nodes_mut(&mut self, network_path: &[NodeId]) -> Option<&mut SelectedNodes> {
 		self.unload_stack_dependents(network_path);
 
-		let last_selection_state = {
-			let Some(network_metadata) = self.network_metadata_mut(network_path) else {
-				log::error!("Could not get nested network_metadata in selected_nodes");
-				return None;
-			};
-
-			network_metadata.persistent_metadata.selection_undo_history.back().cloned().unwrap_or_default()
-		};
-
-		let layers_except_artboards: Vec<_> = last_selection_state.selected_layers_except_artboards(self).collect();
-
-		// If the selection is empty or contains only artboards, skip the undo history update.
-		if layers_except_artboards.is_empty() {
-			let Some(network_metadata) = self.network_metadata_mut(network_path) else {
-				log::error!("Could not get nested network_metadata in selected_nodes");
-				return None;
-			};
-
-			return network_metadata.persistent_metadata.selection_undo_history.back_mut();
-		}
-
 		let Some(network_metadata) = self.network_metadata_mut(network_path) else {
 			log::error!("Could not get nested network_metadata in selected_nodes");
 			return None;
 		};
+
+		let last_selection_state = network_metadata.persistent_metadata.selection_undo_history.back().cloned().unwrap_or_default();
 
 		network_metadata.persistent_metadata.selection_undo_history.push_back(last_selection_state);
 		network_metadata.persistent_metadata.selection_redo_history.clear();

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1608,9 +1608,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 
-		network_metadata.persistent_metadata.selection_redo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
+		network_metadata.persistent_metadata.selection_undo_history.retain(|selected_nodes| selected_nodes.has_selected_nodes());
 
-		if let Some(selection_state) = network_metadata.persistent_metadata.selection_redo_history.pop_back() {
+		if let Some(selection_state) = network_metadata.persistent_metadata.selection_undo_history.pop_back() {
 			network_metadata.persistent_metadata.selection_redo_history.push_front(selection_state);
 		}
 	}

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1011,7 +1011,7 @@ impl Fsm for SelectToolFsmState {
 				let new_selected: HashSet<_> = document.intersect_quad_no_artboards(quad, input).collect();
 				let current_selected: HashSet<_> = document.network_interface.selected_nodes(&[]).unwrap().selected_layers(document.metadata()).collect();
 
-				if new_selected != current_selected && !new_selected.is_empty() {
+				if new_selected != current_selected {
 					tool_data.layers_dragging = new_selected.into_iter().collect();
 					responses.add(NodeGraphMessage::SelectedNodesSet {
 						nodes: tool_data

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1010,9 +1010,7 @@ impl Fsm for SelectToolFsmState {
 				let quad = tool_data.selection_quad();
 				let new_selected: HashSet<_> = document.intersect_quad_no_artboards(quad, input).collect();
 				let current_selected: HashSet<_> = document.network_interface.selected_nodes(&[]).unwrap().selected_layers(document.metadata()).collect();
-				if new_selected.is_empty() {
-					log::info!("Empty selection detected (only artboards). Skipping history update.");
-				}
+
 				if new_selected != current_selected && !new_selected.is_empty() {
 					tool_data.layers_dragging = new_selected.into_iter().collect();
 					responses.add(NodeGraphMessage::SelectedNodesSet {

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1010,7 +1010,10 @@ impl Fsm for SelectToolFsmState {
 				let quad = tool_data.selection_quad();
 				let new_selected: HashSet<_> = document.intersect_quad_no_artboards(quad, input).collect();
 				let current_selected: HashSet<_> = document.network_interface.selected_nodes(&[]).unwrap().selected_layers(document.metadata()).collect();
-				if new_selected != current_selected {
+				if new_selected.is_empty() {
+					log::info!("Empty selection detected (only artboards). Skipping history update.");
+				}
+				if new_selected != current_selected && !new_selected.is_empty() {
 					tool_data.layers_dragging = new_selected.into_iter().collect();
 					responses.add(NodeGraphMessage::SelectedNodesSet {
 						nodes: tool_data


### PR DESCRIPTION
filters empty selections made by select tool  before adding in the selection history