### PR TITLE
Instance tables refactor part 8: Output the type of the input data with the Mirror node as well

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -334,6 +334,15 @@ pub fn reference_point_widget(parameter_widgets_info: ParameterWidgetsInfo, disa
 	if let Some(&TaggedValue::ReferencePoint(reference_point)) = input.as_non_exposed_value() {
 		widgets.extend_from_slice(&[
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
+			CheckboxInput::new(reference_point != ReferencePoint::None)
+				.on_update(update_value(
+					move |x: &CheckboxInput| TaggedValue::ReferencePoint(if x.checked { ReferencePoint::Center } else { ReferencePoint::None }),
+					node_id,
+					index,
+				))
+				.disabled(disabled)
+				.widget_holder(),
+			Separator::new(SeparatorType::Related).widget_holder(),
 			ReferencePointInput::new(reference_point)
 				.on_update(update_value(move |x: &ReferencePointInput| TaggedValue::ReferencePoint(x.value), node_id, index))
 				.disabled(disabled)

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -366,11 +366,11 @@ async fn mirror<I: 'n + Send + Clone>(
 	offset: f64,
 	#[range((-90., 90.))] angle: Angle,
 	#[default(true)] keep_original: bool,
-) -> GraphicGroupTable
+) -> Instances<I>
 where
 	Instances<I>: GraphicElementRendered,
 {
-	let mut result_table = GraphicGroupTable::default();
+	let mut result_table = Instances::default();
 
 	// Normalize the direction vector
 	let normal = DVec2::from_angle(angle.to_radians());
@@ -401,21 +401,16 @@ where
 
 	// Add original instance depending on the keep_original flag
 	if keep_original {
-		result_table.push(Instance {
-			instance: instance.to_graphic_element().clone(),
-			transform: DAffine2::IDENTITY,
-			alpha_blending: Default::default(),
-			source_node_id: None,
-		});
+		for instance in instance.clone().instance_iter() {
+			result_table.push(instance);
+		}
 	}
 
 	// Create and add mirrored instance
-	result_table.push(Instance {
-		instance: instance.to_graphic_element(),
-		transform,
-		alpha_blending: Default::default(),
-		source_node_id: None,
-	});
+	for mut instance in instance.instance_iter() {
+		instance.transform = transform * instance.transform;
+		result_table.push(instance);
+	}
 
 	result_table
 }


### PR DESCRIPTION
Partly closes #1834.

The mirror node now outputs `Instances<VectorData>` when input `Instances<VectorData>`. Previously it output `Instances<GraphicElement>`

The advantage being of course that the colour is slightly different:
![greenish](https://github.com/user-attachments/assets/383d5a49-af5a-418f-8127-6562a5d2dbb2)
![bluish](https://github.com/user-attachments/assets/004f73b1-15a6-4ddd-80a1-e0e5ed5293d2)
