### PR TITLE
Improve issues with selection history

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1592,13 +1592,17 @@ impl NodeNetworkInterface {
 			let empty = current.selected_layers_except_artboards(self).next().is_none();
 			(current, previous, empty)
 		};
-
 		self.unload_stack_dependents(network_path);
 
 		let Some(network_metadata) = self.network_metadata_mut(network_path) else {
 			log::error!("Could not get nested network_metadata in selected_nodes");
 			return None;
 		};
+
+		// Initialize default value if selection_undo_history is empty
+		if network_metadata.persistent_metadata.selection_undo_history.is_empty() {
+			network_metadata.persistent_metadata.selection_undo_history.push_back(SelectedNodes::default());
+		}
 
 		// Update history only if selection is non-empty/does not contain only artboards
 		if !is_selection_empty && prev_state.as_ref() != Some(&last_selection_state) {


### PR DESCRIPTION
By merging this PR the following fixes/improvements will be implemented:
- Empty selections are no longer added to the selection history (fix for [discord's code-todo-list](https://discord.com/channels/731730685944922173/881073965047636018/1299601627006631966)).
- This closes #2137.
- Previously, If a new layer was drawn, we had to press `Alt` + `[` / `Alt` + `]` twice in order to move between the selections. This has been fixed, ie only one call is required now.
- Previously, If we pressed `Alt` + `[` many times after reaching the end of selection history, we had to press `Alt` + `]` that many times to access the selections again. This is fixed now (ie, it takes only one call of `Alt` + `]` to access the selections again).
