### PR TITLE
feat: Allow duplicating layers by Alt+Dragging

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -84,6 +84,10 @@ pub enum PortfolioMessage {
 		parent: LayerNodeIdentifier,
 		insert_index: usize,
 	},
+	DuplicateSelectedLayers {
+		parent: LayerNodeIdentifier,
+		insert_index: usize,
+	},
 	PasteSerializedData {
 		data: String,
 	},

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -471,6 +471,43 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				// Load the document into the portfolio so it opens in the editor
 				self.load_document(document, document_id, responses, to_front);
 			}
+			PortfolioMessage::DuplicateSelectedLayers { parent, insert_index } => {
+				let Some(document) = self.active_document_mut() else {
+					return;
+				};
+
+				let mut all_new_ids = Vec::new();
+				let selected_layers = document.network_interface.selected_nodes().selected_layers(document.metadata()).collect::<Vec<_>>();
+
+				responses.add(DocumentMessage::DeselectAllLayers);
+				responses.add(DocumentMessage::AddTransaction);
+
+				for layer in selected_layers {
+					let layer_node_id = layer.to_node();
+
+					let mut copy_ids = HashMap::new();
+					copy_ids.insert(layer_node_id, NodeId(0));
+
+					document
+						.network_interface
+						.upstream_flow_back_from_nodes(vec![layer_node_id], &[], network_interface::FlowType::LayerChildrenUpstreamFlow)
+						.enumerate()
+						.for_each(|(index, node_id)| {
+							copy_ids.insert(node_id, NodeId((index + 1) as u64));
+						});
+
+					                    let nodes: Vec<_> = document.network_interface.copy_nodes(&copy_ids, &[]).collect();
+					let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
+					let new_layer = LayerNodeIdentifier::new_unchecked(new_ids[&NodeId(0)]);
+					all_new_ids.extend(new_ids.values().cloned());
+
+					responses.add(NodeGraphMessage::AddNodes { nodes, new_ids: new_ids.clone() });
+					responses.add(NodeGraphMessage::MoveLayerToStack { layer: new_layer, parent, insert_index });
+				}
+
+				responses.add(NodeGraphMessage::RunDocumentGraph);
+				responses.add(NodeGraphMessage::SelectedNodesSet { nodes: all_new_ids });
+			}
 			PortfolioMessage::PasteIntoFolder { clipboard, parent, insert_index } => {
 				let mut all_new_ids = Vec::new();
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>, all_new_ids: &mut Vec<NodeId>| {

--- a/frontend/src/components/panels/Layers.svelte
+++ b/frontend/src/components/panels/Layers.svelte
@@ -54,6 +54,7 @@
 	let draggingData: undefined | DraggingData = undefined;
 	let fakeHighlightOfNotYetSelectedLayerBeingDragged: undefined | bigint = undefined;
 	let dragInPanel = false;
+	let isDuplicating = false;
 
 	// Interactive clipping
 	let layerToClipUponClick: LayerListingInfo | undefined = undefined;
@@ -382,8 +383,9 @@
 
 		// Set style of cursor for drag
 		if (event.dataTransfer) {
-			event.dataTransfer.dropEffect = "move";
-			event.dataTransfer.effectAllowed = "move";
+			isDuplicating = event.altKey;
+			event.dataTransfer.dropEffect = isDuplicating ? "copy" : "move";
+			event.dataTransfer.effectAllowed = isDuplicating ? "copy" : "move";
 		}
 
 		if (list) draggingData = calculateDragIndex(list, event.clientY, select);
@@ -406,11 +408,15 @@
 		e.preventDefault();
 
 		if (e.dataTransfer) {
-			// Moving layers
+			// Moving or duplicating layers
 			if (e.dataTransfer.items.length === 0) {
 				if (draggable && dragInPanel) {
 					select?.();
-					editor.handle.moveLayerInTree(insertParentId, insertIndex);
+					if (isDuplicating) {
+						editor.handle.duplicateLayer(insertParentId, insertIndex);
+					} else {
+						editor.handle.moveLayerInTree(insertParentId, insertIndex);
+					}
 				}
 			}
 			// Importing files
@@ -444,6 +450,7 @@
 		draggingData = undefined;
 		fakeHighlightOfNotYetSelectedLayerBeingDragged = undefined;
 		dragInPanel = false;
+		isDuplicating = false;
 	}
 
 	function rebuildLayerHierarchy(updateDocumentLayerStructure: DocumentLayerStructure) {

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -670,6 +670,14 @@ impl EditorHandle {
 		self.dispatch(message);
 	}
 
+	/// Duplicate the selected layers
+	#[wasm_bindgen(js_name = duplicateLayer)]
+	pub fn duplicate_layer(&self, parent_id: Option<u64>, insert_index: usize) {
+		let parent = parent_id.map(|id| LayerNodeIdentifier::new_unchecked(NodeId(id))).unwrap_or_default();
+		let message = PortfolioMessage::DuplicateSelectedLayers { parent, insert_index };
+		self.dispatch(message);
+	}
+
 	/// Toggle visibility of a layer or node given its node ID
 	#[wasm_bindgen(js_name = toggleNodeVisibilityLayerPanel)]
 	pub fn toggle_node_visibility_layer(&self, id: u64) {


### PR DESCRIPTION
## Feature: Duplicate Layers via Alt+Drag in Layers Panel

This PR introduces a feature: the ability to duplicate layers directly within the **Layers panel** by holding down the **Alt key** (or **Option on macOS**) while dragging.  
This provides a quick and intuitive way for users to create copies of layers, streamlining their workflow for design iteration and variation.

---

### Key Changes

#### **Frontend**  
**File:** `frontend/src/components/panels/Layers.svelte`

- The drag event handler in the Layers panel now checks for the Alt key press.
- If Alt is held, the drag operation’s `dropEffect` and `effectAllowed` are dynamically set to `"copy"`.
- Upon dropping, the frontend dispatches a new `duplicateLayer` action instead of `moveLayerInTree`.

---

#### **WASM Binding**  
**File:** `frontend/wasm/src/editor_api.rs`

- A new `duplicateLayer` function has been exposed to the JavaScript frontend.
- This function dispatches the `PortfolioMessage::DuplicateSelectedLayers` message to the Rust backend.

---

#### **Backend**  
**Files:**  
- `editor/src/messages/portfolio/portfolio_message.rs`  
- `editor/src/messages/portfolio/portfolio_message_handler.rs`

- A new `DuplicateSelectedLayers` message has been added to the `PortfolioMessage` enum.
- The `PortfolioMessageHandler` includes logic to handle this message:
  - Identifies the currently selected layers.
  - Creates copies of their underlying graph nodes.
  - Inserts these duplicates at the specified parent and index within the document structure.

---
