### PR TITLE
Add Path tool support for dragging along an axis when Shift is held

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -14,7 +14,6 @@ use crate::messages::tool::common_functionality::shape_editor::{
 	ClosestSegment, ManipulatorAngle, OpposingHandleLengths, SelectedPointsInfo, SelectionChange, SelectionShape, SelectionShapeType, ShapeState,
 };
 use crate::messages::tool::common_functionality::snapping::{SnapCache, SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
-use js_sys::Math::abs;
 
 use graphene_core::renderer::Quad;
 use graphene_core::vector::{ManipulatorPointId, PointId};
@@ -755,7 +754,7 @@ impl PathToolData {
 		// second calculate the projected delta and shift the points along those delta
 
 		let delta = current_mouse - drag_start;
-		let axis = if abs(delta.x) >= abs(delta.y) { Axis::X } else { Axis::Y };
+		let axis = if delta.x.abs() >= delta.y.abs() { Axis::X } else { Axis::Y };
 		self.snapping_axis = Some(axis);
 		let projected_delta = match axis {
 			Axis::X => DVec2::new(delta.x, 0.0),

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1188,14 +1188,6 @@ impl Fsm for PathToolFsmState {
 					tool_data.drag_start_pos += offset;
 				}
 
-				if tool_data.auto_panning.shift_viewport(input, responses).is_some() {
-					let equidistant = input.keyboard.get(equidistant as usize);
-					let snap_angle = input.keyboard.get(snap_angle as usize);
-					let lock_angle = input.keyboard.get(lock_angle as usize);
-
-					tool_data.drag(equidistant, lock_angle, snap_angle, shape_editor, document, input, responses);
-				}
-
 				PathToolFsmState::Dragging(dragging_state)
 			}
 			(

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1177,12 +1177,7 @@ impl Fsm for PathToolFsmState {
 
 				PathToolFsmState::Drawing { selection_shape: selection_type }
 			}
-			(
-				PathToolFsmState::Dragging(dragging_state),
-				PathToolMessage::PointerOutsideViewport {
-					equidistant, snap_angle, lock_angle, ..
-				},
-			) => {
+			(PathToolFsmState::Dragging(dragging_state), PathToolMessage::PointerOutsideViewport { .. }) => {
 				// Auto-panning
 				if let Some(offset) = tool_data.auto_panning.shift_viewport(input, responses) {
 					tool_data.drag_start_pos += offset;

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -739,18 +739,14 @@ impl PathToolData {
 	}
 
 	fn start_snap_along_axis(&mut self, shape_editor: &mut ShapeState, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
-		// enable when shift is pressed (need not be managed here only)
-
-		// first find the -ve delta to take the point to the drag start position
-		// let document_to_viewport = document.metadata().document_to_viewport;
+		// find the negative delta to take the point to the drag start position
 		let current_mouse = input.mouse.position;
 		let drag_start = self.drag_start_pos;
 		let opposite_delta = drag_start - current_mouse;
 
 		shape_editor.move_selected_points(None, document, opposite_delta, false, true, None, responses);
 
-		// second calculate the projected delta and shift the points along those delta
-
+		// calculate the projected delta and shift the points along those delta
 		let delta = current_mouse - drag_start;
 		let axis = if delta.x.abs() >= delta.y.abs() { Axis::X } else { Axis::Y };
 		self.snapping_axis = Some(axis);
@@ -764,10 +760,7 @@ impl PathToolData {
 	}
 
 	fn stop_snap_along_axis(&mut self, shape_editor: &mut ShapeState, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
-		// when shift is removed then this is called
-
-		// first calculate the -ve delta of the selection and move it back to the drag start
-		// let document_to_viewport = document.metadata().document_to_viewport;
+		// calculate the negative delta of the selection and move it back to the drag start
 		let current_mouse = input.mouse.position;
 		let drag_start = self.drag_start_pos;
 
@@ -781,7 +774,7 @@ impl PathToolData {
 
 		shape_editor.move_selected_points(None, document, opposite_projected_delta, false, true, None, responses);
 
-		// then calculate what actually would have been original delta for the point and apply that
+		// calculate what actually would have been original delta for the point and apply that
 		let delta = current_mouse - drag_start;
 
 		shape_editor.move_selected_points(None, document, delta, false, true, None, responses);


### PR DESCRIPTION
Part of #1870

- `Shift`, locks the drag to the nearer of the X or Y axes from its drag starting point. (If pressed before the drag begins, it shouldn't break `Shift`-clicking points to add to the selection.)
