### PR TITLE
Instance tables refactor part 3: flatten ImageFrame<P> in lieu of Image<P>

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -28,7 +28,7 @@ use crate::node_graph_executor::NodeGraphExecutor;
 use bezier_rs::Subpath;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{NodeId, NodeInput, NodeNetwork, OldNodeNetwork};
-use graphene_core::raster::image::{ImageFrame, ImageFrameTable};
+use graphene_core::raster::image::ImageFrameTable;
 use graphene_core::raster::BlendMode;
 use graphene_core::vector::style::ViewMode;
 use graphene_std::renderer::{ClickTarget, Quad};
@@ -818,7 +818,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 
 				responses.add(DocumentMessage::AddTransaction);
 
-				let layer = graph_modification_utils::new_image_layer(ImageFrameTable::new(ImageFrame { image }), layer_node_id, self.new_layer_parent(true), responses);
+				let layer = graph_modification_utils::new_image_layer(ImageFrameTable::new(image), layer_node_id, self.new_layer_parent(true), responses);
 
 				if let Some(name) = name {
 					responses.add(NodeGraphMessage::SetDisplayName {

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -20,7 +20,7 @@ use graphene_core::raster::{
 use graphene_core::text::Font;
 use graphene_core::vector::misc::CentroidType;
 use graphene_core::vector::style::{GradientType, LineCap, LineJoin};
-use graphene_std::application_io::TextureFrame;
+use graphene_std::application_io::TextureFrameTable;
 use graphene_std::transform::Footprint;
 use graphene_std::vector::misc::BooleanOperation;
 use graphene_std::vector::style::{Fill, FillChoice, FillType, GradientStops};
@@ -159,7 +159,7 @@ pub(crate) fn property_from_type(
 						Some(x) if x == TypeId::of::<Curve>() => curves_widget(document_node, node_id, index, name, true),
 						Some(x) if x == TypeId::of::<GradientStops>() => color_widget(document_node, node_id, index, name, ColorInput::default().allow_none(false), true),
 						Some(x) if x == TypeId::of::<VectorDataTable>() => vector_widget(document_node, node_id, index, name, true).into(),
-						Some(x) if x == TypeId::of::<RasterFrame>() || x == TypeId::of::<ImageFrameTable<Color>>() || x == TypeId::of::<TextureFrame>() => {
+						Some(x) if x == TypeId::of::<RasterFrame>() || x == TypeId::of::<ImageFrameTable<Color>>() || x == TypeId::of::<TextureFrameTable>() => {
 							raster_widget(document_node, node_id, index, name, true).into()
 						}
 						Some(x) if x == TypeId::of::<GraphicGroupTable>() => group_widget(document_node, node_id, index, name, true).into(),

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -6222,10 +6222,11 @@ impl PropertiesRow {
 fn migrate_output_names<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Vec<String>, D::Error> {
 	use serde::Deserialize;
 
-	const REPLACEMENTS: [(&str, &str); 3] = [
+	const REPLACEMENTS: [(&str, &str); 4] = [
 		("VectorData", "Instances<VectorData>"),
 		("GraphicGroup", "Instances<GraphicGroup>"),
-		("ImageFrame", "Instances<ImageFrame>"),
+		("ImageFrame", "Instances<Image>"),
+		("Instances<ImageFrame>", "Instances<Image>"),
 	];
 
 	let mut names = Vec::<String>::deserialize(deserializer)?;

--- a/node-graph/gcore/src/application_io.rs
+++ b/node-graph/gcore/src/application_io.rs
@@ -64,17 +64,18 @@ impl Size for web_sys::HtmlCanvasElement {
 	}
 }
 
-pub type TextureFrameTable = Instances<TextureFrame>;
+// TODO: Rename to ImageTextureTable
+pub type TextureFrameTable = Instances<ImageTexture>;
 
 #[derive(Debug, Clone)]
-pub struct TextureFrame {
+pub struct ImageTexture {
 	#[cfg(feature = "wgpu")]
 	pub texture: Arc<wgpu::Texture>,
 	#[cfg(not(feature = "wgpu"))]
 	pub texture: (),
 }
 
-impl Hash for TextureFrame {
+impl Hash for ImageTexture {
 	#[cfg(feature = "wgpu")]
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.texture.hash(state);
@@ -83,18 +84,18 @@ impl Hash for TextureFrame {
 	fn hash<H: Hasher>(&self, _state: &mut H) {}
 }
 
-impl PartialEq for TextureFrame {
+impl PartialEq for ImageTexture {
 	fn eq(&self, other: &Self) -> bool {
 		self.texture == other.texture
 	}
 }
 
-unsafe impl StaticType for TextureFrame {
-	type Static = TextureFrame;
+unsafe impl StaticType for ImageTexture {
+	type Static = ImageTexture;
 }
 
 #[cfg(feature = "wgpu")]
-impl Size for TextureFrame {
+impl Size for ImageTexture {
 	fn size(&self) -> UVec2 {
 		UVec2::new(self.texture.width(), self.texture.height())
 	}

--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -1,4 +1,4 @@
-use crate::application_io::{TextureFrame, TextureFrameTable};
+use crate::application_io::{ImageTexture, TextureFrameTable};
 use crate::instances::Instances;
 use crate::raster::image::{Image, ImageFrameTable};
 use crate::raster::BlendMode;
@@ -121,9 +121,9 @@ impl From<ImageFrameTable<Color>> for GraphicGroupTable {
 		Self::new(GraphicGroup::new(vec![GraphicElement::RasterFrame(RasterFrame::ImageFrame(image_frame))]))
 	}
 }
-impl From<TextureFrame> for GraphicGroupTable {
-	fn from(texture_frame: TextureFrame) -> Self {
-		Self::new(GraphicGroup::new(vec![GraphicElement::RasterFrame(RasterFrame::TextureFrame(TextureFrameTable::new(texture_frame)))]))
+impl From<ImageTexture> for GraphicGroupTable {
+	fn from(image_texture: ImageTexture) -> Self {
+		Self::new(GraphicGroup::new(vec![GraphicElement::RasterFrame(RasterFrame::TextureFrame(TextureFrameTable::new(image_texture)))]))
 	}
 }
 impl From<TextureFrameTable> for GraphicGroupTable {
@@ -194,11 +194,14 @@ impl GraphicElement {
 	}
 }
 
+// TODO: Rename to Raster
 #[derive(Clone, Debug, Hash, PartialEq, DynAny)]
 pub enum RasterFrame {
 	/// A CPU-based bitmap image with a finite position and extent, equivalent to the SVG <image> tag: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image
+	// TODO: Rename to ImageTable
 	ImageFrame(ImageFrameTable<Color>),
 	/// A GPU texture with a finite position and extent
+	// TODO: Rename to ImageTextureTable
 	TextureFrame(TextureFrameTable),
 }
 
@@ -239,7 +242,7 @@ impl Artboard {
 	pub fn new(location: IVec2, dimensions: IVec2) -> Self {
 		Self {
 			graphic_group: GraphicGroupTable::default(),
-			label: String::from("Artboard"),
+			label: "Artboard".to_string(),
 			location: location.min(location + dimensions),
 			dimensions: dimensions.abs(),
 			background: Color::WHITE,
@@ -387,11 +390,8 @@ async fn append_artboard(_ctx: impl Ctx, mut artboards: ArtboardGroup, artboard:
 	// let artboard = artboard.eval(ctx).await;
 	// let foot = ctx.footprint();
 	// log::debug!("{:?}", foot);
-	// Get the penultimate element of the node path, or None if the path is too short
-
-	// TODO: Delete this line
-	let _ctx = ctx;
-
+	// Get the penultimate element of the node path, or None if the path is too short.
+	// This is used to get the ID of the user-facing "Artboard" node (which encapsulates this internal "Append Artboard" node).
 	let encapsulating_node_id = node_path.get(node_path.len().wrapping_sub(2)).copied();
 	artboards.append_artboard(artboard, encapsulating_node_id);
 
@@ -410,8 +410,8 @@ impl From<ImageFrameTable<Color>> for GraphicElement {
 	}
 }
 // TODO: Remove this one
-impl From<TextureFrame> for GraphicElement {
-	fn from(texture: TextureFrame) -> Self {
+impl From<ImageTexture> for GraphicElement {
+	fn from(texture: ImageTexture) -> Self {
 		GraphicElement::RasterFrame(RasterFrame::TextureFrame(TextureFrameTable::new(texture)))
 	}
 }
@@ -462,7 +462,7 @@ trait ToGraphicElement: Into<GraphicElement> {}
 
 impl ToGraphicElement for VectorDataTable {}
 impl ToGraphicElement for ImageFrameTable<Color> {}
-impl ToGraphicElement for TextureFrame {}
+impl ToGraphicElement for ImageTexture {}
 
 impl<T> From<T> for GraphicGroup
 where

--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -1,6 +1,6 @@
 use crate::application_io::{TextureFrame, TextureFrameTable};
 use crate::instances::Instances;
-use crate::raster::image::{ImageFrame, ImageFrameTable};
+use crate::raster::image::{Image, ImageFrameTable};
 use crate::raster::BlendMode;
 use crate::transform::{Transform, TransformMut};
 use crate::uuid::NodeId;
@@ -111,9 +111,9 @@ impl From<VectorDataTable> for GraphicGroupTable {
 		Self::new(GraphicGroup::new(vec![GraphicElement::VectorData(vector_data)]))
 	}
 }
-impl From<ImageFrame<Color>> for GraphicGroupTable {
-	fn from(image_frame: ImageFrame<Color>) -> Self {
-		Self::new(GraphicGroup::new(vec![GraphicElement::RasterFrame(RasterFrame::ImageFrame(ImageFrameTable::new(image_frame)))]))
+impl From<Image<Color>> for GraphicGroupTable {
+	fn from(image: Image<Color>) -> Self {
+		Self::new(GraphicGroup::new(vec![GraphicElement::RasterFrame(RasterFrame::ImageFrame(ImageFrameTable::new(image)))]))
 	}
 }
 impl From<ImageFrameTable<Color>> for GraphicGroupTable {
@@ -207,7 +207,7 @@ impl<'de> serde::Deserialize<'de> for RasterFrame {
 	where
 		D: serde::Deserializer<'de>,
 	{
-		Ok(RasterFrame::ImageFrame(ImageFrameTable::new(ImageFrame::deserialize(deserializer)?)))
+		Ok(RasterFrame::ImageFrame(ImageFrameTable::new(Image::deserialize(deserializer)?)))
 	}
 }
 
@@ -382,7 +382,7 @@ async fn to_artboard<Data: Into<GraphicGroupTable> + 'n>(
 }
 
 #[node_macro::node(category(""))]
-async fn append_artboard(ctx: impl Ctx, mut artboards: ArtboardGroup, artboard: Artboard, node_path: Vec<NodeId>) -> ArtboardGroup {
+async fn append_artboard(_ctx: impl Ctx, mut artboards: ArtboardGroup, artboard: Artboard, node_path: Vec<NodeId>) -> ArtboardGroup {
 	// let mut artboards = artboards.eval(ctx.clone()).await;
 	// let artboard = artboard.eval(ctx).await;
 	// let foot = ctx.footprint();
@@ -399,8 +399,8 @@ async fn append_artboard(ctx: impl Ctx, mut artboards: ArtboardGroup, artboard: 
 }
 
 // TODO: Remove this one
-impl From<ImageFrame<Color>> for GraphicElement {
-	fn from(image_frame: ImageFrame<Color>) -> Self {
+impl From<Image<Color>> for GraphicElement {
+	fn from(image_frame: Image<Color>) -> Self {
 		GraphicElement::RasterFrame(RasterFrame::ImageFrame(ImageFrameTable::new(image_frame)))
 	}
 }

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -276,6 +276,7 @@ pub struct RenderMetadata {
 	pub clip_targets: HashSet<NodeId>,
 }
 
+// TODO: Rename to "Graphical"
 pub trait GraphicElementRendered {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams);
 
@@ -992,8 +993,8 @@ impl GraphicElementRendered for RasterFrame {
 		};
 
 		match self {
-			RasterFrame::ImageFrame(image_frame) => {
-				for instance in image_frame.instances() {
+			RasterFrame::ImageFrame(image) => {
+				for instance in image.instances() {
 					let image = &instance.instance;
 					if image.data.is_empty() {
 						return;
@@ -1004,8 +1005,8 @@ impl GraphicElementRendered for RasterFrame {
 					render_stuff(image, *instance.alpha_blending);
 				}
 			}
-			RasterFrame::TextureFrame(texture) => {
-				for instance in texture.instances() {
+			RasterFrame::TextureFrame(image_texture) => {
+				for instance in image_texture.instances() {
 					let image =
 						vello::peniko::Image::new(vec![].into(), peniko::Format::Rgba8, instance.instance.texture.width(), instance.instance.texture.height()).with_extend(peniko::Extend::Repeat);
 

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -831,7 +831,7 @@ impl GraphicElementRendered for ImageFrameTable<Color> {
 
 			match render_params.image_render_mode {
 				ImageRenderMode::Base64 => {
-					let image = &instance.instance.image;
+					let image = &instance.instance;
 					if image.data.is_empty() {
 						return;
 					}
@@ -894,7 +894,7 @@ impl GraphicElementRendered for ImageFrameTable<Color> {
 		use vello::peniko;
 
 		for instance in self.instances() {
-			let image = &instance.instance.image;
+			let image = &instance.instance;
 			if image.data.is_empty() {
 				return;
 			}
@@ -918,7 +918,7 @@ impl GraphicElementRendered for RasterFrame {
 				};
 
 				for instance in image.instances() {
-					let (image, blending) = (&instance.instance.image, instance.alpha_blending);
+					let (image, blending) = (&instance.instance, instance.alpha_blending);
 					if image.data.is_empty() {
 						return;
 					}
@@ -994,7 +994,7 @@ impl GraphicElementRendered for RasterFrame {
 		match self {
 			RasterFrame::ImageFrame(image_frame) => {
 				for instance in image_frame.instances() {
-					let image = &instance.instance.image;
+					let image = &instance.instance;
 					if image.data.is_empty() {
 						return;
 					}

--- a/node-graph/gcore/src/instances.rs
+++ b/node-graph/gcore/src/instances.rs
@@ -1,5 +1,5 @@
 use crate::application_io::{TextureFrame, TextureFrameTable};
-use crate::raster::image::{ImageFrame, ImageFrameTable};
+use crate::raster::image::{Image, ImageFrameTable};
 use crate::raster::Pixel;
 use crate::transform::{Transform, TransformMut};
 use crate::vector::{InstanceId, VectorData, VectorDataTable};
@@ -209,8 +209,8 @@ impl TransformMut for TextureFrameTable {
 	}
 }
 
-// IMAGE FRAME
-impl<P: Pixel> Transform for Instance<'_, ImageFrame<P>> {
+// IMAGE
+impl<P: Pixel> Transform for Instance<'_, Image<P>> {
 	fn transform(&self) -> DAffine2 {
 		*self.transform
 	}
@@ -218,7 +218,7 @@ impl<P: Pixel> Transform for Instance<'_, ImageFrame<P>> {
 		self.transform.transform_point2(pivot)
 	}
 }
-impl<P: Pixel> Transform for InstanceMut<'_, ImageFrame<P>> {
+impl<P: Pixel> Transform for InstanceMut<'_, Image<P>> {
 	fn transform(&self) -> DAffine2 {
 		*self.transform
 	}
@@ -226,7 +226,7 @@ impl<P: Pixel> Transform for InstanceMut<'_, ImageFrame<P>> {
 		self.transform.transform_point2(pivot)
 	}
 }
-impl<P: Pixel> TransformMut for InstanceMut<'_, ImageFrame<P>> {
+impl<P: Pixel> TransformMut for InstanceMut<'_, Image<P>> {
 	fn transform_mut(&mut self) -> &mut DAffine2 {
 		self.transform
 	}
@@ -237,7 +237,7 @@ impl<P: Pixel> Transform for ImageFrameTable<P>
 where
 	P: dyn_any::StaticType,
 	P::Static: Pixel,
-	GraphicElement: From<ImageFrame<P>>,
+	GraphicElement: From<Image<P>>,
 {
 	fn transform(&self) -> DAffine2 {
 		self.one_instance().transform()
@@ -247,7 +247,7 @@ impl<P: Pixel> TransformMut for ImageFrameTable<P>
 where
 	P: dyn_any::StaticType,
 	P::Static: Pixel,
-	GraphicElement: From<ImageFrame<P>>,
+	GraphicElement: From<Image<P>>,
 {
 	fn transform_mut(&mut self) -> &mut DAffine2 {
 		self.transform.first_mut().unwrap_or_else(|| panic!("ONE INSTANCE EXPECTED"))

--- a/node-graph/gcore/src/instances.rs
+++ b/node-graph/gcore/src/instances.rs
@@ -1,4 +1,4 @@
-use crate::application_io::{TextureFrame, TextureFrameTable};
+use crate::application_io::{ImageTexture, TextureFrameTable};
 use crate::raster::image::{Image, ImageFrameTable};
 use crate::raster::Pixel;
 use crate::transform::{Transform, TransformMut};
@@ -180,18 +180,18 @@ impl TransformMut for GraphicGroupTable {
 	}
 }
 
-// TEXTURE FRAME
-impl Transform for Instance<'_, TextureFrame> {
+// IMAGE TEXTURE
+impl Transform for Instance<'_, ImageTexture> {
 	fn transform(&self) -> DAffine2 {
 		*self.transform
 	}
 }
-impl Transform for InstanceMut<'_, TextureFrame> {
+impl Transform for InstanceMut<'_, ImageTexture> {
 	fn transform(&self) -> DAffine2 {
 		*self.transform
 	}
 }
-impl TransformMut for InstanceMut<'_, TextureFrame> {
+impl TransformMut for InstanceMut<'_, ImageTexture> {
 	fn transform_mut(&mut self) -> &mut DAffine2 {
 		self.transform
 	}

--- a/node-graph/gcore/src/raster/adjustments.rs
+++ b/node-graph/gcore/src/raster/adjustments.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "alloc")]
 use crate::raster::curve::{Curve, CurveManipulatorGroup, ValueMapperNode};
 #[cfg(feature = "alloc")]
-use crate::raster::image::{ImageFrame, ImageFrameTable};
+use crate::raster::image::{Image, ImageFrameTable};
 use crate::raster::{Channel, Color, Pixel};
 use crate::registry::types::{Angle, Percentage, SignedPercentage};
 use crate::vector::style::GradientStops;
@@ -605,15 +605,13 @@ impl Blend<Color> for ImageFrameTable<Color> {
 		let mut result = self.clone();
 
 		for (over, under) in result.instances_mut().zip(under.instances()) {
-			let data = over.instance.image.data.iter().zip(under.instance.image.data.iter()).map(|(a, b)| blend_fn(*a, *b)).collect();
+			let data = over.instance.data.iter().zip(under.instance.data.iter()).map(|(a, b)| blend_fn(*a, *b)).collect();
 
-			*over.instance = ImageFrame {
-				image: super::Image {
-					data,
-					width: over.instance.image.width,
-					height: over.instance.image.height,
-					base64_string: None,
-				},
+			*over.instance = Image {
+				data,
+				width: over.instance.width,
+				height: over.instance.height,
+				base64_string: None,
 			};
 		}
 
@@ -738,11 +736,11 @@ impl<P: Pixel> Adjust<P> for ImageFrameTable<P>
 where
 	P: dyn_any::StaticType,
 	P::Static: Pixel,
-	GraphicElement: From<ImageFrame<P>>,
+	GraphicElement: From<Image<P>>,
 {
 	fn adjust(&mut self, map_fn: impl Fn(&P) -> P) {
 		for instance in self.instances_mut() {
-			for c in instance.instance.image.data.iter_mut() {
+			for c in instance.instance.data.iter_mut() {
 				*c = map_fn(c);
 			}
 		}
@@ -1386,7 +1384,7 @@ impl<P: Pixel> MultiplyAlpha for ImageFrameTable<P>
 where
 	P: dyn_any::StaticType,
 	P::Static: Pixel,
-	GraphicElement: From<ImageFrame<P>>,
+	GraphicElement: From<Image<P>>,
 {
 	fn multiply_alpha(&mut self, factor: f64) {
 		for instance in self.instances_mut() {
@@ -1539,13 +1537,13 @@ fn color_overlay<T: Adjust<Color>>(
 
 // #[cfg(feature = "alloc")]
 // mod index_node {
-// 	use crate::raster::{Color, ImageFrame};
+// 	use crate::raster::{Color, Image};
 // 	use crate::Ctx;
 
 // 	#[node_macro::node(category(""))]
 // 	pub fn index<T: Default + Clone>(
 // 		_: impl Ctx,
-// 		#[implementations(Vec<ImageFrame<Color>>, Vec<Color>)]
+// 		#[implementations(Vec<Image<Color>>, Vec<Color>)]
 // 		#[widget(ParsedWidgetOverride::Hidden)]
 // 		input: Vec<T>,
 // 		index: u32,
@@ -1561,7 +1559,7 @@ fn color_overlay<T: Adjust<Color>>(
 
 #[cfg(test)]
 mod test {
-	use crate::raster::image::{ImageFrame, ImageFrameTable};
+	use crate::raster::image::{Image, ImageFrameTable};
 	use crate::raster::{BlendMode, Image};
 	use crate::{Color, Node};
 	use std::pin::Pin;
@@ -1580,7 +1578,7 @@ mod test {
 	#[tokio::test]
 	async fn color_overlay_multiply() {
 		let image_color = Color::from_rgbaf32_unchecked(0.7, 0.6, 0.5, 0.4);
-		let image = ImageFrame { image: Image::new(1, 1, image_color) };
+		let image = Image::new(1, 1, image_color);
 
 		// Color { red: 0., green: 1., blue: 0., alpha: 1. }
 		let overlay_color = Color::GREEN;
@@ -1592,6 +1590,6 @@ mod test {
 		let result = result.one_instance().instance;
 
 		// The output should just be the original green and alpha channels (as we multiply them by 1 and other channels by 0)
-		assert_eq!(result.image.data[0], Color::from_rgbaf32_unchecked(0., image_color.g(), 0., image_color.a()));
+		assert_eq!(result.data[0], Color::from_rgbaf32_unchecked(0., image_color.g(), 0., image_color.a()));
 	}
 }

--- a/node-graph/gcore/src/raster/adjustments.rs
+++ b/node-graph/gcore/src/raster/adjustments.rs
@@ -1559,8 +1559,8 @@ fn color_overlay<T: Adjust<Color>>(
 
 #[cfg(test)]
 mod test {
+	use crate::raster::adjustments::BlendMode;
 	use crate::raster::image::{Image, ImageFrameTable};
-	use crate::raster::{BlendMode, Image};
 	use crate::{Color, Node};
 	use std::pin::Pin;
 

--- a/node-graph/gcore/src/raster/brush_cache.rs
+++ b/node-graph/gcore/src/raster/brush_cache.rs
@@ -32,7 +32,7 @@ struct BrushCacheImpl {
 impl BrushCacheImpl {
 	fn compute_brush_plan(&mut self, mut background: ImageFrameTable<Color>, input: &[BrushStroke]) -> BrushPlan {
 		// Do background invalidation.
-		if background.one_instance().instance.image != self.background.one_instance().instance.image {
+		if background.one_instance().instance != self.background.one_instance().instance {
 			self.background = background.clone();
 			return BrushPlan {
 				strokes: input.to_vec(),

--- a/node-graph/gcore/src/raster/image.rs
+++ b/node-graph/gcore/src/raster/image.rs
@@ -53,6 +53,8 @@ pub struct Image<P: Pixel> {
 	/// to an svg string. This is used as a cache in order to not have to encode the data on every graph evaluation.
 	#[cfg_attr(feature = "serde", serde(skip))]
 	pub base64_string: Option<String>,
+	// TODO: Add an `origin` field to store where in the local space the image is anchored.
+	// TODO: Currently it is always anchored at the top left corner at (0, 0). The bottom right corner of the new origin field would correspond to (1, 1).
 }
 
 impl<P: Pixel + Debug> Debug for Image<P> {
@@ -272,6 +274,7 @@ pub fn migrate_image_frame<'de, D: serde::Deserializer<'de>>(deserializer: D) ->
 	})
 }
 
+// TODO: Rename to ImageTable
 pub type ImageFrameTable<P> = Instances<Image<P>>;
 
 /// Construct a 0x0 image frame table. This is useful because ImageFrameTable::default() will return a 1x1 image frame table.

--- a/node-graph/gcore/src/types.rs
+++ b/node-graph/gcore/src/types.rs
@@ -150,9 +150,14 @@ fn migrate_type_descriptor_names<'de, D: serde::Deserializer<'de>>(deserializer:
 	let name = match name.as_str() {
 		"f32" => "f64".to_string(),
 		"graphene_core::transform::Footprint" => "core::option::Option<alloc::sync::Arc<graphene_core::context::OwnedContextImpl>>".to_string(),
-		"graphene_core::graphic_element::GraphicGroup" => "graphene_core::graphic_element::Instances<graphene_core::graphic_element::GraphicGroup>".to_string(),
-		"graphene_core::vector::vector_data::VectorData" => "graphene_core::graphic_element::Instances<graphene_core::vector::vector_data::VectorData>".to_string(),
-		"graphene_core::raster::image::ImageFrame<Color>" => "graphene_core::graphic_element::Instances<graphene_core::raster::image::ImageFrame<Color>>".to_string(),
+		"graphene_core::graphic_element::GraphicGroup" => "graphene_core::instances::Instances<graphene_core::graphic_element::GraphicGroup>".to_string(),
+		"graphene_core::vector::vector_data::VectorData" => "graphene_core::instances::Instances<graphene_core::vector::vector_data::VectorData>".to_string(),
+		"graphene_core::raster::image::ImageFrame<Color>"
+		| "graphene_core::raster::image::ImageFrame<graphene_core::raster::color::Color>"
+		| "graphene_core::instances::Instances<graphene_core::raster::image::ImageFrame<Color>>"
+		| "graphene_core::instances::Instances<graphene_core::raster::image::ImageFrame<graphene_core::raster::color::Color>>" => {
+			"graphene_core::instances::Instances<graphene_core::raster::image::Image<graphene_core::raster::color::Color>>".to_string()
+		}
 		_ => name,
 	};
 

--- a/node-graph/gstd/src/dehaze.rs
+++ b/node-graph/gstd/src/dehaze.rs
@@ -1,6 +1,5 @@
 use graph_craft::proto::types::Percentage;
-use graphene_core::raster::image::{ImageFrame, ImageFrameTable};
-use graphene_core::raster::Image;
+use graphene_core::raster::image::{Image, ImageFrameTable};
 use graphene_core::transform::{Transform, TransformMut};
 use graphene_core::{Color, Ctx};
 
@@ -13,10 +12,9 @@ async fn dehaze(_: impl Ctx, image_frame: ImageFrameTable<Color>, strength: Perc
 	let image_frame_transform = image_frame.transform();
 	let image_frame_alpha_blending = image_frame.one_instance().alpha_blending;
 
-	let image_frame = image_frame.one_instance().instance;
+	let image = image_frame.one_instance().instance;
 
 	// Prepare the image data for processing
-	let image = &image_frame.image;
 	let image_data = bytemuck::cast_vec(image.data.clone());
 	let image_buffer = image::Rgba32FImage::from_raw(image.width, image.height, image_data).expect("Failed to convert internal image format into image-rs data type.");
 	let dynamic_image: image::DynamicImage = image_buffer.into();
@@ -34,7 +32,7 @@ async fn dehaze(_: impl Ctx, image_frame: ImageFrameTable<Color>, strength: Perc
 		base64_string: None,
 	};
 
-	let mut result = ImageFrameTable::new(ImageFrame { image: dehazed_image });
+	let mut result = ImageFrameTable::new(dehazed_image);
 	*result.transform_mut() = image_frame_transform;
 	*result.one_instance_mut().alpha_blending = *image_frame_alpha_blending;
 

--- a/node-graph/gstd/src/image_color_palette.rs
+++ b/node-graph/gstd/src/image_color_palette.rs
@@ -18,7 +18,7 @@ async fn image_color_palette(
 
 	let image = image.one_instance().instance;
 
-	for pixel in image.image.data.iter() {
+	for pixel in image.data.iter() {
 		let r = pixel.r() * GRID;
 		let g = pixel.g() * GRID;
 		let b = pixel.b() * GRID;
@@ -65,20 +65,18 @@ async fn image_color_palette(
 mod test {
 	use super::*;
 
-	use graphene_core::raster::image::{ImageFrame, ImageFrameTable};
+	use graphene_core::raster::image::{Image, ImageFrameTable};
 	use graphene_core::raster::Image;
 
 	#[test]
 	fn test_image_color_palette() {
 		let result = image_color_palette(
 			(),
-			ImageFrameTable::new(ImageFrame {
-				image: Image {
-					width: 100,
-					height: 100,
-					data: vec![Color::from_rgbaf32(0., 0., 0., 1.).unwrap(); 10000],
-					base64_string: None,
-				},
+			ImageFrameTable::new(Image {
+				width: 100,
+				height: 100,
+				data: vec![Color::from_rgbaf32(0., 0., 0., 1.).unwrap(); 10000],
+				base64_string: None,
 			}),
 			1,
 		);

--- a/node-graph/gstd/src/image_color_palette.rs
+++ b/node-graph/gstd/src/image_color_palette.rs
@@ -66,7 +66,6 @@ mod test {
 	use super::*;
 
 	use graphene_core::raster::image::{Image, ImageFrameTable};
-	use graphene_core::raster::Image;
 
 	#[test]
 	fn test_image_color_palette() {

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -6,8 +6,7 @@ use graphene_core::application_io::SurfaceHandle;
 use graphene_core::application_io::{ApplicationIo, ExportFormat, RenderConfig};
 #[cfg(target_arch = "wasm32")]
 use graphene_core::raster::bbox::Bbox;
-use graphene_core::raster::image::{ImageFrame, ImageFrameTable};
-use graphene_core::raster::Image;
+use graphene_core::raster::image::{Image, ImageFrameTable};
 use graphene_core::renderer::RenderMetadata;
 use graphene_core::renderer::{format_transform_matrix, GraphicElementRendered, ImageRenderMode, RenderParams, RenderSvgSegmentList, SvgRender};
 use graphene_core::transform::Footprint;
@@ -81,13 +80,11 @@ fn decode_image(_: impl Ctx, data: Arc<[u8]>) -> ImageFrameTable<Color> {
 		return ImageFrameTable::empty();
 	};
 	let image = image.to_rgba32f();
-	let image = ImageFrame {
-		image: Image {
-			data: image.chunks(4).map(|pixel| Color::from_unassociated_alpha(pixel[0], pixel[1], pixel[2], pixel[3])).collect(),
-			width: image.width(),
-			height: image.height(),
-			..Default::default()
-		},
+	let image = Image {
+		data: image.chunks(4).map(|pixel| Color::from_unassociated_alpha(pixel[0], pixel[1], pixel[2], pixel[3])).collect(),
+		width: image.width(),
+		height: image.height(),
+		..Default::default()
 	};
 
 	ImageFrameTable::new(image)
@@ -200,9 +197,7 @@ async fn rasterize<T: GraphicElementRendered + graphene_core::transform::Transfo
 
 	let rasterized = context.get_image_data(0., 0., resolution.x as f64, resolution.y as f64).unwrap();
 
-	let mut result = ImageFrameTable::new(ImageFrame {
-		image: Image::from_image_data(&rasterized.data().0, resolution.x as u32, resolution.y as u32),
-	});
+	let mut result = ImageFrameTable::new(Image::from_image_data(&rasterized.data().0, resolution.x as u32, resolution.y as u32));
 	*result.transform_mut() = footprint.transform;
 
 	result

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -12,7 +12,7 @@ use graphene_core::{fn_type_fut, future};
 use graphene_core::{Cow, ProtoNodeIdentifier, Type};
 use graphene_core::{Node, NodeIO, NodeIOTypes};
 use graphene_std::any::{ComposeTypeErased, DowncastBothNode, DynAnyNode, FutureWrapperNode, IntoTypeErasedNode};
-use graphene_std::application_io::TextureFrame;
+use graphene_std::application_io::ImageTexture;
 use graphene_std::wasm_application_io::*;
 use graphene_std::Context;
 use graphene_std::GraphicElement;
@@ -79,7 +79,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		async_node!(graphene_core::ops::IntoNode<GraphicGroupTable>, input: VectorDataTable, params: []),
 		async_node!(graphene_core::ops::IntoNode<GraphicGroupTable>, input: ImageFrameTable<Color>, params: []),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => ImageFrameTable<Color>]),
-		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => TextureFrame]),
+		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => ImageTexture]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => VectorDataTable]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => GraphicGroupTable]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => GraphicElement]),
@@ -268,7 +268,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		async_node!(graphene_core::memo::ImpureMemoNode<_, _, _>, input: Context, fn_params: [Context => ShaderInputFrame]),
 		async_node!(graphene_core::memo::ImpureMemoNode<_, _, _>, input: Context, fn_params: [Context => WgpuSurface]),
 		async_node!(graphene_core::memo::ImpureMemoNode<_, _, _>, input: Context, fn_params: [Context => Option<WgpuSurface>]),
-		async_node!(graphene_core::memo::ImpureMemoNode<_, _, _>, input: Context, fn_params: [Context => TextureFrame]),
+		async_node!(graphene_core::memo::ImpureMemoNode<_, _, _>, input: Context, fn_params: [Context => ImageTexture]),
 	];
 	let mut map: HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeConstructor>> = HashMap::new();
 	for (id, entry) in graphene_core::registry::NODE_REGISTRY.lock().unwrap().iter() {

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -916,10 +916,10 @@ async fn upload_texture<'a: 'n>(_: impl ExtractFootprint + Ctx, input: ImageFram
 	// let new_data: Vec<RGBA16F> = input.image.data.into_iter().map(|c| c.into()).collect();
 
 	let input = input.one_instance().instance;
-	let new_data: Vec<SRGBA8> = input.image.data.iter().map(|x| (*x).into()).collect();
+	let new_data: Vec<SRGBA8> = input.data.iter().map(|x| (*x).into()).collect();
 	let new_image = Image {
-		width: input.image.width,
-		height: input.image.height,
+		width: input.width,
+		height: input.height,
 		data: new_data,
 		base64_string: None,
 	};

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -6,7 +6,7 @@ pub use executor::GpuExecutor;
 
 use dyn_any::{DynAny, StaticType};
 use gpu_executor::{ComputePassDimensions, GPUConstant, StorageBufferOptions, TextureBufferOptions, TextureBufferType, ToStorageBuffer, ToUniformBuffer};
-use graphene_core::application_io::{ApplicationIo, EditorApi, SurfaceHandle, TextureFrame};
+use graphene_core::application_io::{ApplicationIo, EditorApi, ImageTexture, SurfaceHandle};
 use graphene_core::raster::image::ImageFrameTable;
 use graphene_core::raster::{Image, SRGBA8};
 use graphene_core::transform::{Footprint, Transform};
@@ -912,7 +912,7 @@ async fn render_texture<'a: 'n>(
 }
 
 #[node_macro::node(category(""))]
-async fn upload_texture<'a: 'n>(_: impl ExtractFootprint + Ctx, input: ImageFrameTable<Color>, executor: &'a WgpuExecutor) -> TextureFrame {
+async fn upload_texture<'a: 'n>(_: impl ExtractFootprint + Ctx, input: ImageFrameTable<Color>, executor: &'a WgpuExecutor) -> ImageTexture {
 	// let new_data: Vec<RGBA16F> = input.image.data.into_iter().map(|c| c.into()).collect();
 
 	let input = input.one_instance().instance;
@@ -931,9 +931,9 @@ async fn upload_texture<'a: 'n>(_: impl ExtractFootprint + Ctx, input: ImageFram
 		_ => unreachable!("Unsupported ShaderInput type"),
 	};
 
-	TextureFrame {
+	ImageTexture {
 		texture: texture.into(),
-		// TODO: Find an alternate way to encode the transform and alpha_blend now that these fields have been moved up out of TextureFrame
+		// TODO: Find an alternate way to encode the transform and alpha_blend now that these fields have been moved up out of ImageTexture
 		// transform: input.transform,
 		// alpha_blend: Default::default(),
 	}


### PR DESCRIPTION
Part 3 of #1834.

Flattens the one-field `ImageFrame<P>` struct, removing it to put `Image<P>` in its place.

This PR is based on top of #2249. The first commit in the chain of this PR's changes is b36f57fe8a4b16f7ccd182ef59a0601c9e6c297b. This PR is blocked on that PR being merged first.