### PR TITLE
Fix lasso select extending the previous selection area after it was aborted

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1402,6 +1402,7 @@ impl Fsm for SelectToolFsmState {
 				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
 				tool_data.axis_align = false;
+				tool_data.lasso_polygon.clear();
 				responses.add(OverlaysMessage::Draw);
 
 				let selection = tool_data.nested_selection_behavior;
@@ -1422,6 +1423,7 @@ impl Fsm for SelectToolFsmState {
 
 				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
+				tool_data.lasso_polygon.clear();
 				responses.add(OverlaysMessage::Draw);
 
 				let selection = tool_data.nested_selection_behavior;


### PR DESCRIPTION
Currently after aborting an in-progress lasso selection with RMB or ESC, starting a new lasso selection will extend the previous lasso selection instead of starting a new selection. This fix ensures the previous selection is cleared after abort.

Partly closes #2647

# before fix
https://github.com/user-attachments/assets/647fecd5-1be1-4b88-a902-6b3e739979d3

# after fix
https://github.com/user-attachments/assets/cd9a44c2-7259-4972-b1cf-0d064e4e1f04