### PR TITLE
Fix some number input widgets becoming selected after dragging left/right in Firefox

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -57,10 +57,9 @@
 	export let incrementCallbackDecrease: (() => void) | undefined = undefined;
 
 	let self: FieldInput | undefined;
-	let isdragging: boolean;
-	isdragging = false;
 	let inputRangeElement: HTMLInputElement | undefined;
 	let text = displayText(value, unit);
+	let isDragging = false;
 	let editing = false;
 	// Stays in sync with a binding to the actual input range slider element.
 	let rangeSliderValue = value !== undefined ? value : 0;
@@ -189,9 +188,8 @@
 		editing = true;
 
 		self?.selectAllText(text);
-		if (isdragging) {
-			self?.unFocus();
-		}
+		// Workaround for weird behavior in Firefox: <https://github.com/GraphiteEditor/Graphite/issues/2215>
+		if (isDragging) self?.unFocus();
 	}
 
 	// Called only when `value` is changed from the <input> element via user input and committed, either with the
@@ -286,7 +284,7 @@
 		const onMove = () => {
 			if (alreadyActedGuard) return;
 			alreadyActedGuard = true;
-			isdragging = true;
+			isDragging = true;
 			beginDrag(e);
 			removeEventListener("pointermove", onMove);
 		};
@@ -294,7 +292,7 @@
 		const onUp = () => {
 			if (alreadyActedGuard) return;
 			alreadyActedGuard = true;
-			isdragging = false;
+			isDragging = false;
 			self?.focus();
 			removeEventListener("pointerup", onUp);
 		};

--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -57,6 +57,8 @@
 	export let incrementCallbackDecrease: (() => void) | undefined = undefined;
 
 	let self: FieldInput | undefined;
+	let isdragging: boolean;
+	isdragging = false;
 	let inputRangeElement: HTMLInputElement | undefined;
 	let text = displayText(value, unit);
 	let editing = false;
@@ -187,6 +189,9 @@
 		editing = true;
 
 		self?.selectAllText(text);
+		if (isdragging) {
+			self?.unFocus();
+		}
 	}
 
 	// Called only when `value` is changed from the <input> element via user input and committed, either with the
@@ -281,7 +286,7 @@
 		const onMove = () => {
 			if (alreadyActedGuard) return;
 			alreadyActedGuard = true;
-
+			isdragging = true;
 			beginDrag(e);
 			removeEventListener("pointermove", onMove);
 		};
@@ -289,7 +294,7 @@
 		const onUp = () => {
 			if (alreadyActedGuard) return;
 			alreadyActedGuard = true;
-
+			isdragging = false;
 			self?.focus();
 			removeEventListener("pointerup", onUp);
 		};


### PR DESCRIPTION

Closes #2215 

https://github.com/user-attachments/assets/828c905a-23ce-466c-9ee8-4e47ae9e6dbf


