### PR TITLE
Make the Path tool's segment drag molding work with linear segments

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -16,7 +16,7 @@ use crate::messages::tool::common_functionality::shape_editor::{
 };
 use crate::messages::tool::common_functionality::snapping::{SnapCache, SnapCandidatePoint, SnapConstraint, SnapData, SnapManager};
 use crate::messages::tool::common_functionality::utility_functions::{calculate_segment_angle, find_two_param_best_approximate};
-use bezier_rs::{Bezier, TValue};
+use bezier_rs::{Bezier, BezierHandles, TValue};
 use graphene_std::renderer::Quad;
 use graphene_std::vector::{HandleExt, HandleId, NoHashBuilder, SegmentId, VectorData};
 use graphene_std::vector::{ManipulatorPointId, PointId, VectorModificationType};
@@ -674,13 +674,15 @@ impl PathToolData {
 				responses.add(OverlaysMessage::Draw);
 				PathToolFsmState::Dragging(self.dragging_state)
 			} else {
-				let handle1 = ManipulatorPointId::PrimaryHandle(segment.segment());
-				let handle2 = ManipulatorPointId::EndHandle(segment.segment());
-				if let Some(vector_data) = document.network_interface.compute_modified_vector(segment.layer()) {
-					if let (Some(pos1), Some(pos2)) = (handle1.get_position(&vector_data), handle2.get_position(&vector_data)) {
-						self.molding_info = Some((pos1, pos2))
-					}
-				}
+				let start_pos = segment.bezier().start;
+				let end_pos = segment.bezier().end;
+
+				let [pos1, pos2] = match segment.bezier().handles {
+					BezierHandles::Cubic { handle_start, handle_end } => [handle_start, handle_end],
+					BezierHandles::Quadratic { handle } => [handle, end_pos],
+					BezierHandles::Linear => [start_pos + (end_pos - start_pos) / 3., end_pos + (start_pos - end_pos) / 3.],
+				};
+				self.molding_info = Some((pos1, pos2));
 				PathToolFsmState::Dragging(self.dragging_state)
 			}
 		}


### PR DESCRIPTION
If a segment is linear (because its handles don't exist or are zero-length), update molding so in that special case, it creates handles at the 1/3 and 2/3 points along the linear segment and starts dragging those.
