### PR TITLE
Fix Pen tool creates single anchor path

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -294,7 +294,6 @@ struct PenToolData {
 	handle_end: Option<DVec2>,
 	next_point: DVec2,
 	next_handle_start: DVec2,
-	last_layer: LayerNodeIdentifier,
 
 	g1_continuous: bool,
 	toggle_colinear_debounce: bool,
@@ -922,8 +921,6 @@ impl PenToolData {
 		tool_options.stroke.apply_stroke(tool_options.line_weight, layer, responses);
 		self.end_point_segment = None;
 		self.draw_mode = DrawMode::ContinuePath;
-		self.last_layer = layer;
-
 		responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![layer.to_node()] });
 
 		// This causes the following message to be run only after the next graph evaluation runs and the transforms are updated
@@ -1613,9 +1610,9 @@ impl Fsm for PenToolFsmState {
 				tool_data.draw_mode = DrawMode::BreakPath;
 				tool_data.snap_manager.cleanup(responses);
 
-				if should_delete_layer {
+				if should_delete_layer && layer.is_some() {
 					responses.add(NodeGraphMessage::DeleteNodes {
-						node_ids: vec![tool_data.last_layer.to_node()],
+						node_ids: vec![layer.unwrap().to_node()],
 						delete_children: true,
 					});
 					responses.add(NodeGraphMessage::RunDocumentGraph);


### PR DESCRIPTION
This pull request fixes #2503 by adding a new field to track the last layer and implementing logic to handle layer deletion upon aborting a path with only one point.
