### PR TITLE
Reenable Specta integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,6 +2594,7 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "specta-typescript",
  "spin",
  "thiserror 2.0.12",
  "tokio",
@@ -6248,6 +6249,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "specta-serde"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77216504061374659e7245eac53d30c7b3e5fe64b88da97c753e7184b0781e63"
+dependencies = [
+ "specta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-typescript"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3220a0c365e51e248ac98eab5a6a32f544ff6f961906f09d3ee10903a4f52b2d"
+dependencies = [
+ "specta",
+ "specta-serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,11 +85,11 @@ fern = { version = "0.7", features = ["colored"] }
 num_enum = "0.7"
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
-specta = { version = "2.0.0-rc.22", features = [
-	"glam",
+specta = { version = "=2.0.0-rc.22", features = [
 	"derive",
-	# "typescript",
+	"glam",
 ] }
+specta-typescript = { version = "=0.0.9" }
 syn = { version = "2.0", default-features = false, features = [
 	"full",
 	"derive",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -44,6 +44,7 @@ futures = { workspace = true }
 glam = { workspace = true, features = ["serde", "debug-glam-assert"] }
 derivative = { workspace = true }
 specta = { workspace = true }
+specta-typescript = { workspace = true }
 image = { workspace = true, features = ["bmp", "png"] }
 dyn-any = { workspace = true }
 num_enum = { workspace = true }

--- a/editor/src/generate_ts_types.rs
+++ b/editor/src/generate_ts_types.rs
@@ -1,34 +1,15 @@
 /// Running this test will generate a `types.ts` file at the root of the repo,
 /// containing every type annotated with `specta::Type`
-// #[cfg(all(test, feature = "specta-export"))]
-#[ignore]
+
 #[test]
 fn generate_ts_types() {
-	// TODO: Un-comment this out when we figure out how to reenable the "typescript` Specta feature flag
+	use specta::TypeCollection;
+	use specta_typescript::{BigIntExportBehavior, Typescript};
 
-	// use crate::messages::prelude::FrontendMessage;
-	// use specta::ts::{export_named_datatype, BigIntExportBehavior, ExportConfig};
-	// use specta::{NamedType, TypeMap};
-	// use std::fs::File;
-	// use std::io::Write;
+	use crate::messages::prelude::FrontendMessage;
 
-	// let config = ExportConfig::new().bigint(BigIntExportBehavior::Number);
-
-	// let mut type_map = TypeMap::default();
-
-	// let datatype = FrontendMessage::definition_named_data_type(&mut type_map);
-
-	// let mut export = String::new();
-
-	// export += &export_named_datatype(&config, &datatype, &type_map).unwrap();
-
-	// type_map
-	// 	.iter()
-	// 	.map(|(_, v)| v)
-	// 	.flat_map(|v| export_named_datatype(&config, v, &type_map))
-	// 	.for_each(|e| export += &format!("\n\n{e}"));
-
-	// let mut file = File::create("../types.ts").unwrap();
-
-	// write!(file, "{export}").ok();
+	Typescript::default()
+		.bigint(BigIntExportBehavior::Number)
+		.export_to("../frontend/src/bindings.ts", TypeCollection::default().register::<FrontendMessage>())
+		.unwrap();
 }


### PR DESCRIPTION
This fixes the commented out Specta integrating resolving the TODO comment.

It might be worth moving the type exporting code into the startup of the application if possible when in a debug build so that you don't need to run `cargo test ...` to generate the bindings but I don't know enough about Graphite's setup to know where is best. I also suppose any Rust running in wasm would not be a good place for that as it won't have filesystem access.