### PR TITLE
Add node description tooltips in the Properties panel and on secondary inputs in the graph

### DIFF
--- a/editor/src/dispatcher.rs
+++ b/editor/src/dispatcher.rs
@@ -167,7 +167,6 @@ impl Dispatcher {
 
 					// Send the information for tooltips and categories for each node/input.
 					queue.add(FrontendMessage::SendUIMetadata {
-						input_type_descriptions: Vec::new(),
 						node_descriptions: document_node_definitions::collect_node_descriptions(),
 						node_types: document_node_definitions::collect_node_types(),
 					});

--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -44,8 +44,6 @@ pub enum FrontendMessage {
 
 	// Send prefix: Send global, static data to the frontend that is never updated
 	SendUIMetadata {
-		#[serde(rename = "inputTypeDescriptions")]
-		input_type_descriptions: Vec<(String, String)>,
 		#[serde(rename = "nodeDescriptions")]
 		node_descriptions: Vec<(String, String)>,
 		#[serde(rename = "nodeTypes")]

--- a/editor/src/messages/layout/utility_types/layout_widget.rs
+++ b/editor/src/messages/layout/utility_types/layout_widget.rs
@@ -325,7 +325,14 @@ pub enum LayoutGroup {
 	},
 	// TODO: Move this from being a child of `enum LayoutGroup` to being a child of `enum Layout`
 	#[serde(rename = "section")]
-	Section { name: String, visible: bool, pinned: bool, id: u64, layout: SubLayout },
+	Section {
+		name: String,
+		description: String,
+		visible: bool,
+		pinned: bool,
+		id: u64,
+		layout: SubLayout,
+	},
 }
 
 impl Default for LayoutGroup {
@@ -402,6 +409,7 @@ impl LayoutGroup {
 			(
 				Self::Section {
 					name: current_name,
+					description: current_description,
 					visible: current_visible,
 					pinned: current_pinned,
 					id: current_id,
@@ -409,6 +417,7 @@ impl LayoutGroup {
 				},
 				Self::Section {
 					name: new_name,
+					description: new_description,
 					visible: new_visible,
 					pinned: new_pinned,
 					id: new_id,
@@ -417,9 +426,16 @@ impl LayoutGroup {
 			) => {
 				// Resend the entire panel if the lengths, names, visibility, or node IDs are different
 				// TODO: Diff insersion and deletion of items
-				if current_layout.len() != new_layout.len() || *current_name != new_name || *current_visible != new_visible || *current_pinned != new_pinned || *current_id != new_id {
+				if current_layout.len() != new_layout.len()
+					|| *current_name != new_name
+					|| *current_description != new_description
+					|| *current_visible != new_visible
+					|| *current_pinned != new_pinned
+					|| *current_id != new_id
+				{
 					// Update self to reflect new changes
 					current_name.clone_from(&new_name);
+					current_description.clone_from(&new_description);
 					*current_visible = new_visible;
 					*current_pinned = new_pinned;
 					*current_id = new_id;
@@ -428,6 +444,7 @@ impl LayoutGroup {
 					// Push an update layout group to the diff
 					let new_value = DiffUpdate::LayoutGroup(Self::Section {
 						name: new_name,
+						description: new_description,
 						visible: new_visible,
 						pinned: new_pinned,
 						id: new_id,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -353,7 +353,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageData<'_>> for DocumentMessag
 					}
 					let Some(bounds) = self.metadata().bounding_box_document(layer) else { continue };
 
-					let name = self.network_interface.frontend_display_name(&layer.to_node(), &[]);
+					let name = self.network_interface.display_name(&layer.to_node(), &[]);
 
 					let transform = self.metadata().document_to_viewport
 						* DAffine2::from_translation(bounds[0].min(bounds[1]))

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -240,7 +240,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageData<'_>> for Gr
 
 					responses.add(NodeGraphMessage::SetDisplayName {
 						node_id,
-						alias: network_interface.frontend_display_name(&artboard.to_node(), &[]),
+						alias: network_interface.display_name(&artboard.to_node(), &[]),
 						skip_adding_history_step: true,
 					});
 

--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -120,7 +120,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Out".to_string()],
 					..Default::default()
 				},
@@ -141,7 +141,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Out".to_string()],
 					..Default::default()
 				},
@@ -203,7 +203,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Graphical Data".into(), "Over".into()],
+					input_properties: vec![("Graphical Data", "TODO").into(), ("Over", "TODO").into()],
 					output_names: vec!["Out".to_string()],
 					node_type_metadata: NodeTypePersistentMetadata::layer(IVec2::new(0, 0)),
 					network_metadata: Some(NodeNetworkMetadata {
@@ -316,10 +316,11 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
 					input_properties: vec![
-						"Artboards".into(),
-						PropertiesRow::with_override("Contents", WidgetOverride::Hidden),
+						("Artboards", "TODO").into(),
+						PropertiesRow::with_override("Contents", "TODO", WidgetOverride::Hidden),
 						PropertiesRow::with_override(
 							"Location",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "X".to_string(),
 								y: "Y".to_string(),
@@ -329,6 +330,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Dimensions",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "W".to_string(),
 								y: "H".to_string(),
@@ -336,8 +338,8 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 								..Default::default()
 							}),
 						),
-						PropertiesRow::with_override("Background", WidgetOverride::Custom("artboard_background".to_string())),
-						"Clip".into(),
+						PropertiesRow::with_override("Background", "TODO", WidgetOverride::Custom("artboard_background".to_string())),
+						("Clip", "TODO").into(),
 					],
 					output_names: vec!["Out".to_string()],
 					node_type_metadata: NodeTypePersistentMetadata::layer(IVec2::new(0, 0)),
@@ -420,7 +422,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Empty".into(), "URL".into()],
+					input_properties: vec![("Empty", "TODO").into(), ("URL", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -570,7 +572,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Canvas".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -670,7 +672,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Artwork".into(), "Footprint".into()],
+					input_properties: vec![("Artwork", "TODO").into(), ("Footprint", "TODO").into()],
 					output_names: vec!["Canvas".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -730,7 +732,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into(), PropertiesRow::with_override("Stencil", WidgetOverride::Custom("mask_stencil".to_string()))],
+					input_properties: vec![
+						("Image", "TODO").into(),
+						PropertiesRow::with_override("Stencil", "TODO", WidgetOverride::Custom("mask_stencil".to_string())),
+					],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -754,7 +759,11 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into(), PropertiesRow::with_override("Insertion", WidgetOverride::Hidden), "Into".into()],
+					input_properties: vec![
+						("Image", "TODO").into(),
+						PropertiesRow::with_override("Insertion", "TODO", WidgetOverride::Hidden),
+						("Into", "TODO").into(),
+					],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -779,7 +788,13 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["None".into(), "Red".into(), "Green".into(), "Blue".into(), "Alpha".into()],
+					input_properties: vec![
+						("None", "TODO").into(),
+						("Red", "TODO").into(),
+						("Green", "TODO").into(),
+						("Blue", "TODO").into(),
+						("Alpha", "TODO").into(),
+					],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -848,7 +863,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into()],
+					input_properties: vec![("Image", "TODO").into()],
 					output_names: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string(), "Alpha".to_string()],
 					has_primary_output: false,
 					network_metadata: Some(NodeNetworkMetadata {
@@ -933,7 +948,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Vector2".into()],
+					input_properties: vec![("Vector2", "TODO").into()],
 					output_names: vec!["X".to_string(), "Y".to_string()],
 					has_primary_output: false,
 					network_metadata: Some(NodeNetworkMetadata {
@@ -1003,7 +1018,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Background".into(), "Bounds".into(), "Trace".into(), "Cache".into()],
+					input_properties: vec![("Background", "TODO").into(), ("Bounds", "TODO").into(), ("Trace", "TODO").into(), ("Cache", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1040,7 +1055,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into()],
+					input_properties: vec![("Image", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -1059,7 +1074,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into()],
+					input_properties: vec![("Image", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -1093,7 +1108,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Empty".into(), "Image".into()],
+					input_properties: vec![("Empty", "TODO").into(), ("Image", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1156,7 +1171,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Uniform".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1235,7 +1250,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Storage".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1314,7 +1329,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into(), "In".into()],
+					input_properties: vec![("In", "TODO").into(), ("In", "TODO").into()],
 					output_names: vec!["Output Buffer".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1403,7 +1418,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into(), "In".into(), "In".into()],
+					input_properties: vec![("In", "TODO").into(), ("In", "TODO").into(), ("In", "TODO").into()],
 					output_names: vec!["Command Buffer".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1463,7 +1478,12 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Shader Handle".into(), "String".into(), "Bindgroup".into(), "Arc Shader Input".into()],
+					input_properties: vec![
+						("Shader Handle", "TODO").into(),
+						("String", "TODO").into(),
+						("Bindgroup", "TODO").into(),
+						("Arc Shader Input", "TODO").into(),
+					],
 					output_names: vec!["Pipeline Layout".to_string()],
 					..Default::default()
 				},
@@ -1508,7 +1528,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Pipeline Result".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1588,7 +1608,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Buffer".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1733,7 +1753,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Texture".into(), "Surface".into()],
+					input_properties: vec![("Texture", "TODO").into(), ("Surface", "TODO").into()],
 					output_names: vec!["Rendered Texture".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1806,7 +1826,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["In".into()],
+					input_properties: vec![("In", "TODO").into()],
 					output_names: vec!["Texture".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -1864,7 +1884,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Image".into(), "Node".into()],
+					input_properties: vec![("Image", "TODO").into(), ("Node", "TODO").into()],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
 				},
@@ -1882,7 +1902,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Node".into()],
+					input_properties: vec![("Node", "TODO").into()],
 					output_names: vec!["Document Node".to_string()],
 					..Default::default()
 				},
@@ -1909,10 +1929,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
 					input_properties: vec![
-						"Image".into(),
-						PropertiesRow::with_override("Brightness", WidgetOverride::Custom("brightness".to_string())),
-						PropertiesRow::with_override("Brightness", WidgetOverride::Custom("contrast".to_string())),
-						"Use Classic".into(),
+						("Image", "TODO").into(),
+						PropertiesRow::with_override("Brightness", "TODO", WidgetOverride::Custom("brightness".to_string())),
+						PropertiesRow::with_override("Brightness", "TODO", WidgetOverride::Custom("contrast".to_string())),
+						("Use Classic", "TODO").into(),
 					],
 					output_names: vec!["Image".to_string()],
 					..Default::default()
@@ -1938,7 +1958,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 		// 			..Default::default()
 		// 		},
 		// 		persistent_node_metadata: DocumentNodePersistentMetadata {
-		// 			input_properties: vec!["Image".into(), "Curve".into()],
+		// 			input_properties: vec![("Image", "TODO").into(), ("Curve", "TODO").into()],
 		// 			output_names: vec!["Image".to_string()],
 		// 			..Default::default()
 		// 		},
@@ -1963,9 +1983,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
 					input_properties: vec![
-						"None".into(),
+						("None", "TODO").into(),
 						PropertiesRow::with_override(
 							"Start",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "X".to_string(),
 								y: "Y".to_string(),
@@ -1975,6 +1996,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"End",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "X".to_string(),
 								y: "Y".to_string(),
@@ -2025,7 +2047,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					..Default::default()
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
-					input_properties: vec!["Vector Data".into(), "Modification".into()],
+					input_properties: vec![("Vector Data", "TODO").into(), ("Modification", "TODO").into()],
 					output_names: vec!["Vector Data".to_string()],
 					network_metadata: Some(NodeNetworkMetadata {
 						persistent_metadata: NodeNetworkPersistentMetadata {
@@ -2085,11 +2107,12 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
 					input_properties: vec![
-						"Editor API".into(),
-						PropertiesRow::with_override("Text", WidgetOverride::Custom("text_area".to_string())),
-						PropertiesRow::with_override("Font", WidgetOverride::Custom("text_font".to_string())),
+						("Editor API", "TODO").into(),
+						PropertiesRow::with_override("Text", "TODO", WidgetOverride::Custom("text_area".to_string())),
+						PropertiesRow::with_override("Font", "TODO", WidgetOverride::Custom("text_font".to_string())),
 						PropertiesRow::with_override(
 							"Size",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								unit: Some(" px".to_string()),
 								min: Some(1.),
@@ -2098,6 +2121,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Line Height",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								step: Some(0.1),
@@ -2106,6 +2130,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Character Spacing",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								step: Some(0.1),
@@ -2114,6 +2139,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Max Width",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(1.),
 								blank_assist: false,
@@ -2122,6 +2148,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Max Height",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(1.),
 								blank_assist: false,
@@ -2211,9 +2238,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						..Default::default()
 					}),
 					input_properties: vec![
-						"Vector Data".into(),
+						("Vector Data", "TODO").into(),
 						PropertiesRow::with_override(
 							"Translation",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "X".to_string(),
 								y: "Y".to_string(),
@@ -2221,9 +2249,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 								..Default::default()
 							}),
 						),
-						PropertiesRow::with_override("Rotation", WidgetOverride::Custom("transform_rotation".to_string())),
+						PropertiesRow::with_override("Rotation", "TODO", WidgetOverride::Custom("transform_rotation".to_string())),
 						PropertiesRow::with_override(
 							"Scale",
+							"TODO",
 							WidgetOverride::Vec2(Vec2InputSettings {
 								x: "W".to_string(),
 								y: "H".to_string(),
@@ -2231,8 +2260,8 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 								..Default::default()
 							}),
 						),
-						PropertiesRow::with_override("Skew", WidgetOverride::Custom("transform_skew".to_string())),
-						PropertiesRow::with_override("Pivot", WidgetOverride::Hidden),
+						PropertiesRow::with_override("Skew", "TODO", WidgetOverride::Custom("transform_skew".to_string())),
+						PropertiesRow::with_override("Pivot", "TODO", WidgetOverride::Hidden),
 					],
 					output_names: vec!["Data".to_string()],
 					..Default::default()
@@ -2332,7 +2361,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						},
 						..Default::default()
 					}),
-					input_properties: vec!["Group of Paths".into(), "Operation".into()],
+					input_properties: vec![("Group of Paths", "TODO").into(), ("Operation", "TODO").into()],
 					output_names: vec!["Vector".to_string()],
 					..Default::default()
 				},
@@ -2363,10 +2392,11 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 				},
 				persistent_node_metadata: DocumentNodePersistentMetadata {
 					input_properties: vec![
-						"Points".into(),
-						Into::<PropertiesRow>::into("Instance").with_tooltip("Artwork to be copied and placed at each point"),
+						("Points", "TODO").into(),
+						Into::<PropertiesRow>::into(("Instance", "TODO")).with_tooltip("Artwork to be copied and placed at each point"),
 						PropertiesRow::with_override(
 							"Random Scale Min",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								mode: NumberInputMode::Range,
@@ -2379,6 +2409,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Minimum range of randomized sizes given to each instance"),
 						PropertiesRow::with_override(
 							"Random Scale Max",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								mode: NumberInputMode::Range,
@@ -2391,6 +2422,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Minimum range of randomized sizes given to each instance"),
 						PropertiesRow::with_override(
 							"Random Scale Bias",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								mode: NumberInputMode::Range,
 								range_min: Some(-50.),
@@ -2401,6 +2433,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Bias for the probability distribution of randomized sizes (0 is uniform, negatives favor more of small sizes, positives favor more of large sizes)"),
 						PropertiesRow::with_override(
 							"Random Scale Seed",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								is_integer: true,
@@ -2410,6 +2443,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Seed to determine unique variations on all the randomized instance sizes"),
 						PropertiesRow::with_override(
 							"Random Rotation",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								max: Some(360.),
@@ -2421,6 +2455,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Range of randomized angles given to each instance, in degrees ranging from furthest clockwise to counterclockwise"),
 						PropertiesRow::with_override(
 							"Random Rotation Seed",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								is_integer: true,
@@ -2552,9 +2587,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						..Default::default()
 					}),
 					input_properties: vec![
-						"Vector Data".into(),
+						("Vector Data", "TODO").into(),
 						PropertiesRow::with_override(
 							"Spacing",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(1.),
 								unit: Some(" px".to_string()),
@@ -2564,6 +2600,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Distance between each instance (exact if 'Adaptive Spacing' is disabled, approximate if enabled)"),
 						PropertiesRow::with_override(
 							"Start Offset",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								unit: Some(" px".to_string()),
@@ -2573,6 +2610,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						.with_tooltip("Exclude some distance from the start of the path before the first instance"),
 						PropertiesRow::with_override(
 							"Stop Offset",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								unit: Some(" px".to_string()),
@@ -2580,7 +2618,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 							}),
 						)
 						.with_tooltip("Exclude some distance from the end of the path after the last instance"),
-						Into::<PropertiesRow>::into("Adaptive Spacing").with_tooltip("Round 'Spacing' to a nearby value that divides into the path length evenly"),
+						Into::<PropertiesRow>::into(("Adaptive Spacing", "TODO")).with_tooltip("Round 'Spacing' to a nearby value that divides into the path length evenly"),
 					],
 					output_names: vec!["Vector".to_string()],
 					..Default::default()
@@ -2686,9 +2724,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						..Default::default()
 					}),
 					input_properties: vec![
-						"Vector Data".into(),
+						("Vector Data", "TODO").into(),
 						PropertiesRow::with_override(
 							"Separation Disk Diameter",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.01),
 								mode: NumberInputMode::Range,
@@ -2699,6 +2738,7 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 						),
 						PropertiesRow::with_override(
 							"Seed",
+							"TODO",
 							WidgetOverride::Number(NumberInputSettings {
 								min: Some(0.),
 								is_integer: true,
@@ -2800,10 +2840,10 @@ fn static_nodes() -> Vec<DocumentNodeDefinition> {
 					input_properties: fields
 						.iter()
 						.map(|f| match f.widget_override {
-							RegistryWidgetOverride::None => f.name.into(),
-							RegistryWidgetOverride::Hidden => PropertiesRow::with_override(f.name, WidgetOverride::Hidden),
-							RegistryWidgetOverride::String(str) => PropertiesRow::with_override(f.name, WidgetOverride::String(str.to_string())),
-							RegistryWidgetOverride::Custom(str) => PropertiesRow::with_override(f.name, WidgetOverride::Custom(str.to_string())),
+							RegistryWidgetOverride::None => (f.name, f.description).into(),
+							RegistryWidgetOverride::Hidden => PropertiesRow::with_override(f.name, f.description, WidgetOverride::Hidden),
+							RegistryWidgetOverride::String(str) => PropertiesRow::with_override(f.name, f.description, WidgetOverride::String(str.to_string())),
+							RegistryWidgetOverride::Custom(str) => PropertiesRow::with_override(f.name, f.description, WidgetOverride::Custom(str.to_string())),
 						})
 						.collect(),
 					output_names: vec![output_type.to_string()],
@@ -2994,7 +3034,7 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"number".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let mut number_input = NumberInput::default();
 			if let Some(unit) = context
 				.network_interface
@@ -3060,14 +3100,14 @@ fn static_input_properties() -> InputProperties {
 					true
 				});
 			Ok(vec![LayoutGroup::Row {
-				widgets: node_properties::number_widget(document_node, node_id, index, input_name, number_input, blank_assist),
+				widgets: node_properties::number_widget(document_node, node_id, index, input_name, input_description, number_input, blank_assist),
 			}])
 		}),
 	);
 	map.insert(
 		"vec2".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let x = context
 				.network_interface
 				.input_metadata(&node_id, index, "x", context.selection_network_path)
@@ -3102,6 +3142,7 @@ fn static_input_properties() -> InputProperties {
 				node_id,
 				index,
 				input_name,
+				input_description,
 				x,
 				y,
 				unit,
@@ -3113,39 +3154,48 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_scale".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, _, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
-			let scale = node_properties::number_widget(document_node, node_id, index, input_name, NumberInput::default().min(0.).disabled(!coherent_noise_active), true);
+			let scale = node_properties::number_widget(
+				document_node,
+				node_id,
+				index,
+				input_name,
+				input_description,
+				NumberInput::default().min(0.).disabled(!coherent_noise_active),
+				true,
+			);
 			Ok(vec![scale.into()])
 		}),
 	);
 	map.insert(
 		"noise_properties_noise_type".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
-			let noise_type_row = node_properties::noise_type(document_node, node_id, index, input_name, true);
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
+			let noise_type_row = node_properties::noise_type(document_node, node_id, index, input_name, input_description, true);
 			Ok(vec![noise_type_row, LayoutGroup::Row { widgets: Vec::new() }])
 		}),
 	);
 	map.insert(
 		"noise_properties_domain_warp_type".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, _, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
-			let domain_warp_type = node_properties::domain_warp_type(document_node, node_id, index, input_name, true, !coherent_noise_active);
+			let domain_warp_type = node_properties::domain_warp_type(document_node, node_id, index, input_name, input_description, true, !coherent_noise_active);
 			Ok(vec![domain_warp_type])
 		}),
 	);
 	map.insert(
 		"noise_properties_domain_warp_amplitude".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, _, _, domain_warp_active, _) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let domain_warp_amplitude = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default().min(0.).disabled(!coherent_noise_active || !domain_warp_active),
 				true,
 			);
@@ -3155,22 +3205,23 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_fractal_type".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, _, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
-			let fractal_type_row = node_properties::fractal_type(document_node, node_id, index, input_name, true, !coherent_noise_active);
+			let fractal_type_row = node_properties::fractal_type(document_node, node_id, index, input_name, input_description, true, !coherent_noise_active);
 			Ok(vec![fractal_type_row])
 		}),
 	);
 	map.insert(
 		"noise_properties_fractal_octaves".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (fractal_active, coherent_noise_active, _, _, _, domain_warp_only_fractal_type_wrongly_active) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let fractal_octaves = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.min(1.)
@@ -3186,13 +3237,14 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_fractal_lacunarity".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (fractal_active, coherent_noise_active, _, _, _, domain_warp_only_fractal_type_wrongly_active) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let fractal_lacunarity = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.min(0.)
@@ -3206,13 +3258,14 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_fractal_gain".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (fractal_active, coherent_noise_active, _, _, _, domain_warp_only_fractal_type_wrongly_active) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let fractal_gain = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.min(0.)
@@ -3226,13 +3279,14 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_fractal_weighted_strength".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (fractal_active, coherent_noise_active, _, _, _, domain_warp_only_fractal_type_wrongly_active) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let fractal_weighted_strength = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.min(0.)
@@ -3246,13 +3300,14 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_ping_pong_strength".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (fractal_active, coherent_noise_active, _, ping_pong_active, _, domain_warp_only_fractal_type_wrongly_active) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let fractal_ping_pong_strength = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.min(0.)
@@ -3266,31 +3321,33 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"noise_properties_cellular_distance_function".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, cellular_noise_active, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
-			let cellular_distance_function_row = node_properties::cellular_distance_function(document_node, node_id, index, input_name, true, !coherent_noise_active || !cellular_noise_active);
+			let cellular_distance_function_row =
+				node_properties::cellular_distance_function(document_node, node_id, index, input_name, input_description, true, !coherent_noise_active || !cellular_noise_active);
 			Ok(vec![cellular_distance_function_row])
 		}),
 	);
 	map.insert(
 		"noise_properties_cellular_return_type".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, cellular_noise_active, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
-			let cellular_return_type = node_properties::cellular_return_type(document_node, node_id, index, input_name, true, !coherent_noise_active || !cellular_noise_active);
+			let cellular_return_type = node_properties::cellular_return_type(document_node, node_id, index, input_name, input_description, true, !coherent_noise_active || !cellular_noise_active);
 			Ok(vec![cellular_return_type])
 		}),
 	);
 	map.insert(
 		"noise_properties_cellular_jitter".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let (_, coherent_noise_active, cellular_noise_active, _, _, _) = node_properties::query_noise_pattern_state(node_id, context)?;
 			let cellular_jitter = node_properties::number_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default()
 					.mode_range()
 					.range_min(Some(0.))
@@ -3304,7 +3361,7 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"brightness".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let is_use_classic = document_node
 				.inputs
 				.iter()
@@ -3319,6 +3376,7 @@ fn static_input_properties() -> InputProperties {
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default().mode_range().range_min(Some(b_min)).range_max(Some(b_max)).unit("%").display_decimal_places(2),
 				true,
 			);
@@ -3328,7 +3386,7 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"contrast".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let is_use_classic = document_node
 				.inputs
 				.iter()
@@ -3343,6 +3401,7 @@ fn static_input_properties() -> InputProperties {
 				node_id,
 				index,
 				input_name,
+				input_description,
 				NumberInput::default().mode_range().range_min(Some(c_min)).range_max(Some(c_max)).unit("%").display_decimal_places(2),
 				true,
 			);
@@ -3352,52 +3411,68 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"assign_colors_gradient".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
-			let gradient_row = node_properties::color_widget(document_node, node_id, index, input_name, ColorInput::default().allow_none(false), true);
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
+			let gradient_row = node_properties::color_widget(document_node, node_id, index, input_name, input_description, ColorInput::default().allow_none(false), true);
 			Ok(vec![gradient_row])
 		}),
 	);
 	map.insert(
 		"assign_colors_seed".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let randomize_enabled = node_properties::query_assign_colors_randomize(node_id, context)?;
-			let seed_row = node_properties::number_widget(document_node, node_id, index, input_name, NumberInput::default().min(0.).int().disabled(!randomize_enabled), true);
+			let seed_row = node_properties::number_widget(
+				document_node,
+				node_id,
+				index,
+				input_name,
+				input_description,
+				NumberInput::default().min(0.).int().disabled(!randomize_enabled),
+				true,
+			);
 			Ok(vec![seed_row.into()])
 		}),
 	);
 	map.insert(
 		"assign_colors_repeat_every".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			let randomize_enabled = node_properties::query_assign_colors_randomize(node_id, context)?;
-			let repeat_every_row = node_properties::number_widget(document_node, node_id, index, input_name, NumberInput::default().min(0.).int().disabled(randomize_enabled), true);
+			let repeat_every_row = node_properties::number_widget(
+				document_node,
+				node_id,
+				index,
+				input_name,
+				input_description,
+				NumberInput::default().min(0.).int().disabled(randomize_enabled),
+				true,
+			);
 			Ok(vec![repeat_every_row.into()])
 		}),
 	);
 	map.insert(
 		"mask_stencil".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
-			let mask = node_properties::color_widget(document_node, node_id, index, input_name, ColorInput::default(), true);
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
+			let mask = node_properties::color_widget(document_node, node_id, index, input_name, input_description, ColorInput::default(), true);
 			Ok(vec![mask])
 		}),
 	);
 	map.insert(
 		"spline_input".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			Ok(vec![LayoutGroup::Row {
-				widgets: node_properties::vec_dvec2_input(document_node, node_id, index, input_name, TextInput::default().centered(true), true),
+				widgets: node_properties::vec_dvec2_input(document_node, node_id, index, input_name, input_description, TextInput::default().centered(true), true),
 			}])
 		}),
 	);
 	map.insert(
 		"transform_rotation".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 
-			let mut widgets = node_properties::start_widgets(document_node, node_id, index, input_name, super::utility_types::FrontendGraphDataType::Number, true);
+			let mut widgets = node_properties::start_widgets(document_node, node_id, index, input_name, input_description, super::utility_types::FrontendGraphDataType::Number, true);
 
 			let Some(input) = document_node.inputs.get(index) else {
 				return Err("Input not found in transform rotation input override".to_string());
@@ -3427,9 +3502,9 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"transform_skew".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 
-			let mut widgets = node_properties::start_widgets(document_node, node_id, index, input_name, super::utility_types::FrontendGraphDataType::Number, true);
+			let mut widgets = node_properties::start_widgets(document_node, node_id, index, input_name, input_description, super::utility_types::FrontendGraphDataType::Number, true);
 
 			let Some(input) = document_node.inputs.get(index) else {
 				return Err("Input not found in transform skew input override".to_string());
@@ -3472,17 +3547,17 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"text_area".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			Ok(vec![LayoutGroup::Row {
-				widgets: node_properties::text_area_widget(document_node, node_id, index, input_name, true),
+				widgets: node_properties::text_area_widget(document_node, node_id, index, input_name, input_description, true),
 			}])
 		}),
 	);
 	map.insert(
 		"text_font".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
-			let (font, style) = node_properties::font_inputs(document_node, node_id, index, input_name, true);
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
+			let (font, style) = node_properties::font_inputs(document_node, node_id, index, input_name, input_description, true);
 			let mut result = vec![LayoutGroup::Row { widgets: font }];
 			if let Some(style) = style {
 				result.push(LayoutGroup::Row { widgets: style });
@@ -3493,12 +3568,13 @@ fn static_input_properties() -> InputProperties {
 	map.insert(
 		"artboard_background".to_string(),
 		Box::new(|node_id, index, context| {
-			let (document_node, input_name) = node_properties::query_node_and_input_name(node_id, index, context)?;
+			let (document_node, input_name, input_description) = node_properties::query_node_and_input_info(node_id, index, context)?;
 			Ok(vec![node_properties::color_widget(
 				document_node,
 				node_id,
 				index,
 				input_name,
+				input_description,
 				ColorInput::default().allow_none(false),
 				true,
 			)])

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -2051,7 +2051,7 @@ impl NodeGraphMessageHandler {
 						Separator::new(SeparatorType::Related).widget_holder(),
 						IconLabel::new("Layer").tooltip("Name of the selected layer").widget_holder(),
 						Separator::new(SeparatorType::Related).widget_holder(),
-						TextInput::new(context.network_interface.frontend_display_name(&layer, context.selection_network_path))
+						TextInput::new(context.network_interface.display_name(&layer, context.selection_network_path))
 							.tooltip("Name of the selected layer")
 							.on_update(move |text_input| {
 								NodeGraphMessage::SetDisplayName {
@@ -2095,9 +2095,10 @@ impl NodeGraphMessageHandler {
 							!context.network_interface.is_layer(node_id, context.selection_network_path)
 						}
 					})
+					.map(|(_, node_id)| node_id)
 					.collect::<Vec<_>>()
-					.iter()
-					.map(|(_, node_id)| node_properties::generate_node_properties(*node_id, context))
+					.into_iter()
+					.map(|node_id| node_properties::generate_node_properties(node_id, context))
 					.collect::<Vec<_>>();
 
 				layer_properties.extend(node_properties);
@@ -2215,6 +2216,7 @@ impl NodeGraphMessageHandler {
 					resolved_type: Some(format!("{:?} from {:?}", &input.ty, input.type_source)),
 					valid_types: input.valid_types.iter().map(|ty| ty.to_string()).collect(),
 					name: input.name.unwrap_or_else(|| input.ty.nested_type().to_string()),
+					description: input.description.unwrap_or_default(),
 					connected_to: input.output_connector,
 				})
 			});
@@ -2234,6 +2236,7 @@ impl NodeGraphMessageHandler {
 				Some(FrontendGraphOutput {
 					data_type: frontend_data_type,
 					name: "Output 1".to_string(),
+					description: String::new(),
 					resolved_type: primary_output_type.map(|(input, type_source)| format!("{input:?} from {type_source:?}")),
 					connected_to,
 				})
@@ -2267,6 +2270,7 @@ impl NodeGraphMessageHandler {
 				exposed_outputs.push(FrontendGraphOutput {
 					data_type: frontend_data_type,
 					name: output_name,
+					description: String::new(),
 					resolved_type: exposed_output.clone().map(|(input, type_source)| format!("{input:?} from {type_source:?}")),
 					connected_to,
 				});
@@ -2306,7 +2310,7 @@ impl NodeGraphMessageHandler {
 					.is_some_and(|node_metadata| node_metadata.persistent_metadata.is_layer()),
 				can_be_layer: can_be_layer_lookup.contains(&node_id),
 				reference: network_interface.reference(&node_id, breadcrumb_network_path).cloned().unwrap_or_default(),
-				display_name: network_interface.frontend_display_name(&node_id, breadcrumb_network_path),
+				display_name: network_interface.display_name(&node_id, breadcrumb_network_path),
 				primary_input,
 				exposed_inputs,
 				primary_output,
@@ -2332,7 +2336,7 @@ impl NodeGraphMessageHandler {
 			if let Some(network) = node.implementation.get_network() {
 				current_network = network;
 			};
-			subgraph_names.push(network_interface.frontend_display_name(node_id, &current_network_path));
+			subgraph_names.push(network_interface.display_name(node_id, &current_network_path));
 			current_network_path.push(*node_id)
 		}
 		Some(subgraph_names)
@@ -2395,7 +2399,7 @@ impl NodeGraphMessageHandler {
 
 				let data = LayerPanelEntry {
 					id: node_id,
-					alias: network_interface.frontend_display_name(&node_id, &[]),
+					alias: network_interface.display_name(&node_id, &[]),
 					tooltip: if cfg!(debug_assertions) { format!("Layer ID: {node_id}") } else { "".into() },
 					in_selected_network: selection_network_path.is_empty(),
 					children_allowed,
@@ -2522,6 +2526,7 @@ impl NodeGraphMessageHandler {
 #[derive(Default)]
 struct InputLookup {
 	name: Option<String>,
+	description: Option<String>,
 	ty: Type,
 	type_source: TypeSource,
 	valid_types: Vec<Type>,
@@ -2552,11 +2557,16 @@ fn frontend_inputs_lookup(breadcrumb_network_path: &[NodeId], network_interface:
 				.input_name(&node_id, index, breadcrumb_network_path)
 				.filter(|s| !s.is_empty())
 				.map(|name| name.to_string());
+			let description = network_interface
+				.input_description(&node_id, index, breadcrumb_network_path)
+				.filter(|s| !s.is_empty())
+				.map(|description| description.to_string());
 			// Get the output connector that feeds into this input (done here as well for simplicity)
 			let connector = OutputConnector::from_input(input);
 
 			inputs.push(Some(InputLookup {
 				name,
+				description,
 				output_connector: connector,
 				..Default::default()
 			}));

--- a/editor/src/messages/portfolio/document/node_graph/utility_types.rs
+++ b/editor/src/messages/portfolio/document/node_graph/utility_types.rs
@@ -48,6 +48,7 @@ pub struct FrontendGraphInput {
 	#[serde(rename = "dataType")]
 	pub data_type: FrontendGraphDataType,
 	pub name: String,
+	pub description: String,
 	#[serde(rename = "resolvedType")]
 	pub resolved_type: Option<String>,
 	#[serde(rename = "validTypes")]
@@ -61,6 +62,7 @@ pub struct FrontendGraphOutput {
 	#[serde(rename = "dataType")]
 	pub data_type: FrontendGraphDataType,
 	pub name: String,
+	pub description: String,
 	#[serde(rename = "resolvedType")]
 	pub resolved_type: Option<String>,
 	#[serde(rename = "connectedTo")]

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -818,6 +818,7 @@ impl NodeNetworkInterface {
 							FrontendGraphOutput {
 								data_type,
 								name: import_name,
+								description: String::new(),
 								resolved_type: Some(format!("{input_type:?} from {type_source:?}")),
 								connected_to,
 							},
@@ -902,6 +903,7 @@ impl NodeNetworkInterface {
 						FrontendGraphInput {
 							data_type: frontend_data_type,
 							name: export_name,
+							description: String::new(),
 							resolved_type: input_type.map(|(export_type, source)| format!("{export_type:?} from {source:?}")),
 							valid_types: self.valid_input_types(&InputConnector::Export(*export_index), network_path).iter().map(|ty| ty.to_string()).collect(),
 							connected_to,
@@ -1132,6 +1134,14 @@ impl NodeNetworkInterface {
 		value.as_str()
 	}
 
+	pub fn input_description(&self, node_id: &NodeId, index: usize, network_path: &[NodeId]) -> Option<&str> {
+		let Some(value) = self.input_metadata(node_id, index, "input_description", network_path) else {
+			log::error!("Could not get input_description for node {node_id} index {index}");
+			return None;
+		};
+		value.as_str()
+	}
+
 	pub fn input_properties_row(&self, node_id: &NodeId, index: usize, network_path: &[NodeId]) -> Option<&PropertiesRow> {
 		self.node_metadata(node_id, network_path)
 			.and_then(|node_metadata| node_metadata.persistent_metadata.input_properties.get(index))
@@ -1145,16 +1155,7 @@ impl NodeNetworkInterface {
 		input_row.input_data.get(field)
 	}
 
-	// Use frontend display name instead
-	fn display_name(&self, node_id: &NodeId, network_path: &[NodeId]) -> String {
-		let Some(node_metadata) = self.node_metadata(node_id, network_path) else {
-			log::error!("Could not get node_metadata in display_name");
-			return "".to_string();
-		};
-		node_metadata.persistent_metadata.display_name.clone()
-	}
-
-	pub fn frontend_display_name(&self, node_id: &NodeId, network_path: &[NodeId]) -> String {
+	pub fn display_name(&self, node_id: &NodeId, network_path: &[NodeId]) -> String {
 		let is_layer = self
 			.node_metadata(node_id, network_path)
 			.expect("Could not get persistent node metadata in untitled_layer_label")
@@ -1165,15 +1166,28 @@ impl NodeNetworkInterface {
 			return "".to_string();
 		};
 
-		if self.display_name(node_id, network_path).is_empty() {
+		let display_name = if let Some(node_metadata) = self.node_metadata(node_id, network_path) {
+			node_metadata.persistent_metadata.display_name.clone()
+		} else {
+			log::error!("Could not get node_metadata in display_name");
+			String::new()
+		};
+
+		if display_name.is_empty() {
 			if is_layer && *reference == Some("Merge".to_string()) {
 				"Untitled Layer".to_string()
 			} else {
 				reference.clone().unwrap_or("Untitled Node".to_string())
 			}
 		} else {
-			self.display_name(node_id, network_path)
+			display_name
 		}
+	}
+
+	pub fn description(&self, node_id: &NodeId, network_path: &[NodeId]) -> String {
+		self.get_node_definition(network_path, *node_id)
+			.and_then(|node_definition| Some(node_definition.description.to_string()))
+			.unwrap_or_default()
 	}
 
 	pub fn is_locked(&self, node_id: &NodeId, network_path: &[NodeId]) -> bool {
@@ -1472,7 +1486,7 @@ impl NodeNetworkInterface {
 			_ => {}
 		};
 
-		let name = self.frontend_display_name(node_id, network_path);
+		let name = self.display_name(node_id, network_path);
 
 		div.set_text_content(Some(&name));
 
@@ -3415,9 +3429,9 @@ impl NodeNetworkInterface {
 			return;
 		};
 		if insert_index == -1 {
-			node_metadata.persistent_metadata.input_properties.push(input_name.into());
+			node_metadata.persistent_metadata.input_properties.push((input_name, "TODO").into());
 		} else {
-			node_metadata.persistent_metadata.input_properties.insert(insert_index as usize, input_name.into());
+			node_metadata.persistent_metadata.input_properties.insert(insert_index as usize, (input_name, "TODO").into());
 		}
 
 		// Clear the reference to the nodes definition
@@ -6159,7 +6173,7 @@ pub enum WidgetOverride {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PropertiesRow {
 	/// A general datastore than can store key value pairs of any types for any input
-	// TODO: This could be simplified to just Value, and key value pairs could be stored as the Object variant
+	// TODO: This could be simplified to just Value, and key value pairs could be stored as the Value::Object variant
 	pub input_data: HashMap<String, Value>,
 	// An input can override a widget, which would otherwise be automatically generated from the type
 	// The string is the identifier to the widget override function stored in INPUT_OVERRIDES
@@ -6168,20 +6182,21 @@ pub struct PropertiesRow {
 
 impl Default for PropertiesRow {
 	fn default() -> Self {
-		"".into()
+		("", "TODO").into()
 	}
 }
 
-impl From<&str> for PropertiesRow {
-	fn from(input_name: &str) -> Self {
-		PropertiesRow::with_override(input_name, WidgetOverride::None)
+impl From<(&str, &str)> for PropertiesRow {
+	fn from(input_name_and_description: (&str, &str)) -> Self {
+		PropertiesRow::with_override(input_name_and_description.0, input_name_and_description.1, WidgetOverride::None)
 	}
 }
 
 impl PropertiesRow {
-	pub fn with_override(input_name: &str, widget_override: WidgetOverride) -> Self {
+	pub fn with_override(input_name: &str, input_description: &str, widget_override: WidgetOverride) -> Self {
 		let mut input_data = HashMap::new();
 		input_data.insert("input_name".to_string(), Value::String(input_name.to_string()));
+		input_data.insert("input_description".to_string(), Value::String(input_description.to_string()));
 		match widget_override {
 			WidgetOverride::None => PropertiesRow { input_data, widget_override: None },
 			WidgetOverride::Hidden => PropertiesRow {
@@ -6351,7 +6366,7 @@ impl From<DocumentNodePersistentMetadataInputNames> for DocumentNodePersistentMe
 			.as_ref()
 			.and_then(|reference| resolve_document_node_type(reference))
 			.map(|definition| definition.node_template.persistent_node_metadata.input_properties.clone())
-			.unwrap_or(old.input_names.into_iter().map(|name| name.as_str().into()).collect());
+			.unwrap_or(old.input_names.into_iter().map(|name| (name.as_str(), "TODO").into()).collect());
 
 		DocumentNodePersistentMetadata {
 			reference: old.reference,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -830,7 +830,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 
 					// Upgrade artboard name being passed as hidden value input to "To Artboard"
 					if reference == "Artboard" && upgrade_from_before_returning_nested_click_targets {
-						let label = document.network_interface.frontend_display_name(node_id, network_path);
+						let label = document.network_interface.display_name(node_id, network_path);
 						document
 							.network_interface
 							.set_input(&InputConnector::node(NodeId(0), 1), NodeInput::value(TaggedValue::String(label), false), &[*node_id]);

--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -1069,7 +1069,7 @@
 					<div class="secondary" class:in-selected-network={$nodeGraph.inSelectedNetwork}>
 						{#each exposedInputsOutputs as [input, output]}
 							<div class={`secondary-row expanded ${input !== undefined ? "input" : "output"}`}>
-								<TextLabel tooltip={input !== undefined ? input.name : output.name}>
+								<TextLabel tooltip={(input !== undefined ? `${input.name}\n\n${input.description}` : `${output.name}\n\n${output.description}`).trim()}>
 									{input !== undefined ? input.name : output.name}
 								</TextLabel>
 							</div>

--- a/frontend/src/components/widgets/WidgetSection.svelte
+++ b/frontend/src/components/widgets/WidgetSection.svelte
@@ -26,7 +26,7 @@
 <LayoutCol class={`widget-section ${className}`.trim()} {classes}>
 	<button class="header" class:expanded on:click|stopPropagation={() => (expanded = !expanded)} tabindex="0">
 		<div class="expand-arrow" />
-		<TextLabel bold={true}>{widgetData.name}</TextLabel>
+		<TextLabel tooltip={widgetData.description} bold={true}>{widgetData.name}</TextLabel>
 		<IconButton
 			icon={widgetData.pinned ? "PinActive" : "PinInactive"}
 			tooltip={widgetData.pinned ? "Unpin this node so it's no longer shown here when nothing is selected" : "Pin this node so it's shown here when nothing is selected"}

--- a/frontend/src/messages.ts
+++ b/frontend/src/messages.ts
@@ -110,12 +110,9 @@ export class UpdateNodeGraphTransform extends JsMessage {
 	readonly transform!: NodeGraphTransform;
 }
 
-const InputTypeDescriptions = Transform(({ obj }) => new Map(obj.inputTypeDescriptions));
 const NodeDescriptions = Transform(({ obj }) => new Map(obj.nodeDescriptions));
 
 export class SendUIMetadata extends JsMessage {
-	@InputTypeDescriptions
-	readonly inputTypeDescriptions!: Map<string, string>;
 	@NodeDescriptions
 	readonly nodeDescriptions!: Map<string, string>;
 	@Type(() => FrontendNode)
@@ -220,6 +217,8 @@ export class FrontendGraphInput {
 
 	readonly name!: string;
 
+	readonly description!: string;
+
 	readonly resolvedType!: string | undefined;
 
 	readonly validTypes!: string[];
@@ -250,6 +249,8 @@ export class FrontendGraphOutput {
 	readonly dataType!: FrontendGraphDataType;
 
 	readonly name!: string;
+
+	readonly description!: string;
 
 	readonly resolvedType!: string | undefined;
 
@@ -1508,7 +1509,7 @@ export function isWidgetTable(layoutTable: LayoutGroup): layoutTable is WidgetTa
 	return Boolean((layoutTable as WidgetTable)?.tableWidgets);
 }
 
-export type WidgetSection = { name: string; visible: boolean; pinned: boolean; id: bigint; layout: LayoutGroup[] };
+export type WidgetSection = { name: string; description: string; visible: boolean; pinned: boolean; id: bigint; layout: LayoutGroup[] };
 export function isWidgetSection(layoutRow: LayoutGroup): layoutRow is WidgetSection {
 	return Boolean((layoutRow as WidgetSection)?.layout);
 }
@@ -1550,6 +1551,7 @@ function createLayoutGroup(layoutGroup: any): LayoutGroup {
 	if (layoutGroup.section) {
 		const result: WidgetSection = {
 			name: layoutGroup.section.name,
+			description: layoutGroup.section.description,
 			visible: layoutGroup.section.visible,
 			pinned: layoutGroup.section.pinned,
 			id: layoutGroup.section.id,

--- a/frontend/src/state-providers/node-graph.ts
+++ b/frontend/src/state-providers/node-graph.ts
@@ -43,7 +43,6 @@ export function createNodeGraphState(editor: Editor) {
 		wires: [] as FrontendNodeWire[],
 		wiresDirectNotGridAligned: false,
 		wirePathInProgress: undefined as WirePath | undefined,
-		inputTypeDescriptions: new Map<string, string>(),
 		nodeDescriptions: new Map<string, string>(),
 		nodeTypes: [] as FrontendNodeType[],
 		thumbnails: new Map<bigint, string>(),
@@ -55,11 +54,10 @@ export function createNodeGraphState(editor: Editor) {
 	});
 
 	// Set up message subscriptions on creation
-	editor.subscriptions.subscribeJsMessage(SendUIMetadata, (UIMetadata) => {
+	editor.subscriptions.subscribeJsMessage(SendUIMetadata, (uiMetadata) => {
 		update((state) => {
-			state.inputTypeDescriptions = UIMetadata.inputTypeDescriptions;
-			state.nodeDescriptions = UIMetadata.nodeDescriptions;
-			state.nodeTypes = UIMetadata.nodeTypes;
+			state.nodeDescriptions = uiMetadata.nodeDescriptions;
+			state.nodeTypes = uiMetadata.nodeTypes;
 			return state;
 		});
 	});


### PR DESCRIPTION
This adds the following...

Node descriptions in the Properties panel:

![capture](https://github.com/user-attachments/assets/c6ba8c7e-a539-4d35-8464-24e09d1d7ea5)

Parameter descriptions in the Properties panel:

![capture](https://github.com/user-attachments/assets/9d153792-26ef-4846-8a26-3db54112cf8f)

Secondary input descriptions in the node graph:

![capture](https://github.com/user-attachments/assets/56803e43-097b-4c66-8169-4b6ae9b55f9a)