### PR TITLE
File > Import should allow the user to place the image(s) in the viewport

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -102,7 +102,10 @@ pub enum PortfolioMessage {
 		mouse: Option<(f64, f64)>,
 		parent_and_insert_index: Option<(LayerNodeIdentifier, usize)>,
 	},
-	PreviewImage,
+	PreviewImage {
+		name: Option<String>,
+		svg: String,
+	},
 	PrevDocument,
 	SetActivePanel {
 		panel: PanelType,

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -1081,8 +1081,11 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 					responses.add(FrontendMessage::TriggerDelayedZoomCanvasToFitAll);
 				}
 			}
-			PortfolioMessage::PreviewImage => {
+			PortfolioMessage::PreviewImage { name, svg } => {
 				debug!("PortfolioMessage Preview Image")
+				//TODO: draw a preview image following cursor
+
+				//TODO: get a preview
 			}
 			PortfolioMessage::PrevDocument => {
 				if let Some(active_document_id) = self.active_document_id {

--- a/frontend/src/components/floating-menus/ImportImagePreview.svelte
+++ b/frontend/src/components/floating-menus/ImportImagePreview.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import FloatingMenu from "@graphite/components/layout/FloatingMenu.svelte";
+	export let pastedImage: ImageData | undefined = undefined;
+	export let x: number;
+	export let y: number;
+
+	//define fucntions here
+</script>
+
+<FloatingMenu open={true} class="import-image-paste-preview" type="Cursor" styles={{ left: x + "px", top: y + "px" }}>
+	<!-- <div class="image-preview">
+		<img classn/>
+	</div> -->
+	<img src="" />
+</FloatingMenu>
+
+<style lang="scss" global></style>

--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -22,6 +22,7 @@
 	import { updateBoundsOfViewports } from "@graphite/utility-functions/viewports";
 
 	import EyedropperPreview, { ZOOM_WINDOW_DIMENSIONS } from "@graphite/components/floating-menus/EyedropperPreview.svelte";
+	import ImportImagePreview from "@graphite/components/floating-menus/ImportImagePreview.svelte";
 	import LayoutCol from "@graphite/components/layout/LayoutCol.svelte";
 	import LayoutRow from "@graphite/components/layout/LayoutRow.svelte";
 	import Graph from "@graphite/components/views/Graph.svelte";

--- a/frontend/src/state-providers/portfolio.ts
+++ b/frontend/src/state-providers/portfolio.ts
@@ -72,8 +72,8 @@ export function createPortfolioState(editor: Editor) {
 
 		if (data.type.includes("svg")) {
 			const svg = new TextDecoder().decode(data.content.data);
-			editor.handle.pasteSvg(data.filename, svg);//calls to the backend for a immediate image paste 
-			editor.handle.previewImage();
+			//editor.handle.pasteSvg(data.filename, svg); //calls to the backend for a immediate image paste
+			editor.handle.previewImage(data.filename, svg);
 			return;
 		}
 
@@ -84,9 +84,8 @@ export function createPortfolioState(editor: Editor) {
 		}
 
 		const imageData = await extractPixelData(new Blob([data.content.data], { type: data.type }));
-		console.debug("editor paste Image ")
+		console.debug("editor paste Image ");
 		editor.handle.pasteImage(data.filename, new Uint8Array(imageData.data), imageData.width, imageData.height);
-
 	});
 	editor.subscriptions.subscribeJsMessage(TriggerDownloadTextFile, (triggerFileDownload) => {
 		downloadFileText(triggerFileDownload.name, triggerFileDownload.document);

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -660,8 +660,8 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 	#[wasm_bindgen(js_name=previewImage)]
-	pub fn preview_image(&self) {
-		let message = PortfolioMessage::PreviewImage {};
+	pub fn preview_image(&self, name: Option<String>, svg: String) {
+		let message = PortfolioMessage::PreviewImage { name, svg };
 		debug!("editor api,preview image,dispatch message to PortfolioMessage PreviewMessage");
 		self.dispatch(message);
 	}


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #2621

I am trying to implement features mentioned in #2621 

## Progress
- Create new message PreviewImage and its handler in portfolio messages. Updated wasm bindings


## TODO: 
- [ ] Display Image under cursor when preview image
- [ ] Paste the Image when user selects where to paste it 
