### PR TITLE
Make the Pen tool extend an endpoint by starting with a colinear, equidistant handle

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -624,52 +624,9 @@ impl PenToolData {
 		self.handle_end = None;
 
 		let tolerance = crate::consts::SNAP_POINT_TOLERANCE;
-		if let Some((layer, point, position)) = should_extend(document, viewport, tolerance, selected_nodes.selected_layers(document.metadata()), preferences) {
-			// Perform extension of an existing path
-			let vector_data = document.network_interface.compute_modified_vector(layer);
-			let (handle_start, in_segment) = if let Some(vector_data) = &vector_data {
-				vector_data
-					.segment_bezier_iter()
-					.find_map(|(segment_id, bezier, start, end)| {
-						let is_end = point == end;
-						let is_start = point == start;
-						if is_end || is_start {
-							let handle = match bezier.handles {
-								BezierHandles::Cubic { handle_start, handle_end, .. } => {
-									if is_start {
-										handle_start
-									} else {
-										handle_end
-									}
-								}
-								BezierHandles::Quadratic { handle } => handle,
-								_ => return None,
-							};
-							Some((segment_id, is_end, handle))
-						} else {
-							None
-						}
-					})
-					.map(|(segment_id, is_end, handle)| {
-						let mirrored_handle = position * 2.0 - handle;
-						let in_segment = if is_end { Some(segment_id) } else { None };
-						(mirrored_handle, in_segment)
-					})
-					.unwrap_or_else(|| (position, None))
-			} else {
-				(position, None)
-			};
-
-			self.add_point(LastPoint {
-				id: point,
-				pos: position,
-				in_segment: in_segment,
-				handle_start: handle_start,
-			});
-			responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![layer.to_node()] });
-			self.next_point = position;
-			self.next_handle_start = handle_start;
-
+		let extension_choice = should_extend(document, viewport, tolerance, selected_nodes.selected_layers(document.metadata()), preferences);
+		if let Some((layer, point, position)) = extension_choice {
+			self.extend_existing_path(document, layer, point, position, responses);
 			return;
 		}
 
@@ -697,6 +654,55 @@ impl PenToolData {
 		responses.add(Message::StartBuffer);
 		// It is necessary to defer this until the transform of the layer can be accurately computed (quite hacky)
 		responses.add(PenToolMessage::AddPointLayerPosition { layer, viewport });
+	}
+
+	/// Perform extension of an existing path
+	fn extend_existing_path(&mut self, document: &DocumentMessageHandler, layer: LayerNodeIdentifier, point: PointId, position: DVec2, responses: &mut VecDeque<Message>) {
+		let vector_data = document.network_interface.compute_modified_vector(layer);
+		let (handle_start, in_segment) = if let Some(vector_data) = &vector_data {
+			vector_data
+				.segment_bezier_iter()
+				.find_map(|(segment_id, bezier, start, end)| {
+					let is_end = point == end;
+					let is_start = point == start;
+					if !is_end && !is_start {
+						return None;
+					}
+
+					let handle = match bezier.handles {
+						BezierHandles::Cubic { handle_start, handle_end, .. } => {
+							if is_start {
+								handle_start
+							} else {
+								handle_end
+							}
+						}
+						BezierHandles::Quadratic { handle } => handle,
+						_ => return None,
+					};
+					Some((segment_id, is_end, handle))
+				})
+				.map(|(segment_id, is_end, handle)| {
+					let mirrored_handle = position * 2. - handle;
+					let in_segment = if is_end { Some(segment_id) } else { None };
+					(mirrored_handle, in_segment)
+				})
+				.unwrap_or_else(|| (position, None))
+		} else {
+			(position, None)
+		};
+
+		self.add_point(LastPoint {
+			id: point,
+			pos: position,
+			in_segment,
+			handle_start,
+		});
+
+		responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![layer.to_node()] });
+
+		self.next_point = position;
+		self.next_handle_start = handle_start;
 	}
 
 	fn add_point_layer_position(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>, layer: LayerNodeIdentifier, viewport: DVec2) {

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -626,15 +626,49 @@ impl PenToolData {
 		let tolerance = crate::consts::SNAP_POINT_TOLERANCE;
 		if let Some((layer, point, position)) = should_extend(document, viewport, tolerance, selected_nodes.selected_layers(document.metadata()), preferences) {
 			// Perform extension of an existing path
+			let vector_data = document.network_interface.compute_modified_vector(layer);
+			let (handle_start, in_segment) = if let Some(vector_data) = &vector_data {
+				vector_data
+					.segment_bezier_iter()
+					.find_map(|(segment_id, bezier, start, end)| {
+						let is_end = point == end;
+						let is_start = point == start;
+						if is_end || is_start {
+							let handle = match bezier.handles {
+								BezierHandles::Cubic { handle_start, handle_end, .. } => {
+									if is_start {
+										handle_start
+									} else {
+										handle_end
+									}
+								}
+								BezierHandles::Quadratic { handle } => handle,
+								_ => return None,
+							};
+							Some((segment_id, is_end, handle))
+						} else {
+							None
+						}
+					})
+					.map(|(segment_id, is_end, handle)| {
+						let mirrored_handle = position * 2.0 - handle;
+						let in_segment = if is_end { Some(segment_id) } else { None };
+						(mirrored_handle, in_segment)
+					})
+					.unwrap_or_else(|| (position, None))
+			} else {
+				(position, None)
+			};
+
 			self.add_point(LastPoint {
 				id: point,
 				pos: position,
-				in_segment: None,
-				handle_start: position,
+				in_segment: in_segment,
+				handle_start: handle_start,
 			});
 			responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![layer.to_node()] });
 			self.next_point = position;
-			self.next_handle_start = position;
+			self.next_handle_start = handle_start;
 
 			return;
 		}

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -703,6 +703,7 @@ impl PenToolData {
 
 		self.next_point = position;
 		self.next_handle_start = handle_start;
+		self.handle_mode = HandleMode::ColinearEquidistant;
 	}
 
 	fn add_point_layer_position(&mut self, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>, layer: LayerNodeIdentifier, viewport: DVec2) {


### PR DESCRIPTION
Part of #1870 

- clicking a path's endpoint should begin drawing from it with an initial handle that's colinear and equidistant from the opposite handle, instead of the current behavior where clicking the endpoint begins drawing the segment with a zero-length handle. If the user wants the current behavior, they can simply click the endpoint anchor a second time to make the current segment's handle zero-length. This solves the pain point that switching away from the Pen tool, then back to it, causes a discontinuity at the previous endpoint where the handles can't easily be opposite each other like when drawing consecutive segments normally.


