### PR TITLE
Fix broken animations by removing deadlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 *.exrc
 perf.data*
 profile.json
+profile.json.gz
 flamegraph.svg
 .idea/
 .direnv

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -239,7 +239,8 @@ impl EditorHandle {
 				wasm_bindgen_futures::spawn_local(poll_node_graph_evaluation());
 
 				if !EDITOR_HAS_CRASHED.load(Ordering::SeqCst) {
-					editor_and_handle(|_, handle| {
+					handle(|handle| {
+						log::debug!("animation frame");
 						handle.dispatch(InputPreprocessorMessage::CurrentTime {
 							timestamp: js_sys::Date::now() as u64,
 						});
@@ -914,7 +915,10 @@ fn set_timeout(f: &Closure<dyn FnMut()>, delay: Duration) {
 fn editor<T: Default>(callback: impl FnOnce(&mut editor::application::Editor) -> T) -> T {
 	EDITOR.with(|editor| {
 		let mut guard = editor.try_lock();
-		let Ok(Some(editor)) = guard.as_deref_mut() else { return T::default() };
+		let Ok(Some(editor)) = guard.as_deref_mut() else {
+			log::error!("Failed to borrow editor");
+			return T::default();
+		};
 
 		callback(editor)
 	})
@@ -922,17 +926,24 @@ fn editor<T: Default>(callback: impl FnOnce(&mut editor::application::Editor) ->
 
 /// Provides access to the `Editor` and its `EditorHandle` by calling the given closure with them as arguments.
 pub(crate) fn editor_and_handle(callback: impl FnOnce(&mut Editor, &mut EditorHandle)) {
-	EDITOR_HANDLE.with(|editor_handle| {
+	handle(|editor_handle| {
 		editor(|editor| {
-			let mut guard = editor_handle.try_lock();
-			let Ok(Some(editor_handle)) = guard.as_deref_mut() else {
-				log::error!("Failed to borrow editor handle");
-				return;
-			};
-
 			// Call the closure with the editor and its handle
 			callback(editor, editor_handle);
 		})
+	});
+}
+/// Provides access to the `EditorHandle` by calling the given closure with them as arguments.
+pub(crate) fn handle(callback: impl FnOnce(&mut EditorHandle)) {
+	EDITOR_HANDLE.with(|editor_handle| {
+		let mut guard = editor_handle.try_lock();
+		let Ok(Some(editor_handle)) = guard.as_deref_mut() else {
+			log::error!("Failed to borrow editor handle");
+			return;
+		};
+
+		// Call the closure with the editor and its handle
+		callback(editor_handle);
 	});
 }
 

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -240,7 +240,6 @@ impl EditorHandle {
 
 				if !EDITOR_HAS_CRASHED.load(Ordering::SeqCst) {
 					handle(|handle| {
-						log::debug!("animation frame");
 						handle.dispatch(InputPreprocessorMessage::CurrentTime {
 							timestamp: js_sys::Date::now() as u64,
 						});


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->
Fixes regression from: #2951


Previously, we had a deadlock in the main evaluation queue but due to the global message queue lock imposed by the message buffering we never noticed that.
This pr removes the nested mutex acquisition
