### PR TITLE
Fixes #2038: Safari click and drag fix

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -326,13 +326,14 @@
 			alreadyActedGuard = true;
 			isDragging = true;
 
-			// We need to request pointer lock as immediately as possible for Safari compatibility
+			// We begin dragging if the target supports pointer lock.
+			// We need to request pointer lock as immediately as possible for Safari compatibility.
 			const target = e.target || undefined;
-			if (!(target instanceof HTMLElement)) return;
+			if (target instanceof HTMLElement) {
+				target.requestPointerLock();
+				beginDrag();
+			}
 
-			target.requestPointerLock();
-
-			beginDrag();
 			removeEventListener("pointermove", onMove);
 		};
 		// If it's a mouseup, we'll begin editing the text field.


### PR DESCRIPTION
Closes #2038

For the last PR, I had put the `target.requestPointerLock();` immediately inside the `onDragPointerDown` function which made dragging possible for Safari but crashed the possibility of text input within the number fields. The current solution I've found which both fixes the dragging issues for Safari and keeps the text input possibility the same as before is moving the `target.requestPointerLock();` to the event handler definition `onMove`:


<img width="685" height="276" alt="Image" src="https://github.com/user-attachments/assets/1c8f020d-2cfd-47a0-a454-f4434f13f12a" />

This seems to work reliably on Safari, Firefox and Chrome.

Let me know if it needs any changes!