### PR TITLE
Fix grid overlay values getting wiped when switching between isometric/rectangular and back

### DIFF
--- a/editor/src/messages/portfolio/document/overlays/grid_overlays.rs
+++ b/editor/src/messages/portfolio/document/overlays/grid_overlays.rs
@@ -236,12 +236,24 @@ pub fn overlay_options(grid: &GridSnapping) -> Vec<LayoutGroup> {
 			TextLabel::new("Type").table_align(true).widget_holder(),
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
 			RadioInput::new(vec![
-				RadioEntryData::new("rectangular")
-					.label("Rectangular")
-					.on_update(update_val(grid, |grid, _| grid.grid_type = GridType::RECTANGULAR)),
-				RadioEntryData::new("isometric")
-					.label("Isometric")
-					.on_update(update_val(grid, |grid, _| grid.grid_type = GridType::ISOMETRIC)),
+				RadioEntryData::new("rectangular").label("Rectangular").on_update(update_val(grid, |grid, _| {
+					if let GridType::Isometric { y_axis_spacing, angle_a, angle_b } = grid.grid_type {
+						grid.isometric_y_spacing = y_axis_spacing;
+						grid.isometric_angle_a = angle_a;
+						grid.isometric_angle_b = angle_b;
+					}
+					grid.grid_type = GridType::Rectangular { spacing: grid.rectangular_spacing };
+				})),
+				RadioEntryData::new("isometric").label("Isometric").on_update(update_val(grid, |grid, _| {
+					if let GridType::Rectangular { spacing } = grid.grid_type {
+						grid.rectangular_spacing = spacing;
+					}
+					grid.grid_type = GridType::Isometric {
+						y_axis_spacing: grid.isometric_y_spacing,
+						angle_a: grid.isometric_angle_a,
+						angle_b: grid.isometric_angle_b,
+					};
+				})),
 			])
 			.min_width(200)
 			.selected_index(Some(match grid.grid_type {

--- a/editor/src/messages/portfolio/document/utility_types/misc.rs
+++ b/editor/src/messages/portfolio/document/utility_types/misc.rs
@@ -226,9 +226,9 @@ impl Default for GridSnapping {
 			origin: DVec2::ZERO,
 			grid_type: Default::default(),
 			rectangular_spacing: DVec2::ONE,
-			isometric_y_spacing: 1.0,
-			isometric_angle_a: 30.0,
-			isometric_angle_b: 30.0,
+			isometric_y_spacing: 1.,
+			isometric_angle_a: 30.,
+			isometric_angle_b: 30.,
 			grid_color: Color::from_rgb_str(COLOR_OVERLAY_GRAY.strip_prefix('#').unwrap()).unwrap(),
 			dot_display: false,
 		}

--- a/editor/src/messages/portfolio/document/utility_types/misc.rs
+++ b/editor/src/messages/portfolio/document/utility_types/misc.rs
@@ -176,17 +176,11 @@ pub enum GridType {
 
 impl Default for GridType {
 	fn default() -> Self {
-		Self::RECTANGULAR
+		Self::Rectangular { spacing: DVec2::ONE }
 	}
 }
 
 impl GridType {
-	pub const RECTANGULAR: Self = GridType::Rectangular { spacing: DVec2::ONE };
-	pub const ISOMETRIC: Self = GridType::Isometric {
-		y_axis_spacing: 1.,
-		angle_a: 30.,
-		angle_b: 30.,
-	};
 	pub fn rectangular_spacing(&mut self) -> Option<&mut DVec2> {
 		match self {
 			Self::Rectangular { spacing } => Some(spacing),
@@ -218,6 +212,10 @@ impl GridType {
 pub struct GridSnapping {
 	pub origin: DVec2,
 	pub grid_type: GridType,
+	pub rectangular_spacing: DVec2,
+	pub isometric_y_spacing: f64,
+	pub isometric_angle_a: f64,
+	pub isometric_angle_b: f64,
 	pub grid_color: Color,
 	pub dot_display: bool,
 }
@@ -227,6 +225,10 @@ impl Default for GridSnapping {
 		Self {
 			origin: DVec2::ZERO,
 			grid_type: Default::default(),
+			rectangular_spacing: DVec2::ONE,
+			isometric_y_spacing: 1.0,
+			isometric_angle_a: 30.0,
+			isometric_angle_b: 30.0,
 			grid_color: Color::from_rgb_str(COLOR_OVERLAY_GRAY.strip_prefix('#').unwrap()).unwrap(),
 			dot_display: false,
 		}


### PR DESCRIPTION
Fixes https://discord.com/channels/731730685944922173/881073965047636018/1360813352376598598