### PR TITLE
Allow printing proto graph in graphite-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,21 +935,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -2428,6 +2430,7 @@ dependencies = [
  "bezier-rs",
  "bitflags 2.8.0",
  "chrono",
+ "clap",
  "dyn-any",
  "fern",
  "futures",

--- a/node-graph/graphene-cli/Cargo.toml
+++ b/node-graph/graphene-cli/Cargo.toml
@@ -45,6 +45,9 @@ image = { workspace = true, default-features = false, features = [
 	"png",
 ] }
 
+# Required dependencies
+clap = { version = "4.5.31", features = ["cargo"] }
+
 # Optional local dependencies
 wgpu-executor = { path = "../wgpu-executor", optional = true }
 gpu-executor = { path = "../gpu-executor", optional = true }


### PR DESCRIPTION
As in the title. I see this change as being useful for debugging purposes. Additionally, since executing the node graph isn’t always needed, this adds another option `--no-run` to prevent this.

(This was previously discussed on the Discord server.)