### PR TITLE
Fixed point drag from inside shape

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -453,6 +453,7 @@ impl PathToolData {
 		}
 		// We didn't find a segment path, so consider selecting the nearest shape instead
 		else if let Some(layer) = document.click(input) {
+			shape_editor.deselect_all_points();
 			if extend_selection {
 				responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![layer.to_node()] });
 			} else {


### PR DESCRIPTION
The selected points need to be deselected when the mouse down in not near any point and edge.
[graphite2.webm](https://github.com/user-attachments/assets/ebb3cc82-5df4-4aed-87ee-cc1aadf8cf47) 
Fixes #2254



