### PR TITLE
Fix Path tool multi-point handle scaling behavior and double-click smooth/sharp conversion on rectangles

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -616,7 +616,7 @@ impl<'a> Selected<'a> {
 			responses.add(GraphOperationMessage::Vector { layer, modification_type });
 		}
 
-		if transform_operation.is_some_and(|transform_operation| matches!(transform_operation, TransformOperation::Scaling(_))) && initial_points.anchors.len() > 1 {
+		if transform_operation.is_some_and(|transform_operation| matches!(transform_operation, TransformOperation::Scaling(_))) && initial_points.anchors.len() < 3 {
 			return;
 		}
 

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -616,7 +616,7 @@ impl<'a> Selected<'a> {
 			responses.add(GraphOperationMessage::Vector { layer, modification_type });
 		}
 
-		if transform_operation.is_some_and(|transform_operation| matches!(transform_operation, TransformOperation::Scaling(_))) && initial_points.anchors.len() < 3 {
+		if transform_operation.is_some_and(|transform_operation| matches!(transform_operation, TransformOperation::Scaling(_))) && (initial_points.anchors.len() == 2) {
 			return;
 		}
 

--- a/editor/src/messages/portfolio/document/utility_types/transformation.rs
+++ b/editor/src/messages/portfolio/document/utility_types/transformation.rs
@@ -9,9 +9,7 @@ use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::utility_types::ToolType;
 use glam::{DAffine2, DMat2, DVec2};
 use graphene_std::renderer::Quad;
-use graphene_std::vector::VectorModificationType;
-use graphene_std::vector::{HandleExt, ManipulatorPointId};
-use graphene_std::vector::{HandleId, PointId};
+use graphene_std::vector::{HandleExt, HandleId, ManipulatorPointId, PointId, VectorModificationType};
 use std::collections::{HashMap, VecDeque};
 use std::f64::consts::PI;
 

--- a/node-graph/gcore/src/vector/vector_data.rs
+++ b/node-graph/gcore/src/vector/vector_data.rs
@@ -11,7 +11,7 @@ use crate::transform::Transform;
 use crate::vector::click_target::{ClickTargetType, FreePoint};
 use crate::{AlphaBlending, Color, GraphicGroupTable};
 pub use attributes::*;
-use bezier_rs::ManipulatorGroup;
+use bezier_rs::{BezierHandles, ManipulatorGroup};
 use core::borrow::Borrow;
 use core::hash::Hash;
 use dyn_any::DynAny;
@@ -332,6 +332,13 @@ impl VectorData {
 	pub fn connected_points(&self, current: PointId) -> impl Iterator<Item = PointId> + '_ {
 		let index = [self.point_domain.resolve_id(current)].into_iter().flatten();
 		index.flat_map(|index| self.segment_domain.connected_points(index).map(|index| self.point_domain.ids()[index]))
+	}
+
+	/// Returns the number of linear segments connected to the given point.
+	pub fn connected_linear_segments(&self, point_id: PointId) -> usize {
+		self.segment_bezier_iter()
+			.filter(|(_, bez, start, end)| ((*start == point_id || *end == point_id) && matches!(bez.handles, BezierHandles::Linear)))
+			.count()
 	}
 
 	/// Get an array slice of all segment IDs.


### PR DESCRIPTION
 - fixed while scaling 2+ anchors ,should scale to their common center while also scaling their handles in unison.
 - double-click on anchor connected to linear segments fails to flip between smooth-sharp