### PR TITLE
Polish the G/R/S feature behavior, visualizations, and hints

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -93,7 +93,7 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(Minus); action_dispatch=TransformLayerMessage::TypeNegate),
 		entry!(KeyDown(Comma); action_dispatch=TransformLayerMessage::TypeDecimalPoint),
 		entry!(KeyDown(Period); action_dispatch=TransformLayerMessage::TypeDecimalPoint),
-		entry!(PointerMove; refresh_keys=[Control, Shift], action_dispatch=TransformLayerMessage::PointerMove { slow_key: Shift, snap_key: Control }),
+		entry!(PointerMove; refresh_keys=[Control, Shift], action_dispatch=TransformLayerMessage::PointerMove { slow_key: Shift, increments_key: Control }),
 		//
 		// SelectToolMessage
 		entry!(PointerMove; refresh_keys=[Control, Alt, Shift], action_dispatch=SelectToolMessage::PointerMove(SelectToolPointerKeys { axis_align: Shift, snap_angle: Control, center: Alt, duplicate: Alt })),

--- a/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
@@ -295,8 +295,7 @@ impl fmt::Display for Key {
 			Self::MouseMiddle => "MMB",
 			Self::MouseBack => "Mouse Back",
 			Self::MouseForward => "Mouse Fwd",
-
-			Self::NumKeys => "0-9",
+			Self::NumKeys => "0–9",
 
 			_ => key_name.as_str(),
 		};
@@ -319,20 +318,6 @@ struct LayoutKey {
 	key: String,
 	label: String,
 }
-/*
-impl Serialize for Key {
-	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-		let key = format!("{:?}", self.0);
-		let label = self.0.to_string();
-
-		assert_eq!(serde_json::to_string(Key::KeyEscape), {"key": KeyEscape, "label": "Esc"});
-
-		let mut state = serializer.serialize_struct("KeyWithLabel", 2)?;
-		state.serialize_field("key", &key)?;
-		state.serialize_field("label", &label)?;
-		state.end()
-	}
-}*/
 
 pub const NUMBER_OF_KEYS: usize = Key::NumKeys as usize;
 

--- a/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_keyboard.rs
@@ -296,6 +296,8 @@ impl fmt::Display for Key {
 			Self::MouseBack => "Mouse Back",
 			Self::MouseForward => "Mouse Fwd",
 
+			Self::NumKeys => "0-9",
+
 			_ => key_name.as_str(),
 		};
 

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -156,7 +156,7 @@ impl Translation {
 		};
 		let displacement = transform.inverse().transform_vector2(displacement);
 		if snap {
-			(displacement).round()
+			displacement.round()
 		} else {
 			displacement
 		}
