### PR TITLE
Remove the `serde` feature and instead just always require it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,6 @@ dependencies = [
  "rand 0.9.0",
  "rand_chacha 0.9.0",
  "reqwest",
- "serde",
  "tokio",
  "usvg",
  "vello",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ bezier-rs = { path = "libraries/bezier-rs", features = ["dyn-any", "serde"] }
 dyn-any = { path = "libraries/dyn-any", features = ["derive", "glam", "reqwest", "log-bad-types", "rc"] }
 math-parser = { path = "libraries/math-parser" }
 path-bool = { path = "libraries/path-bool" }
-graphene-core = { path = "node-graph/gcore", default-features = false }
-graph-craft = { path = "node-graph/graph-craft", features = ["serde"] }
+graphene-core = { path = "node-graph/gcore" }
+graph-craft = { path = "node-graph/graph-craft" }
 graphene-std = { path = "node-graph/gstd" }
 interpreted-executor = { path = "node-graph/interpreted-executor" }
 node-macro = { path = "node-graph/node-macro" }
@@ -130,7 +130,7 @@ kurbo = { version = "0.11.0", features = ["serde"] }
 petgraph = { version = "0.7.1", default-features = false, features = [
 	"graphmap",
 ] }
-half = { version = "2.4.1", default-features = false, features = ["bytemuck"] }
+half = { version = "2.4.1", default-features = false, features = ["bytemuck", "serde"] }
 tinyvec = { version = "1" }
 criterion = { version = "0.5", features = ["html_reports"] }
 iai-callgrind = { version = "0.12.3" }

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -27,10 +27,8 @@ ron = ["dep:ron"]
 # Local dependencies
 graphite-proc-macros = { workspace = true }
 graph-craft = { workspace = true }
-interpreted-executor = { workspace = true, features = [
-	"serde",
-] }
-graphene-std = { workspace = true, features = ["serde"] }
+interpreted-executor = { workspace = true }
+graphene-std = { workspace = true }
 
 # Workspace dependencies
 js-sys = { workspace = true }

--- a/node-graph/gcore/Cargo.toml
+++ b/node-graph/gcore/Cargo.toml
@@ -14,14 +14,6 @@ wasm = ["web-sys"]
 wgpu = ["dep:wgpu"]
 vello = ["dep:vello", "bezier-rs/kurbo", "wgpu"]
 dealloc_nodes = []
-serde = [
-	"dep:serde",
-	"glam/serde",
-	"bezier-rs/serde",
-	"bezier-rs/serde",
-	"half/serde",
-	"base64",
-]
 
 [dependencies]
 # Local dependencies
@@ -49,10 +41,10 @@ half = { workspace = true }
 tinyvec = { workspace = true }
 kurbo = { workspace = true }
 log = { workspace = true }
+base64 = { workspace = true }
 
 # Optional workspace dependencies
 serde = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true }

