### PR TITLE
Make Path tool deselect all points on single-click, and select all on double-click, of shape's fill

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1655,8 +1655,7 @@ impl DocumentMessageHandler {
 	/// Finds the artboard that bounds the point in viewport space and be the container of any newly added layers.
 	pub fn new_layer_bounding_artboard(&self, ipp: &InputPreprocessorMessageHandler) -> LayerNodeIdentifier {
 		self.click_xray(ipp)
-			.filter(|layer| self.network_interface.is_artboard(&layer.to_node(), &[]))
-			.next()
+			.find(|layer| self.network_interface.is_artboard(&layer.to_node(), &[]))
 			.unwrap_or(LayerNodeIdentifier::ROOT_PARENT)
 	}
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -787,7 +787,7 @@ impl Fsm for PathToolFsmState {
 				let nearest_point = shape_editor.find_nearest_point_indices(&document.network_interface, current_mouse, SELECTION_THRESHOLD);
 
 				if let Some((_layer, _)) = nearest_point {
-					if !tool_data.double_click_handled {
+					if !tool_data.double_click_handled && tool_data.drag_start_pos.distance(input.mouse.position) <= DRAG_THRESHOLD {
 						shape_editor.flip_smooth_sharp(&document.network_interface, current_mouse, SELECTION_TOLERANCE, responses);
 						responses.add(PathToolMessage::SelectedPointUpdated);
 					}


### PR DESCRIPTION
This PR brings improvements in the Path Tool - 

1. Single-clicking the interior of shape deselects all the points, earlier all points would be selected. Double clicking inside the shape selects all the points(anchors). [discord code-todo-list](https://discord.com/channels/731730685944922173/881073965047636018/1217283700736266331)
3. fixes the issue when double clicking on a point then dragging and on mouse up changes the point to Smooth/Sharp(fix for [discord code-todo-list](https://discord.com/channels/731730685944922173/881073965047636018/1208885174134243348)
