### PR TITLE
Improve Pen tool segment drawing confirm/cancel behavior

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1169,7 +1169,7 @@ impl NodeNetworkInterface {
 			if is_layer && *reference == Some("Merge".to_string()) {
 				"Untitled Layer".to_string()
 			} else {
-				reference.clone().unwrap_or("Untitled node".to_string())
+				reference.clone().unwrap_or("Untitled Node".to_string())
 			}
 		} else {
 			self.display_name(node_id, network_path)

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use super::tool_prelude::*;
 use crate::consts::{DEFAULT_STROKE_WIDTH, HIDE_HANDLE_DISTANCE, LINE_ROTATE_SNAP_ANGLE};
 use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
@@ -2033,8 +2035,8 @@ impl Fsm for PenToolFsmState {
 				let mut dragging_hint_data = HintData(Vec::new());
 				dragging_hint_data.0.push(HintGroup(vec![
 					HintInfo::mouse(MouseMotion::Rmb, ""),
-					HintInfo::keys([Key::Escape], "").prepend_slash(),
-					HintInfo::keys([Key::Enter], "End Path").prepend_slash(),
+					HintInfo::keys([Key::Escape], "Cancel Placement").prepend_slash(),
+					HintInfo::keys([Key::Enter], "End Path"),
 				]));
 
 				let mut toggle_group = match mode {


### PR DESCRIPTION
Implemented the following features requested by @Keavon's screencast (with narration) below:
- Enter now finalizes the preview segment when dragging a handle.
- Right-click or Esc cancels the placement.

https://github.com/user-attachments/assets/db429eb4-aaaa-4577-9b53-86c8ad2a28e4

