### PR TITLE
Add duplicate layer functionality

### DIFF
--- a/editor/src/messages/portfolio/portfolio_message.rs
+++ b/editor/src/messages/portfolio/portfolio_message.rs
@@ -84,6 +84,10 @@ pub enum PortfolioMessage {
 		parent: LayerNodeIdentifier,
 		insert_index: usize,
 	},
+	DuplicateSelectedLayers {
+		parent: LayerNodeIdentifier,
+		insert_index: usize,
+	},
 	PasteSerializedData {
 		data: String,
 	},

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -473,6 +473,47 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageData<'_>> for PortfolioMes
 				// Load the document into the portfolio so it opens in the editor
 				self.load_document(document, document_id, responses, to_front);
 			}
+			PortfolioMessage::DuplicateSelectedLayers { parent, insert_index } => {
+				let Some(document) = self.active_document_mut() else {
+					return;
+				};
+
+				let mut all_new_ids = Vec::new();
+				let selected_layers = document.network_interface.selected_nodes().selected_layers(document.metadata()).collect::<Vec<_>>();
+
+				responses.add(DocumentMessage::DeselectAllLayers);
+				responses.add(DocumentMessage::AddTransaction);
+
+				for layer in selected_layers {
+					let layer_node_id = layer.to_node();
+
+					let mut copy_ids = HashMap::new();
+					copy_ids.insert(layer_node_id, NodeId(0));
+
+					document
+						.network_interface
+						.upstream_flow_back_from_nodes(vec![layer_node_id], &[], network_interface::FlowType::LayerChildrenUpstreamFlow)
+						.enumerate()
+						.for_each(|(index, node_id)| {
+							copy_ids.insert(node_id, NodeId((index + 1) as u64));
+						});
+
+					let nodes: Vec<_> = document.network_interface.copy_nodes(&copy_ids, &[]).collect();
+					let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
+					let new_layer = LayerNodeIdentifier::new_unchecked(new_ids[&NodeId(0)]);
+					all_new_ids.extend(new_ids.values().cloned());
+
+					responses.add(NodeGraphMessage::AddNodes { nodes, new_ids: new_ids.clone() });
+					responses.add(NodeGraphMessage::MoveLayerToStack {
+						layer: new_layer,
+						parent,
+						insert_index,
+					});
+				}
+
+				responses.add(NodeGraphMessage::RunDocumentGraph);
+				responses.add(NodeGraphMessage::SelectedNodesSet { nodes: all_new_ids });
+			}
 			PortfolioMessage::PasteIntoFolder { clipboard, parent, insert_index } => {
 				let mut all_new_ids = Vec::new();
 				let paste = |entry: &CopyBufferEntry, responses: &mut VecDeque<_>, all_new_ids: &mut Vec<NodeId>| {

--- a/frontend/src/components/panels/Layers.svelte
+++ b/frontend/src/components/panels/Layers.svelte
@@ -54,6 +54,7 @@
 	let draggingData: undefined | DraggingData = undefined;
 	let fakeHighlightOfNotYetSelectedLayerBeingDragged: undefined | bigint = undefined;
 	let dragInPanel = false;
+	let isDuplicating = false;
 
 	// Interactive clipping
 	let layerToClipUponClick: LayerListingInfo | undefined = undefined;
@@ -382,8 +383,9 @@
 
 		// Set style of cursor for drag
 		if (event.dataTransfer) {
-			event.dataTransfer.dropEffect = "move";
-			event.dataTransfer.effectAllowed = "move";
+			isDuplicating = event.altKey;
+			event.dataTransfer.dropEffect = isDuplicating ? "copy" : "move";
+			event.dataTransfer.effectAllowed = isDuplicating ? "copy" : "move";
 		}
 
 		if (list) draggingData = calculateDragIndex(list, event.clientY, select);
@@ -406,11 +408,15 @@
 		e.preventDefault();
 
 		if (e.dataTransfer) {
-			// Moving layers
+			// Moving or duplicating layers
 			if (e.dataTransfer.items.length === 0) {
 				if (draggable && dragInPanel) {
 					select?.();
-					editor.handle.moveLayerInTree(insertParentId, insertIndex);
+					if (isDuplicating) {
+						editor.handle.duplicateLayer(insertParentId, insertIndex);
+					} else {
+						editor.handle.moveLayerInTree(insertParentId, insertIndex);
+					}
 				}
 			}
 			// Importing files
@@ -444,6 +450,7 @@
 		draggingData = undefined;
 		fakeHighlightOfNotYetSelectedLayerBeingDragged = undefined;
 		dragInPanel = false;
+		isDuplicating = false;
 	}
 
 	function rebuildLayerHierarchy(updateDocumentLayerStructure: DocumentLayerStructure) {

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -669,6 +669,13 @@ impl EditorHandle {
 		};
 		self.dispatch(message);
 	}
+	/// Duplicate the selected layers
+	#[wasm_bindgen(js_name = duplicateLayer)]
+	pub fn duplicate_layer(&self, parent_id: Option<u64>, insert_index: usize) {
+		let parent = parent_id.map(|id| LayerNodeIdentifier::new_unchecked(NodeId(id))).unwrap_or_default();
+		let message = PortfolioMessage::DuplicateSelectedLayers { parent, insert_index };
+		self.dispatch(message);
+	}
 
 	/// Toggle visibility of a layer or node given its node ID
 	#[wasm_bindgen(js_name = toggleNodeVisibilityLayerPanel)]


### PR DESCRIPTION
This PR introduces the ability to duplicate selected layers within the editor. Users can now duplicate layers by dragging them while holding the Alt key.

This includes:

Adding a new DuplicateSelectedLayers message.

Implementing the logic to copy and insert duplicated layers into the document.

Updating the frontend to detect the Alt key during drag operations and trigger the duplication.

Exposing the duplicateLayer function in the WASM API.