### PR TITLE
Fix transform cage rotation abort causing broken state upon next transformation

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1064,9 +1064,9 @@ impl Fsm for SelectToolFsmState {
 					}
 				});
 
-				responses.add(OverlaysMessage::Draw);
-
+				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
+				responses.add(OverlaysMessage::Draw);
 
 				let selection = tool_data.nested_selection_behavior;
 				SelectToolFsmState::Ready { selection }


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Ensures Abort and Redraw events are added to the responses when an Abort event occurs.
