### PR TITLE
Fixes undo due to AbortTransaction of new tool causing stashing of old tool transaction

### DIFF
--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -102,8 +102,9 @@ impl MessageHandler<ToolMessage, ToolMessageData<'_>> for ToolMessageHandler {
 						}
 					}
 				};
-				send_abort_to_tool(tool_type, true);
+
 				send_abort_to_tool(old_tool, false);
+				send_abort_to_tool(tool_type, true);
 
 				// Unsubscribe old tool from the broadcaster
 				tool_data.tools.get(&tool_type).unwrap().deactivate(responses);


### PR DESCRIPTION
Fixes https://discord.com/channels/731730685944922173/881073965047636018/1327376421034922045

The fixed code was introduced first introduced [here](https://github.com/GraphiteEditor/Graphite/commit/a6c91204d621bb6878c1b55a8f49f2541f0b8665#diff-130b143801d544fee86db19d1784fdfd0aa3dc8c3af525e0730717187c2c70a1R52-R53) and not changed.
To ensure correctness, probably needs a lot of QA testing.