### PR TITLE
Fix regression with inability to drag segments using the Path tool's segment mode

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1701,9 +1701,9 @@ impl Fsm for PathToolFsmState {
 							break_molding,
 							tool_data.temporary_adjacent_handles_while_molding,
 						);
-					}
 
-					return PathToolFsmState::Dragging(tool_data.dragging_state);
+						return PathToolFsmState::Dragging(tool_data.dragging_state);
+					}
 				}
 
 				let anchor_and_handle_toggled = input.keyboard.get(move_anchor_with_handles as usize);


### PR DESCRIPTION
Fix segment dragging issue which appeared in https://github.com/GraphiteEditor/Graphite/pull/2835
