### PR TITLE
Fix Poisson-disk sampling with negative space from nested subpaths

### DIFF
--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -389,7 +389,7 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 	///
 	/// While the conceptual process described above asymptotically slows down and is never guaranteed to produce a maximal set in finite time,
 	/// this is implemented with an algorithm that produces a maximal set in O(n) time. The slowest part is actually checking if points are inside the subpath shape.
-	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64, shapes: &[(Self, [DVec2; 2])], shape_index: usize) -> Vec<DVec2> {
+	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64, subpaths: &[(Self, [DVec2; 2])], subpath_index: usize) -> Vec<DVec2> {
 		let Some(bounding_box) = self.bounding_box() else { return Vec::new() };
 		let (offset_x, offset_y) = bounding_box[0].into();
 		let (width, height) = (bounding_box[1] - bounding_box[0]).into();
@@ -403,14 +403,14 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 		let point_in_shape_checker = |point: DVec2| {
 			// Check against all paths the point is contained in to compute the correct winding number
 			let mut number = 0;
-			for (i, (shape, bb)) in shapes.iter().enumerate() {
+			for (i, (shape, bb)) in subpaths.iter().enumerate() {
 				let point = point + bounding_box[0];
 				if bb[0].x > point.x || bb[0].y > point.y || bb[1].x < point.x || bb[1].y < point.y {
 					continue;
 				}
 				let winding = shape.winding_order(point);
 
-				if i == shape_index && winding == 0 {
+				if i == subpath_index && winding == 0 {
 					return false;
 				}
 				number += winding;

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -389,7 +389,7 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 	///
 	/// While the conceptual process described above asymptotically slows down and is never guaranteed to produce a maximal set in finite time,
 	/// this is implemented with an algorithm that produces a maximal set in O(n) time. The slowest part is actually checking if points are inside the subpath shape.
-	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64, shapes: &[(Self, [DVec2; 2])]) -> Vec<DVec2> {
+	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64, shapes: &[(Self, [DVec2; 2])], shape_index: usize) -> Vec<DVec2> {
 		let Some(bounding_box) = self.bounding_box() else { return Vec::new() };
 		let (offset_x, offset_y) = bounding_box[0].into();
 		let (width, height) = (bounding_box[1] - bounding_box[0]).into();
@@ -402,17 +402,19 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 
 		let point_in_shape_checker = |point: DVec2| {
 			// Check against all paths the point is contained in to compute the correct winding number
-			let number: i32 = shapes
-				.iter()
-				.map(|(shape, bb)| {
-					let point = point + bounding_box[0];
-					if bb[0].x > point.x || bb[0].y > point.y || bb[1].x < point.x || bb[1].y < point.y {
-						return 0;
-					}
+			let mut number = 0;
+			for (i, (shape, bb)) in shapes.iter().enumerate() {
+				let point = point + bounding_box[0];
+				if bb[0].x > point.x || bb[0].y > point.y || bb[1].x < point.x || bb[1].y < point.y {
+					continue;
+				}
+				let winding = shape.winding_order(point);
 
-					shape.winding_order(point)
-				})
-				.sum();
+				if i == shape_index && winding == 0 {
+					return false;
+				}
+				number += winding;
+			}
 			number != 0
 		};
 

--- a/libraries/bezier-rs/src/subpath/solvers.rs
+++ b/libraries/bezier-rs/src/subpath/solvers.rs
@@ -389,7 +389,7 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 	///
 	/// While the conceptual process described above asymptotically slows down and is never guaranteed to produce a maximal set in finite time,
 	/// this is implemented with an algorithm that produces a maximal set in O(n) time. The slowest part is actually checking if points are inside the subpath shape.
-	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64) -> Vec<DVec2> {
+	pub fn poisson_disk_points(&self, separation_disk_diameter: f64, rng: impl FnMut() -> f64, shapes: &[(Self, [DVec2; 2])]) -> Vec<DVec2> {
 		let Some(bounding_box) = self.bounding_box() else { return Vec::new() };
 		let (offset_x, offset_y) = bounding_box[0].into();
 		let (width, height) = (bounding_box[1] - bounding_box[0]).into();
@@ -400,7 +400,21 @@ impl<PointId: crate::Identifier> Subpath<PointId> {
 		shape.set_closed(true);
 		shape.apply_transform(DAffine2::from_translation((-offset_x, -offset_y).into()));
 
-		let point_in_shape_checker = |point: DVec2| shape.winding_order(point) != 0;
+		let point_in_shape_checker = |point: DVec2| {
+			// Check against all paths the point is contained in to compute the correct winding number
+			let number: i32 = shapes
+				.iter()
+				.map(|(shape, bb)| {
+					let point = point + bounding_box[0];
+					if bb[0].x > point.x || bb[0].y > point.y || bb[1].x < point.x || bb[1].y < point.y {
+						return 0;
+					}
+
+					shape.winding_order(point)
+				})
+				.sum();
+			number != 0
+		};
 
 		let square_edges_intersect_shape_checker = |corner1: DVec2, size: f64| {
 			let corner2 = corner1 + DVec2::splat(size);

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -67,7 +67,7 @@ serde = { workspace = true, optional = true, features = ["derive"] }
 ctor = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
-bezier-rs = { workspace = true, optional = true }
+bezier-rs = { workspace = true, optional = true, features = ["log"] }
 kurbo = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -1254,14 +1254,14 @@ async fn poisson_disk_points(
 		})
 		.collect();
 
-	for (subpath, _) in &path_with_bounding_boxes {
+	for (i, (subpath, _)) in path_with_bounding_boxes.iter().enumerate() {
 		if subpath.manipulator_groups().len() < 3 {
 			continue;
 		}
 
 		let mut previous_point_index: Option<usize> = None;
 
-		for point in subpath.poisson_disk_points(separation_disk_diameter, || rng.random::<f64>(), &path_with_bounding_boxes) {
+		for point in subpath.poisson_disk_points(separation_disk_diameter, || rng.random::<f64>(), &path_with_bounding_boxes, i) {
 			let point_id = PointId::generate();
 			result.point_domain.push(point_id, point);
 

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -137,7 +137,7 @@ impl WasmSubpath {
 		let r = separation_disk_diameter / 2.;
 
 		let subpath_svg = self.to_default_svg();
-		let points = self.0.poisson_disk_points(separation_disk_diameter, Math::random);
+		let points = self.0.poisson_disk_points(separation_disk_diameter, Math::random, &[(self.0.clone(), self.0.bounding_box().unwrap())]);
 
 		let points_style = format!("<style class=\"poisson\">style.poisson ~ circle {{ fill: {RED}; opacity: 0.25; }}</style>");
 		let content = points

--- a/website/other/bezier-rs-demos/wasm/src/subpath.rs
+++ b/website/other/bezier-rs-demos/wasm/src/subpath.rs
@@ -137,7 +137,9 @@ impl WasmSubpath {
 		let r = separation_disk_diameter / 2.;
 
 		let subpath_svg = self.to_default_svg();
-		let points = self.0.poisson_disk_points(separation_disk_diameter, Math::random, &[(self.0.clone(), self.0.bounding_box().unwrap())]);
+		let points = self
+			.0
+			.poisson_disk_points(separation_disk_diameter, Math::random, &[(self.0.clone(), self.0.bounding_box().unwrap())], 0);
 
 		let points_style = format!("<style class=\"poisson\">style.poisson ~ circle {{ fill: {RED}; opacity: 0.25; }}</style>");
 		let content = points


### PR DESCRIPTION
Previously all Subpaths were considered independently for the poisson disk sampling evaluation. We now check against all Subpaths which might contain the point to fix shapes with holes such as fonts with letters with holes in them

Before:

![Image](https://github.com/user-attachments/assets/94d66728-0728-4171-b3fb-3badf0801645)

After:
![image](https://github.com/user-attachments/assets/0cd5780e-64ee-4653-9869-80a3962e85bb)


<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes: #2568 