### PR TITLE
Fix crash when ungrouping a direct child of the root in debug mode

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1208,9 +1208,15 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 						insert_index: folder_index,
 					});
 
-					let layer_local_transform = self.network_interface.document_metadata().transform_to_viewport(child);
-					let undo_transform = self.network_interface.document_metadata().transform_to_viewport(parent).inverse();
-					let transform = undo_transform * layer_local_transform;
+					let metadata = self.network_interface.document_metadata();
+					let layer_local_transform = metadata.transform_to_viewport(child);
+					let undo_parent_transform = if parent == LayerNodeIdentifier::ROOT_PARENT {
+						// This is functionally the same as transform_to_viewport for the root, however to_node cannot run on the root in debug mode.
+						metadata.document_to_viewport.inverse()
+					} else {
+						metadata.transform_to_viewport(parent).inverse()
+					};
+					let transform = undo_parent_transform * layer_local_transform;
 					responses.add(GraphOperationMessage::TransformSet {
 						layer: child,
 						transform,


### PR DESCRIPTION
As [reported by @Keavon](https://discord.com/channels/731730685944922173/881073965047636018/1334432065977843746).

I'm not sure why it is bad for `to_node()` to be run on the root node in debug mode.
```rs
debug_assert!(id != NodeId(0), "LayerNodeIdentifier::ROOT_PARENT cannot be converted to NodeId");
```

This PR simply works around the issue