### PR TITLE
Desktop: Ready runtime and render node for desktop

### DIFF
--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -14,7 +14,6 @@ license = "Apache-2.0"
 default = ["wasm"]
 wasm = ["wasm-bindgen", "graphene-std/wasm", "wasm-bindgen-futures"]
 gpu = ["interpreted-executor/gpu", "wgpu-executor"]
-tauri = ["ron", "decouple-execution"]
 decouple-execution = []
 resvg = ["graphene-std/resvg"]
 vello = ["graphene-std/vello", "resvg"]

--- a/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
+++ b/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
@@ -78,7 +78,9 @@ impl<'a> serde::Deserialize<'a> for CheckboxId {
 	where
 		D: serde::Deserializer<'a>,
 	{
-		let id = u64::deserialize(deserializer)?;
+		let optional_id: Option<u64> = Option::deserialize(deserializer)?;
+		// let id = u64::deserialize(deserializer)?;
+		let id = optional_id.unwrap_or(0);
 		let checkbox_id = CheckboxId(OnceCell::new().into());
 		checkbox_id.0.set(id).map_err(serde::de::Error::custom)?;
 		Ok(checkbox_id)

--- a/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
+++ b/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
@@ -79,7 +79,7 @@ impl<'a> serde::Deserialize<'a> for CheckboxId {
 		D: serde::Deserializer<'a>,
 	{
 		let optional_id: Option<u64> = Option::deserialize(deserializer)?;
-		// let id = u64::deserialize(deserializer)?;
+		// TODO: This is potentially weird because after deserialization the two labels will be decoupled if the value not existent
 		let id = optional_id.unwrap_or(0);
 		let checkbox_id = CheckboxId(OnceCell::new().into());
 		checkbox_id.0.set(id).map_err(serde::de::Error::custom)?;

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -364,6 +364,7 @@ impl NodeGraphExecutor {
 						);
 						responses.add(FrontendMessage::UpdateDocumentArtwork { svg });
 					}
+					graphene_std::wasm_application_io::RenderOutputType::Texture { .. } => {}
 					_ => {
 						return Err(format!("Invalid node graph output type: {:#?}", render_output.data));
 					}

--- a/editor/src/node_graph_executor/runtime_io.rs
+++ b/editor/src/node_graph_executor/runtime_io.rs
@@ -1,24 +1,11 @@
 use super::*;
 use std::sync::mpsc::{Receiver, Sender};
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-extern "C" {
-	// Invoke with arguments (default)
-	#[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
-	async fn invoke(cmd: &str, args: JsValue) -> JsValue;
-	#[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"], js_name="invoke")]
-	async fn invoke_without_arg(cmd: &str) -> JsValue;
-}
 
 /// Handles communication with the NodeRuntime, either locally or via Tauri
 #[derive(Debug)]
 pub struct NodeRuntimeIO {
 	// Send to
-	#[cfg(any(not(feature = "tauri"), test))]
 	sender: Sender<GraphRuntimeRequest>,
-	#[cfg(all(feature = "tauri", not(test)))]
-	sender: Sender<NodeGraphUpdate>,
 	receiver: Receiver<NodeGraphUpdate>,
 }
 
@@ -31,25 +18,13 @@ impl Default for NodeRuntimeIO {
 impl NodeRuntimeIO {
 	/// Creates a new NodeRuntimeIO instance
 	pub fn new() -> Self {
-		#[cfg(any(not(feature = "tauri"), test))]
-		{
-			let (response_sender, response_receiver) = std::sync::mpsc::channel();
-			let (request_sender, request_receiver) = std::sync::mpsc::channel();
-			futures::executor::block_on(replace_node_runtime(NodeRuntime::new(request_receiver, response_sender)));
+		let (response_sender, response_receiver) = std::sync::mpsc::channel();
+		let (request_sender, request_receiver) = std::sync::mpsc::channel();
+		futures::executor::block_on(replace_node_runtime(NodeRuntime::new(request_receiver, response_sender)));
 
-			Self {
-				sender: request_sender,
-				receiver: response_receiver,
-			}
-		}
-
-		#[cfg(all(feature = "tauri", not(test)))]
-		{
-			let (response_sender, response_receiver) = std::sync::mpsc::channel();
-			Self {
-				sender: response_sender,
-				receiver: response_receiver,
-			}
+		Self {
+			sender: request_sender,
+			receiver: response_receiver,
 		}
 	}
 	#[cfg(test)]
@@ -59,44 +34,11 @@ impl NodeRuntimeIO {
 
 	/// Sends a message to the NodeRuntime
 	pub fn send(&self, message: GraphRuntimeRequest) -> Result<(), String> {
-		#[cfg(any(not(feature = "tauri"), test))]
-		{
-			self.sender.send(message).map_err(|e| e.to_string())
-		}
-
-		#[cfg(all(feature = "tauri", not(test)))]
-		{
-			let serialized = ron::to_string(&message).map_err(|e| e.to_string()).unwrap();
-			wasm_bindgen_futures::spawn_local(async move {
-				let js_message = create_message_object(&serialized);
-				invoke("runtime_message", js_message).await;
-			});
-			Ok(())
-		}
+		self.sender.send(message).map_err(|e| e.to_string())
 	}
 
 	/// Receives any pending updates from the NodeRuntime
 	pub fn receive(&self) -> impl Iterator<Item = NodeGraphUpdate> + use<'_> {
-		// TODO: This introduces extra latency
-		#[cfg(all(feature = "tauri", not(test)))]
-		{
-			let sender = self.sender.clone();
-			// In the Tauri case, responses are handled separately via poll_node_runtime_updates
-			wasm_bindgen_futures::spawn_local(async move {
-				let messages = invoke_without_arg("poll_node_graph").await;
-				let vec: Vec<_> = ron::from_str(&messages.as_string().unwrap()).unwrap();
-				for message in vec {
-					sender.send(message).unwrap();
-				}
-			});
-		}
 		self.receiver.try_iter()
 	}
-}
-
-#[cfg(all(feature = "tauri", not(test)))]
-pub fn create_message_object(message: &str) -> JsValue {
-	let obj = js_sys::Object::new();
-	js_sys::Reflect::set(&obj, &JsValue::from_str("message"), &JsValue::from_str(message)).unwrap();
-	obj.into()
 }

--- a/frontend/wasm/Cargo.toml
+++ b/frontend/wasm/Cargo.toml
@@ -13,7 +13,6 @@ license = "Apache-2.0"
 [features]
 default = ["gpu"]
 gpu = ["editor/gpu"]
-tauri = ["editor/tauri"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -931,7 +931,7 @@ async fn poll_node_graph_evaluation() {
 		return;
 	}
 
-	if !editor::node_graph_executor::run_node_graph().await {
+	if !editor::node_graph_executor::run_node_graph().await.0 {
 		return;
 	};
 

--- a/node-graph/gapplication-io/src/lib.rs
+++ b/node-graph/gapplication-io/src/lib.rs
@@ -49,12 +49,23 @@ impl Size for web_sys::HtmlCanvasElement {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ImageTexture {
+	#[serde(skip)]
 	#[cfg(feature = "wgpu")]
 	pub texture: Arc<wgpu::Texture>,
+	#[serde(skip)]
 	#[cfg(not(feature = "wgpu"))]
 	pub texture: (),
+}
+
+impl<'a> serde::Deserialize<'a> for ImageTexture {
+	fn deserialize<D>(_: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'a>,
+	{
+		unimplemented!("attempted to serialize a texture")
+	}
 }
 
 impl Hash for ImageTexture {

--- a/node-graph/gapplication-io/src/lib.rs
+++ b/node-graph/gapplication-io/src/lib.rs
@@ -49,12 +49,10 @@ impl Size for web_sys::HtmlCanvasElement {
 	}
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
 pub struct ImageTexture {
-	#[serde(skip)]
 	#[cfg(feature = "wgpu")]
 	pub texture: Arc<wgpu::Texture>,
-	#[serde(skip)]
 	#[cfg(not(feature = "wgpu"))]
 	pub texture: (),
 }

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -4,7 +4,7 @@ use crate::wasm_application_io::WasmEditorApi;
 use dyn_any::DynAny;
 pub use dyn_any::StaticType;
 pub use glam::{DAffine2, DVec2, IVec2, UVec2};
-use graphene_application_io::SurfaceFrame;
+use graphene_application_io::{ImageTexture, SurfaceFrame};
 use graphene_brush::brush_cache::BrushCache;
 use graphene_brush::brush_stroke::BrushStroke;
 use graphene_core::raster::Image;
@@ -429,6 +429,7 @@ pub struct RenderOutput {
 #[derive(Debug, Clone, Hash, PartialEq, dyn_any::DynAny, serde::Serialize, serde::Deserialize)]
 pub enum RenderOutputType {
 	CanvasFrame(SurfaceFrame),
+	Texture(ImageTexture),
 	Svg { svg: String, image_data: Vec<(u64, Image<Color>)> },
 	Image(Vec<u8>),
 }

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -429,8 +429,12 @@ pub struct RenderOutput {
 #[derive(Debug, Clone, Hash, PartialEq, dyn_any::DynAny, serde::Serialize, serde::Deserialize)]
 pub enum RenderOutputType {
 	CanvasFrame(SurfaceFrame),
+	#[serde(skip)]
 	Texture(ImageTexture),
-	Svg { svg: String, image_data: Vec<(u64, Image<Color>)> },
+	Svg {
+		svg: String,
+		image_data: Vec<(u64, Image<Color>)>,
+	},
 	Image(Vec<u8>),
 }
 

--- a/node-graph/graph-craft/src/wasm_application_io.rs
+++ b/node-graph/graph-craft/src/wasm_application_io.rs
@@ -137,7 +137,6 @@ impl WasmApplicationIo {
 		let wgpu_available = executor.is_some();
 		WGPU_AVAILABLE.store(wgpu_available as i8, Ordering::SeqCst);
 
-		// Always enable wgpu when running with Tauri
 		let mut io = Self {
 			#[cfg(target_arch = "wasm32")]
 			ids: AtomicU64::new(0),
@@ -162,11 +161,7 @@ impl WasmApplicationIo {
 		let wgpu_available = executor.is_some();
 		WGPU_AVAILABLE.store(wgpu_available as i8, Ordering::SeqCst);
 
-		// Always enable wgpu when running with Tauri
 		let mut io = Self {
-			#[cfg(target_arch = "wasm32")]
-			ids: AtomicU64::new(0),
-			#[cfg(feature = "wgpu")]
 			gpu_executor: executor,
 			windows: Vec::new(),
 			resources: HashMap::new(),

--- a/node-graph/graph-craft/src/wasm_application_io.rs
+++ b/node-graph/graph-craft/src/wasm_application_io.rs
@@ -151,6 +151,31 @@ impl WasmApplicationIo {
 
 		io
 	}
+	#[cfg(all(not(target_arch = "wasm32"), feature = "wgpu"))]
+	pub fn new_with_context(context: wgpu_executor::Context) -> Self {
+		#[cfg(feature = "wgpu")]
+		let executor = WgpuExecutor::with_context(context);
+
+		#[cfg(not(feature = "wgpu"))]
+		let wgpu_available = false;
+		#[cfg(feature = "wgpu")]
+		let wgpu_available = executor.is_some();
+		WGPU_AVAILABLE.store(wgpu_available as i8, Ordering::SeqCst);
+
+		// Always enable wgpu when running with Tauri
+		let mut io = Self {
+			#[cfg(target_arch = "wasm32")]
+			ids: AtomicU64::new(0),
+			#[cfg(feature = "wgpu")]
+			gpu_executor: executor,
+			windows: Vec::new(),
+			resources: HashMap::new(),
+		};
+
+		io.resources.insert("null".to_string(), Arc::from(include_bytes!("null.png").to_vec()));
+
+		io
+	}
 }
 
 unsafe impl StaticType for WasmApplicationIo {

--- a/node-graph/gstd/src/wasm_application_io.rs
+++ b/node-graph/gstd/src/wasm_application_io.rs
@@ -170,10 +170,10 @@ async fn render_canvas(
 	render_config: RenderConfig,
 	data: impl GraphicElementRendered,
 	editor: &WasmEditorApi,
-	surface_handle: wgpu_executor::WgpuSurface,
+	surface_handle: Option<wgpu_executor::WgpuSurface>,
 	render_params: RenderParams,
 ) -> RenderOutputType {
-	use graphene_application_io::SurfaceFrame;
+	use graphene_application_io::{ImageTexture, SurfaceFrame};
 
 	let footprint = render_config.viewport;
 	let Some(exec) = editor.application_io.as_ref().unwrap().gpu_executor() else {
@@ -194,17 +194,26 @@ async fn render_canvas(
 	if !data.contains_artboard() && !render_config.hide_artboards {
 		background = Color::WHITE;
 	}
-	exec.render_vello_scene(&scene, &surface_handle, footprint.resolution, &context, background)
-		.await
-		.expect("Failed to render Vello scene");
+	if let Some(surface_handle) = surface_handle {
+		exec.render_vello_scene(&scene, &surface_handle, footprint.resolution, &context, background)
+			.await
+			.expect("Failed to render Vello scene");
 
-	let frame = SurfaceFrame {
-		surface_id: surface_handle.window_id,
-		resolution: render_config.viewport.resolution,
-		transform: glam::DAffine2::IDENTITY,
-	};
+		let frame = SurfaceFrame {
+			surface_id: surface_handle.window_id,
+			resolution: render_config.viewport.resolution,
+			transform: glam::DAffine2::IDENTITY,
+		};
 
-	RenderOutputType::CanvasFrame(frame)
+		RenderOutputType::CanvasFrame(frame)
+	} else {
+		let texture = exec
+			.render_vello_scene_to_texture(&scene, footprint.resolution, &context, background)
+			.await
+			.expect("Failed to render Vello scene");
+
+		RenderOutputType::Texture(ImageTexture { texture: Arc::new(texture) })
+	}
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -316,12 +325,14 @@ async fn render<'a: 'n, T: 'n + GraphicElementRendered + WasmNotSend>(
 	let data = data.eval(ctx.clone()).await;
 	let editor_api = editor_api.eval(None).await;
 
-	#[cfg(all(feature = "vello", not(test)))]
-	let surface_handle = _surface_handle.eval(None).await;
+	#[cfg(all(feature = "vello", not(test), target_arch = "wasm32"))]
+	let _surface_handle = _surface_handle.eval(None).await;
+	#[cfg(not(target_arch = "wasm32"))]
+	let _surface_handle: Option<wgpu_executor::WgpuSurface> = None;
 
 	let use_vello = editor_api.editor_preferences.use_vello();
-	#[cfg(all(feature = "vello", not(test)))]
-	let use_vello = use_vello && surface_handle.is_some();
+	#[cfg(all(feature = "vello", not(test), target_arch = "wasm32"))]
+	let use_vello = use_vello && _surface_handle.is_some();
 
 	let mut metadata = RenderMetadata::default();
 	data.collect_metadata(&mut metadata, footprint, None);
@@ -333,7 +344,7 @@ async fn render<'a: 'n, T: 'n + GraphicElementRendered + WasmNotSend>(
 			if use_vello && editor_api.application_io.as_ref().unwrap().gpu_executor().is_some() {
 				#[cfg(all(feature = "vello", not(test)))]
 				return RenderOutput {
-					data: render_canvas(render_config, data, editor_api, surface_handle.unwrap(), render_params).await,
+					data: render_canvas(render_config, data, editor_api, _surface_handle, render_params).await,
 					metadata,
 				};
 				#[cfg(any(not(feature = "vello"), test))]

--- a/node-graph/wgpu-executor/src/context.rs
+++ b/node-graph/wgpu-executor/src/context.rs
@@ -33,7 +33,10 @@ impl Context {
 			.request_device(&wgpu::DeviceDescriptor {
 				label: None,
 				// #[cfg(not(feature = "passthrough"))]
+				#[cfg(target_arch = "wasm32")]
 				required_features: wgpu::Features::empty(),
+				#[cfg(not(target_arch = "wasm32"))]
+				required_features: wgpu::Features::PUSH_CONSTANTS,
 				// Currently disabled because not all backend support passthrough.
 				// TODO: reenable only when vulkan adapter is available
 				// #[cfg(feature = "passthrough")]
@@ -45,11 +48,6 @@ impl Context {
 			.await
 			.ok()?;
 
-		let info = adapter.get_info();
-		// skip this on LavaPipe temporarily
-		if info.vendor == 0x10005 {
-			return None;
-		}
 		Some(Self {
 			device: Arc::new(device),
 			queue: Arc::new(queue),

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -238,7 +238,6 @@ impl WgpuExecutor {
 		let vello_renderer = Renderer::new(
 			&context.device,
 			RendererOptions {
-				// surface_format: Some(wgpu::TextureFormat::Rgba8Unorm),
 				pipeline_cache: None,
 				use_cpu: false,
 				antialiasing_support: AaSupport::all(),


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Ready the node graph executor to be able to use an external gpu executor and to return textures.