--- a/node-graph/gcore/src/animation.rs
+++ b/node-graph/gcore/src/animation.rs
@@ -2,8 +2,7 @@ use crate::{Ctx, ExtractAnimationTime, ExtractTime};
 
 const DAY: f64 = 1000. * 3600. * 24.;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, dyn_any::DynAny, Default, Hash, node_macro::ChoiceType)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, dyn_any::DynAny, Default, Hash, node_macro::ChoiceType, serde::Serialize, serde::Deserialize)]
 pub enum RealTimeMode {
 	#[label("UTC")]
 	Utc,

--- a/node-graph/gcore/src/application_io.rs
+++ b/node-graph/gcore/src/application_io.rs
@@ -11,8 +11,7 @@ use std::ptr::addr_of;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SurfaceId(pub u64);
 
 impl std::fmt::Display for SurfaceId {
@@ -21,8 +20,7 @@ impl std::fmt::Display for SurfaceId {
 	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SurfaceFrame {
 	pub surface_id: SurfaceId,
 	pub resolution: UVec2,

--- a/node-graph/gcore/src/graphic_element.rs
+++ b/node-graph/gcore/src/graphic_element.rs
@@ -12,8 +12,7 @@ use std::hash::Hash;
 
 pub mod renderer;
 
-#[derive(Copy, Clone, Debug, PartialEq, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Copy, Clone, Debug, PartialEq, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
 pub struct AlphaBlending {
 	pub blend_mode: BlendMode,
@@ -74,15 +73,13 @@ impl AlphaBlending {
 pub fn migrate_graphic_group<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<GraphicGroupTable, D::Error> {
 	use serde::Deserialize;
 
-	#[derive(Clone, Debug, PartialEq, DynAny, Default)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Debug, PartialEq, DynAny, Default, serde::Serialize, serde::Deserialize)]
 	pub struct OldGraphicGroup {
 		elements: Vec<(GraphicElement, Option<NodeId>)>,
 		transform: DAffine2,
 		alpha_blending: AlphaBlending,
 	}
-	#[derive(Clone, Debug, PartialEq, DynAny, Default)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Debug, PartialEq, DynAny, Default, serde::Serialize, serde::Deserialize)]
 	pub struct GraphicGroup {
 		elements: Vec<(GraphicElement, Option<NodeId>)>,
 	}
@@ -162,8 +159,7 @@ impl From<RasterDataTable<GPU>> for GraphicGroupTable {
 }
 
 /// The possible forms of graphical content held in a Vec by the `elements` field of [`GraphicElement`].
-#[derive(Clone, Debug, Hash, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub enum GraphicElement {
 	/// Equivalent to the SVG <g> tag: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
 	GraphicGroup(GraphicGroupTable),
@@ -279,8 +275,7 @@ impl serde::Serialize for Raster<GPU> {
 }
 
 /// Some [`ArtboardData`] with some optional clipping bounds that can be exported.
-#[derive(Clone, Debug, Hash, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Hash, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct Artboard {
 	pub graphic_group: GraphicGroupTable,
 	pub label: String,
@@ -313,8 +308,7 @@ impl Artboard {
 pub fn migrate_artboard_group<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<ArtboardGroupTable, D::Error> {
 	use serde::Deserialize;
 
-	#[derive(Clone, Default, Debug, Hash, PartialEq, DynAny)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Default, Debug, Hash, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 	pub struct ArtboardGroup {
 		pub artboards: Vec<(Artboard, Option<NodeId>)>,
 	}

--- a/node-graph/gcore/src/graphic_element/renderer.rs
+++ b/node-graph/gcore/src/graphic_element/renderer.rs
@@ -350,8 +350,7 @@ pub fn to_transform(transform: DAffine2) -> usvg::Transform {
 
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
 // This will require that the transform for child layers into that layer space be calculated, or it could be returned from the RenderOutput instead of click targets.
-#[derive(Debug, Default, Clone, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Default, Clone, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct RenderMetadata {
 	pub upstream_footprints: HashMap<NodeId, Footprint>,
 	pub local_transforms: HashMap<NodeId, DAffine2>,

--- a/node-graph/gcore/src/memo.rs
+++ b/node-graph/gcore/src/memo.rs
@@ -149,7 +149,6 @@ pub struct MemoHash<T: Hash> {
 	value: T,
 }
 
-#[cfg(feature = "serde")]
 impl<'de, T: serde::Deserialize<'de> + Hash> serde::Deserialize<'de> for MemoHash<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
@@ -159,7 +158,6 @@ impl<'de, T: serde::Deserialize<'de> + Hash> serde::Deserialize<'de> for MemoHas
 	}
 }
 
-#[cfg(feature = "serde")]
 impl<T: Hash + serde::Serialize> serde::Serialize for MemoHash<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where

--- a/node-graph/gcore/src/ops.rs
+++ b/node-graph/gcore/src/ops.rs
@@ -530,8 +530,7 @@ fn extract_xy<T: Into<DVec2>>(_: impl Ctx, #[implementations(DVec2, IVec2, UVec2
 }
 
 /// The X or Y component of a coordinate.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Dropdown)]
 pub enum XY {
 	#[default]

--- a/node-graph/gcore/src/raster.rs
+++ b/node-graph/gcore/src/raster.rs
@@ -110,12 +110,10 @@ impl<T: Rec709Primaries> RGBPrimaries for T {
 
 pub trait SRGB: Rec709Primaries {}
 
-#[cfg(feature = "serde")]
 pub trait Serde: serde::Serialize + for<'a> serde::Deserialize<'a> {}
 #[cfg(not(feature = "serde"))]
 pub trait Serde {}
 
-#[cfg(feature = "serde")]
 impl<T: serde::Serialize + for<'a> serde::Deserialize<'a>> Serde for T {}
 #[cfg(not(feature = "serde"))]
 impl<T> Serde for T {}

--- a/node-graph/gcore/src/raster/adjustments.rs
+++ b/node-graph/gcore/src/raster/adjustments.rs
@@ -29,8 +29,7 @@ use std::fmt::Debug;
 // https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#:~:text=%27clrL%27%20%3D%20Color%20Lookup
 // https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#:~:text=Color%20Lookup%20(Photoshop%20CS6
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, Hash, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, Hash, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Dropdown)]
 pub enum LuminanceCalculation {
 	#[default]
@@ -42,8 +41,7 @@ pub enum LuminanceCalculation {
 	MaximumChannels,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, Hash, specta::Type)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, Hash, specta::Type, serde::Serialize, serde::Deserialize)]
 #[repr(i32)] // TODO: Enable Int8 capability for SPIR-V so that we don't need this?
 pub enum BlendMode {
 	// Basic group
@@ -916,8 +914,7 @@ async fn vibrance<T: Adjust<Color>>(
 }
 
 /// Color Channel
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Radio)]
 pub enum RedGreenBlue {
 	#[default]
@@ -927,8 +924,7 @@ pub enum RedGreenBlue {
 }
 
 /// Color Channel
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Radio)]
 pub enum RedGreenBlueAlpha {
 	#[default]
@@ -939,8 +935,7 @@ pub enum RedGreenBlueAlpha {
 }
 
 /// Style of noise pattern
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Dropdown)]
 pub enum NoiseType {
 	#[default]
@@ -955,8 +950,7 @@ pub enum NoiseType {
 	WhiteNoise,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 /// Style of layered levels of the noise pattern
 pub enum FractalType {
 	#[default]
@@ -972,8 +966,7 @@ pub enum FractalType {
 }
 
 /// Distance function used by the cellular noise
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 pub enum CellularDistanceFunction {
 	#[default]
 	Euclidean,
@@ -983,8 +976,7 @@ pub enum CellularDistanceFunction {
 	Hybrid,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 pub enum CellularReturnType {
 	CellValue,
 	#[default]
@@ -1003,8 +995,7 @@ pub enum CellularReturnType {
 }
 
 /// Type of domain warp
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Dropdown)]
 pub enum DomainWarpType {
 	#[default]
@@ -1113,8 +1104,7 @@ async fn channel_mixer<T: Adjust<Color>>(
 	image
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 #[widget(Radio)]
 pub enum RelativeAbsolute {
 	#[default]
@@ -1123,8 +1113,7 @@ pub enum RelativeAbsolute {
 }
 
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, DynAny, node_macro::ChoiceType, specta::Type, serde::Serialize, serde::Deserialize)]
 pub enum SelectiveColorChoice {
 	#[default]
 	Reds,

--- a/node-graph/gcore/src/raster/brush_cache.rs
+++ b/node-graph/gcore/src/raster/brush_cache.rs
@@ -9,22 +9,21 @@ use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-#[derive(Clone, Debug, PartialEq, DynAny, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, DynAny, Default, serde::Serialize, serde::Deserialize)]
 struct BrushCacheImpl {
 	// The full previous input that was cached.
 	prev_input: Vec<BrushStroke>,
 
 	// The strokes that have been fully processed and blended into the background.
-	#[cfg_attr(feature = "serde", serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance"))]
+	#[serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance")]
 	background: Instance<Raster<CPU>>,
-	#[cfg_attr(feature = "serde", serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance"))]
+	#[serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance")]
 	blended_image: Instance<Raster<CPU>>,
-	#[cfg_attr(feature = "serde", serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance"))]
+	#[serde(deserialize_with = "crate::graphene_core::raster::image::migrate_image_frame_instance")]
 	last_stroke_texture: Instance<Raster<CPU>>,
 
 	// A cache for brush textures.
-	#[cfg_attr(feature = "serde", serde(skip))]
+	#[serde(skip)]
 	brush_texture_cache: HashMap<BrushStyle, Raster<CPU>>,
 }
 
@@ -104,8 +103,7 @@ pub struct BrushPlan {
 	pub first_stroke_point_skip: usize,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, DynAny)]
+#[derive(Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct BrushCache {
 	inner: Arc<Mutex<BrushCacheImpl>>,
 	proto: bool,

--- a/node-graph/gcore/src/raster/color.rs
+++ b/node-graph/gcore/src/raster/color.rs
@@ -10,8 +10,7 @@ use spirv_std::num_traits::float::Float;
 use std::hash::Hash;
 
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, serde::Serialize, serde::Deserialize)]
 pub struct RGBA16F {
 	red: f16,
 	green: f16,
@@ -83,8 +82,7 @@ impl Alpha for RGBA16F {
 impl Pixel for RGBA16F {}
 
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct SRGBA8 {
 	red: u8,
 	green: u8,
@@ -164,8 +162,7 @@ impl Alpha for SRGBA8 {
 impl Pixel for SRGBA8 {}
 
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct Luma(pub f32);
 
 impl Luminance for Luma {
@@ -205,8 +202,7 @@ impl Pixel for Luma {}
 /// The other components (RGB) are stored as `f32` that range from `0.0` up to `f32::MAX`,
 /// the values encode the brightness of each channel proportional to the light intensity in cd/m² (nits) in HDR, and `0.0` (black) to `1.0` (white) in SDR color.
 #[repr(C)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, DynAny, Pod, Zeroable, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct Color {
 	red: f32,
 	green: f32,

--- a/node-graph/gcore/src/raster/curve.rs
+++ b/node-graph/gcore/src/raster/curve.rs
@@ -3,8 +3,7 @@ use crate::Node;
 use dyn_any::{DynAny, StaticType, StaticTypeSized};
 use std::ops::{Add, Mul, Sub};
 
-#[derive(Debug, Clone, PartialEq, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct Curve {
 	#[serde(rename = "manipulatorGroups")]
 	pub manipulator_groups: Vec<CurveManipulatorGroup>,
@@ -31,8 +30,7 @@ impl std::hash::Hash for Curve {
 	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct CurveManipulatorGroup {
 	pub anchor: [f32; 2],
 	pub handles: [[f32; 2]; 2],

--- a/node-graph/gcore/src/raster/image.rs
+++ b/node-graph/gcore/src/raster/image.rs
@@ -8,7 +8,6 @@ use dyn_any::{DynAny, StaticType};
 use glam::{DAffine2, DVec2};
 use std::vec::Vec;
 
-#[cfg(feature = "serde")]
 mod base64_serde {
 	//! Basic wrapper for [`serde`] to perform [`base64`] encoding
 
@@ -37,16 +36,15 @@ mod base64_serde {
 	}
 }
 
-#[derive(Clone, PartialEq, Default, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, PartialEq, Default, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct Image<P: Pixel> {
 	pub width: u32,
 	pub height: u32,
-	#[cfg_attr(feature = "serde", serde(serialize_with = "base64_serde::as_base64", deserialize_with = "base64_serde::from_base64"))]
+	#[serde(serialize_with = "base64_serde::as_base64", deserialize_with = "base64_serde::from_base64")]
 	pub data: Vec<P>,
 	/// Optional: Stores a base64 string representation of the image which can be used to speed up the conversion
 	/// to an svg string. This is used as a cache in order to not have to encode the data on every graph evaluation.
-	#[cfg_attr(feature = "serde", serde(skip))]
+	#[serde(skip)]
 	pub base64_string: Option<String>,
 	// TODO: Add an `origin` field to store where in the local space the image is anchored.
 	// TODO: Currently it is always anchored at the top left corner at (0, 0). The bottom right corner of the new origin field would correspond to (1, 1).
@@ -230,8 +228,7 @@ pub fn migrate_image_frame<'de, D: serde::Deserializer<'de>>(deserializer: D) ->
 		}
 	}
 
-	#[derive(Clone, Debug, Hash, PartialEq, DynAny)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Debug, Hash, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 	pub enum GraphicElement {
 		/// Equivalent to the SVG <g> tag: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
 		GraphicGroup(GraphicGroupTable),
@@ -240,8 +237,7 @@ pub fn migrate_image_frame<'de, D: serde::Deserializer<'de>>(deserializer: D) ->
 		RasterFrame(RasterFrame),
 	}
 
-	#[derive(Clone, Default, Debug, PartialEq, specta::Type)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Default, Debug, PartialEq, specta::Type, serde::Serialize, serde::Deserialize)]
 	pub struct ImageFrame<P: Pixel> {
 		pub image: Image<P>,
 	}
@@ -269,8 +265,7 @@ pub fn migrate_image_frame<'de, D: serde::Deserializer<'de>>(deserializer: D) ->
 		type Static = ImageFrame<P::Static>;
 	}
 
-	#[derive(Clone, Default, Debug, PartialEq, specta::Type)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Default, Debug, PartialEq, specta::Type, serde::Serialize, serde::Deserialize)]
 	pub struct OldImageFrame<P: Pixel> {
 		image: Image<P>,
 		transform: DAffine2,
@@ -326,8 +321,7 @@ pub fn migrate_image_frame_instance<'de, D: serde::Deserializer<'de>>(deserializ
 		}
 	}
 
-	#[derive(Clone, Debug, Hash, PartialEq, DynAny)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Debug, Hash, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 	pub enum GraphicElement {
 		/// Equivalent to the SVG <g> tag: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g
 		GraphicGroup(GraphicGroupTable),
@@ -336,8 +330,7 @@ pub fn migrate_image_frame_instance<'de, D: serde::Deserializer<'de>>(deserializ
 		RasterFrame(RasterFrame),
 	}
 
-	#[derive(Clone, Default, Debug, PartialEq, specta::Type)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Default, Debug, PartialEq, specta::Type, serde::Serialize, serde::Deserialize)]
 	pub struct ImageFrame<P: Pixel> {
 		pub image: Image<P>,
 	}
@@ -365,8 +358,7 @@ pub fn migrate_image_frame_instance<'de, D: serde::Deserializer<'de>>(deserializ
 		type Static = ImageFrame<P::Static>;
 	}
 
-	#[derive(Clone, Default, Debug, PartialEq, specta::Type)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Default, Debug, PartialEq, specta::Type, serde::Serialize, serde::Deserialize)]
 	pub struct OldImageFrame<P: Pixel> {
 		image: Image<P>,
 		transform: DAffine2,

--- a/node-graph/gcore/src/transform.rs
+++ b/node-graph/gcore/src/transform.rs
@@ -67,8 +67,7 @@ impl TransformMut for Footprint {
 	}
 }
 
-#[derive(Debug, Clone, Copy, dyn_any::DynAny, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, dyn_any::DynAny, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum RenderQuality {
 	/// Low quality, fast rendering
 	Preview,
@@ -81,8 +80,7 @@ pub enum RenderQuality {
 	/// Render at full quality
 	Full,
 }
-#[derive(Debug, Clone, Copy, dyn_any::DynAny, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, dyn_any::DynAny, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Footprint {
 	/// Inverse of the transform which will be applied to the node output during the rendering process
 	pub transform: DAffine2,

--- a/node-graph/gcore/src/types.rs
+++ b/node-graph/gcore/src/types.rs
@@ -124,8 +124,7 @@ impl std::fmt::Debug for NodeIOTypes {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct ProtoNodeIdentifier {
 	pub name: Cow<'static, str>,
 }
@@ -156,10 +155,9 @@ fn migrate_type_descriptor_names<'de, D: serde::Deserializer<'de>>(deserializer:
 	Ok(Cow::Owned(name))
 }
 
-#[derive(Clone, Debug, Eq, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct TypeDescriptor {
-	#[cfg_attr(feature = "serde", serde(skip))]
+	#[serde(skip)]
 	#[specta(skip)]
 	pub id: Option<TypeId>,
 	#[serde(deserialize_with = "migrate_type_descriptor_names")]
@@ -192,8 +190,7 @@ impl PartialEq for TypeDescriptor {
 }
 
 /// Graph runtime type information used for type inference.
-#[derive(Clone, PartialEq, Eq, Hash, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, PartialEq, Eq, Hash, specta::Type, serde::Serialize, serde::Deserialize)]
 pub enum Type {
 	/// A wrapper for some type variable used within the inference system. Resolved at inference time and replaced with a concrete type.
 	Generic(Cow<'static, str>),

--- a/node-graph/gcore/src/vector/brush_stroke.rs
+++ b/node-graph/gcore/src/vector/brush_stroke.rs
@@ -6,8 +6,7 @@ use glam::DVec2;
 use std::hash::{Hash, Hasher};
 
 /// The style of a brush.
-#[derive(Clone, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct BrushStyle {
 	pub color: Color,
 	pub diameter: f64,
@@ -55,8 +54,7 @@ impl PartialEq for BrushStyle {
 }
 
 /// A single sample of brush parameters across the brush stroke.
-#[derive(Clone, Debug, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct BrushInputSample {
 	// The position of the sample in layer space, in pixels.
 	// The origin of layer space is not specified.
@@ -72,8 +70,7 @@ impl Hash for BrushInputSample {
 }
 
 /// The parameters for a single stroke brush.
-#[derive(Clone, Debug, PartialEq, Hash, Default, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Hash, Default, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct BrushStroke {
 	pub style: BrushStyle,
 	pub trace: Vec<BrushInputSample>,

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -21,8 +21,7 @@ use std::collections::HashMap;
 pub fn migrate_vector_data<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<VectorDataTable, D::Error> {
 	use serde::Deserialize;
 
-	#[derive(Clone, Debug, PartialEq, DynAny)]
-	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Clone, Debug, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 	pub struct OldVectorData {
 		pub transform: DAffine2,
 		pub alpha_blending: AlphaBlending,
@@ -75,8 +74,7 @@ pub type VectorDataTable = Instances<VectorData>;
 /// It contains a list of subpaths (that may be open or closed), a transform, and some style information.
 ///
 /// Segments are connected if they share endpoints.
-#[derive(Clone, Debug, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct VectorData {
 	pub style: PathStyle,
 
@@ -495,8 +493,7 @@ impl VectorData {
 }
 
 /// A selectable part of a curve, either an anchor (start or end of a bézier) or a handle (doesn't necessarily go through the bézier but influences curvature).
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub enum ManipulatorPointId {
 	/// A control anchor - the start or end point of a bézier.
 	Anchor(PointId),
@@ -583,8 +580,7 @@ impl ManipulatorPointId {
 }
 
 /// The type of handle found on a bézier curve.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub enum HandleType {
 	/// The first handle on a cubic bézier or the only handle on a quadratic bézier.
 	Primary,
@@ -593,8 +589,7 @@ pub enum HandleType {
 }
 
 /// Represents a primary or end handle found in a particular segment.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct HandleId {
 	pub ty: HandleType,
 	pub segment: SegmentId,

--- a/node-graph/gcore/src/vector/vector_data/attributes.rs
+++ b/node-graph/gcore/src/vector/vector_data/attributes.rs
@@ -12,7 +12,7 @@ macro_rules! create_ids {
 	($($id:ident),*) => {
 		$(
 			#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, DynAny)]
-			#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+			#[derive(serde::Serialize, serde::Deserialize)]
 			/// A strongly typed ID
 			pub struct $id(u64);
 
@@ -77,8 +77,7 @@ impl std::hash::BuildHasher for NoHashBuilder {
 	}
 }
 
-#[derive(Clone, Debug, Default, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 /// Stores data which is per-point. Each point is merely a position and can be used in a point cloud or to for a bézier path. In future this will be extendable at runtime with custom attributes.
 pub struct PointDomain {
 	id: Vec<PointId>,
@@ -195,8 +194,7 @@ impl PointDomain {
 	}
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 /// Stores data which is per-segment. A segment is a bézier curve between two end points with a stroke. In future this will be extendable at runtime with custom attributes.
 pub struct SegmentDomain {
 	#[serde(alias = "ids")]
@@ -439,8 +437,7 @@ impl SegmentDomain {
 	}
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 /// Stores data which is per-region. A region is an enclosed area composed of a range of segments from the
 /// [`SegmentDomain`] that can be given a fill. In future this will be extendable at runtime with custom attributes.
 pub struct RegionDomain {

--- a/node-graph/gcore/src/vector/vector_data/modification.rs
+++ b/node-graph/gcore/src/vector/vector_data/modification.rs
@@ -9,8 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 
 /// Represents a procedural change to the [`PointDomain`] in [`VectorData`].
-#[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PointModification {
 	add: Vec<PointId>,
 	remove: HashSet<PointId>,
@@ -81,8 +80,7 @@ impl PointModification {
 }
 
 /// Represents a procedural change to the [`SegmentDomain`] in [`VectorData`].
-#[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SegmentModification {
 	add: Vec<SegmentId>,
 	remove: HashSet<SegmentId>,
@@ -254,8 +252,7 @@ impl SegmentModification {
 }
 
 /// Represents a procedural change to the [`RegionDomain`] in [`VectorData`].
-#[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RegionModification {
 	add: Vec<RegionId>,
 	remove: HashSet<RegionId>,
@@ -299,8 +296,7 @@ impl RegionModification {
 }
 
 /// Represents a procedural change to the [`VectorData`].
-#[derive(Clone, Debug, Default, PartialEq, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, PartialEq, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct VectorModification {
 	points: PointModification,
 	segments: SegmentModification,

--- a/node-graph/graph-craft/Cargo.toml
+++ b/node-graph/graph-craft/Cargo.toml
@@ -6,12 +6,11 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = ["dealloc_nodes"]
-serde = ["dep:serde", "graphene-core/serde", "glam/serde", "bezier-rs/serde"]
 dealloc_nodes = ["graphene-core/dealloc_nodes"]
 wgpu = ["wgpu-executor"]
 tokio = ["dep:tokio"]
 wayland = []
-loading = ["serde_json", "serde"]
+loading = ["serde_json"]
 
 [dependencies]
 # Local dependencies
@@ -26,10 +25,10 @@ specta = { workspace = true }
 rustc-hash = { workspace = true }
 url = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 
 # Optional workspace dependencies
 wgpu-executor = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -25,7 +25,6 @@ fn merge_ids(a: NodeId, b: NodeId) -> NodeId {
 
 /// Utility function for providing a default boolean value to serde.
 #[inline(always)]
-#[cfg(feature = "serde")]
 fn return_true() -> bool {
 	true
 }
@@ -33,8 +32,7 @@ fn return_true() -> bool {
 /// An instance of a [`DocumentNodeDefinition`] that has been instantiated in a [`NodeNetwork`].
 /// Currently, when an instance is made, it lives all on its own without any lasting connection to the definition.
 /// But we will want to change it in the future so it merely references its definition.
-#[derive(Clone, Debug, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct DocumentNode {
 	/// The inputs to a node, which are either:
 	/// - From other nodes within this graph [`NodeInput::Node`],
@@ -44,7 +42,7 @@ pub struct DocumentNode {
 	/// In the root network, it is resolved when evaluating the borrow tree.
 	/// Ensure the click target in the encapsulating network is updated when the inputs cause the node shape to change (currently only when exposing/hiding an input)
 	/// by using network.update_click_target(node_id).
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(alias = "outputs"))]
+	#[cfg_attr(target_arch = "wasm32", serde(alias = "outputs"))]
 	pub inputs: Vec<NodeInput>,
 	/// Manual composition is the methodology by which most nodes are implemented, involving a call argument and upstream inputs.
 	/// By contrast, automatic composition is an alternative way to handle the composition of nodes as they execute in the graph.
@@ -144,29 +142,27 @@ pub struct DocumentNode {
 	// A nested document network or a proto-node identifier.
 	pub implementation: DocumentNodeImplementation,
 	/// Represents the eye icon for hiding/showing the node in the graph UI. When hidden, a node gets replaced with an identity node during the graph flattening step.
-	#[cfg_attr(feature = "serde", serde(default = "return_true"))]
+	#[serde(default = "return_true")]
 	pub visible: bool,
 	/// When two different proto nodes hash to the same value (e.g. two value nodes each containing `2_u32` or two multiply nodes that have the same node IDs as input), the duplicates are removed.
 	/// See [`ProtoNetwork::generate_stable_node_ids`] for details.
 	/// However sometimes this is not desirable, for example in the case of a [`graphene_core::memo::MonitorNode`] that needs to be accessed outside of the graph.
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub skip_deduplication: bool,
 	/// The path to this node and its inputs and outputs as of when [`NodeNetwork::generate_node_paths`] was called.
-	#[cfg_attr(feature = "serde", serde(skip))]
+	#[serde(skip)]
 	pub original_location: OriginalLocation,
 }
 
 /// Represents the original location of a node input/output when [`NodeNetwork::generate_node_paths`] was called, allowing the types and errors to be derived.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct Source {
 	pub node: Vec<NodeId>,
 	pub index: usize,
 }
 
 /// The path to this node and its inputs and outputs as of when [`NodeNetwork::generate_node_paths`] was called.
-#[derive(Clone, Debug, PartialEq, Eq, DynAny, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, DynAny, Default, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub struct OriginalLocation {
 	/// The original location to the document node - e.g. [grandparent_id, parent_id, node_id].
@@ -285,8 +281,7 @@ impl DocumentNode {
 }
 
 /// Represents the possible inputs to a node.
-#[derive(Debug, Clone, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 pub enum NodeInput {
 	/// A reference to another node in the same network from which this node can receive its input.
 	Node { node_id: NodeId, output_index: usize, lambda: bool },
@@ -309,8 +304,7 @@ pub enum NodeInput {
 	Inline(InlineRust),
 }
 
-#[derive(Debug, Clone, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct InlineRust {
 	pub expr: String,
 	pub ty: Type,
@@ -322,8 +316,7 @@ impl InlineRust {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 pub enum DocumentNodeMetadata {
 	DocumentNodePath,
 }
@@ -408,8 +401,7 @@ impl NodeInput {
 	}
 }
 
-#[derive(Clone, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 /// Represents the implementation of a node, which can be a nested [`NodeNetwork`], a proto [`ProtoNodeIdentifier`], or `Extract`.
 pub enum OldDocumentNodeImplementation {
 	/// This describes a (document) node built out of a subgraph of other (document) nodes.
@@ -419,7 +411,7 @@ pub enum OldDocumentNodeImplementation {
 	/// This describes a (document) node implemented as a proto node.
 	///
 	/// A proto node identifier which can be found in `node_registry.rs`.
-	#[cfg_attr(feature = "serde", serde(alias = "Unresolved"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "Unresolved")] // TODO: Eventually remove this alias document upgrade code
 	ProtoNode(ProtoNodeIdentifier),
 	/// The Extract variant is a tag which tells the compilation process to do something special. It invokes language-level functionality built for use by the ExtractNode to enable metaprogramming.
 	/// When the ExtractNode is compiled, it gets replaced by a value node containing a representation of the source code for the function/lambda of the document node that's fed into the ExtractNode
@@ -443,8 +435,7 @@ pub enum OldDocumentNodeImplementation {
 	Extract,
 }
 
-#[derive(Clone, Debug, PartialEq, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 /// Represents the implementation of a node, which can be a nested [`NodeNetwork`], a proto [`ProtoNodeIdentifier`], or `Extract`.
 pub enum DocumentNodeImplementation {
 	/// This describes a (document) node built out of a subgraph of other (document) nodes.
@@ -454,7 +445,7 @@ pub enum DocumentNodeImplementation {
 	/// This describes a (document) node implemented as a proto node.
 	///
 	/// A proto node identifier which can be found in `node_registry.rs`.
-	#[cfg_attr(feature = "serde", serde(alias = "Unresolved"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "Unresolved")] // TODO: Eventually remove this alias document upgrade code
 	ProtoNode(ProtoNodeIdentifier),
 	/// The Extract variant is a tag which tells the compilation process to do something special. It invokes language-level functionality built for use by the ExtractNode to enable metaprogramming.
 	/// When the ExtractNode is compiled, it gets replaced by a value node containing a representation of the source code for the function/lambda of the document node that's fed into the ExtractNode
@@ -519,24 +510,21 @@ impl DocumentNodeImplementation {
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
 pub enum NodeExportVersions {
 	OldNodeInput(NodeOutput),
 	NodeInput(NodeInput),
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[derive(Debug, serde::Deserialize)]
 pub struct NodeOutput {
 	pub node_id: NodeId,
 	pub node_output_index: usize,
 }
 
 // TODO: Eventually remove this document upgrade code
-#[cfg(feature = "serde")]
 fn deserialize_exports<'de, D>(deserializer: D) -> Result<Vec<NodeInput>, D::Error>
 where
 	D: serde::Deserializer<'de>,
@@ -562,16 +550,15 @@ where
 /// An instance of a [`DocumentNodeDefinition`] that has been instantiated in a [`NodeNetwork`].
 /// Currently, when an instance is made, it lives all on its own without any lasting connection to the definition.
 /// But we will want to change it in the future so it merely references its definition.
-#[derive(Clone, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 pub struct OldDocumentNode {
 	/// A name chosen by the user for this instance of the node. Empty indicates no given name, in which case the node definition's name is displayed to the user in italics.
 	///  Ensure the click target in the encapsulating network is updated when this is modified by using network.update_click_target(node_id).
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub alias: String,
 	// TODO: Replace this name with a reference to the [`DocumentNodeDefinition`] node definition to use the name from there instead.
 	/// The name of the node definition, as originally set by [`DocumentNodeDefinition`], used to display in the UI and to display the appropriate properties.
-	#[cfg_attr(feature = "serde", serde(deserialize_with = "migrate_layer_to_merge"))]
+	#[serde(deserialize_with = "migrate_layer_to_merge")]
 	pub name: String,
 	/// The inputs to a node, which are either:
 	/// - From other nodes within this graph [`NodeInput::Node`],
@@ -580,48 +567,46 @@ pub struct OldDocumentNode {
 	///
 	/// In the root network, it is resolved when evaluating the borrow tree.
 	/// Ensure the click target in the encapsulating network is updated when the inputs cause the node shape to change (currently only when exposing/hiding an input) by using network.update_click_target(node_id).
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(alias = "outputs"))]
+	#[cfg_attr(target_arch = "wasm32", serde(alias = "outputs"))]
 	pub inputs: Vec<NodeInput>,
 	pub manual_composition: Option<Type>,
 	// TODO: Remove once this references its definition instead (see above TODO).
 	/// Indicates to the UI if a primary output should be drawn for this node.
 	/// True for most nodes, but the Split Channels node is an example of a node that has multiple secondary outputs but no primary output.
-	#[cfg_attr(feature = "serde", serde(default = "return_true"))]
+	#[serde(default = "return_true")]
 	pub has_primary_output: bool,
 	// A nested document network or a proto-node identifier.
 	pub implementation: OldDocumentNodeImplementation,
 	/// User chosen state for displaying this as a left-to-right node or bottom-to-top layer. Ensure the click target in the encapsulating network is updated when the node changes to a layer by using network.update_click_target(node_id).
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub is_layer: bool,
 	/// Represents the eye icon for hiding/showing the node in the graph UI. When hidden, a node gets replaced with an identity node during the graph flattening step.
-	#[cfg_attr(feature = "serde", serde(default = "return_true"))]
+	#[serde(default = "return_true")]
 	pub visible: bool,
 	/// Represents the lock icon for locking/unlocking the node in the graph UI. When locked, a node cannot be moved in the graph UI.
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub locked: bool,
 	/// Metadata about the node including its position in the graph UI. Ensure the click target in the encapsulating network is updated when the node moves by using network.update_click_target(node_id).
 	pub metadata: OldDocumentNodeMetadata,
 	/// When two different proto nodes hash to the same value (e.g. two value nodes each containing `2_u32` or two multiply nodes that have the same node IDs as input), the duplicates are removed.
 	/// See [`ProtoNetwork::generate_stable_node_ids`] for details.
 	/// However sometimes this is not desirable, for example in the case of a [`graphene_core::memo::MonitorNode`] that needs to be accessed outside of the graph.
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub skip_deduplication: bool,
 	/// The path to this node and its inputs and outputs as of when [`NodeNetwork::generate_node_paths`] was called.
-	#[cfg_attr(feature = "serde", serde(skip))]
+	#[serde(skip)]
 	pub original_location: OriginalLocation,
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(Clone, Debug, PartialEq, Default, specta::Type, Hash, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Default, specta::Type, Hash, DynAny, serde::Serialize, serde::Deserialize)]
 /// Metadata about the node including its position in the graph UI
 pub struct OldDocumentNodeMetadata {
 	pub position: IVec2,
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(Clone, Copy, Debug, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 /// Root Node is the "default" export for a node network. Used by document metadata, displaying UI-only "Export" node, and for restoring the default preview node.
 pub struct OldRootNode {
 	pub id: NodeId,
@@ -629,8 +614,7 @@ pub struct OldRootNode {
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(PartialEq, Debug, Clone, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(PartialEq, Debug, Clone, Hash, Default, serde::Serialize, serde::Deserialize)]
 pub enum OldPreviewing {
 	/// If there is a node to restore the connection to the export for, then it is stored in the option.
 	/// Otherwise, nothing gets restored and the primary export is disconnected.
@@ -640,34 +624,32 @@ pub enum OldPreviewing {
 }
 
 // TODO: Eventually remove this document upgrade code
-#[derive(Clone, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 /// A network (subgraph) of nodes containing each [`DocumentNode`] and its ID, as well as list mapping each export to its connected node, or a value if disconnected
 pub struct OldNodeNetwork {
 	/// The list of data outputs that are exported from this network to the parent network.
 	/// Each export is a reference to a node within this network, paired with its output index, that is the source of the network's exported data.
-	#[cfg_attr(feature = "serde", serde(alias = "outputs", deserialize_with = "deserialize_exports"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "outputs", deserialize_with = "deserialize_exports")] // TODO: Eventually remove this alias document upgrade code
 	pub exports: Vec<NodeInput>,
 	/// The list of all nodes in this network.
-	//cfg_attr(feature = "serde", #[cfg_attr(feature = "serde", serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")))]
+	//cfg_attr(feature = "serde", #[serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap"))]
 	pub nodes: HashMap<NodeId, OldDocumentNode>,
 	/// Indicates whether the network is currently rendered with a particular node that is previewed, and if so, which connection should be restored when the preview ends.
-	#[cfg_attr(feature = "serde", serde(default))]
+	#[serde(default)]
 	pub previewing: OldPreviewing,
 	/// Temporary fields to store metadata for "Import"/"Export" UI-only nodes, eventually will be replaced with lines leading to edges
-	#[cfg_attr(feature = "serde", serde(default = "default_import_metadata"))]
+	#[serde(default = "default_import_metadata")]
 	pub imports_metadata: (NodeId, IVec2),
-	#[cfg_attr(feature = "serde", serde(default = "default_export_metadata"))]
+	#[serde(default = "default_export_metadata")]
 	pub exports_metadata: (NodeId, IVec2),
 
 	/// A network may expose nodes as constants which can by used by other nodes using a `NodeInput::Scope(key)`.
-	#[cfg_attr(feature = "serde", serde(default))]
-	//cfg_attr(feature = "serde", #[cfg_attr(feature = "serde", serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")))]
+	#[serde(default)]
+	//cfg_attr(feature = "serde", #[serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap"))]
 	pub scope_injections: HashMap<String, (NodeId, Type)>,
 }
 
 // TODO: Eventually remove this document upgrade code
-#[cfg(feature = "serde")]
 fn migrate_layer_to_merge<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<String, D::Error> {
 	let mut s: String = serde::Deserialize::deserialize(deserializer)?;
 	if s == "Layer" {
@@ -676,39 +658,30 @@ fn migrate_layer_to_merge<'de, D: serde::Deserializer<'de>>(deserializer: D) -> 
 	Ok(s)
 }
 // TODO: Eventually remove this document upgrade code
-#[cfg(feature = "serde")]
 fn default_import_metadata() -> (NodeId, IVec2) {
 	(NodeId::new(), IVec2::new(-25, -4))
 }
 // TODO: Eventually remove this document upgrade code
-#[cfg(feature = "serde")]
 fn default_export_metadata() -> (NodeId, IVec2) {
 	(NodeId::new(), IVec2::new(8, -4))
 }
 
-#[derive(Clone, Default, Debug, DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Default, Debug, DynAny, serde::Serialize, serde::Deserialize)]
 /// A network (subgraph) of nodes containing each [`DocumentNode`] and its ID, as well as list mapping each export to its connected node, or a value if disconnected
 pub struct NodeNetwork {
 	/// The list of data outputs that are exported from this network to the parent network.
 	/// Each export is a reference to a node within this network, paired with its output index, that is the source of the network's exported data.
 	// TODO: Eventually remove this alias document upgrade code
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(alias = "outputs", deserialize_with = "deserialize_exports"))]
+	#[cfg_attr(target_arch = "wasm32", serde(alias = "outputs", deserialize_with = "deserialize_exports"))]
 	pub exports: Vec<NodeInput>,
 	// TODO: Instead of storing import types in each NodeInput::Network connection, the types are stored here. This is similar to how types need to be defined for parameters when creating a function in Rust.
 	// pub import_types: Vec<Type>,
 	/// The list of all nodes in this network.
-	#[cfg_attr(
-		feature = "serde",
-		serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")
-	)]
+	#[serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")]
 	pub nodes: FxHashMap<NodeId, DocumentNode>,
 	/// A network may expose nodes as constants which can by used by other nodes using a `NodeInput::Scope(key)`.
-	#[cfg_attr(feature = "serde", serde(default))]
-	#[cfg_attr(
-		feature = "serde",
-		serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")
-	)]
+	#[serde(default)]
+	#[serde(serialize_with = "graphene_core::vector::serialize_hashmap", deserialize_with = "graphene_core::vector::deserialize_hashmap")]
 	pub scope_injections: FxHashMap<String, (NodeId, Type)>,
 }
 

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -24,15 +24,14 @@ pub struct TaggedValueTypeError;
 macro_rules! tagged_value {
 	($ ($( #[$meta:meta] )* $identifier:ident ($ty:ty) ),* $(,)?) => {
 		/// A type that is known, allowing serialization (serde::Deserialize is not object safe)
-		#[derive(Clone, Debug, PartialEq)]
-		#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+		#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 		#[allow(clippy::large_enum_variant)] // TODO(TrueDoctor): Properly solve this disparity between the size of the largest and next largest variants
 		pub enum TaggedValue {
 			None,
 			$( $(#[$meta] ) *$identifier( $ty ), )*
 			RenderOutput(RenderOutput),
 			SurfaceFrame(graphene_core::SurfaceFrame),
-			#[cfg_attr(feature = "serde", serde(skip))]
+			#[serde(skip)]
 			EditorApi(Arc<WasmEditorApi>)
 		}
 
@@ -159,7 +158,7 @@ tagged_value! {
 	// ===============
 	// PRIMITIVE TYPES
 	// ===============
-	#[cfg_attr(feature = "serde", serde(alias = "F32"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "F32")] // TODO: Eventually remove this alias document upgrade code
 	F64(f64),
 	U32(u32),
 	U64(u64),
@@ -174,25 +173,25 @@ tagged_value! {
 	// ==========================
 	// PRIMITIVE COLLECTION TYPES
 	// ==========================
-	#[cfg_attr(feature = "serde", serde(alias = "VecF32"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "VecF32")] // TODO: Eventually remove this alias document upgrade code
 	VecF64(Vec<f64>),
 	VecU64(Vec<u64>),
 	VecDVec2(Vec<DVec2>),
 	F64Array4([f64; 4]),
 	NodePath(Vec<NodeId>),
-	#[cfg_attr(feature = "serde", serde(alias = "ManipulatorGroupIds"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "ManipulatorGroupIds")] // TODO: Eventually remove this alias document upgrade code
 	PointIds(Vec<graphene_core::vector::PointId>),
 	// ====================
 	// GRAPHICAL DATA TYPES
 	// ====================
 	GraphicElement(graphene_core::GraphicElement),
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(deserialize_with = "graphene_core::vector::migrate_vector_data"))] // TODO: Eventually remove this migration document upgrade code
+	#[cfg_attr(target_arch = "wasm32", serde(deserialize_with = "graphene_core::vector::migrate_vector_data"))] // TODO: Eventually remove this migration document upgrade code
 	VectorData(graphene_core::vector::VectorDataTable),
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(alias = "ImageFrame", deserialize_with = "graphene_core::raster::image::migrate_image_frame"))] // TODO: Eventually remove this migration document upgrade code
+	#[cfg_attr(target_arch = "wasm32", serde(alias = "ImageFrame", deserialize_with = "graphene_core::raster::image::migrate_image_frame"))] // TODO: Eventually remove this migration document upgrade code
 	RasterData(graphene_core::raster_types::RasterDataTable<CPU>),
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(deserialize_with = "graphene_core::migrate_graphic_group"))] // TODO: Eventually remove this migration document upgrade code
+	#[cfg_attr(target_arch = "wasm32", serde(deserialize_with = "graphene_core::migrate_graphic_group"))] // TODO: Eventually remove this migration document upgrade code
 	GraphicGroup(graphene_core::GraphicGroupTable),
-	#[cfg_attr(all(feature = "serde", target_arch = "wasm32"), serde(deserialize_with = "graphene_core::migrate_artboard_group"))] // TODO: Eventually remove this migration document upgrade code
+	#[cfg_attr(target_arch = "wasm32", serde(deserialize_with = "graphene_core::migrate_artboard_group"))] // TODO: Eventually remove this migration document upgrade code
 	ArtboardGroup(graphene_core::ArtboardGroupTable),
 	// ============
 	// STRUCT TYPES
@@ -206,7 +205,7 @@ tagged_value! {
 	Fill(graphene_core::vector::style::Fill),
 	Stroke(graphene_core::vector::style::Stroke),
 	Gradient(graphene_core::vector::style::Gradient),
-	#[cfg_attr(feature = "serde", serde(alias = "GradientPositions"))] // TODO: Eventually remove this alias document upgrade code
+	#[serde(alias = "GradientPositions")] // TODO: Eventually remove this alias document upgrade code
 	GradientStops(graphene_core::vector::style::GradientStops),
 	Font(graphene_core::text::Font),
 	BrushStrokes(Vec<graphene_core::vector::brush_stroke::BrushStroke>),
@@ -422,15 +421,13 @@ impl<T: AsRef<U> + Sync + Send, U: Sync + Send> UpcastAsRefNode<T, U> {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, dyn_any::DynAny)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, dyn_any::DynAny, serde::Serialize, serde::Deserialize)]
 pub struct RenderOutput {
 	pub data: RenderOutputType,
 	pub metadata: RenderMetadata,
 }
 
-#[derive(Debug, Clone, PartialEq, dyn_any::DynAny, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, dyn_any::DynAny, Hash, serde::Serialize, serde::Deserialize)]
 pub enum RenderOutputType {
 	CanvasFrame(graphene_core::SurfaceFrame),
 	Svg(String),

--- a/node-graph/graph-craft/src/imaginate_input.rs
+++ b/node-graph/graph-craft/src/imaginate_input.rs
@@ -5,8 +5,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[derive(Default, Debug, Clone, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Debug, Clone, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct ImaginateCache(Arc<Mutex<graphene_core::raster::Image<Color>>>);
 
 impl ImaginateCache {
@@ -31,8 +30,7 @@ pub trait ImaginateTerminationHandle: Debug + Send + 'static {
 	fn terminate(&self);
 }
 
-#[derive(Default, Debug, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Debug, specta::Type, serde::Serialize, serde::Deserialize)]
 struct InternalImaginateControl {
 	#[serde(skip)]
 	status: Mutex<ImaginateStatus>,
@@ -42,8 +40,7 @@ struct InternalImaginateControl {
 	termination_sender: Mutex<Option<Box<dyn ImaginateTerminationHandle>>>,
 }
 
-#[derive(Debug, Default, Clone, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Default, Clone, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct ImaginateController(Arc<InternalImaginateControl>);
 
 impl ImaginateController {
@@ -90,8 +87,7 @@ impl core::hash::Hash for ImaginateController {
 	}
 }
 
-#[derive(Default, Debug, Clone, PartialEq, DynAny, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default, Debug, Clone, PartialEq, DynAny, specta::Type, serde::Serialize, serde::Deserialize)]
 pub enum ImaginateStatus {
 	#[default]
 	Ready,
@@ -152,16 +148,14 @@ impl ImaginateServerStatus {
 	}
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, specta::Type, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, specta::Type, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ImaginateMaskPaintMode {
 	#[default]
 	Inpaint,
 	Outpaint,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, specta::Type, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, DynAny, specta::Type, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ImaginateMaskStartingFill {
 	#[default]
 	Fill,
@@ -192,8 +186,7 @@ impl std::fmt::Display for ImaginateMaskStartingFill {
 	}
 }
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, DynAny, specta::Type, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, DynAny, specta::Type, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ImaginateSamplingMethod {
 	#[default]
 	EulerA,

--- a/node-graph/graph-craft/src/proto.rs
+++ b/node-graph/graph-craft/src/proto.rs
@@ -3,14 +3,12 @@ use crate::document::{NodeId, OriginalLocation};
 pub use graphene_core::registry::*;
 use graphene_core::*;
 use rustc_hash::FxHashMap;
-#[cfg(feature = "serde")]
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Default, PartialEq, Clone, Hash, Eq)]
+#[derive(Debug, Default, PartialEq, Clone, Hash, Eq, serde::Serialize, serde::Deserialize)]
 /// A list of [`ProtoNode`]s, which is an intermediate step between the [`crate::document::NodeNetwork`] and the `BorrowTree` containing a single flattened network.
 pub struct ProtoNetwork {
 	// TODO: remove this since it seems to be unused?
@@ -72,8 +70,7 @@ impl core::fmt::Display for ProtoNetwork {
 	}
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 /// Defines the arguments used to construct the boxed node struct. This is used to call the constructor function in the `node_registry.rs` file - which is hidden behind a wall of macros.
 pub enum ConstructionArgs {
 	/// A value of a type that is known, allowing serialization (serde::Deserialize is not object safe)
@@ -132,8 +129,7 @@ impl ConstructionArgs {
 	}
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq, serde::Serialize, serde::Deserialize)]
 /// A proto node is an intermediate step between the `DocumentNode` and the boxed struct that actually runs the node (found in the [`BorrowTree`]).
 /// At different stages in the compilation process, this struct will be transformed into a reduced (more restricted) form acting as a subset of its original form, but that restricted form is still valid in the earlier stage in the compilation process before it was transformed.
 pub struct ProtoNode {
@@ -157,8 +153,7 @@ impl Default for ProtoNode {
 }
 
 /// Similar to the document node's [`crate::document::NodeInput`].
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ProtoNodeInput {
 	/// This input will be converted to `()` as the call argument.
 	None,
@@ -532,8 +527,7 @@ impl ProtoNetwork {
 		Ok(())
 	}
 }
-#[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum GraphErrorType {
 	NodeNotFound(NodeId),
 	InputNodeNotFound(NodeId),
@@ -589,8 +583,7 @@ impl Debug for GraphErrorType {
 		}
 	}
 }
-#[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GraphError {
 	pub node_path: Vec<NodeId>,
 	pub identifier: Cow<'static, str>,

--- a/node-graph/graph-craft/src/wasm_application_io.rs
+++ b/node-graph/graph-craft/src/wasm_application_io.rs
@@ -315,8 +315,7 @@ pub type WasmSurfaceHandle = SurfaceHandle<wgpu_executor::Window>;
 #[cfg(feature = "wgpu")]
 pub type WasmSurfaceHandleFrame = graphene_core::application_io::SurfaceHandleFrame<wgpu_executor::Window>;
 
-#[derive(Clone, Debug, PartialEq, Hash, specta::Type)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Hash, specta::Type, serde::Serialize, serde::Deserialize)]
 pub struct EditorPreferences {
 	// pub imaginate_hostname: String,
 	pub use_vello: bool,

--- a/node-graph/graphene-cli/Cargo.toml
+++ b/node-graph/graphene-cli/Cargo.toml
@@ -21,7 +21,7 @@ gpu = [
 [dependencies]
 # Local dependencies
 graphene-core = { workspace = true }
-graphene-std = { workspace = true, features = ["serde"] }
+graphene-std = { workspace = true }
 interpreted-executor = { workspace = true }
 graph-craft = { workspace = true, features = ["loading"] }
 

--- a/node-graph/gstd/Cargo.toml
+++ b/node-graph/gstd/Cargo.toml
@@ -20,9 +20,9 @@ wayland = ["graph-craft/wayland"]
 [dependencies]
 # Local dependencies
 dyn-any = { workspace = true }
-graph-craft = { workspace = true, features = ["serde"] }
+graph-craft = { workspace = true }
 wgpu-executor = { workspace = true }
-graphene-core = { workspace = true, features = ["serde"] }
+graphene-core = { workspace = true }
 
 # Workspace dependencies
 fastnoise-lite = { workspace = true }
@@ -45,7 +45,6 @@ wasm-bindgen = { workspace = true, optional = true }
 wasm-bindgen-futures = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = [
 	"Window",
 	"CanvasRenderingContext2d",

--- a/node-graph/gstd/src/imaginate.rs
+++ b/node-graph/gstd/src/imaginate.rs
@@ -178,20 +178,17 @@ impl core::fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-#[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[derive(Default, Debug, Clone, serde::Deserialize)]
 struct ImageResponse {
 	images: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[derive(Default, Debug, Clone, serde::Deserialize)]
 struct ProgressResponse {
 	progress: f64,
 }
 
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 struct ImaginateTextToImageRequestOverrideSettings {
 	show_progress_every_n_steps: u32,
 }
@@ -204,8 +201,7 @@ impl Default for ImaginateTextToImageRequestOverrideSettings {
 	}
 }
 
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 struct ImaginateImageToImageRequestOverrideSettings {
 	show_progress_every_n_steps: u32,
 	img2img_fix_steps: bool,
@@ -220,16 +216,14 @@ impl Default for ImaginateImageToImageRequestOverrideSettings {
 	}
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, serde::Serialize)]
 struct ImaginateTextToImageRequest<'a> {
-	#[cfg_attr(feature = "serde", serde(flatten))]
+	#[serde(flatten)]
 	common: ImaginateCommonImageRequest<'a>,
 	override_settings: ImaginateTextToImageRequestOverrideSettings,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, serde::Serialize)]
 struct ImaginateMask {
 	mask: String,
 	mask_blur: String,
@@ -238,21 +232,19 @@ struct ImaginateMask {
 	inpainting_mask_invert: u32,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, serde::Serialize)]
 struct ImaginateImageToImageRequest<'a> {
-	#[cfg_attr(feature = "serde", serde(flatten))]
+	#[serde(flatten)]
 	common: ImaginateCommonImageRequest<'a>,
 	override_settings: ImaginateImageToImageRequestOverrideSettings,
 
 	init_images: Vec<String>,
 	denoising_strength: f64,
-	#[cfg_attr(feature = "serde", serde(flatten))]
+	#[serde(flatten)]
 	mask: Option<ImaginateMask>,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, serde::Serialize)]
 struct ImaginateCommonImageRequest<'a> {
 	prompt: String,
 	seed: f64,

--- a/node-graph/gstd/src/raster.rs
+++ b/node-graph/gstd/src/raster.rs
@@ -305,7 +305,6 @@ fn image_value(_: impl Ctx, _primary: (), image: RasterDataTable<CPU>) -> Raster
 	image
 }
 
-// #[cfg(feature = "serde")]
 // macro_rules! generate_imaginate_node {
 // 	($($val:ident: $t:ident: $o:ty,)*) => {
 // 		pub struct ImaginateNode<P: Pixel, E, C, G, $($t,)*> {
@@ -386,7 +385,6 @@ fn image_value(_: impl Ctx, _primary: (), image: RasterDataTable<CPU>) -> Raster
 // 	}
 // }
 
-// #[cfg(feature = "serde")]
 // generate_imaginate_node! {
 // 	seed: Seed: f64,
 // 	res: Res: Option<DVec2>,

--- a/node-graph/interpreted-executor/Cargo.toml
+++ b/node-graph/interpreted-executor/Cargo.toml
@@ -6,12 +6,11 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-serde = ["dep:serde", "graphene-std/serde", "glam/serde"]
 gpu = ["graphene-std/gpu", "graphene-std/wgpu"]
 
 [dependencies]
 # Local dependencies
-graphene-std = { workspace = true, features = ["serde"] }
+graphene-std = { workspace = true }
 graph-craft = { workspace = true }
 wgpu-executor = { workspace = true }
 graphene-core = { workspace = true }
@@ -22,9 +21,7 @@ log = { workspace = true }
 glam = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
-
-# Optional workspace dependencies
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 # Workspace dependencies

--- a/node-graph/interpreted-executor/src/dynamic_executor.rs
+++ b/node-graph/interpreted-executor/src/dynamic_executor.rs
@@ -33,23 +33,20 @@ impl Default for DynamicExecutor {
 	}
 }
 
-#[derive(PartialEq, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(PartialEq, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct NodeTypes {
 	pub inputs: Vec<Type>,
 	pub output: Type,
 }
 
-#[derive(PartialEq, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(PartialEq, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ResolvedDocumentNodeTypes {
 	pub types: HashMap<Vec<NodeId>, NodeTypes>,
 }
 
 type Path = Box<[NodeId]>;
 
-#[derive(PartialEq, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(PartialEq, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ResolvedDocumentNodeTypesDelta {
 	pub add: Vec<(Path, NodeTypes)>,
 	pub remove: Vec<Path>,


### PR DESCRIPTION
# Requires https://github.com/GraphiteEditor/Graphite/pull/2736

Everything needs serde anyway