### PR TITLE
Fix Select tool's box selection not being able to extend a selection with shift

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -665,7 +665,7 @@ impl Fsm for SelectToolFsmState {
 						responses.add(DocumentMessage::StartTransaction);
 						SelectToolFsmState::Dragging
 					} else {
-						//Make a Selection box,keeping previously selected layers
+						// Make a box selection, preserving previously selected layers
 						let selection = tool_data.nested_selection_behavior;
 						SelectToolFsmState::DrawingBox { selection }
 					}
@@ -1009,7 +1009,7 @@ impl Fsm for SelectToolFsmState {
 					let parent_selected: HashSet<_> = new_selected
 						.into_iter()
 						.map(|layer| {
-							// Find the  parent node
+							// Find the parent node
 							layer.ancestors(document.metadata()).filter(not_artboard(document)).last().unwrap_or(layer)
 						})
 						.collect();


### PR DESCRIPTION
This PR fixes:

Extending box selection in select tool was broken only the newly selected layers were selected . Now the original and newly selected are selected in both modes. [#discord](https://discord.com/channels/731730685944922173/1216976541947531264)
