### PR TITLE
Make CI audit security advisories daily instead of in each PR

### DIFF
--- a/.github/workflows/build-dev-and-ci.yml
+++ b/.github/workflows/build-dev-and-ci.yml
@@ -100,3 +100,21 @@ jobs:
   #     - name: 🧪 Run Rust miri
   #       run: |
   #         mold -run cargo +nightly miri nextest run -j32 --all-features
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Clone and checkout repository
+        uses: actions/checkout@v3
+
+      - name: 📜 Check crate license compatibility for root workspace
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+
+      - name: 📜 Check crate license compatibility for /libraries/rawkit
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+          manifest-path: libraries/rawkit/Cargo.toml

--- a/.github/workflows/build-dev-and-ci.yml
+++ b/.github/workflows/build-dev-and-ci.yml
@@ -100,33 +100,3 @@ jobs:
   #     - name: 🧪 Run Rust miri
   #       run: |
   #         mold -run cargo +nightly miri nextest run -j32 --all-features
-
-  cargo-deny:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-
-    steps:
-      - name: 📥 Clone and checkout repository
-        uses: actions/checkout@v3
-
-      - name: 🔒 Check crate security advisories for root workspace
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories
-
-      - name: 🔒 Check crate security advisories for /libraries/rawkit
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories
-          manifest-path: libraries/rawkit/Cargo.toml
-
-      - name: 📜 Check crate license compatibility for root workspace
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
-
-      - name: 📜 Check crate license compatibility for /libraries/rawkit
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
-          manifest-path: libraries/rawkit/Cargo.toml

--- a/.github/workflows/build-dev-and-ci.yml
+++ b/.github/workflows/build-dev-and-ci.yml
@@ -103,6 +103,7 @@ jobs:
 
   cargo-deny:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: 📥 Clone and checkout repository

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,4 +1,4 @@
-name: "Check Dependencies"
+name: "Audit Security Advisories"
 
 on:
   # Run once each day
@@ -22,15 +22,4 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories
-          manifest-path: libraries/rawkit/Cargo.toml
-
-      - name: 📜 Check crate license compatibility for root workspace
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
-
-      - name: 📜 Check crate license compatibility for /libraries/rawkit
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
           manifest-path: libraries/rawkit/Cargo.toml

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,36 @@
+name: "Check Dependencies"
+
+on:
+  # Run once each day
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Clone and checkout repository
+        uses: actions/checkout@v3
+
+      - name: 🔒 Check crate security advisories for root workspace
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
+      - name: 🔒 Check crate security advisories for /libraries/rawkit
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+          manifest-path: libraries/rawkit/Cargo.toml
+
+      - name: 📜 Check crate license compatibility for root workspace
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+
+      - name: 📜 Check crate license compatibility for /libraries/rawkit
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
+          manifest-path: libraries/rawkit/Cargo.toml


### PR DESCRIPTION
Currently the CI fails on all the PRs if any package gets marked as unmaintained.

This is rather annoying as the CI failure isn't at all related to the changes in the PR.

With this change, I have made a separate job to audit the security vulnerabilities on a cron job. The result will be viewable in the actions tab and probably also emailed.