### PR TITLE
Add ability to start lasso select within object without dragging layers

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -97,7 +97,7 @@ pub fn input_mappings() -> Mapping {
 		//
 		// SelectToolMessage
 		entry!(PointerMove; refresh_keys=[Control, Alt, Shift], action_dispatch=SelectToolMessage::PointerMove(SelectToolPointerKeys { axis_align: Shift, snap_angle: Shift, center: Alt, duplicate: Alt })),
-		entry!(KeyDown(MouseLeft); action_dispatch=SelectToolMessage::DragStart { extend_selection: Shift, remove_from_selection: Alt, select_deepest: Accel, lasso_select: Control, skew: Control }),
+		entry!(KeyDown(MouseLeft); action_dispatch=SelectToolMessage::DragStart { extend_selection: Shift, remove_from_selection: Alt, select_deepest_key: Accel, lasso_select_key: Control, skew: Control }),
 		entry!(KeyUp(MouseLeft); action_dispatch=SelectToolMessage::DragStop { remove_from_selection: Alt }),
 		entry!(KeyDown(Enter); action_dispatch=SelectToolMessage::Enter),
 		entry!(DoubleClick(MouseButton::Left); action_dispatch=SelectToolMessage::EditLayer),

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -594,7 +594,7 @@ impl PathToolData {
 			PathToolFsmState::Dragging(self.dragging_state)
 		}
 		// We didn't find a point nearby, so we will see if there is a segment to insert a point on
-		else if let Some(closed_segment) = &mut self.segment {
+		else if !lasso_select && let Some(closed_segment) = &mut self.segment {
 			responses.add(DocumentMessage::StartTransaction);
 
 			// Calculating and storing handle positions
@@ -610,7 +610,7 @@ impl PathToolData {
 			PathToolFsmState::MoldingSegment
 		}
 		// We didn't find a segment, so consider selecting the nearest shape instead
-		else if let Some(layer) = document.click(input) {
+		else if !lasso_select && let Some(layer) = document.click(input) {
 			shape_editor.deselect_all_points();
 			if extend_selection {
 				responses.add(NodeGraphMessage::SelectedNodesAdd { nodes: vec![layer.to_node()] });

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -888,6 +888,7 @@ impl Fsm for SelectToolFsmState {
 				let show_compass = bounds.is_some_and(|quad| quad.all_sides_at_least_width(COMPASS_ROSE_HOVER_RING_DIAMETER) && quad.contains(mouse_position));
 				let can_grab_compass_rose = compass_rose_state.can_grab() && (show_compass || bounds.is_none());
 
+				let lasso_select = input.keyboard.key(lasso_select_key);
 				let state = if is_over_pivot
 				// Dragging the pivot
 				{
@@ -907,7 +908,9 @@ impl Fsm for SelectToolFsmState {
 					SelectToolFsmState::SkewingBounds { skew: Key::Control }
 				}
 				// Dragging the selected layers around to transform them
-				else if can_grab_compass_rose || intersection.is_some_and(|intersection| selected.iter().any(|selected_layer| intersection.starts_with(*selected_layer, document.metadata()))) {
+				else if !lasso_select
+					&& (can_grab_compass_rose || intersection.is_some_and(|intersection| selected.iter().any(|selected_layer| intersection.starts_with(*selected_layer, document.metadata()))))
+				{
 					responses.add(DocumentMessage::StartTransaction);
 
 					if input.keyboard.key(select_deepest_key) || tool_data.nested_selection_behavior == NestedSelectionBehavior::Deepest {
@@ -944,7 +947,6 @@ impl Fsm for SelectToolFsmState {
 						tool_data.layers_dragging.clear();
 					}
 
-					let lasso_select = input.keyboard.key(lasso_select_key);
 					if !lasso_select && let Some(intersection) = intersection {
 						tool_data.layer_selected_on_start = Some(intersection);
 						selected = intersection_list;


### PR DESCRIPTION
When beginning a lasso select from within an object, currently the behavior is to drag its layers. This PR updates this behavior such that a lasso select beginning within an object will remain a lasso selection over the existing layers.

Part of [#2647](https://github.com/GraphiteEditor/Graphite/issues/2647)
