### PR TITLE
Display acceptable input types  for protonodes

### DIFF
--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -696,7 +696,7 @@
 							style:--data-color-dim={`var(--color-data-${node.primaryInput.dataType.toLowerCase()}-dim)`}
 							bind:this={inputs[nodeIndex + 1][0]}
 						>
-							<title>{`${dataTypeTooltip(node.primaryInput)}\n${inputConnectedToText(node.primaryInput)}`}</title>
+							<title>{`Supported types:\n${node.primaryInput.dataType}\n${dataTypeTooltip(node.primaryInput)}\n${inputConnectedToText(node.primaryInput)}`}</title>
 							{#if node.primaryInput.connectedTo !== undefined}
 								<path d="M0,6.306A1.474,1.474,0,0,0,2.356,7.724L7.028,5.248c1.3-.687,1.3-1.809,0-2.5L2.356.276A1.474,1.474,0,0,0,0,1.694Z" fill="var(--data-color)" />
 							{:else}
@@ -716,7 +716,9 @@
 								style:--data-color-dim={`var(--color-data-${secondary.dataType.toLowerCase()}-dim)`}
 								bind:this={inputs[nodeIndex + 1][index + (node.primaryInput ? 1 : 0)]}
 							>
-								<title>{`${dataTypeTooltip(secondary)}\n${inputConnectedToText(secondary)}`}</title>
+								<title>
+									{`Supported types:\n${secondary.dataType}\n${dataTypeTooltip(secondary)}\n${inputConnectedToText(secondary)}`}
+								</title>
 								{#if secondary.connectedTo !== undefined}
 									<path d="M0,6.306A1.474,1.474,0,0,0,2.356,7.724L7.028,5.248c1.3-.687,1.3-1.809,0-2.5L2.356.276A1.474,1.474,0,0,0,0,1.694Z" fill="var(--data-color)" />
 								{:else}


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #2069

It shows the acceptable input types of the protonodes which looks something like this:

![brave_8ZQtQMwnrm](https://github.com/user-attachments/assets/7d0bc02f-519c-47d6-84be-09a31abfdbd2)

![brave_nWHsuolAfX](https://github.com/user-attachments/assets/79345d25-e260-4773-b5d1-e12f9edb45db)

![brave_qTkFsElQYy](https://github.com/user-attachments/assets/bee5f616-c583-45cc-a4e9-c12afa42090b)


