### PR TITLE
Hide window title when insufficient horizontal space is available

### DIFF
--- a/frontend/src/components/window/title-bar/TitleBar.svelte
+++ b/frontend/src/components/window/title-bar/TitleBar.svelte
@@ -34,12 +34,20 @@
 	];
 
 	let entries: MenuListEntry[] = [];
+	let windowWidth = typeof window !== "undefined" ? window.innerWidth : 1000;
 
 	$: docIndex = $portfolio.activeDocumentIndex;
 	$: displayName = $portfolio.documents[docIndex]?.displayName || "";
 	$: windowTitle = `${displayName}${displayName && " - "}Graphite`;
+	$: showTitle = windowWidth >= 820;
 
 	onMount(() => {
+		const handleResize = () => {
+			windowWidth = window.innerWidth;
+		};
+
+		window.addEventListener("resize", handleResize);
+
 		const arraysEqual = (a: KeyRaw[], b: KeyRaw[]): boolean => a.length === b.length && a.every((aValue, i) => aValue === b[i]);
 		const shortcutRequiresLock = (shortcut: LayoutKeysGroup): boolean => {
 			const shortcutKeys = shortcut.map((keyWithLabel) => keyWithLabel.key);
@@ -66,6 +74,10 @@
 
 			entries = updateMenuBarLayout.layout.map(menuBarEntryToMenuListEntry);
 		});
+
+		return () => {
+			window.removeEventListener("resize", handleResize);
+		};
 	});
 </script>
 
@@ -80,11 +92,11 @@
 			{/each}
 		{/if}
 	</LayoutRow>
-	<!-- Document title -->
-	<LayoutRow class="center">
-		<WindowTitle text={windowTitle} />
-	</LayoutRow>
-	<!-- Window buttons (except on Mac) -->
+	{#if showTitle}
+		<LayoutRow class="center">
+			<WindowTitle text={windowTitle} />
+		</LayoutRow>
+	{/if}
 	<LayoutRow class="right">
 		{#if platform === "Windows" || platform === "Linux"}
 			<WindowButtonsWindows {maximized} />
@@ -112,6 +124,13 @@
 
 			&.right {
 				justify-content: flex-end;
+				// Default: can grow, can shrink, fills space
+				flex: 1 1 100%;
+
+				@media (max-width: 819px) {
+					// When narrow: no grow, no shrink, auto width
+					flex: 0 0 auto;
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

fixes:[Window Title](https://discord.com/channels/731730685944922173/881073965047636018/1223206184152993812)

## Changes
- Added responsive behavior to title bar for better handling of narrow viewports
- Hides center title when window width is below 820px
- Right section (window controls) shrinks to content width below 819px
- Added window resize listener with cleanup

## Implementation Details
- Added reactive `windowWidth` state to track viewport size
- Used Svelte conditional rendering (`{#if showTitle}`) for center title
- Implemented media query for right section flex behavior
- Proper event listener cleanup in `onMount` return function
