### PR TITLE
Fix Shape tools bugs with stars/polygons with negative radii and circle radius click detection when viewport is zoomed

### DIFF
--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/circle_arc_radius_handle.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/circle_arc_radius_handle.rs
@@ -138,20 +138,9 @@ impl RadiusHandle {
 					return;
 				}
 
-				overlay_context.dashed_ellipse(
-					center,
-					x_point.distance(center),
-					y_point.distance(center),
-					None,
-					None,
-					None,
-					None,
-					None,
-					None,
-					Some(4.),
-					Some(4.),
-					Some(0.5),
-				);
+				let radius_x = x_point.distance(center);
+				let radius_y = y_point.distance(center);
+				overlay_context.dashed_ellipse(center, radius_x, radius_y, None, None, None, None, None, None, Some(4.), Some(4.), Some(0.5));
 			}
 		}
 	}

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/number_of_points_dial.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/number_of_points_dial.rs
@@ -189,8 +189,8 @@ impl NumberOfPointsDial {
 	}
 
 	pub fn update_number_of_sides(&self, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>, drag_start: DVec2) {
-		let delta = input.mouse.position - document.metadata().document_to_viewport.transform_point2(drag_start);
-		let sign = (input.mouse.position.x - document.metadata().document_to_viewport.transform_point2(drag_start).x).signum();
+		let delta = input.mouse.position - drag_start;
+		let sign = (input.mouse.position.x - drag_start.x).signum();
 		let net_delta = (delta.length() / 25.).round() * sign;
 
 		let Some(layer) = self.layer else { return };

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/point_radius_handle.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/point_radius_handle.rs
@@ -202,7 +202,6 @@ impl PointRadiusHandle {
 					star_outline(Some(layer), document, overlay_context);
 
 					// Make the ticks for snapping
-
 					if (radius1.signum() * radius2.signum()).is_sign_positive() {
 						draw_snapping_ticks(&self.snap_radii, direction, viewport, angle, overlay_context);
 					}
@@ -347,10 +346,10 @@ impl PointRadiusHandle {
 		};
 
 		let both_radii_negative = radius_1.is_sign_negative() && radius_2.is_sign_negative();
-		let both_radii_negative_or_positive = (radius_1.signum() * radius_2.signum()).is_sign_positive();
+		let both_radii_same_sign = (radius_1.signum() * radius_2.signum()).is_sign_positive();
 
-		// When only one of the radius is negative no need for snapping
-		if !both_radii_negative_or_positive {
+		// When only one of the radii is negative, no need for snapping
+		if !both_radii_same_sign {
 			return snap_radii;
 		}
 
@@ -434,7 +433,9 @@ impl PointRadiusHandle {
 		let new_radius = original_radius + net_delta;
 
 		self.update_state(PointRadiusHandleState::Dragging);
+
 		self.check_if_radius_flipped(original_radius, new_radius, document, layer, radius_index);
+
 		if let Some((index, snapped_delta)) = self.check_snapping(new_radius, original_radius) {
 			net_delta = snapped_delta;
 			self.update_state(PointRadiusHandleState::Snapped(index));

--- a/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
@@ -67,7 +67,7 @@ impl ShapeGizmoHandler for PolygonGizmoHandler {
 		overlay_context: &mut OverlayContext,
 	) {
 		self.number_of_points_dial.overlays(document, selected_polygon_layer, shape_editor, mouse_position, overlay_context);
-		self.point_radius_handle.overlays(selected_polygon_layer, document, input, mouse_position, overlay_context);
+		self.point_radius_handle.overlays(selected_polygon_layer, document, input, overlay_context);
 
 		polygon_outline(selected_polygon_layer, document, overlay_context);
 	}
@@ -85,7 +85,7 @@ impl ShapeGizmoHandler for PolygonGizmoHandler {
 		}
 
 		if self.point_radius_handle.is_dragging_or_snapped() {
-			self.point_radius_handle.overlays(None, document, input, mouse_position, overlay_context);
+			self.point_radius_handle.overlays(None, document, input, overlay_context);
 		}
 	}
 

--- a/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
@@ -64,7 +64,7 @@ impl ShapeGizmoHandler for StarGizmoHandler {
 		overlay_context: &mut OverlayContext,
 	) {
 		self.number_of_points_dial.overlays(document, selected_star_layer, shape_editor, mouse_position, overlay_context);
-		self.point_radius_handle.overlays(selected_star_layer, document, input, mouse_position, overlay_context);
+		self.point_radius_handle.overlays(selected_star_layer, document, input, overlay_context);
 
 		star_outline(selected_star_layer, document, overlay_context);
 	}
@@ -82,7 +82,7 @@ impl ShapeGizmoHandler for StarGizmoHandler {
 		}
 
 		if self.point_radius_handle.is_dragging_or_snapped() {
-			self.point_radius_handle.overlays(None, document, input, mouse_position, overlay_context);
+			self.point_radius_handle.overlays(None, document, input, overlay_context);
 		}
 	}
 

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -743,7 +743,7 @@ impl Fsm for ShapeToolFsmState {
 				self
 			}
 			(ShapeToolFsmState::ModifyingGizmo, ShapeToolMessage::PointerMove(..)) => {
-				tool_data.gizmo_manager.handle_update(tool_data.data.drag_start, document, input, responses);
+				tool_data.gizmo_manager.handle_update(tool_data.data.viewport_drag_start(document), document, input, responses);
 
 				responses.add(OverlaysMessage::Draw);
 


### PR DESCRIPTION
Fix star/polygon dragging and tick rendering for negative radii, and correct radius handle click detection at non-100% zoom.