### PR TITLE
Temporary pen/freehand/spline tool fix

### DIFF
--- a/node-graph/gcore/src/vector/vector_data/modification.rs
+++ b/node-graph/gcore/src/vector/vector_data/modification.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::Ctx;
+use crate::instances::Instance;
 use crate::uuid::generate_uuid;
 use bezier_rs::BezierHandles;
 use core::hash::BuildHasher;
@@ -424,8 +425,13 @@ impl core::hash::Hash for VectorModification {
 /// A node that applies a procedural modification to some [`VectorData`].
 #[node_macro::node(category(""))]
 async fn path_modify(_ctx: impl Ctx, mut vector_data: VectorDataTable, modification: Box<VectorModification>) -> VectorDataTable {
-	for vector_data_instance in vector_data.instance_mut_iter() {
-		modification.apply(vector_data_instance.instance);
+	if vector_data.is_empty() {
+		vector_data.push(Instance::default());
+	}
+	let vector_data_instance = vector_data.get_mut(0).expect("push should give one item");
+	modification.apply(vector_data_instance.instance);
+	if vector_data.len() > 1 {
+		warn!("The path modify ran on {} instances of vector data. Only the first can be modified.", vector_data.len());
 	}
 	vector_data
 }


### PR DESCRIPTION
Previously the pen/freehand/spline tools were broken because the path tool did nothing when it received an empty input. This is now fixed.