### PR TITLE
Add stroke scaling option to Stroke node

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -27,7 +27,7 @@ use graphene_std::vector::misc::GridType;
 use graphene_std::vector::misc::{ArcType, MergeByDistanceAlgorithm};
 use graphene_std::vector::misc::{CentroidType, PointSpacingType};
 use graphene_std::vector::style::{Fill, FillChoice, FillType, GradientStops};
-use graphene_std::vector::style::{GradientType, PaintOrder, StrokeAlign, StrokeCap, StrokeJoin};
+use graphene_std::vector::style::{GradientType, PaintOrder, StrokeAlign, StrokeCap, StrokeJoin, StrokeScaling};
 use graphene_std::{GraphicGroupTable, NodeInputDecleration};
 
 pub(crate) fn string_properties(text: &str) -> Vec<LayoutGroup> {
@@ -1807,6 +1807,9 @@ pub fn stroke_properties(node_id: NodeId, context: &mut NodePropertiesContext) -
 	let dash_lengths = array_of_number_widget(ParameterWidgetsInfo::new(node_id, DashLengthsInput::INDEX, true, context), TextInput::default().centered(true));
 	let number_input = disabled_number_input;
 	let dash_offset = number_widget(ParameterWidgetsInfo::new(node_id, DashOffsetInput::INDEX, true, context), number_input);
+	let scaling = enum_choice::<StrokeScaling>()
+		.for_socket(ParameterWidgetsInfo::new(node_id, ScalingInput::INDEX, true, context))
+		.property_row();
 
 	vec![
 		color,
@@ -1818,6 +1821,7 @@ pub fn stroke_properties(node_id: NodeId, context: &mut NodePropertiesContext) -
 		paint_order,
 		LayoutGroup::Row { widgets: dash_lengths },
 		LayoutGroup::Row { widgets: dash_offset },
+		scaling,
 	]
 }
 

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -643,8 +643,6 @@ impl Fsm for ShapeToolFsmState {
 					}
 				}
 				tool_options.stroke.apply_stroke(tool_options.line_weight, layer, defered_responses);
-
-				tool_options.stroke.apply_stroke(tool_options.line_weight, layer, defered_responses);
 				tool_data.data.layer = Some(layer);
 
 				responses.add(DeferMessage::AfterGraphRun {

--- a/node-graph/gcore/src/vector/style.rs
+++ b/node-graph/gcore/src/vector/style.rs
@@ -260,6 +260,21 @@ impl PaintOrder {
 	}
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, Hash, DynAny, specta::Type, node_macro::ChoiceType)]
+#[widget(Radio)]
+pub enum StrokeScaling {
+	#[default]
+	ScaleWithShape,
+	NonScaling,
+}
+
+impl StrokeScaling {
+	pub fn is_non_scaling(self) -> bool {
+		self == Self::NonScaling
+	}
+}
+
 fn daffine2_identity() -> DAffine2 {
 	DAffine2::IDENTITY
 }

--- a/node-graph/gcore/src/vector/vector_nodes.rs
+++ b/node-graph/gcore/src/vector/vector_nodes.rs
@@ -14,7 +14,7 @@ use crate::vector::algorithms::bezpath_algorithms::{eval_pathseg_euclidean, is_l
 use crate::vector::algorithms::merge_by_distance::MergeByDistanceExt;
 use crate::vector::misc::{MergeByDistanceAlgorithm, PointSpacingType};
 use crate::vector::misc::{handles_to_segment, segment_to_handles};
-use crate::vector::style::{PaintOrder, StrokeAlign, StrokeCap, StrokeJoin};
+use crate::vector::style::{PaintOrder, StrokeAlign, StrokeCap, StrokeJoin, StrokeScaling};
 use crate::vector::{FillId, RegionId};
 use crate::{CloneVarArgs, Color, Context, Ctx, ExtractAll, GraphicElement, GraphicGroupTable, OwnedContextImpl};
 
@@ -191,6 +191,8 @@ async fn stroke<C: Into<Option<Color>> + 'n + Send, V>(
 	/// The phase offset distance from the starting point of the dash pattern.
 	#[unit(" px")]
 	dash_offset: f64,
+	/// Whether the stroke should scale with shape transformations or maintain a constant visual width.
+	scaling: StrokeScaling,
 ) -> Instances<V>
 where
 	Instances<V>: VectorDataTableIterMut + 'n + Send,
@@ -205,7 +207,7 @@ where
 		join_miter_limit: miter_limit,
 		align,
 		transform: DAffine2::IDENTITY,
-		non_scaling: false,
+		non_scaling: scaling.is_non_scaling(),
 		paint_order,
 	};
 

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -242,6 +242,7 @@ tagged_value! {
 	StrokeJoin(graphene_core::vector::style::StrokeJoin),
 	StrokeAlign(graphene_core::vector::style::StrokeAlign),
 	PaintOrder(graphene_core::vector::style::PaintOrder),
+	StrokeScaling(graphene_core::vector::style::StrokeScaling),
 	FillType(graphene_core::vector::style::FillType),
 	FillChoice(graphene_core::vector::style::FillChoice),
 	GradientType(graphene_core::vector::style::GradientType),


### PR DESCRIPTION
Add a "Scaling" field to the Stroke node that allows users to toggle whether strokes should scale with shape transformations or maintain a constant visual width.

* Add StrokeScaling enum with ScaleWithShape and NonScaling options
* Add new "Scaling" parameter to the Stroke node
* Update document migration to handle the new parameter
* Fix migration bug that caused index out of bounds error
* Remove duplicate apply_stroke call in shape_tool.rs

Closes #2960