### PR TITLE
Fix regression where Pen tool resumes segment placement after returning from another tool

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -339,7 +339,6 @@ impl PenToolData {
 				},
 			});
 		}
-		responses.add(DocumentMessage::EndTransaction);
 		if !close_subpath {
 			self.add_point(LastPoint {
 				id: end,
@@ -348,6 +347,7 @@ impl PenToolData {
 				handle_start: next_handle_start,
 			});
 		}
+		responses.add(DocumentMessage::EndTransaction);
 		Some(if close_subpath { PenToolFsmState::Ready } else { PenToolFsmState::PlacingAnchor })
 	}
 
@@ -857,10 +857,14 @@ impl Fsm for PenToolFsmState {
 			}
 			(_, PenToolMessage::Abort) => {
 				responses.add(DocumentMessage::AbortTransaction);
+				tool_data.handle_end = None;
+				tool_data.latest_points.clear();
+				tool_data.point_index = 0;
+				tool_data.snap_manager.cleanup(responses);
 
 				responses.add(OverlaysMessage::Draw);
 
-				self
+				PenToolFsmState::Ready
 			}
 			(PenToolFsmState::DraggingHandle | PenToolFsmState::PlacingAnchor, PenToolMessage::Undo) => {
 				if tool_data.point_index > 0 {


### PR DESCRIPTION
Fixes https://discord.com/channels/731730685944922173/1332187131623506095/1333775276160585788.