### PR TITLE
Fix a Pen tool regression where a new single-point layer doesn't get deleted but should

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -1980,7 +1980,6 @@ impl Fsm for PenToolFsmState {
 
 				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.cleanup(responses);
-				tool_data.cleanup_target_selections(shape_editor, layer, document, responses);
 
 				if should_delete_layer {
 					responses.add(NodeGraphMessage::DeleteNodes {


### PR DESCRIPTION
Issue #2503 was reintroduced in #2452 by the line [1928 in `pen_tool.rs`](https://github.com/GraphiteEditor/Graphite/commit/6a8386d1e916a97dec1c48002e18f15c86f63d92#diff-635fd86b9ded69107348350c9cb0c66b2ec561ba807c06239f7794e9db62b202R1928). This PR fixes it but please check the improvements done in #2452 are still working fine.