### PR TITLE
Fix Alt-drag duplication not preserving the original layer order

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1255,7 +1255,6 @@ impl NodeNetworkInterface {
 			log::error!("Could not get selected nodes in shallowest_unique_layers");
 			Vec::new()
 		};
-
 		// Sorting here creates groups of similar UUID paths
 		sorted_layers.sort();
 		sorted_layers.dedup_by(|a, b| a.starts_with(b));

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -8,6 +8,7 @@ use crate::messages::portfolio::document::overlays::utility_types::OverlayContex
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::misc::{AlignAggregate, AlignAxis, FlipAxis};
 use crate::messages::portfolio::document::utility_types::network_interface::{FlowType, NodeNetworkInterface, NodeTemplate};
+use crate::messages::portfolio::document::utility_types::nodes::SelectedNodes;
 use crate::messages::portfolio::document::utility_types::transformation::Selected;
 use crate::messages::tool::common_functionality::graph_modification_utils::is_layer_fed_by_node_of_name;
 use crate::messages::tool::common_functionality::pivot::Pivot;
@@ -340,7 +341,7 @@ impl SelectToolData {
 
 			let nodes = document.network_interface.copy_nodes(&copy_ids, &[]).collect::<Vec<(NodeId, NodeTemplate)>>();
 
-			let insert_index = DocumentMessageHandler::get_calculated_insert_index(document.metadata(), document.network_interface.selected_nodes(&[]).unwrap(), parent);
+			let insert_index = DocumentMessageHandler::get_calculated_insert_index(document.metadata(), SelectedNodes(vec![layer.to_node()]), parent);
 
 			let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
 


### PR DESCRIPTION
- in the function `start_duplicates`, `get_calculated_insert_index` was taking all the layers in the parameter but we needed to only pass the layer that is currrently in the loop so that it will return the correct index to push the layer.

- I passed the current layer `SelectedNodes(vec![layer.to_node()])` under the loop to that function.

https://discord.com/channels/731730685944922173/881073965047636018/1294525859142569994