@@ -376,33 +376,32 @@ impl TransformOperation {
 			input_hints.push(HintInfo::keys([Key::Minus], "Negate Direction"));
 			input_hints.push(HintInfo::keys([Key::Backspace], "Delete Digit"));
 			input_hints.push(HintInfo::keys([Key::NumKeys], "Enter Number"));
-		} else {
-			if matches!(self, TransformOperation::Grabbing(_) | TransformOperation::Scaling(_)) {
-				let axis_constraint = match self {
-					TransformOperation::Grabbing(grabbing) => grabbing.constraint,
-					TransformOperation::Scaling(scaling) => scaling.constraint,
-					_ => Axis::Both,
-				};
-				match axis_constraint {
-					Axis::Both => {
-						input_hints.push(HintInfo::keys([Key::KeyX], "Along X Axis"));
-						input_hints.push(HintInfo::keys([Key::KeyY], "Along Y Axis"));
+		} else if matches!(self, TransformOperation::Grabbing(_) | TransformOperation::Scaling(_)) {
+			let axis_constraint = match self {
+				TransformOperation::Grabbing(grabbing) => grabbing.constraint,
+				TransformOperation::Scaling(scaling) => scaling.constraint,
+				_ => Axis::Both,
+			};
+			let clear_constraint = "Clear Constraint";
+			match axis_constraint {
+				Axis::Both => {
+					input_hints.push(HintInfo::keys([Key::KeyX], "Along X Axis"));
+					input_hints.push(HintInfo::keys([Key::KeyY], "Along Y Axis"));
+				}
+				Axis::X => {
+					let x_label = if local { clear_constraint } else { "Along Local X Axis" };
+					input_hints.push(HintInfo::keys([Key::KeyX], x_label));
+					input_hints.push(HintInfo::keys([Key::KeyY], "Along Y Axis"));
+					if !local {
+						input_hints.push(HintInfo::keys([Key::KeyX, Key::KeyX], clear_constraint));
 					}
-					Axis::X => {
-						let x_label = if local { "Clear Constraint" } else { "Along Local X Axis" };
-						input_hints.push(HintInfo::keys([Key::KeyX], x_label));
-						input_hints.push(HintInfo::keys([Key::KeyY], "Along Y Axis"));
-						if !local {
-							input_hints.push(HintInfo::keys([Key::KeyX, Key::KeyX], "Clear Constraint"));
-						}
-					}
-					Axis::Y => {
-						let y_label = if local { "Clear Constraint" } else { "Along Local Y Axis" };
-						input_hints.push(HintInfo::keys([Key::KeyX], "Along X Axis"));
-						input_hints.push(HintInfo::keys([Key::KeyY], y_label));
-						if !local {
-							input_hints.push(HintInfo::keys([Key::KeyY, Key::KeyY], "Clear Constraint"));
-						}
+				}
+				Axis::Y => {
+					let y_label = if local { clear_constraint } else { "Along Local Y Axis" };
+					input_hints.push(HintInfo::keys([Key::KeyX], "Along X Axis"));
+					input_hints.push(HintInfo::keys([Key::KeyY], y_label));
+					if !local {
+						input_hints.push(HintInfo::keys([Key::KeyY, Key::KeyY], clear_constraint));
 					}
 				}
 			}
@@ -417,7 +416,7 @@ impl TransformOperation {
 
 		let mut hint_groups = vec![grs_hint_group];
 		if !self.is_typing() {
-			let modifiers = vec![HintInfo::keys([Key::Shift], "Slow Mode"), HintInfo::keys([Key::Control], "Snap")];
+			let modifiers = vec![HintInfo::keys([Key::Shift], "Slow"), HintInfo::keys([Key::Control], "Increments")];
 			hint_groups.push(HintGroup(modifiers));
 		}
 		hint_groups.push(HintGroup(input_hints));
@@ -653,7 +652,7 @@ const DECIMAL_POINT: u8 = 10;
 impl Typing {
 	pub fn type_number(&mut self, number: u8) -> Option<f64> {
 		self.digits.push(number);
-		self.string.push((number as u8 + b'0') as char);
+		self.string.push((b'0' + number) as char);
 
 		self.evaluate()
 	}

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -587,6 +587,7 @@ impl<'a> Selected<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Typing {
 	pub digits: Vec<u8>,
+	pub string: String,
 	pub contains_decimal: bool,
 	pub negative: bool,
 }
@@ -596,6 +597,7 @@ const DECIMAL_POINT: u8 = 10;
 impl Typing {
 	pub fn type_number(&mut self, number: u8) -> Option<f64> {
 		self.digits.push(number);
+		self.string.push((number as u8 + b'0') as char);
 
 		self.evaluate()
 	}
@@ -610,7 +612,7 @@ impl Typing {
 			Some(_) => (),
 			None => self.negative = false,
 		}
-
+		self.string.pop();
 		self.evaluate()
 	}
 
@@ -618,6 +620,7 @@ impl Typing {
 		if !self.contains_decimal {
 			self.contains_decimal = true;
 			self.digits.push(DECIMAL_POINT);
+			self.string.push('.');
 		}
 
 		self.evaluate()
@@ -625,6 +628,11 @@ impl Typing {
 
 	pub fn type_negate(&mut self) -> Option<f64> {
 		self.negative = !self.negative;
+		if self.negative {
+			self.string.insert(0, '-');
+		} else {
+			self.string.remove(0);
+		}
 
 		self.evaluate()
 	}
@@ -660,6 +668,7 @@ impl Typing {
 
 	pub fn clear(&mut self) {
 		self.digits.clear();
+		self.string.clear();
 		self.contains_decimal = false;
 		self.negative = false;
 	}

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -429,7 +429,7 @@ impl Fsm for BrushToolFsmState {
 		let hint_data = match self {
 			BrushToolFsmState::Ready => HintData(vec![
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Draw")]),
-				HintGroup(vec![HintInfo::keys([Key::BracketLeft, Key::BracketRight], "Shrink/Grow Brush")]),
+				HintGroup(vec![HintInfo::multi_keys([[Key::BracketLeft], [Key::BracketRight]], "Shrink/Grow Brush")]),
 			]),
 			BrushToolFsmState::Drawing => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Rmb, ""), HintInfo::keys([Key::Escape], "Cancel").prepend_slash()])]),
 		};

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1055,7 +1055,7 @@ impl Fsm for PathToolFsmState {
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDouble, "Make Anchor Smooth/Sharp")]),
 				// TODO: Only show the following hints if at least one point is selected
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Drag Selected")]),
-				HintGroup(vec![HintInfo::keys([Key::KeyG, Key::KeyR, Key::KeyS], "Grab/Rotate/Scale Selected")]),
+				HintGroup(vec![HintInfo::multi_keys([[Key::KeyG], [Key::KeyR], [Key::KeyS]], "Grab/Rotate/Scale Selected")]),
 				HintGroup(vec![HintInfo::arrow_keys("Nudge Selected"), HintInfo::keys([Key::Shift], "10x").prepend_plus()]),
 				HintGroup(vec![
 					HintInfo::keys([Key::Delete], "Delete Selected"),

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1198,7 +1198,7 @@ impl Fsm for SelectToolFsmState {
 						HintInfo::mouse(MouseMotion::LmbDrag, "Select Area"),
 						HintInfo::keys([Key::Shift], "Extend Selection").prepend_plus(),
 					]),
-					HintGroup(vec![HintInfo::keys([Key::KeyG, Key::KeyR, Key::KeyS], "Grab/Rotate/Scale Selected")]),
+					HintGroup(vec![HintInfo::multi_keys([[Key::KeyG], [Key::KeyR], [Key::KeyS]], "Grab/Rotate/Scale Selected")]),
 					HintGroup(vec![
 						HintInfo::arrow_keys("Nudge Selected"),
 						HintInfo::keys([Key::Shift], "10x").prepend_plus(),

--- a/editor/src/messages/tool/transform_layer/transform_layer_message.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message.rs
@@ -7,6 +7,9 @@ use glam::DVec2;
 #[impl_message(Message, ToolMessage, TransformLayer)]
 #[derive(PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum TransformLayerMessage {
+	// Overlays
+	Overlays(OverlayContext),
+
 	// Messages
 	ApplyTransformOperation,
 	BeginGrab,
@@ -18,7 +21,6 @@ pub enum TransformLayerMessage {
 	CancelTransformOperation,
 	ConstrainX,
 	ConstrainY,
-	Overlays(OverlayContext),
 	PointerMove { slow_key: Key, snap_key: Key },
 	SelectionChanged,
 	TypeBackspace,

--- a/editor/src/messages/tool/transform_layer/transform_layer_message.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message.rs
@@ -21,7 +21,7 @@ pub enum TransformLayerMessage {
 	CancelTransformOperation,
 	ConstrainX,
 	ConstrainY,
-	PointerMove { slow_key: Key, snap_key: Key },
+	PointerMove { slow_key: Key, increments_key: Key },
 	SelectionChanged,
 	TypeBackspace,
 	TypeDecimalPoint,

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -162,7 +162,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 					match self.transform_operation {
 						TransformOperation::None => (),
 						TransformOperation::Grabbing(translation) => {
-							let translation = document_to_viewport.inverse().transform_vector2(translation.to_dvec(document_to_viewport));
+							let translation = translation.to_dvec(document_to_viewport, self.snap);
 							let vec_to_end = self.mouse_position - self.start_mouse;
 							let quad = Quad::from_box([self.grab_target, self.grab_target + vec_to_end]).0;
 							let e1 = (self.fixed_bbox.0[1] - self.fixed_bbox.0[0]).normalize();

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -177,7 +177,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 							let quad = Quad::from_box([self.grab_target, self.grab_target + viewport_translate]).0;
 							let e1 = (self.fixed_bbox.0[1] - self.fixed_bbox.0[0]).normalize();
 
-							if matches!(axis_constraint, Axis::Both | Axis::X) {
+							if matches!(axis_constraint, Axis::Both | Axis::X) && translation.x != 0. {
 								let end = if self.local {
 									(quad[1] - quad[0]).length() * e1 * e1.dot(quad[1] - quad[0]).signum() + quad[0]
 								} else {
@@ -189,7 +189,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 								overlay_context.text(&format_rounded(translation.x, 3), COLOR_OVERLAY_BLUE, None, x_transform, 4., [Pivot::Middle, Pivot::End]);
 							}
 
-							if matches!(axis_constraint, Axis::Both | Axis::Y) {
+							if matches!(axis_constraint, Axis::Both | Axis::Y) && translation.y != 0. {
 								let end = if self.local {
 									(quad[3] - quad[0]).length() * e1.perp() * e1.perp().dot(quad[3] - quad[0]).signum() + quad[0]
 								} else {
@@ -209,7 +209,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 									overlay_context.text(&format_rounded(translation.y, 2), COLOR_OVERLAY_BLUE, None, y_transform, 3., [pivot_selection, Pivot::Middle]);
 								}
 							}
-							if matches!(axis_constraint, Axis::Both) {
+							if matches!(axis_constraint, Axis::Both) && translation.x != 0. && translation.y != 0. {
 								overlay_context.dashed_line(quad[1], quad[2], None, Some(2.), Some(2.), Some(0.5));
 								overlay_context.dashed_line(quad[3], quad[2], None, Some(2.), Some(2.), Some(0.5));
 							}

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -15,6 +15,10 @@ use glam::{DAffine2, DVec2};
 use std::f64::consts::TAU;
 
 const TRANSFORM_GRS_OVERLAY_PROVIDER: OverlayProvider = |context| TransformLayerMessage::Overlays(context).into();
+const MESSAGE_TO_RUSH_OVERLAY: TransformLayerMessage = TransformLayerMessage::PointerMove {
+	slow_key: Key::Shift,
+	snap_key: Key::Control,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct TransformLayerMessageHandler {
@@ -320,6 +324,8 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 				};
 
 				responses.add(OverlaysMessage::AddProvider(TRANSFORM_GRS_OVERLAY_PROVIDER));
+				// Find a way better than this hack
+				responses.add(MESSAGE_TO_RUSH_OVERLAY);
 			}
 			TransformLayerMessage::BeginGrab => {
 				if (!using_path_tool && !using_select_tool && !using_pen_tool)
@@ -341,6 +347,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 				selected.original_transforms.clear();
 
 				responses.add(OverlaysMessage::AddProvider(TRANSFORM_GRS_OVERLAY_PROVIDER));
+				responses.add(MESSAGE_TO_RUSH_OVERLAY);
 			}
 			TransformLayerMessage::BeginRotate => {
 				let selected_points: Vec<&ManipulatorPointId> = shape_editor.selected_points().collect();
@@ -391,6 +398,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 				selected.original_transforms.clear();
 
 				responses.add(OverlaysMessage::AddProvider(TRANSFORM_GRS_OVERLAY_PROVIDER));
+				responses.add(MESSAGE_TO_RUSH_OVERLAY);
 			}
 			TransformLayerMessage::BeginScale => {
 				let selected_points: Vec<&ManipulatorPointId> = shape_editor.selected_points().collect();
@@ -440,6 +448,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 				selected.original_transforms.clear();
 
 				responses.add(OverlaysMessage::AddProvider(TRANSFORM_GRS_OVERLAY_PROVIDER));
+				responses.add(MESSAGE_TO_RUSH_OVERLAY);
 			}
 			TransformLayerMessage::CancelTransformOperation => {
 				if using_pen_tool {

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -248,7 +248,13 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 						TransformOperation::Rotating(rotation) => {
 							let angle = rotation.to_f64(self.snap);
 							let quad = self.fixed_bbox.0;
-							let offset_angle = if self.grs_pen_handle { self.handle - self.last_point } else { quad[1] - quad[0] };
+							let offset_angle = if self.grs_pen_handle {
+								self.handle - self.last_point
+							} else if using_path_tool {
+								self.start_mouse - self.pivot
+							} else {
+								quad[1] - quad[0]
+							};
 							let offset_angle = offset_angle.to_angle();
 							let width = viewport_box.max_element();
 							let radius = self.start_mouse.distance(self.pivot);

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -151,8 +151,6 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 					};
 
 					let viewport_box = input.viewport_bounds.size();
-					let transform = DAffine2::from_translation(DVec2::new(0., viewport_box.y)) * DAffine2::from_scale(DVec2::splat(1.2));
-
 					let axis_constraint = match self.transform_operation {
 						TransformOperation::Grabbing(grabbing) => grabbing.constraint,
 						TransformOperation::Scaling(scaling) => scaling.constraint,
@@ -160,23 +158,6 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 					};
 
 					let format_rounded = |value: f64, precision: usize| format!("{:.*}", precision, value).trim_end_matches('0').trim_end_matches('.').to_string();
-
-					let axis_text = |vector: DVec2, separate: bool| match (axis_constraint, separate) {
-						(Axis::Both, false) => format!("by {}", format_rounded(vector.x, 3)),
-						(Axis::Both, true) => format!("by ({}, {})", format_rounded(vector.x, 3), format_rounded(vector.y, 3)),
-						(Axis::X, _) => format!("X by {}", format_rounded(vector.x, 3)),
-						(Axis::Y, _) => format!("Y by {}", format_rounded(vector.y, 3)),
-					};
-
-					let grs_value_text = match self.transform_operation {
-						TransformOperation::None => String::new(),
-						TransformOperation::Grabbing(translation) => format!(
-							"Translating {}",
-							axis_text(document_to_viewport.inverse().transform_vector2(translation.to_dvec(document_to_viewport)), true)
-						),
-						TransformOperation::Rotating(rotation) => format!("Rotating by {}°", format_rounded(rotation.to_f64(self.snap).to_degrees(), 3)),
-						TransformOperation::Scaling(scale) => format!("Scaling {}", axis_text(scale.to_dvec(self.snap), false)),
-					};
 
 					match self.transform_operation {
 						TransformOperation::None => (),
@@ -278,8 +259,6 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 							overlay_context.text(&text, COLOR_OVERLAY_BLUE, None, transform, 16., [Pivot::Middle, Pivot::Middle]);
 						}
 					}
-
-					overlay_context.text(&grs_value_text, COLOR_OVERLAY_WHITE, Some(COLOR_OVERLAY_SNAP_BACKGROUND), transform, 4., [Pivot::Start, Pivot::End]);
 				}
 			}
 			TransformLayerMessage::ApplyTransformOperation => {

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -163,8 +163,8 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 						TransformOperation::None => (),
 						TransformOperation::Grabbing(translation) => {
 							let translation = translation.to_dvec(document_to_viewport, self.snap);
-							let vec_to_end = self.mouse_position - self.start_mouse;
-							let quad = Quad::from_box([self.grab_target, self.grab_target + vec_to_end]).0;
+							let viewport_translate = document_to_viewport.transform_vector2(translation);
+							let quad = Quad::from_box([self.grab_target, self.grab_target + viewport_translate]).0;
 							let e1 = (self.fixed_bbox.0[1] - self.fixed_bbox.0[0]).normalize();
 
 							if matches!(axis_constraint, Axis::Both | Axis::X) {
@@ -186,7 +186,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 									quad[3]
 								};
 								overlay_context.line(quad[0], end, None);
-								let x_parameter = vec_to_end.x.clamp(-1., 1.);
+								let x_parameter = viewport_translate.x.clamp(-1., 1.);
 								let y_transform = DAffine2::from_translation((quad[0] + end) / 2. + x_parameter * DVec2::X * 0.);
 								let pivot_selection = if x_parameter > 0. {
 									Pivot::Start

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -1,4 +1,4 @@
-use crate::consts::{ANGLE_MEASURE_RADIUS_FACTOR, ARC_MEASURE_RADIUS_FACTOR_RANGE, COLOR_OVERLAY_BLUE, COLOR_OVERLAY_SNAP_BACKGROUND, COLOR_OVERLAY_WHITE, SLOWING_DIVISOR};
+use crate::consts::{ANGLE_MEASURE_RADIUS_FACTOR, ARC_MEASURE_RADIUS_FACTOR_RANGE, COLOR_OVERLAY_BLUE, SLOWING_DIVISOR};
 use crate::messages::input_mapper::utility_types::input_mouse::ViewportPosition;
 use crate::messages::portfolio::document::overlays::utility_types::{OverlayProvider, Pivot};
 use crate::messages::portfolio::document::utility_types::transformation::{Axis, OriginalTransforms, Selected, TransformOperation, Typing};
@@ -519,8 +519,12 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 				.transform_operation
 				.grs_typed(self.typing.type_backspace(), &mut selected, self.snap, self.local, self.fixed_bbox, document_to_viewport),
 			TransformLayerMessage::TypeDecimalPoint => {
-				self.transform_operation
-					.grs_typed(self.typing.type_decimal_point(), &mut selected, self.snap, self.local, self.fixed_bbox, document_to_viewport)
+				if self.typing.digits.is_empty() {
+					self.typing.negative = false;
+				} else {
+					self.transform_operation
+						.grs_typed(self.typing.type_decimal_point(), &mut selected, self.snap, self.local, self.fixed_bbox, document_to_viewport)
+				}
 			}
 			TransformLayerMessage::TypeDigit { digit } => {
 				self.transform_operation

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -157,7 +157,13 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 						_ => Axis::Both,
 					};
 
-					let format_rounded = |value: f64, precision: usize| format!("{:.*}", precision, value).trim_end_matches('0').trim_end_matches('.').to_string();
+					let format_rounded = |value: f64, precision: usize| {
+						if self.typing.string.is_empty() {
+							format!("{:.*}", precision, value).trim_end_matches('0').trim_end_matches('.').to_string()
+						} else {
+							self.typing.string.clone()
+						}
+					};
 
 					match self.transform_operation {
 						TransformOperation::None => (),
@@ -195,7 +201,9 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 								} else {
 									Pivot::End
 								};
-								overlay_context.text(&format_rounded(translation.y, 2), COLOR_OVERLAY_BLUE, None, y_transform, 3., [pivot_selection, Pivot::Middle]);
+								if axis_constraint != Axis::Both || self.typing.digits.is_empty() {
+									overlay_context.text(&format_rounded(translation.y, 2), COLOR_OVERLAY_BLUE, None, y_transform, 3., [pivot_selection, Pivot::Middle]);
+								}
 							}
 							if matches!(axis_constraint, Axis::Both) {
 								overlay_context.dashed_line(quad[1], quad[2], None, Some(2.), Some(2.), Some(0.5));

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -162,7 +162,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 					};
 
 					let format_rounded = |value: f64, precision: usize| {
-						if self.typing.string.is_empty() {
+						if self.typing.digits.is_empty() {
 							format!("{:.*}", precision, value).trim_end_matches('0').trim_end_matches('.').to_string()
 						} else {
 							self.typing.string.clone()

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -536,7 +536,7 @@ impl MessageHandler<TransformLayerMessage, TransformData<'_>> for TransformLayer
 							let change = if self.slow { change / SLOWING_DIVISOR } else { change };
 
 							let sign = to_mouse_final.dot(to_mouse_start).signum();
-							let scale = scale.increment_amount(change);
+							let scale = scale.increment_amount(change * scale.to_f64(self.snap).signum());
 							self.transform_operation = TransformOperation::Scaling(scale);
 
 							let op = TransformOperation::Scaling(if sign > 0. { scale } else { scale.negate() });

--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -49,7 +49,7 @@ impl TransformLayerMessageHandler {
 	}
 
 	pub fn hints(&self, responses: &mut VecDeque<Message>) {
-		self.transform_operation.hints(responses);
+		self.transform_operation.hints(responses, self.local);
 	}
 }
 

--- a/editor/src/messages/tool/utility_types.rs
+++ b/editor/src/messages/tool/utility_types.rs
@@ -482,8 +482,12 @@ pub struct HintInfo {
 }
 
 impl HintInfo {
+	/// Used for a hint where a single key or key stroke is used to perform one action.
+	/// Examples:
+	/// - The Escape key can be used to cancel an action
+	/// - The Ctrl+C key stroke can be used to copy
 	pub fn keys(keys: impl IntoIterator<Item = Key>, label: impl Into<Cow<'static, str>>) -> Self {
-		let keys: Vec<_> = keys.into_iter().collect();
+		let keys = keys.into_iter().collect();
 		Self {
 			key_groups: vec![KeysGroup(keys).into()],
 			key_groups_mac: None,
@@ -494,6 +498,10 @@ impl HintInfo {
 		}
 	}
 
+	/// Used for a hint where multiple different individual keys can be used to perform variations of the same action. These keys are represented with a slight separation between them compared to [`Self::keys`].
+	/// Examples:
+	/// - The four arrow keys can be used to nudge a layer in different directions
+	/// - The G, R, and S keys can be used to enter GRS transformation mode
 	pub fn multi_keys(multi_keys: impl IntoIterator<Item = impl IntoIterator<Item = Key>>, label: impl Into<Cow<'static, str>>) -> Self {
 		let key_groups = multi_keys.into_iter().map(|keys| KeysGroup(keys.into_iter().collect()).into()).collect();
 		Self {
@@ -529,7 +537,7 @@ impl HintInfo {
 	}
 
 	pub fn keys_and_mouse(keys: impl IntoIterator<Item = Key>, mouse_motion: MouseMotion, label: impl Into<Cow<'static, str>>) -> Self {
-		let keys: Vec<_> = keys.into_iter().collect();
+		let keys = keys.into_iter().collect();
 		Self {
 			key_groups: vec![KeysGroup(keys).into()],
 			key_groups_mac: None,
@@ -568,7 +576,7 @@ impl HintInfo {
 	}
 
 	pub fn add_mac_keys(mut self, keys: impl IntoIterator<Item = Key>) -> Self {
-		let mac_keys: Vec<_> = keys.into_iter().collect();
+		let mac_keys = keys.into_iter().collect();
 		self.key_groups_mac = Some(vec![KeysGroup(mac_keys).into()]);
 		self
 	}


### PR DESCRIPTION
- [x] Another change: when typing values, we shouldn't round the number to 2 decimal places, instead it should show the exact number the user types, including trailing zeros if the user types those.
- [x] For Scale, the solid vs. dashed line that follows the cursor is following the projected location of the cursor onto that line. It should not be doing that, instead it should be displaying the actual scale ratio. 0 means at the center. 1 means at the starting point of the Sscale. 0.5 means half is solid, half is dashed. Notice in my video below, I'm able to make the solid line's end go all the way to the center, which should occur at a scale factor of 0, without ever having the scale factor even go below 0.5. Because currently the two values aren't related. Furthermore, this is necessary to visualize snapping when Ctrl is pressed and to properly handle slowing when Shift is pressed. [Video](https://files.keavon.com/-/QuirkyYummyGrayfox/capture_38_.mp4)
- [x] Implement integer-value snapping for Grab when Ctrl is pressed? It should work whether we're freely moving or constrained to X or Y (but still mouse controlled; Ctrl doesn't affect typed numbers). So when Ctrl is held, we shouldn't see decimal values. You'll need to zoom in past 100% to see decimal values.
- [x] We don't enter G, R, or S mode until after pressing one of those keys and then moving the mouse cursor. It should happen immediately upon pressing the key, before needing to move the cursor.
- [x] The hints need to be updated to work dynamically with the state of global vs. local X and Y constraint, and include `-` negation, numbers, and Backspace if numbers are typed.
- [x] In the Path tool, we actually do want the Rotation to start from the direction of the cursor rather than the local rotation of the layer. So if you can undo that change specifically for the Path tool, but keep it for the Select tool, that would be ideal.
- [x] When G is constrained to Y in both Path and Select tools, the number label shouldn't swap sides based on moving the mouse left and right offset by the pivot-to-start-point X offset distance. Alternatively, you could keep this behavior but make it swap to the side that the mouse is currently on (removing the pivot-to-start-point X offset from the current mouse position). When solving this, just be sure you don't break the correct behavior for G when unconstrained to an axis, since we like how the Y component label swaps sides. Please also double-check that you're not drawing any extra (overlapping) overlay lines than the necessary 1 when in X or Y constraint mode, or when X or Y happen to be precisely 0. [Video](https://files.keavon.com/-/EachWeeArcticseal/capture_39_.mp4)
- [x] Remove the bottom-left viewport overlay labels for the G/R/S status
- [x] If you type `-` it negates the mouse-controlled GRS. Then if you type a number, it becomes that negative number. If you then type `-` it negates that number, etc.