### PR TITLE
Fix Vello rendering the infinite canvas without a white background color

### DIFF
--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -864,7 +864,7 @@ impl Color {
 	/// ```
 	#[inline(always)]
 	pub fn to_rgba8_srgb(&self) -> [u8; 4] {
-		let gamma = self.to_gamma_srgb().to_gamma_srgb();
+		let gamma = self.to_gamma_srgb();
 		[(gamma.red * 255.) as u8, (gamma.green * 255.) as u8, (gamma.blue * 255.) as u8, (gamma.alpha * 255.) as u8]
 	}
 

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -136,7 +136,11 @@ async fn render_canvas(render_config: RenderConfig, data: impl GraphicElementRen
 	// TODO: Instead of applying the transform here, pass the transform during the translation to avoid the O(Nr cost
 	scene.append(&child, Some(kurbo::Affine::new(footprint.transform.to_cols_array())));
 
-	exec.render_vello_scene(&scene, &surface_handle, footprint.resolution.x, footprint.resolution.y, &context)
+	let mut background = Color::from_rgb8_srgb(0x22, 0x22, 0x22);
+	if !data.contains_artboard() && !render_config.hide_artboards {
+		background = Color::WHITE;
+	}
+	exec.render_vello_scene(&scene, &surface_handle, footprint.resolution.x, footprint.resolution.y, &context, background)
 		.await
 		.expect("Failed to render Vello scene");
 


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Change background fill color based on whether an artboard is present, note that this detection is currently broken in master since  #2265. Once that regression is fixed, vello and non-vello infinite canvas should work as expected

Closes #2006 
