### PR TITLE
Fix copied/duplicated selected layers getting misordered

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -8,6 +8,7 @@ use crate::messages::frontend::utility_types::FrontendDocumentDetails;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
 use crate::messages::portfolio::document::utility_types::clipboards::{Clipboard, CopyBufferEntry, INTERNAL_CLIPBOARD_COUNT};
+use crate::messages::portfolio::document::utility_types::nodes::SelectedNodes;
 use crate::messages::portfolio::document::DocumentMessageData;
 use crate::messages::preferences::SelectionMode;
 use crate::messages::prelude::*;
@@ -202,9 +203,16 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				};
 
 				let mut copy_val = |buffer: &mut Vec<CopyBufferEntry>| {
-					let ordered_last_elements = active_document.network_interface.shallowest_unique_layers(&[]);
+					let mut ordered_last_elements: Vec<LayerNodeIdentifier> = active_document.network_interface.shallowest_unique_layers(&[]).collect();
 
-					for layer in ordered_last_elements {
+					fn get_layer_insert_index(document: &mut DocumentMessageHandler, layer: &LayerNodeIdentifier) -> Option<usize> {
+						let parent = layer.parent(document.metadata())?;
+						Some(DocumentMessageHandler::get_calculated_insert_index(document.metadata(), &SelectedNodes(vec![layer.to_node()]), parent))
+					}
+
+					ordered_last_elements.sort_by_key(|layer| get_layer_insert_index(active_document, layer).unwrap_or(usize::MAX));
+
+					for layer in ordered_last_elements.into_iter() {
 						let layer_node_id = layer.to_node();
 
 						let mut copy_ids = HashMap::new();

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -203,14 +203,12 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				};
 
 				let mut copy_val = |buffer: &mut Vec<CopyBufferEntry>| {
-					let mut ordered_last_elements: Vec<LayerNodeIdentifier> = active_document.network_interface.shallowest_unique_layers(&[]).collect();
+					let mut ordered_last_elements = active_document.network_interface.shallowest_unique_layers(&[]).collect::<Vec<_>>();
 
-					fn get_layer_insert_index(document: &mut DocumentMessageHandler, layer: &LayerNodeIdentifier) -> Option<usize> {
-						let parent = layer.parent(document.metadata())?;
-						Some(DocumentMessageHandler::get_calculated_insert_index(document.metadata(), &SelectedNodes(vec![layer.to_node()]), parent))
-					}
-
-					ordered_last_elements.sort_by_key(|layer| get_layer_insert_index(active_document, layer).unwrap_or(usize::MAX));
+					ordered_last_elements.sort_by_key(|layer| {
+						let Some(parent) = layer.parent(active_document.metadata()) else { return usize::MAX };
+						DocumentMessageHandler::get_calculated_insert_index(active_document.metadata(), &SelectedNodes(vec![layer.to_node()]), parent)
+					});
 
 					for layer in ordered_last_elements.into_iter() {
 						let layer_node_id = layer.to_node();


### PR DESCRIPTION
- The `get_calculated_insert_index` needed only the current layer so that the duplicated layer is placed in correct position.
- `shallowest_unique_layers` method doesn't returns the layers in the correct order of indexes, so while moving the new layers to stack messes up the order. Hence we need to sort the layers according to the index.

https://discord.com/channels/731730685944922173/881073965047636018/1294525859142569994
