### PR TITLE
Make selected Text category nodes show a multi-line text area instead of one-line text field

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -176,6 +176,7 @@ pub(crate) fn property_from_type(
 				Some("SeedValue") => number_widget(default_info, number_input.int().min(min(0.))).into(),
 				Some("Resolution") => coordinate_widget(default_info, "W", "H", unit.unwrap_or(" px"), Some(64.)),
 				Some("PixelSize") => coordinate_widget(default_info, "X", "Y", unit.unwrap_or(" px"), None),
+				Some("TextArea") => text_area_widget(default_info).into(),
 
 				// For all other types, use TypeId-based matching
 				_ => {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 The Graphite frontend is a web app that provides the presentation for the editor. It displays the GUI based on state from the backend and provides users with interactive widgets that send updates to the backend, which is the source of truth for state information. The frontend is built out of reactive components using the [Svelte](https://svelte.dev/) framework. The backend is written in Rust and compiled to WebAssembly (WASM) to be run in the browser alongside the JS code.
 
-For lack of other options, the frontend is currently written as a web app. Maintaining web compatibility will always be a requirement, but the long-term plan is to port this code to a Rust-based native GUI framework, either written by the Rust community or created by our project if necessary. As a medium-term compromise, we may wrap the web-based frontend in a desktop webview windowing solution like Electron (probably not) or [Tauri](https://tauri.studio/) (probably).
+For lack of other options, the frontend is currently written as a web app. Maintaining web compatibility will always be a requirement, but the long-term plan is to port this code to a Rust-based native GUI framework, either written by the Rust community or created by our project if necessary. As a medium-term compromise, we may wrap the web-based frontend in a desktop webview windowing solution like Electron (probably not) or [Tauri](https://tauri.app/) (probably).
 
 ## Bundled assets: `assets/`
 

--- a/node-graph/gcore/src/logic.rs
+++ b/node-graph/gcore/src/logic.rs
@@ -3,6 +3,7 @@ use crate::Color;
 use crate::GraphicElement;
 use crate::GraphicGroupTable;
 use crate::gradient::GradientStops;
+use crate::graphene_core::registry::types::TextArea;
 use crate::raster_types::{CPU, GPU, RasterDataTable};
 use crate::vector::VectorDataTable;
 use crate::{Context, Ctx};
@@ -14,12 +15,12 @@ fn to_string<T: std::fmt::Debug>(_: impl Ctx, #[implementations(String, bool, f6
 }
 
 #[node_macro::node(category("Text"))]
-fn string_concatenate(_: impl Ctx, #[implementations(String)] first: String, #[implementations(String)] second: String) -> String {
+fn string_concatenate(_: impl Ctx, #[implementations(String)] first: String, second: TextArea) -> String {
 	first.clone() + &second
 }
 
 #[node_macro::node(category("Text"))]
-fn string_replace(_: impl Ctx, #[implementations(String)] string: String, from: String, to: String) -> String {
+fn string_replace(_: impl Ctx, #[implementations(String)] string: String, from: TextArea, to: TextArea) -> String {
 	string.replace(&from, &to)
 }
 

--- a/node-graph/gcore/src/registry.rs
+++ b/node-graph/gcore/src/registry.rs
@@ -30,6 +30,8 @@ pub mod types {
 	pub type Resolution = glam::UVec2;
 	/// DVec2 with px unit
 	pub type PixelSize = glam::DVec2;
+	/// String with one or more than one line
+	pub type TextArea = String;
 }
 
 // Translation struct between macro and definition

--- a/node-graph/gmath-nodes/src/lib.rs
+++ b/node-graph/gmath-nodes/src/lib.rs
@@ -1,6 +1,6 @@
 use glam::DVec2;
 use graphene_core::gradient::GradientStops;
-use graphene_core::registry::types::{Fraction, Percentage};
+use graphene_core::registry::types::{Fraction, Percentage, TextArea};
 use graphene_core::{Color, Ctx, num_traits};
 use log::warn;
 use math_parser::ast;
@@ -603,7 +603,7 @@ fn gradient_value(_: impl Ctx, _primary: (), gradient: GradientStops) -> Gradien
 
 /// Constructs a string value which may be set to any plain text.
 #[node_macro::node(category("Value"))]
-fn string_value(_: impl Ctx, _primary: (), string: String) -> String {
+fn string_value(_: impl Ctx, _primary: (), string: TextArea) -> String {
 	string
 }
 


### PR DESCRIPTION
Modified Nodes
- String Value
- String Concatenate
- Replace String

Resolves https://discord.com/channels/731730685944922173/881073965047636018/1389675678865297488

Also closes #2806
