### PR TITLE
Remove errant line following cursor in snap overlays during constrained line drawing

### DIFF
--- a/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
+++ b/editor/src/messages/tool/common_functionality/snapping/layer_snapper.rs
@@ -156,7 +156,7 @@ impl LayerSnapper {
 							target: path.target,
 							distance,
 							tolerance,
-							curves: [path.bounds.is_none().then_some(path.document_curve), Some(constraint_path)],
+							curves: [path.bounds.is_none().then_some(path.document_curve), None],
 							source: point.source,
 							target_bounds: path.bounds,
 							at_intersection: true,

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -167,6 +167,7 @@ impl Fsm for LineToolFsmState {
 		match (self, event) {
 			(_, LineToolMessage::Overlays(mut overlay_context)) => {
 				tool_data.snap_manager.draw_overlays(SnapData::new(document, input), &mut overlay_context);
+
 				self
 			}
 			(LineToolFsmState::Ready, LineToolMessage::DragStart) => {

--- a/editor/src/messages/tool/tool_messages/line_tool.rs
+++ b/editor/src/messages/tool/tool_messages/line_tool.rs
@@ -167,7 +167,6 @@ impl Fsm for LineToolFsmState {
 		match (self, event) {
 			(_, LineToolMessage::Overlays(mut overlay_context)) => {
 				tool_data.snap_manager.draw_overlays(SnapData::new(document, input), &mut overlay_context);
-
 				self
 			}
 			(LineToolFsmState::Ready, LineToolMessage::DragStart) => {


### PR DESCRIPTION
## Problem
When using the line tool with shift/ctrl held down to constrain angles, an unwanted blue overlay indicator appears near the cursor.
ref discord message: 
https://discord.com/channels/731730685944922173/881073965047636018/1321318332053454879
## Solution
Modified `snap_paths_constrained` to not include constraint path in curves array, preventing it from being drawn as overlay while maintaining snapping functionality.