### PR TITLE
Fix the 'Bounding Box' node crashing on empty or single-point vector data input

### DIFF
--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -942,8 +942,13 @@ async fn bounding_box(_: impl Ctx, vector_data: VectorDataTable) -> VectorDataTa
 	let vector_data_transform = vector_data.transform();
 	let vector_data = vector_data.one_instance().instance;
 
-	let bounding_box = vector_data.bounding_box_with_transform(vector_data_transform).unwrap();
-	let mut result = VectorData::from_subpath(Subpath::new_rect(bounding_box[0], bounding_box[1]));
+	let bounding_box = vector_data.bounding_box_with_transform(vector_data_transform);
+	let mut result = if let Some(bb) = bounding_box {
+		VectorData::from_subpath(Subpath::new_rect(bb[0], bb[1]))
+	} else {
+		VectorData::empty()
+	};
+
 	result.style = vector_data.style.clone();
 	result.style.set_stroke_transform(DAffine2::IDENTITY);
 

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -942,13 +942,10 @@ async fn bounding_box(_: impl Ctx, vector_data: VectorDataTable) -> VectorDataTa
 	let vector_data_transform = vector_data.transform();
 	let vector_data = vector_data.one_instance().instance;
 
-	let bounding_box = vector_data.bounding_box_with_transform(vector_data_transform);
-	let mut result = if let Some(bb) = bounding_box {
-		VectorData::from_subpath(Subpath::new_rect(bb[0], bb[1]))
-	} else {
-		VectorData::empty()
-	};
-
+	let mut result = vector_data
+		.bounding_box_with_transform(vector_data_transform)
+		.map(|bounding_box| VectorData::from_subpath(Subpath::new_rect(bounding_box[0], bounding_box[1])))
+		.unwrap_or_default();
 	result.style = vector_data.style.clone();
 	result.style.set_stroke_transform(DAffine2::IDENTITY);
 


### PR DESCRIPTION
Fixes a crash when using the text tool and the Text node is connected to a Bounding Box node.