### PR TITLE
Desktop: Handle another instance is already running

### DIFF
--- a/desktop/src/cef/internal/browser_process_handler.rs
+++ b/desktop/src/cef/internal/browser_process_handler.rs
@@ -29,6 +29,10 @@ impl<H: CefEventHandler + Clone> ImplBrowserProcessHandler for BrowserProcessHan
 		self.event_handler.schedule_cef_message_loop_work(Instant::now() + Duration::from_millis(delay_ms as u64));
 	}
 
+	fn on_already_running_app_relaunch(&self, _command_line: Option<&mut cef::CommandLine>, _current_directory: Option<&CefString>) -> ::std::os::raw::c_int {
+		1 // Return 1 to prevent default behavior of opening a empty browser window
+	}
+
 	fn get_raw(&self) -> *mut _cef_browser_process_handler_t {
 		self.object.cast()
 	}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -41,8 +41,12 @@ fn main() {
 	let wgpu_context = futures::executor::block_on(WgpuContext::new());
 	let cef_context = match cef_context.init(cef::CefHandler::new(window_size_receiver, event_loop.create_proxy(), wgpu_context.clone())) {
 		Ok(c) => c,
-		Err(cef::InitError::InitializationFailed) => {
-			tracing::error!("Cef initialization failed");
+		Err(cef::InitError::AlreadyRunning) => {
+			tracing::error!("Another instance is already running, Exiting.");
+			exit(0);
+		}
+		Err(cef::InitError::InitializationFailed(code)) => {
+			tracing::error!("Cef initialization failed with code: {code}");
 			exit(1);
 		}
 	};


### PR DESCRIPTION
We need to handle on_already_running_app_relaunch to prevent cef from opening a plain browser app.

Also adds explicit error for cef initialize failing because of it another instance is running.