### PR TITLE
Add nix configuration for the rust-gpu toolchain

### DIFF
--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -143,9 +143,6 @@
           gnuplot
           samply
           cargo-flamegraph
-
-          # Useful for rust-gpu debugging
-          pkgs.spirv-tools
         ];
       in
       {


### PR DESCRIPTION
# Requires https://github.com/GraphiteEditor/Graphite/pull/3096 and https://github.com/GraphiteEditor/Graphite/pull/3103

## And we would follow a non-main rust-gpu rev currently!