### PR TITLE
Add an error dialog that is displayed if there is an error when exporting artwork

### DIFF
--- a/editor/src/messages/dialog/dialog_message.rs
+++ b/editor/src/messages/dialog/dialog_message.rs
@@ -8,8 +8,6 @@ pub enum DialogMessage {
 	ExportDialog(ExportDialogMessage),
 	#[child]
 	NewDocumentDialog(NewDocumentDialogMessage),
-	#[child]
-	PreferencesDialog(PreferencesDialogMessage),
 
 	// Messages
 	CloseAllDocumentsWithConfirmation,

--- a/editor/src/messages/dialog/mod.rs
+++ b/editor/src/messages/dialog/mod.rs
@@ -10,7 +10,6 @@ mod dialog_message_handler;
 
 pub mod export_dialog;
 pub mod new_document_dialog;
-pub mod preferences_dialog;
 pub mod simple_dialogs;
 
 #[doc(inline)]

--- a/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
@@ -14,12 +14,16 @@ pub struct NewDocumentDialogMessageHandler {
 #[message_handler_data]
 impl MessageHandler<NewDocumentDialogMessage, ()> for NewDocumentDialogMessageHandler {
 	fn process_message(&mut self, message: NewDocumentDialogMessage, responses: &mut VecDeque<Message>, _: ()) {
+		let mut dismiss = false;
+
 		match message {
 			NewDocumentDialogMessage::Name(name) => self.name = name,
 			NewDocumentDialogMessage::Infinite(infinite) => self.infinite = infinite,
 			NewDocumentDialogMessage::DimensionsX(x) => self.dimensions.x = x as u32,
 			NewDocumentDialogMessage::DimensionsY(y) => self.dimensions.y = y as u32,
 			NewDocumentDialogMessage::Submit => {
+				responses.add(FrontendMessage::DisplayDialogDismiss);
+				dismiss = true;
 				responses.add(PortfolioMessage::NewDocumentWithName { name: self.name.clone() });
 
 				let create_artboard = !self.infinite && self.dimensions.x > 0 && self.dimensions.y > 0;
@@ -41,7 +45,10 @@ impl MessageHandler<NewDocumentDialogMessage, ()> for NewDocumentDialogMessageHa
 			}
 		}
 
-		self.send_dialog_to_frontend(responses);
+		// Don't send the dialogue if the form was already dismissed (this would reopen it)
+		if !dismiss {
+			self.send_dialog_to_frontend(responses);
+		}
 	}
 
 	advertise_actions! {NewDocumentDialogUpdate;}
@@ -53,15 +60,7 @@ impl DialogLayoutHolder for NewDocumentDialogMessageHandler {
 
 	fn layout_buttons(&self) -> Layout {
 		let widgets = vec![
-			TextButton::new("OK")
-				.emphasized(true)
-				.on_update(|_| {
-					DialogMessage::CloseDialogAndThen {
-						followups: vec![NewDocumentDialogMessage::Submit.into()],
-					}
-					.into()
-				})
-				.widget_holder(),
+			TextButton::new("OK").emphasized(true).on_update(|_| NewDocumentDialogMessage::Submit.into()).widget_holder(),
 			TextButton::new("Cancel").on_update(|_| FrontendMessage::DisplayDialogDismiss.into()).widget_holder(),
 		];
 

--- a/editor/src/messages/dialog/preferences_dialog/mod.rs
+++ b/editor/src/messages/dialog/preferences_dialog/mod.rs
@@ -1,7 +1,0 @@
-mod preferences_dialog_message;
-mod preferences_dialog_message_handler;
-
-#[doc(inline)]
-pub use preferences_dialog_message::{PreferencesDialogMessage, PreferencesDialogMessageDiscriminant};
-#[doc(inline)]
-pub use preferences_dialog_message_handler::{PreferencesDialogMessageContext, PreferencesDialogMessageHandler};

--- a/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message.rs
+++ b/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message.rs
@@ -1,7 +1,0 @@
-use crate::messages::prelude::*;
-
-#[impl_message(Message, DialogMessage, PreferencesDialog)]
-#[derive(Eq, PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub enum PreferencesDialogMessage {
-	Confirm,
-}

--- a/editor/src/messages/dialog/simple_dialogs/mod.rs
+++ b/editor/src/messages/dialog/simple_dialogs/mod.rs
@@ -5,6 +5,7 @@ mod coming_soon_dialog;
 mod demo_artwork_dialog;
 mod error_dialog;
 mod licenses_dialog;
+mod preferences_dialog;
 
 pub use about_graphite_dialog::AboutGraphiteDialog;
 pub use close_all_documents_dialog::CloseAllDocumentsDialog;
@@ -14,3 +15,4 @@ pub use demo_artwork_dialog::ARTWORK;
 pub use demo_artwork_dialog::DemoArtworkDialog;
 pub use error_dialog::ErrorDialog;
 pub use licenses_dialog::LicensesDialog;
+pub use preferences_dialog::PreferencesDialog;

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -662,7 +662,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					return;
 				}
 
-				let layers_to_move = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
+				let layers_to_move = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
 				// Offset the index for layers to move that are below another layer to move. For example when moving 1 and 2 between 3 and 4, 2 should be inserted at the same index as 1 since 1 is moved first.
 				let layers_to_move_with_insert_offset = layers_to_move
 					.iter()
@@ -717,7 +717,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 			}
 			DocumentMessage::MoveSelectedLayersToGroup { parent } => {
 				// Group all shallowest unique selected layers in order
-				let all_layers_to_group_sorted = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
+				let all_layers_to_group_sorted = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
 
 				for layer_to_group in all_layers_to_group_sorted.into_iter().rev() {
 					responses.add(NodeGraphMessage::MoveLayerToStack {

--- a/editor/src/messages/prelude.rs
+++ b/editor/src/messages/prelude.rs
@@ -9,7 +9,6 @@ pub use crate::messages::debug::{DebugMessage, DebugMessageDiscriminant, DebugMe
 pub use crate::messages::defer::{DeferMessage, DeferMessageDiscriminant, DeferMessageHandler};
 pub use crate::messages::dialog::export_dialog::{ExportDialogMessage, ExportDialogMessageContext, ExportDialogMessageDiscriminant, ExportDialogMessageHandler};
 pub use crate::messages::dialog::new_document_dialog::{NewDocumentDialogMessage, NewDocumentDialogMessageDiscriminant, NewDocumentDialogMessageHandler};
-pub use crate::messages::dialog::preferences_dialog::{PreferencesDialogMessage, PreferencesDialogMessageContext, PreferencesDialogMessageDiscriminant, PreferencesDialogMessageHandler};
 pub use crate::messages::dialog::{DialogMessage, DialogMessageContext, DialogMessageDiscriminant, DialogMessageHandler};
 pub use crate::messages::frontend::{FrontendMessage, FrontendMessageDiscriminant};
 pub use crate::messages::globals::{GlobalsMessage, GlobalsMessageDiscriminant, GlobalsMessageHandler};


### PR DESCRIPTION
If an error is encountered during export, the error dialogue should be shown. However currently it is not. This is due to the fact that the export dialogue puts a `FrontendMessage::DisplayDialogDismiss` after running the exporting process, causing the error to be immediately dismissed.

Also
- refactor preferences message handler to reduce duplication
- remove some unnecessary allocations