### PR TITLE
Desktop add viewport texture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
 name = "graphite-desktop"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "cef",
  "dirs",
  "futures",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -28,4 +28,5 @@ cef = { workspace = true }
 include_dir = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
-dirs = {workspace = true}
+dirs = { workspace = true }
+bytemuck = { workspace = true }

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -83,7 +83,7 @@ impl ApplicationHandler<CustomEvent> for WinitApp {
 		match event {
 			CustomEvent::UiUpdate(texture) => {
 				if let Some(graphics_state) = self.graphics_state.as_mut() {
-					graphics_state.bind_texture(&texture);
+					graphics_state.bind_ui_texture(&texture);
 					graphics_state.resize(texture.width(), texture.height());
 				}
 				if let Some(window) = &self.window {

--- a/desktop/src/render/fullscreen_texture.wgsl
+++ b/desktop/src/render/fullscreen_texture.wgsl
@@ -25,12 +25,25 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 	return out;
 }
 
+struct Constants {
+    viewport_offset: vec2<f32>,
+};
+
+var<push_constant> constants: Constants;
+
 @group(0) @binding(0)
-var t_diffuse: texture_2d<f32>;
+var t_ui: texture_2d<f32>;
 @group(0) @binding(1)
+var t_viewport: texture_2d<f32>;
+@group(0) @binding(2)
 var s_diffuse: sampler;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-	return textureSample(t_diffuse, s_diffuse, in.tex_coords);
+	let ui_color: vec4<f32> = textureSample(t_ui, s_diffuse, in.tex_coords);
+	if (ui_color.a == 1.0) {
+		return ui_color;
+	}
+	let viewport_color: vec4<f32> = textureSample(t_viewport, s_diffuse, in.tex_coords - constants.viewport_offset);
+	return ui_color * ui_color.a + viewport_color * (1.0 - ui_color.a);
 }

--- a/desktop/src/render/fullscreen_texture.wgsl
+++ b/desktop/src/render/fullscreen_texture.wgsl
@@ -26,6 +26,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 }
 
 struct Constants {
+	viewport_scale: vec2<f32>,
     viewport_offset: vec2<f32>,
 };
 
@@ -44,6 +45,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 	if (ui_color.a == 1.0) {
 		return ui_color;
 	}
-	let viewport_color: vec4<f32> = textureSample(t_viewport, s_diffuse, in.tex_coords - constants.viewport_offset);
+	let viewport_tex_coords = (in.tex_coords - constants.viewport_offset) * constants.viewport_scale;
+	let viewport_color: vec4<f32> = textureSample(t_viewport, s_diffuse, viewport_tex_coords);
 	return ui_color * ui_color.a + viewport_color * (1.0 - ui_color.a);
 }

--- a/desktop/src/render/fullscreen_texture.wgsl
+++ b/desktop/src/render/fullscreen_texture.wgsl
@@ -27,7 +27,7 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 
 struct Constants {
 	viewport_scale: vec2<f32>,
-    viewport_offset: vec2<f32>,
+	viewport_offset: vec2<f32>,
 };
 
 var<push_constant> constants: Constants;


### PR DESCRIPTION
Small pr that add support for rendering the a viewport texture beneath the ui texture.
Functionality implemented here should be used in following PRs.

This pr doesn't change the functionality of the current desktop app.

for testing use `desktop-test-add-viewport-texture` branch
