### PR TITLE
Fix pen tool

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -1249,6 +1249,7 @@ impl PenToolData {
 		responses.add(DeferMessage::AfterGraphRun {
 			messages: vec![PenToolMessage::AddPointLayerPosition { layer, viewport }.into()],
 		});
+		responses.add(NodeGraphMessage::RunDocumentGraph);
 	}
 
 	/// Perform extension of an existing path


### PR DESCRIPTION
In order to ensure `PenToolMessage::AddPointLayerPosition` is called it is necessary to add a `NodeGraphMessage::RunDocumentGraph` after it is added to the defer queue.