### PR TITLE
Make the 'Tangent Inverse' node accept DVec2 in lieu of the separate atan2 node

### DIFF
--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -248,19 +248,6 @@ impl TangentInverse for glam::DVec2 {
 	}
 }
 
-/// The inverse tangent trigonometric function (atan2) calculates the angle whose tangent is the ratio of the two specified values.
-#[node_macro::node(name("Tangent Inverse 2-Argument"), category("Math: Trig"))]
-fn tangent_inverse_2_argument<U: num_traits::float::Float>(
-	_: impl Ctx,
-	#[implementations(f64, f32)] y: U,
-	#[expose]
-	#[implementations(f64, f32)]
-	x: U,
-	radians: bool,
-) -> U {
-	if radians { y.atan2(x) } else { y.atan2(x).to_degrees() }
-}
-
 /// The random function (rand) converts a seed into a random number within the specified range, inclusive of the minimum and exclusive of the maximum. The minimum and maximum values are automatically swapped if they are reversed.
 #[node_macro::node(category("Math: Numeric"))]
 fn random<U: num_traits::float::Float>(

--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -219,10 +219,33 @@ fn cosine_inverse<U: num_traits::float::Float>(_: impl Ctx, #[implementations(f6
 	if radians { value.acos() } else { value.acos().to_degrees() }
 }
 
-/// The inverse tangent trigonometric function (atan) calculates the angle whose tangent is the specified value.
+/// The inverse tangent trigonometric function (atan) calculates the angle whose tangent is the specified value, or the angle of a line from the origin to the specified point.
 #[node_macro::node(category("Math: Trig"))]
-fn tangent_inverse<U: num_traits::float::Float>(_: impl Ctx, #[implementations(f64, f32)] value: U, radians: bool) -> U {
-	if radians { value.atan() } else { value.atan().to_degrees() }
+fn tangent_inverse<U: TangentInverse>(_: impl Ctx, #[implementations(f64, f32, DVec2)] value: U, radians: bool) -> U::Output {
+	value.atan(radians)
+}
+
+pub trait TangentInverse {
+	type Output: num_traits::float::Float;
+	fn atan(self, radians: bool) -> Self::Output;
+}
+impl TangentInverse for f32 {
+	type Output = f32;
+	fn atan(self, radians: bool) -> Self::Output {
+		if radians { self.atan() } else { self.atan().to_degrees() }
+	}
+}
+impl TangentInverse for f64 {
+	type Output = f64;
+	fn atan(self, radians: bool) -> Self::Output {
+		if radians { self.atan() } else { self.atan().to_degrees() }
+	}
+}
+impl TangentInverse for glam::DVec2 {
+	type Output = f64;
+	fn atan(self, radians: bool) -> Self::Output {
+		if radians { self.y.atan2(self.x) } else { self.y.atan2(self.x).to_degrees() }
+	}
 }
 
 /// The inverse tangent trigonometric function (atan2) calculates the angle whose tangent is the ratio of the two specified values.

--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -219,7 +219,9 @@ fn cosine_inverse<U: num_traits::float::Float>(_: impl Ctx, #[implementations(f6
 	if radians { value.acos() } else { value.acos().to_degrees() }
 }
 
-/// The inverse tangent trigonometric function (atan) calculates the angle whose tangent is the specified value, or the angle of a line from the origin to the specified point.
+/// The inverse tangent trigonometric function (atan or atan2, depending on input type) calculates:
+/// atan: the angle whose tangent is the specified scalar number.
+/// atan2: the angle of a ray from the origin to the specified vector2 point.
 #[node_macro::node(category("Math: Trig"))]
 fn tangent_inverse<U: TangentInverse>(_: impl Ctx, #[implementations(f64, f32, DVec2)] value: U, radians: bool) -> U::Output {
 	value.atan(radians)


### PR DESCRIPTION
In this fashion it doubles as atan2; in theory the dedicated atan2 node can now be removed or replaced with a subgraph, but that might break existing files.