### PR TITLE
Add `devEngines` parameter to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,5 +67,17 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/GraphiteEditor/Graphite.git"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": ">=20",
+			"onFail": "error"
+		},
+		"packageManager": {
+			"name": "npm",
+			"version": ">11",
+			"onFail": "error"
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,17 @@
 		"---------- UTILITIES ----------": "",
 		"lint": "cd frontend && npm run lint",
 		"lint-fix": "cd frontend && npm run lint-fix"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": ">=20",
+			"onFail": "error"
+		},
+		"packageManager": {
+			"name": "npm",
+			"version": ">11",
+			"onFail": "error"
+		}
 	}
 }


### PR DESCRIPTION
## Description
The `devEngines` field is now supported by npm and corepack.

The goal is to streamline dev and CI/CD in accordance to https://github.com/openjs-foundation/package-metadata-interoperability-collab-space/pull/27

<hr />

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

### Open to discussion
Maybe, once the below mentioned issues and PRs are resolved the project can migrate away from `.nvmrc` 

Version Manager & CI/CD `devEngines` acceptance tracking:
1. NVM - https://github.com/nvm-sh/nvm/issues/3595
2. FNM - https://github.com/Schniz/fnm/pull/1433/
3. Volta - https://github.com/volta-cli/volta/issues/2050
4. Github Action Node - https://github.com/actions/setup-node/pull/1283 


