### PR TITLE
Improve node creation menu and categorization

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -1211,16 +1211,16 @@ pub(crate) fn grid_properties(node_id: NodeId, context: &mut NodePropertiesConte
 		}
 	}
 
-	let rows = number_widget(
-		ParameterWidgetsInfo::from_index(document_node, node_id, RowsInput::INDEX, true, context),
-		NumberInput::default().min(1.),
-	);
 	let columns = number_widget(
 		ParameterWidgetsInfo::from_index(document_node, node_id, ColumnsInput::INDEX, true, context),
 		NumberInput::default().min(1.),
 	);
+	let rows = number_widget(
+		ParameterWidgetsInfo::from_index(document_node, node_id, RowsInput::INDEX, true, context),
+		NumberInput::default().min(1.),
+	);
 
-	widgets.extend([LayoutGroup::Row { widgets: rows }, LayoutGroup::Row { widgets: columns }]);
+	widgets.extend([LayoutGroup::Row { widgets: columns }, LayoutGroup::Row { widgets: rows }]);
 
 	widgets
 }

--- a/frontend/src/components/floating-menus/NodeCatalog.svelte
+++ b/frontend/src/components/floating-menus/NodeCatalog.svelte
@@ -164,6 +164,7 @@
 					.text-label {
 						padding-left: 16px;
 						position: relative;
+						pointer-events: none;
 
 						&::before {
 							content: "";

--- a/node-graph/gcore/src/logic.rs
+++ b/node-graph/gcore/src/logic.rs
@@ -37,7 +37,7 @@ fn string_length(_: impl Ctx, #[implementations(String)] string: String) -> usiz
 	string.len()
 }
 
-#[node_macro::node(category("Text"))]
+#[node_macro::node(category("Math: Logic"))]
 async fn switch<T, C: Send + 'n + Clone>(
 	#[implementations(Context)] ctx: C,
 	condition: bool,

--- a/node-graph/gcore/src/vector/generator_nodes.rs
+++ b/node-graph/gcore/src/vector/generator_nodes.rs
@@ -158,8 +158,8 @@ fn grid<T: GridSpacing>(
 	#[implementations(f64, DVec2)]
 	spacing: T,
 	#[default(30., 30.)] angles: DVec2,
-	#[default(10)] rows: u32,
 	#[default(10)] columns: u32,
+	#[default(10)] rows: u32,
 ) -> VectorDataTable {
 	let (x_spacing, y_spacing) = spacing.as_dvec2().into();
 	let (angle_a, angle_b) = angles.into();

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -210,7 +210,7 @@ where
 	vector_data
 }
 
-#[node_macro::node(category("Vector"), path(graphene_core::vector))]
+#[node_macro::node(category("Instancing"), path(graphene_core::vector))]
 async fn repeat<I: 'n + Send + Clone>(
 	_: impl Ctx,
 	// TODO: Implement other GraphicElementRendered types.
@@ -249,7 +249,7 @@ where
 	result_table
 }
 
-#[node_macro::node(category("Vector"), path(graphene_core::vector))]
+#[node_macro::node(category("Instancing"), path(graphene_core::vector))]
 async fn circular_repeat<I: 'n + Send + Clone>(
 	_: impl Ctx,
 	// TODO: Implement other GraphicElementRendered types.
@@ -284,7 +284,7 @@ where
 	result_table
 }
 
-#[node_macro::node(name("Copy to Points"), category("Vector"), path(graphene_core::vector))]
+#[node_macro::node(name("Copy to Points"), category("Instancing"), path(graphene_core::vector))]
 async fn copy_to_points<I: 'n + Send + Clone>(
 	_: impl Ctx,
 	points: VectorDataTable,


### PR DESCRIPTION
- Fix the clickability area of categories in the node editor context menu #2718
- Node editor context menu nodes category swaps:
  1. Circular Repeat: Vector → Instancing
  2. Copy to Points: Vector → Instancing
  3. Repeat: Vector → Instancing
  4. Switch: Text → Math: Logic
- ~~Organize code for certain nodes across files to reflect their new categories~~

Closes #2718
Resolves https://discordapp.com/channels/731730685944922173/881073965047636018/1383884104566706217 and https://discordapp.com/channels/731730685944922173/881073965047636018/1384323535316713542
