### PR TITLE
Fix regression with migration code changed in node UI wire refactor

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -4093,6 +4093,18 @@ impl NodeNetworkInterface {
 		}
 	}
 
+	// When opening an old document to ensure the output names match the number of exports
+	pub fn validate_output_names(&mut self, node_id: &NodeId, node: &DocumentNode, network_path: &[NodeId]) {
+		if let DocumentNodeImplementation::Network(network) = &node.implementation {
+			let number_of_exports = network.exports.len();
+			let Some(metadata) = self.node_metadata_mut(node_id, network_path) else {
+				log::error!("Could not get metadata for node: {:?}", node_id);
+				return;
+			};
+			metadata.persistent_metadata.output_names.resize(number_of_exports, "".to_string());
+		}
+	}
+
 	/// Keep metadata in sync with the new implementation if this is used by anything other than the upgrade scripts
 	pub fn replace_reference_name(&mut self, node_id: &NodeId, network_path: &[NodeId], reference_name: String) {
 		let Some(node_metadata) = self.node_metadata_mut(node_id, network_path) else {
@@ -5639,7 +5651,6 @@ impl NodeNetworkInterface {
 		self.unload_all_nodes_bounding_box(network_path);
 	}
 
-	// TODO: Run the auto layout system to make space for the new nodes
 	/// Disconnect the layers primary output and the input to the last non layer node feeding into it through primary flow, reconnects, then moves the layer to the new layer and stack index
 	pub fn move_layer_to_stack(&mut self, layer: LayerNodeIdentifier, mut parent: LayerNodeIdentifier, mut insert_index: usize, network_path: &[NodeId]) {
 		// Prevent moving an artboard anywhere but to the ROOT_PARENT child stack

--- a/editor/src/messages/portfolio/document_migration.rs
+++ b/editor/src/messages/portfolio/document_migration.rs
@@ -614,16 +614,15 @@ pub fn document_migration_upgrades(document: &mut DocumentMessageHandler, reset_
 
 		// Make the "Quantity" parameter a u32 instead of f64
 		if reference == "Sample Polyline" {
-			let node_definition = resolve_document_node_type("Sample Polyline").unwrap();
-			let mut new_node_template = node_definition.default_node_template();
-
 			// Get the inputs, obtain the quantity value, and put the inputs back
-			let old_inputs = document.network_interface.replace_inputs(node_id, network_path, &mut new_node_template).unwrap();
-			let quantity_value = old_inputs.get(3).cloned();
+			let quantity_value = document
+				.network_interface
+				.input_from_connector(&InputConnector::Node { node_id: *node_id, input_index: 3 }, network_path)
+				.unwrap();
 
-			if let Some(NodeInput::Value { tagged_value, exposed }) = quantity_value {
-				if let TaggedValue::F64(value) = *tagged_value {
-					let new_quantity_value = NodeInput::value(TaggedValue::U32(value as u32), exposed);
+			if let NodeInput::Value { tagged_value, exposed } = quantity_value {
+				if let TaggedValue::F64(value) = **tagged_value {
+					let new_quantity_value = NodeInput::value(TaggedValue::U32(value as u32), *exposed);
 					document.network_interface.set_input(&InputConnector::node(*node_id, 3), new_quantity_value, network_path);
 				}
 			}

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -431,6 +431,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				for (node_id, node, path) in document.network_interface.document_network().clone().recursive_nodes() {
 					document.network_interface.validate_input_metadata(node_id, node, &path);
 					document.network_interface.validate_display_name_metadata(node_id, &path);
+					document.network_interface.validate_output_names(node_id, node, &path);
 				}
 
 				// Ensure layers are positioned as stacks if they are upstream siblings of another layer


### PR DESCRIPTION
Fixes sample polylines upgrade code, validates output names to prevent crashes in old artwork when removing an export, and improves layer insertion

Closes #2833
