### PR TITLE
Add Path tool support for G/R/S rotation and scaling with a single selected handle

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -258,6 +258,8 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(MouseRight); action_dispatch=PenToolMessage::Confirm),
 		entry!(KeyDown(Escape); action_dispatch=PenToolMessage::Confirm),
 		entry!(KeyDown(Enter); action_dispatch=PenToolMessage::Confirm),
+		entry!(KeyDown(Delete); action_dispatch=PenToolMessage::RemovePreviousHandle),
+		entry!(KeyDown(Backspace); action_dispatch=PenToolMessage::RemovePreviousHandle),
 		//
 		// FreehandToolMessage
 		entry!(PointerMove; action_dispatch=FreehandToolMessage::PointerMove),

--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -101,6 +101,7 @@ impl MessageHandler<ToolMessage, ToolMessageData<'_>> for ToolMessageHandler {
 							tool.process_message(ToolMessage::UpdateCursor, responses, &mut data);
 						}
 					}
+
 					if matches!(old_tool, ToolType::Path | ToolType::Select) {
 						responses.add(TransformLayerMessage::CancelTransformOperation);
 					}

--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -76,8 +76,8 @@ impl MessageHandler<ToolMessage, ToolMessageData<'_>> for ToolMessageHandler {
 				self.tool_is_active = true;
 
 				// Send the old and new tools a transition to their FSM Abort states
-				let mut send_abort_to_tool = |tool_type, update_hints_and_cursor: bool| {
-					if let Some(tool) = tool_data.tools.get_mut(&tool_type) {
+				let mut send_abort_to_tool = |old_tool: ToolType, new_tool: ToolType, update_hints_and_cursor: bool| {
+					if let Some(tool) = tool_data.tools.get_mut(&new_tool) {
 						let mut data = ToolActionHandlerData {
 							document,
 							document_id,
@@ -101,9 +101,13 @@ impl MessageHandler<ToolMessage, ToolMessageData<'_>> for ToolMessageHandler {
 							tool.process_message(ToolMessage::UpdateCursor, responses, &mut data);
 						}
 					}
+					if matches!(old_tool, ToolType::Path | ToolType::Select) {
+						responses.add(TransformLayerMessage::CancelTransformOperation);
+					}
 				};
-				send_abort_to_tool(tool_type, true);
-				send_abort_to_tool(old_tool, false);
+
+				send_abort_to_tool(old_tool, tool_type, true);
+				send_abort_to_tool(old_tool, old_tool, false);
 
 				// Unsubscribe old tool from the broadcaster
 				tool_data.tools.get(&tool_type).unwrap().deactivate(responses);

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -648,19 +648,7 @@ impl Fsm for PathToolFsmState {
 				self
 			}
 			(Self::InsertPoint, PathToolMessage::Escape | PathToolMessage::Delete | PathToolMessage::RightClick) => tool_data.end_insertion(shape_editor, responses, InsertEndKind::Abort),
-			(Self::InsertPoint, PathToolMessage::GRS { key: propagate }) => {
-				// MAYBE: use `InputMapperMessage::KeyDown(..)` instead
-				match propagate {
-					// TODO: Don't use `Key::G` directly, instead take it as a variable from the input mappings list like in all other places
-					Key::KeyG => responses.add(TransformLayerMessage::BeginGrab),
-					// TODO: Don't use `Key::R` directly, instead take it as a variable from the input mappings list like in all other places
-					Key::KeyR => responses.add(TransformLayerMessage::BeginRotate),
-					// TODO: Don't use `Key::S` directly, instead take it as a variable from the input mappings list like in all other places
-					Key::KeyS => responses.add(TransformLayerMessage::BeginScale),
-					_ => warn!("Unexpected GRS key"),
-				}
-				tool_data.end_insertion(shape_editor, responses, InsertEndKind::Abort)
-			}
+			(Self::InsertPoint, PathToolMessage::GRS { key: _ }) => PathToolFsmState::InsertPoint,
 			// Mouse down
 			(
 				_,

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -176,7 +176,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for PenTool
 				PointerMove,
 				Confirm,
 				Abort,
-				RemovePreviousHandle
+				RemovePreviousHandle,
 			),
 		}
 	}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -62,6 +62,7 @@ pub enum PenToolMessage {
 	Undo,
 	UpdateOptions(PenOptionsUpdate),
 	RecalculateLatestPointsPosition,
+	RemovePreviousHandle,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -175,6 +176,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionHandlerData<'a>> for PenTool
 				PointerMove,
 				Confirm,
 				Abort,
+				RemovePreviousHandle
 			),
 		}
 	}
