### PR TITLE
Improve Path tool behavior when double-clicking anchor points 

### DIFF
--- a/editor/src/consts.rs
+++ b/editor/src/consts.rs
@@ -136,3 +136,6 @@ pub const DEFAULT_DOCUMENT_NAME: &str = "Untitled Document";
 pub const FILE_SAVE_SUFFIX: &str = ".graphite";
 pub const MAX_UNDO_HISTORY_LEN: usize = 100; // TODO: Add this to user preferences
 pub const AUTO_SAVE_TIMEOUT_SECONDS: u64 = 15;
+
+// INPUT
+pub const DOUBLE_CLICK_MILLISECONDS: u64 = 500;


### PR DESCRIPTION
Part of #1870 

Added feature:

> When double-clicking an anchor:
> 
> - Currently this swaps between smooth and sharp, but doesn't work if multiple handles are multi-selected to convert them all to smooth or sharp. If they're of mixed type, the specific one that's double clicked on should be the decider for the rest of them as to which they should all be swapped to.