@@ -684,6 +686,15 @@ impl Fsm for PenToolFsmState {
 					responses.add(PenToolMessage::DragStart { append_to_selected });
 					PenToolFsmState::PlacingAnchor
 				}
+			}
+			(PenToolFsmState::PlacingAnchor, PenToolMessage::RemovePreviousHandle) => {
+				if let Some(last_point) = tool_data.latest_points.last_mut() {
+					last_point.handle_start = last_point.pos;
+					responses.add(OverlaysMessage::Draw);
+				} else {
+					log::warn!("No latest point available to modify handle_start.");
+				}
+				self
 			}
 			(PenToolFsmState::DraggingHandle, PenToolMessage::DragStop) => tool_data
 				.finish_placing_handle(SnapData::new(document, input), transform, responses)

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -403,6 +403,13 @@ impl HandleId {
 		}
 	}
 
+	pub fn get_handle_length(self, vector_data: &VectorData) -> f64 {
+		let anchor_position = self.to_manipulator_point().get_anchor_position(&vector_data).unwrap();
+		let handle_position = self.to_manipulator_point().get_position(&vector_data);
+		let handle_length = handle_position.map(|pos| (pos - anchor_position).length()).unwrap_or(f64::MAX);
+		handle_length
+	}
+
 	/// Set the handle's position relative to the anchor which is the start anchor for the primary handle and end anchor for the end handle.
 	#[must_use]
 	pub fn set_relative_position(self, relative_position: DVec2) -> VectorModificationType {

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -306,6 +306,13 @@ impl ManipulatorPointId {
 		}
 	}
 
+	pub fn get_anchor_position(&self, vector_data: &VectorData) -> Option<DVec2> {
+		match self {
+			ManipulatorPointId::EndHandle(_) | ManipulatorPointId::PrimaryHandle(_) => self.get_anchor(vector_data).and_then(|id| vector_data.point_domain.position_from_id(id)),
+			_ => self.get_position(vector_data),
+		}
+	}
+
 	/// Attempt to get a pair of handles. For an anchor this is the first two handles connected. For a handle it is self and the first opposing handle.
 	#[must_use]
 	pub fn get_handle_pair(self, vector_data: &VectorData) -> Option<[HandleId; 2]> {

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -403,11 +403,11 @@ impl HandleId {
 		}
 	}
 
-	pub fn get_handle_length(self, vector_data: &VectorData) -> f64 {
-		let anchor_position = self.to_manipulator_point().get_anchor_position(&vector_data).unwrap();
-		let handle_position = self.to_manipulator_point().get_position(&vector_data);
-		let handle_length = handle_position.map(|pos| (pos - anchor_position).length()).unwrap_or(f64::MAX);
-		handle_length
+	/// Calculate the magnitude of the handle from the anchor.
+	pub fn length(self, vector_data: &VectorData) -> f64 {
+		let anchor_position = self.to_manipulator_point().get_anchor_position(vector_data).unwrap();
+		let handle_position = self.to_manipulator_point().get_position(vector_data);
+		handle_position.map(|pos| (pos - anchor_position).length()).unwrap_or(f64::MAX)
 	}
 
 	/// Set the handle's position relative to the anchor which is the start anchor for the primary handle and end anchor for the end handle.


### PR DESCRIPTION
This pr implements some parts of #1870 and also some minor improvements

- When using the path tool, R/S works about the anchor when a single handle is selected.
- When using the pen tool, Backspace/Delete removes the current segment's handle (equivalent to clicking the current anchor).

Minor improvements as discussed - 

- G/R/S should have no effect (those keys should be ignored) while in the yellow point insertion sliding state - [discord](https://discord.com/channels/731730685944922173/1319602515758682132/1326497890222477364)
- The global G/R/S is actually specific to the Select tool and Path tool - [discord](https://discord.com/channels/731730685944922173/1319602515758682132/1326439382198124555)
- G/R/S when the selection is empty should not activate G/R/S (A layer is selected but not any points in it.) - [discord](https://discord.com/channels/731730685944922173/1319602515758682132/1326726305319882773)
- Aborts from G/R/S when switching tools using hotkeys - [discord](https://discord.com/channels/731730685944922173/1319602515758682132/1326765037427363851)