### PR TITLE
Improve tools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,6 @@
 	"files.insertFinalNewline": true,
 	"files.associations": {
 		"*.graphite": "json"
-	}
+	},
+	"rust-analyzer.checkOnSave": false
 }

--- a/editor/src/messages/dialog/dialog_message.rs
+++ b/editor/src/messages/dialog/dialog_message.rs
@@ -8,8 +8,6 @@ pub enum DialogMessage {
 	ExportDialog(ExportDialogMessage),
 	#[child]
 	NewDocumentDialog(NewDocumentDialogMessage),
-	#[child]
-	PreferencesDialog(PreferencesDialogMessage),
 
 	// Messages
 	CloseAllDocumentsWithConfirmation,

--- a/editor/src/messages/dialog/dialog_message_handler.rs
+++ b/editor/src/messages/dialog/dialog_message_handler.rs
@@ -1,5 +1,5 @@
 use super::new_document_dialog::NewDocumentDialogMessageContext;
-use super::simple_dialogs::{self, AboutGraphiteDialog, ComingSoonDialog, DemoArtworkDialog, LicensesDialog};
+use super::simple_dialogs::{self, *};
 use crate::messages::input_mapper::utility_types::input_mouse::ViewportBounds;
 use crate::messages::layout::utility_types::widget_prelude::*;
 use crate::messages::prelude::*;
@@ -16,7 +16,6 @@ pub struct DialogMessageContext<'a> {
 pub struct DialogMessageHandler {
 	export_dialog: ExportDialogMessageHandler,
 	new_document_dialog: NewDocumentDialogMessageHandler,
-	preferences_dialog: PreferencesDialogMessageHandler,
 }
 
 #[message_handler_data]
@@ -31,7 +30,6 @@ impl MessageHandler<DialogMessage, DialogMessageContext<'_>> for DialogMessageHa
 		match message {
 			DialogMessage::ExportDialog(message) => self.export_dialog.process_message(message, responses, ExportDialogMessageContext { portfolio }),
 			DialogMessage::NewDocumentDialog(message) => self.new_document_dialog.process_message(message, responses, NewDocumentDialogMessageContext { viewport_bounds }),
-			DialogMessage::PreferencesDialog(message) => self.preferences_dialog.process_message(message, responses, PreferencesDialogMessageContext { preferences }),
 
 			DialogMessage::CloseAllDocumentsWithConfirmation => {
 				let dialog = simple_dialogs::CloseAllDocumentsDialog {
@@ -40,13 +38,13 @@ impl MessageHandler<DialogMessage, DialogMessageContext<'_>> for DialogMessageHa
 				dialog.send_dialog_to_frontend(responses);
 			}
 			DialogMessage::CloseDialogAndThen { followups } => {
+				// Since this message is "close dialog and then", the closing of the dialogue must happen first.
+				// This is because processing may spawn another dialogue (e.g. the export dialogue may produce an error dialogue).
+				responses.add(FrontendMessage::DisplayDialogDismiss);
+
 				for message in followups.into_iter() {
 					responses.add(message);
 				}
-
-				// This come after followups, so that the followups (which can cause the dialog to open) happen first, then we close it afterwards.
-				// If it comes before, the dialog reopens (and appears to not close at all).
-				responses.add(FrontendMessage::DisplayDialogDismiss);
 			}
 			DialogMessage::DisplayDialogError { title, description } => {
 				let dialog = simple_dialogs::ErrorDialog { title, description };
@@ -112,8 +110,8 @@ impl MessageHandler<DialogMessage, DialogMessageContext<'_>> for DialogMessageHa
 				self.new_document_dialog.send_dialog_to_frontend(responses);
 			}
 			DialogMessage::RequestPreferencesDialog => {
-				self.preferences_dialog = PreferencesDialogMessageHandler {};
-				self.preferences_dialog.send_dialog_to_frontend(responses, preferences);
+				let dialog = PreferencesDialog { preferences };
+				dialog.send_dialog_to_frontend(responses);
 			}
 		}
 	}

--- a/editor/src/messages/dialog/mod.rs
+++ b/editor/src/messages/dialog/mod.rs
@@ -10,7 +10,6 @@ mod dialog_message_handler;
 
 pub mod export_dialog;
 pub mod new_document_dialog;
-pub mod preferences_dialog;
 pub mod simple_dialogs;
 
 #[doc(inline)]

--- a/editor/src/messages/dialog/preferences_dialog/mod.rs
+++ b/editor/src/messages/dialog/preferences_dialog/mod.rs
@@ -1,7 +1,0 @@
-mod preferences_dialog_message;
-mod preferences_dialog_message_handler;
-
-#[doc(inline)]
-pub use preferences_dialog_message::{PreferencesDialogMessage, PreferencesDialogMessageDiscriminant};
-#[doc(inline)]
-pub use preferences_dialog_message_handler::{PreferencesDialogMessageContext, PreferencesDialogMessageHandler};

--- a/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message.rs
+++ b/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message.rs
@@ -1,7 +1,0 @@
-use crate::messages::prelude::*;
-
-#[impl_message(Message, DialogMessage, PreferencesDialog)]
-#[derive(Eq, PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub enum PreferencesDialogMessage {
-	Confirm,
-}

--- a/editor/src/messages/dialog/simple_dialogs/mod.rs
+++ b/editor/src/messages/dialog/simple_dialogs/mod.rs
@@ -5,6 +5,7 @@ mod coming_soon_dialog;
 mod demo_artwork_dialog;
 mod error_dialog;
 mod licenses_dialog;
+mod preferences_dialog;
 
 pub use about_graphite_dialog::AboutGraphiteDialog;
 pub use close_all_documents_dialog::CloseAllDocumentsDialog;
@@ -14,3 +15,4 @@ pub use demo_artwork_dialog::ARTWORK;
 pub use demo_artwork_dialog::DemoArtworkDialog;
 pub use error_dialog::ErrorDialog;
 pub use licenses_dialog::LicensesDialog;
+pub use preferences_dialog::PreferencesDialog;

--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -165,7 +165,7 @@ pub fn input_mappings() -> Mapping {
 		entry!(KeyDown(MouseLeft); action_dispatch=GradientToolMessage::PointerDown),
 		entry!(PointerMove; refresh_keys=[Shift], action_dispatch=GradientToolMessage::PointerMove { constrain_axis: Shift }),
 		entry!(KeyUp(MouseLeft); action_dispatch=GradientToolMessage::PointerUp),
-		entry!(DoubleClick(MouseButton::Left); action_dispatch=GradientToolMessage::InsertStop),
+		entry!(DoubleClick(MouseButton::Left); action_dispatch=GradientToolMessage::InsertStopProxy),
 		entry!(KeyDown(Delete); action_dispatch=GradientToolMessage::DeleteStop),
 		entry!(KeyDown(Backspace); action_dispatch=GradientToolMessage::DeleteStop),
 		entry!(KeyDown(MouseRight); action_dispatch=GradientToolMessage::Abort),

--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -78,7 +78,8 @@ impl ScrollDelta {
 	}
 }
 
-// TODO: Document the difference between this and EditorMouseState
+/// This is similar to [`EditorMouseState`] except that the position is stored relative to the viewport rather than relative to the UI.
+/// Convert using [`EditorMouseState::to_mouse_state`]
 #[derive(Debug, Copy, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MouseState {
 	pub position: ViewportPosition,
@@ -94,7 +95,8 @@ impl MouseState {
 	}
 }
 
-// TODO: Document the difference between this and MouseState
+/// This is similar to [`MouseState`] except that the position is stored relative to the UI rather than relative to the viewport.
+/// Convert using [`EditorMouseState::to_mouse_state`]
 #[derive(Debug, Copy, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EditorMouseState {
 	pub editor_position: EditorPosition,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -662,7 +662,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					return;
 				}
 
-				let layers_to_move = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
+				let layers_to_move = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
 				// Offset the index for layers to move that are below another layer to move. For example when moving 1 and 2 between 3 and 4, 2 should be inserted at the same index as 1 since 1 is moved first.
 				let layers_to_move_with_insert_offset = layers_to_move
 					.iter()
@@ -717,7 +717,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 			}
 			DocumentMessage::MoveSelectedLayersToGroup { parent } => {
 				// Group all shallowest unique selected layers in order
-				let all_layers_to_group_sorted = self.network_interface.shallowest_unique_layers_sorted(&self.selection_network_path);
+				let all_layers_to_group_sorted = self.network_interface.shallowest_unique_layers(&self.selection_network_path).collect::<Vec<_>>();
 
 				for layer_to_group in all_layers_to_group_sorted.into_iter().rev() {
 					responses.add(NodeGraphMessage::MoveLayerToStack {

--- a/editor/src/messages/portfolio/document/overlays/utility_types_vello.rs
+++ b/editor/src/messages/portfolio/document/overlays/utility_types_vello.rs
@@ -200,6 +200,7 @@ impl core::hash::Hash for OverlayContext {
 }
 
 impl OverlayContext {
+	#[cfg(not(test))]
 	pub(super) fn new(size: DVec2, device_pixel_ratio: f64, visibility_settings: OverlaysVisibilitySettings) -> Self {
 		Self {
 			internal: Arc::new(Mutex::new(OverlayContextInternal::new(size, device_pixel_ratio, visibility_settings))),
@@ -421,6 +422,7 @@ impl Default for OverlayContextInternal {
 }
 
 impl OverlayContextInternal {
+	#[cfg(not(test))]
 	pub(super) fn new(size: DVec2, device_pixel_ratio: f64, visibility_settings: OverlaysVisibilitySettings) -> Self {
 		Self {
 			scene: Scene::new(),

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -451,6 +451,19 @@ impl LayerNodeIdentifier {
 	}
 }
 
+impl PartialEq<NodeId> for LayerNodeIdentifier {
+	fn eq(&self, other: &NodeId) -> bool {
+		self.to_node() == *other
+	}
+}
+
+// Implement <BookFormat> == <Book> comparisons
+impl PartialEq<LayerNodeIdentifier> for NodeId {
+	fn eq(&self, other: &LayerNodeIdentifier) -> bool {
+		other.to_node() == *self
+	}
+}
+
 // ========
 // AxisIter
 // ========

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1314,46 +1314,18 @@ impl NodeNetworkInterface {
 			.reduce(Quad::combine_bounds)
 	}
 
-	/// Layers excluding ones that are children of other layers in the list.
+	/// Layers excluding ones that are children of other layers in the list in layer tree order.
 	// TODO: Cache this
-	pub fn shallowest_unique_layers(&self, network_path: &[NodeId]) -> impl Iterator<Item = LayerNodeIdentifier> + use<> {
-		let mut sorted_layers = if let Some(selected_nodes) = self.selected_nodes_in_nested_network(network_path) {
-			selected_nodes
-				.selected_layers(self.document_metadata())
-				.map(|layer| {
-					let mut layer_path = layer.ancestors(&self.document_metadata).collect::<Vec<_>>();
-					layer_path.reverse();
-					layer_path
-				})
-				.collect::<Vec<_>>()
-		} else {
-			log::error!("Could not get selected nodes in shallowest_unique_layers");
-			Vec::new()
-		};
-
-		// Sorting here creates groups of similar UUID paths
-		sorted_layers.sort();
-		sorted_layers.dedup_by(|a, b| a.starts_with(b));
-		sorted_layers.into_iter().map(|mut path| {
-			let layer = path.pop().expect("Path should not be empty");
-			assert!(
-				layer != LayerNodeIdentifier::ROOT_PARENT,
-				"The root parent cannot be selected, so it cannot be a shallowest selected layer"
-			);
-			layer
-		})
-	}
-
-	pub fn shallowest_unique_layers_sorted(&self, network_path: &[NodeId]) -> Vec<LayerNodeIdentifier> {
-		let all_layers_to_group = self.shallowest_unique_layers(network_path).collect::<Vec<_>>();
-		// Ensure nodes are grouped in the correct order
-		let mut all_layers_to_group_sorted = Vec::new();
-		for descendant in LayerNodeIdentifier::ROOT_PARENT.descendants(self.document_metadata()) {
-			if all_layers_to_group.contains(&descendant) {
-				all_layers_to_group_sorted.push(descendant);
-			};
+	// Now allocation free!
+	pub fn shallowest_unique_layers(&self, network_path: &[NodeId]) -> ShallowestSelectionIter<'_> {
+		// Avoids the clone and filtering from from the selected_nodes_in_nested_network.
+		let metadata = self.network_metadata(network_path);
+		let selection = metadata.and_then(|metadata| metadata.persistent_metadata.selection_undo_history.back());
+		ShallowestSelectionIter {
+			selection: selection.map_or([].as_slice(), |selection| selection.0.as_slice()),
+			next: Some(LayerNodeIdentifier::ROOT_PARENT),
+			metadata: self.document_metadata(),
 		}
-		all_layers_to_group_sorted
 	}
 
 	/// Ancestor that is shared by all layers and that is deepest (more nested). Default may be the root. Skips selected non-folder, non-artboard layers
@@ -7021,4 +6993,33 @@ pub enum TransactionStatus {
 	Modified,
 	#[default]
 	Finished,
+}
+
+/// Iterate through the shallowest selected layers without allocating
+#[derive(Clone)]
+pub struct ShallowestSelectionIter<'a> {
+	next: Option<LayerNodeIdentifier>,
+	selection: &'a [NodeId], // TODO: should be HashSet to avoid duplicates.
+	metadata: &'a DocumentMetadata,
+}
+
+impl Iterator for ShallowestSelectionIter<'_> {
+	type Item = LayerNodeIdentifier;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		while let Some(layer_node) = self.next.take() {
+			// Ignoring the children of this layer, find the next layer that would be displayed in the tree
+			let below_in_tree = || layer_node.ancestors(self.metadata).find_map(|ancestor| ancestor.next_sibling(self.metadata));
+
+			// If the current layer is selected, return it.
+			if layer_node != LayerNodeIdentifier::ROOT_PARENT && self.selection.contains(&layer_node.to_node()) {
+				self.next = below_in_tree(); // Go straight to below and don't look at children
+				return Some(layer_node);
+			}
+			// Go to children or otherwise go to below in the tree
+			self.next = layer_node.first_child(self.metadata).or_else(below_in_tree);
+		}
+
+		None
+	}
 }

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -15,7 +15,6 @@ use crate::messages::portfolio::document::node_graph::document_node_definitions;
 use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
 use crate::messages::portfolio::document::utility_types::clipboards::{Clipboard, CopyBufferEntry, INTERNAL_CLIPBOARD_COUNT};
 use crate::messages::portfolio::document::utility_types::network_interface::OutputConnector;
-use crate::messages::portfolio::document::utility_types::nodes::SelectedNodes;
 use crate::messages::portfolio::document_migration::*;
 use crate::messages::preferences::SelectionMode;
 use crate::messages::prelude::*;
@@ -259,12 +258,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageContext<'_>> for Portfolio
 				};
 
 				let mut copy_val = |buffer: &mut Vec<CopyBufferEntry>| {
-					let mut ordered_last_elements = active_document.network_interface.shallowest_unique_layers(&[]).collect::<Vec<_>>();
-
-					ordered_last_elements.sort_by_key(|layer| {
-						let Some(parent) = layer.parent(active_document.metadata()) else { return usize::MAX };
-						DocumentMessageHandler::get_calculated_insert_index(active_document.metadata(), &SelectedNodes(vec![layer.to_node()]), parent)
-					});
+					let ordered_last_elements = active_document.network_interface.shallowest_unique_layers(&[]).collect::<Vec<_>>();
 
 					for layer in ordered_last_elements.into_iter() {
 						let layer_node_id = layer.to_node();

--- a/editor/src/messages/prelude.rs
+++ b/editor/src/messages/prelude.rs
@@ -9,7 +9,6 @@ pub use crate::messages::debug::{DebugMessage, DebugMessageDiscriminant, DebugMe
 pub use crate::messages::defer::{DeferMessage, DeferMessageDiscriminant, DeferMessageHandler};
 pub use crate::messages::dialog::export_dialog::{ExportDialogMessage, ExportDialogMessageContext, ExportDialogMessageDiscriminant, ExportDialogMessageHandler};
 pub use crate::messages::dialog::new_document_dialog::{NewDocumentDialogMessage, NewDocumentDialogMessageDiscriminant, NewDocumentDialogMessageHandler};
-pub use crate::messages::dialog::preferences_dialog::{PreferencesDialogMessage, PreferencesDialogMessageContext, PreferencesDialogMessageDiscriminant, PreferencesDialogMessageHandler};
 pub use crate::messages::dialog::{DialogMessage, DialogMessageContext, DialogMessageDiscriminant, DialogMessageHandler};
 pub use crate::messages::frontend::{FrontendMessage, FrontendMessageDiscriminant};
 pub use crate::messages::globals::{GlobalsMessage, GlobalsMessageDiscriminant, GlobalsMessageHandler};

--- a/editor/src/messages/tool/common_functionality/pivot.rs
+++ b/editor/src/messages/tool/common_functionality/pivot.rs
@@ -5,7 +5,7 @@ use crate::messages::portfolio::document::utility_types::document_metadata::Laye
 use crate::messages::prelude::*;
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::tool_messages::path_tool::PathOptionsUpdate;
-use crate::messages::tool::tool_messages::select_tool::SelectOptionsUpdate;
+use crate::messages::tool::tool_messages::select_tool::options::SelectOptionsUpdate;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use glam::{DAffine2, DVec2};
 use graphene_std::transform::ReferencePoint;

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -1596,7 +1596,7 @@ impl ShapeState {
 	}
 
 	pub fn find_nearest_visible_point_indices(
-		&mut self,
+		&self,
 		network_interface: &NodeNetworkInterface,
 		mouse_position: DVec2,
 		select_threshold: f64,

--- a/editor/src/messages/tool/common_functionality/shapes/line_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/line_shape.rs
@@ -70,13 +70,16 @@ impl Line {
 			return;
 		};
 
+		let transform_from_document = document.metadata().transform_to_document(layer).inverse();
+		let layer_points = document_points.map(|point| transform_from_document.transform_point2(point));
+
 		responses.add(NodeGraphMessage::SetInput {
 			input_connector: InputConnector::node(node_id, 1),
-			input: NodeInput::value(TaggedValue::DVec2(document_points[0]), false),
+			input: NodeInput::value(TaggedValue::DVec2(layer_points[0]), false),
 		});
 		responses.add(NodeGraphMessage::SetInput {
 			input_connector: InputConnector::node(node_id, 2),
-			input: NodeInput::value(TaggedValue::DVec2(document_points[1]), false),
+			input: NodeInput::value(TaggedValue::DVec2(layer_points[1]), false),
 		});
 		responses.add(NodeGraphMessage::RunDocumentGraph);
 	}

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -528,7 +528,7 @@ impl Fsm for ArtboardToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			ArtboardToolFsmState::Ready { .. } => HintData(vec![
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Draw Artboard")]),
@@ -552,7 +552,7 @@ impl Fsm for ArtboardToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		if let Self::Ready { hovered: false } = self {
 			responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Crosshair });
 		} else {

--- a/editor/src/messages/tool/tool_messages/brush_tool.rs
+++ b/editor/src/messages/tool/tool_messages/brush_tool.rs
@@ -418,7 +418,7 @@ impl Fsm for BrushToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			BrushToolFsmState::Ready => HintData(vec![
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Draw")]),
@@ -430,7 +430,7 @@ impl Fsm for BrushToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/eyedropper_tool.rs
+++ b/editor/src/messages/tool/tool_messages/eyedropper_tool.rs
@@ -124,7 +124,7 @@ impl Fsm for EyedropperToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			EyedropperToolFsmState::Ready => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::Lmb, "Sample to Primary"),
@@ -138,7 +138,7 @@ impl Fsm for EyedropperToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let cursor = match *self {
 			EyedropperToolFsmState::Ready => MouseCursorIcon::Default,
 			EyedropperToolFsmState::SamplingPrimary | EyedropperToolFsmState::SamplingSecondary => MouseCursorIcon::None,

--- a/editor/src/messages/tool/tool_messages/fill_tool.rs
+++ b/editor/src/messages/tool/tool_messages/fill_tool.rs
@@ -145,7 +145,7 @@ impl Fsm for FillToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			FillToolFsmState::Ready => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::Lmb, "Fill with Primary"),
@@ -157,7 +157,7 @@ impl Fsm for FillToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -297,7 +297,7 @@ impl Fsm for FreehandToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			FreehandToolFsmState::Ready => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::LmbDrag, "Draw Polyline"),
@@ -310,7 +310,7 @@ impl Fsm for FreehandToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -259,10 +259,14 @@ impl Fsm for FreehandToolFsmState {
 			}
 			(FreehandToolFsmState::Drawing, FreehandToolMessage::PointerMove) => {
 				if let Some(layer) = tool_data.layer {
-					let transform = document.metadata().transform_to_viewport(layer);
-					let position = transform.inverse().transform_point2(input.mouse.position);
+					if !document.metadata().upstream_footprints.contains_key(&layer.to_node()) {
+						warn!("Freehand tool layer not exist");
+					} else {
+						let transform = document.metadata().transform_to_viewport(layer);
+						let position = transform.inverse().transform_point2(input.mouse.position);
 
-					extend_path_with_next_segment(tool_data, position, true, responses);
+						extend_path_with_next_segment(tool_data, position, true, responses);
+					}
 				}
 
 				FreehandToolFsmState::Drawing

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -519,7 +519,7 @@ impl Fsm for GradientToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			GradientToolFsmState::Ready => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::LmbDrag, "Draw Gradient"),
@@ -534,7 +534,7 @@ impl Fsm for GradientToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/gradient_tool.rs
+++ b/editor/src/messages/tool/tool_messages/gradient_tool.rs
@@ -351,7 +351,8 @@ impl Fsm for GradientToolFsmState {
 					let (start, end) = (transform.transform_point2(gradient.start), transform.transform_point2(gradient.end));
 
 					// Compute the distance from the mouse to the gradient line in viewport space
-					let distance = (end - start).angle_to(mouse - start).sin() * (mouse - start).length();
+					let direction = (end - start).normalize_or_zero();
+					let distance = direction.dot(mouse - start);
 
 					// If click is on the line then insert point
 					if distance < (SELECTION_THRESHOLD * 2.) {

--- a/editor/src/messages/tool/tool_messages/navigate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/navigate_tool.rs
@@ -145,7 +145,7 @@ impl Fsm for NavigateToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			NavigateToolFsmState::Ready | NavigateToolFsmState::ZoomOrClickZooming => HintData(vec![
 				HintGroup(vec![
@@ -169,7 +169,7 @@ impl Fsm for NavigateToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let cursor = match *self {
 			NavigateToolFsmState::Ready => MouseCursorIcon::ZoomIn,
 			NavigateToolFsmState::Tilting => MouseCursorIcon::Default,

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -2164,7 +2164,7 @@ impl Fsm for PenToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			PenToolFsmState::Ready | PenToolFsmState::GRSHandle => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::Lmb, "Draw Path"),
@@ -2226,7 +2226,7 @@ impl Fsm for PenToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -1650,22 +1650,7 @@ impl Fsm for SelectToolFsmState {
 		}
 	}
 
-	fn standard_tool_messages(&self, message: &ToolMessage, responses: &mut VecDeque<Message>) -> bool {
-		// Check for standard hits or cursor events
-		match message {
-			ToolMessage::UpdateHints => {
-				self.update_hints(responses);
-				true
-			}
-			ToolMessage::UpdateCursor => {
-				self.update_cursor(responses);
-				true
-			}
-			_ => false,
-		}
-	}
-
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		match self {
 			SelectToolFsmState::Ready { selection } => {
 				let hint_data = HintData(vec![
@@ -1752,7 +1737,7 @@ impl Fsm for SelectToolFsmState {
 		}
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/select_tool/drag_state.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool/drag_state.rs
@@ -1,0 +1,84 @@
+use crate::consts::{DRAG_DIRECTION_MODE_DETERMINATION_THRESHOLD, SELECTION_TOLERANCE};
+use crate::messages::{portfolio::document::utility_types::document_metadata::DocumentMetadata, preferences::SelectionMode, tool::tool_messages::tool_prelude::*};
+/// Represents the current drag in progress
+#[derive(Clone, Debug, Default)]
+pub struct DragState {
+	pub start_document: DVec2,
+	pub current_document: DVec2,
+	/// Selection mode is set when the drag exceeds a certain distance. Once resolved, the selection mode cannot change.
+	resolved_selection_mode: Option<SelectionMode>,
+}
+
+impl DragState {
+	pub fn new(input: &InputPreprocessorMessageHandler, metadata: &DocumentMetadata) -> Self {
+		let document_mouse = metadata.document_to_viewport.inverse().transform_point2(input.mouse.position);
+		Self {
+			start_document: document_mouse,
+			current_document: document_mouse,
+			resolved_selection_mode: None,
+		}
+	}
+	pub fn set_current(&mut self, input: &InputPreprocessorMessageHandler, metadata: &DocumentMetadata) {
+		self.current_document = metadata.document_to_viewport.inverse().transform_point2(input.mouse.position);
+	}
+
+	pub fn offset_viewport(&mut self, offset: DVec2, metadata: &DocumentMetadata) {
+		self.current_document = self.current_document + metadata.document_to_viewport.inverse().transform_vector2(offset);
+	}
+
+	pub fn start_viewport(&self, metadata: &DocumentMetadata) -> DVec2 {
+		metadata.document_to_viewport.transform_point2(self.start_document)
+	}
+
+	pub fn current_viewport(&self, metadata: &DocumentMetadata) -> DVec2 {
+		metadata.document_to_viewport.transform_point2(self.current_document)
+	}
+
+	pub fn start_current_viewport(&self, metadata: &DocumentMetadata) -> [DVec2; 2] {
+		[self.start_viewport(metadata), self.current_viewport(metadata)]
+	}
+
+	pub fn total_drag_delta_document(&self) -> DVec2 {
+		self.current_document - self.start_document
+	}
+
+	pub fn total_drag_delta_viewport(&self, metadata: &DocumentMetadata) -> DVec2 {
+		metadata.document_to_viewport.transform_vector2(self.total_drag_delta_document())
+	}
+
+	pub fn inverse_drag_delta_viewport(&self, metadata: &DocumentMetadata) -> DVec2 {
+		-self.total_drag_delta_viewport(metadata)
+	}
+
+	pub fn update_selection_mode(&mut self, metadata: &DocumentMetadata, preferences: &PreferencesMessageHandler) -> SelectionMode {
+		if let Some(resolved_selection_mode) = self.resolved_selection_mode {
+			return resolved_selection_mode;
+		}
+		if preferences.get_selection_mode() != SelectionMode::Directional {
+			self.resolved_selection_mode = Some(preferences.get_selection_mode());
+			return preferences.get_selection_mode();
+		}
+
+		let [start, current] = self.start_current_viewport(metadata);
+
+		// Drag direction cannot be resolved TODO: why not consider only X distance?
+		if start.distance_squared(current) >= DRAG_DIRECTION_MODE_DETERMINATION_THRESHOLD.powi(2) {
+			let selection_mode = if current.x < start.x { SelectionMode::Touched } else { SelectionMode::Enclosed };
+			self.resolved_selection_mode = Some(selection_mode);
+			return selection_mode;
+		}
+
+		SelectionMode::default()
+	}
+
+	/// A viewport quad representing the drag bounds. Expanded if the start == end
+	pub fn expanded_selection_box_viewport(&self, metadata: &DocumentMetadata) -> [DVec2; 2] {
+		let [start, current] = self.start_current_viewport(metadata);
+		if start == current {
+			let tolerance = DVec2::splat(SELECTION_TOLERANCE);
+			[current - tolerance, current + tolerance]
+		} else {
+			[start, current]
+		}
+	}
+}

--- a/editor/src/messages/tool/tool_messages/select_tool/duplicate.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool/duplicate.rs
@@ -1,5 +1,5 @@
 use super::super::tool_prelude::*;
-use super::DragState;
+use super::drag_state::DragState;
 use crate::messages::portfolio::document::utility_types::network_interface::{FlowType, NodeTemplate};
 use crate::messages::portfolio::document::utility_types::nodes::SelectedNodes;
 use crate::messages::tool::tool_messages::select_tool::LayerNodeIdentifier;

--- a/editor/src/messages/tool/tool_messages/select_tool/duplicate.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool/duplicate.rs
@@ -1,0 +1,105 @@
+use super::super::tool_prelude::*;
+use super::DragState;
+use crate::messages::portfolio::document::utility_types::network_interface::{FlowType, NodeTemplate};
+use crate::messages::portfolio::document::utility_types::nodes::SelectedNodes;
+use crate::messages::tool::tool_messages::select_tool::LayerNodeIdentifier;
+use crate::messages::tool::tool_messages::select_tool::TransformIn;
+use graphene_std::uuid::NodeId;
+
+#[derive(Clone, Debug, Default)]
+pub struct DuplcateState {
+	pub non_duplicated_layers: Option<Vec<LayerNodeIdentifier>>,
+}
+
+impl DuplcateState {
+	pub fn reset(&mut self) {
+		self.non_duplicated_layers = None;
+	}
+
+	pub fn set_duplicating(&mut self, state: bool, layers_dragging: &mut Vec<LayerNodeIdentifier>, document: &mut DocumentMessageHandler, dragging: &DragState, responses: &mut VecDeque<Message>) {
+		if !state && self.non_duplicated_layers.is_some() {
+			self.stop_duplicates(layers_dragging, document, dragging, responses);
+		} else if state && self.non_duplicated_layers.is_none() {
+			self.start_duplicates(layers_dragging, document, dragging, responses);
+		}
+	}
+
+	/// Duplicates the currently dragging layers. Called when Alt is pressed and the layers have not yet been duplicated.
+	fn start_duplicates(&mut self, layers_dragging: &mut Vec<LayerNodeIdentifier>, document: &mut DocumentMessageHandler, dragging: &DragState, responses: &mut VecDeque<Message>) {
+		let mut new_dragging = Vec::new();
+
+		// Get the shallowest unique layers and sort by their index relative to parent for ordered processing
+		let layers = document.network_interface.shallowest_unique_layers(&[]).collect::<Vec<_>>();
+
+		for layer in layers.into_iter().rev() {
+			let Some(parent) = layer.parent(document.metadata()) else { continue };
+
+			// Moves the layer back to its starting position.
+			responses.add(GraphOperationMessage::TransformChange {
+				layer,
+				transform: DAffine2::from_translation(dragging.inverse_drag_delta_viewport(document.metadata())),
+				transform_in: TransformIn::Viewport,
+				skip_rerender: true,
+			});
+
+			// Copy the layer
+			let mut copy_ids = HashMap::new();
+			let node_id = layer.to_node();
+			copy_ids.insert(node_id, NodeId(0));
+
+			document
+				.network_interface
+				.upstream_flow_back_from_nodes(vec![layer.to_node()], &[], FlowType::LayerChildrenUpstreamFlow)
+				.enumerate()
+				.for_each(|(index, node_id)| {
+					copy_ids.insert(node_id, NodeId((index + 1) as u64));
+				});
+
+			let nodes = document.network_interface.copy_nodes(&copy_ids, &[]).collect::<Vec<(NodeId, NodeTemplate)>>();
+
+			let insert_index = DocumentMessageHandler::get_calculated_insert_index(document.metadata(), &SelectedNodes(vec![layer.to_node()]), parent);
+
+			let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
+
+			let layer_id = *new_ids.get(&NodeId(0)).expect("Node Id 0 should be a layer");
+			let layer = LayerNodeIdentifier::new_unchecked(layer_id);
+			new_dragging.push(layer);
+			responses.add(NodeGraphMessage::AddNodes { nodes, new_ids });
+			responses.add(NodeGraphMessage::MoveLayerToStack { layer, parent, insert_index });
+		}
+		let nodes = new_dragging.iter().filter(|&&layer| layer != LayerNodeIdentifier::ROOT_PARENT).map(|layer| layer.to_node()).collect();
+		responses.add(NodeGraphMessage::SelectedNodesSet { nodes });
+		responses.add(NodeGraphMessage::RunDocumentGraph);
+		self.non_duplicated_layers = Some(core::mem::replace(layers_dragging, new_dragging));
+	}
+
+	/// Removes the duplicated layers. Called when Alt is released and the layers have previously been duplicated.
+	fn stop_duplicates(&mut self, layers_dragging: &mut Vec<LayerNodeIdentifier>, document: &DocumentMessageHandler, dragging: &DragState, responses: &mut VecDeque<Message>) {
+		let Some(original) = self.non_duplicated_layers.take() else {
+			return;
+		};
+
+		// Delete the duplicated layers
+		for layer in document.network_interface.shallowest_unique_layers(&[]) {
+			responses.add(NodeGraphMessage::DeleteNodes {
+				node_ids: vec![layer.to_node()],
+				delete_children: true,
+			});
+		}
+
+		for &layer in &original {
+			responses.add(GraphOperationMessage::TransformChange {
+				layer,
+				transform: DAffine2::from_translation(dragging.total_drag_delta_viewport(document.metadata())),
+				transform_in: TransformIn::Viewport,
+				skip_rerender: true,
+			});
+		}
+		let nodes = original.iter().filter(|&&layer| layer != LayerNodeIdentifier::ROOT_PARENT).map(|layer| layer.to_node()).collect();
+		responses.add(NodeGraphMessage::SelectedNodesSet { nodes });
+		responses.add(NodeGraphMessage::RunDocumentGraph);
+		responses.add(NodeGraphMessage::SelectedNodesUpdated);
+		responses.add(NodeGraphMessage::SendGraph);
+		*layers_dragging = original;
+	}
+}

--- a/editor/src/messages/tool/tool_messages/select_tool/options.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool/options.rs
@@ -1,0 +1,214 @@
+use super::super::tool_prelude::*;
+use super::SelectTool;
+use crate::messages::portfolio::document::utility_types::misc::{AlignAggregate, AlignAxis, FlipAxis, GroupFolderType};
+use crate::messages::tool::common_functionality::pivot::{PivotGizmoType, PivotToolSource, pin_pivot_widget, pivot_gizmo_type_widget, pivot_reference_point_widget};
+use graphene_std::path_bool::BooleanOperation;
+use graphene_std::vector::ReferencePoint;
+use std::fmt;
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash, serde::Serialize, serde::Deserialize, specta::Type)]
+pub enum SelectOptionsUpdate {
+	NestedSelectionBehavior(NestedSelectionBehavior),
+	PivotGizmoType(PivotGizmoType),
+	TogglePivotGizmoType(bool),
+	TogglePivotPinned,
+}
+
+#[derive(Default, PartialEq, Eq, Clone, Copy, Debug, Hash, serde::Serialize, serde::Deserialize, specta::Type)]
+pub enum NestedSelectionBehavior {
+	#[default]
+	Shallowest,
+	Deepest,
+}
+
+impl fmt::Display for NestedSelectionBehavior {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			NestedSelectionBehavior::Deepest => write!(f, "Deep Select"),
+			NestedSelectionBehavior::Shallowest => write!(f, "Shallow Select"),
+		}
+	}
+}
+
+impl SelectTool {
+	fn deep_selection_widget(&self) -> WidgetHolder {
+		let layer_selection_behavior_entries = [NestedSelectionBehavior::Shallowest, NestedSelectionBehavior::Deepest]
+			.iter()
+			.map(|mode| {
+				MenuListEntry::new(format!("{mode:?}"))
+					.label(mode.to_string())
+					.on_commit(move |_| SelectToolMessage::SelectOptions(SelectOptionsUpdate::NestedSelectionBehavior(*mode)).into())
+			})
+			.collect();
+
+		DropdownInput::new(vec![layer_selection_behavior_entries])
+			.selected_index(Some((self.tool_data.nested_selection_behavior == NestedSelectionBehavior::Deepest) as u32))
+			.tooltip(
+				"Selection Mode\n\
+				\n\
+				Shallow Select: clicks initially select the least-nested layers and double clicks drill deeper into the folder hierarchy.\n\
+				Deep Select: clicks directly select the most-nested layers in the folder hierarchy.",
+			)
+			.widget_holder()
+	}
+
+	fn alignment_widgets(&self, disabled: bool) -> impl Iterator<Item = WidgetHolder> + use<> {
+		[AlignAxis::X, AlignAxis::Y]
+			.into_iter()
+			.flat_map(|axis| [(axis, AlignAggregate::Min), (axis, AlignAggregate::Center), (axis, AlignAggregate::Max)])
+			.map(move |(axis, aggregate)| {
+				let (icon, tooltip) = match (axis, aggregate) {
+					(AlignAxis::X, AlignAggregate::Min) => ("AlignLeft", "Align Left"),
+					(AlignAxis::X, AlignAggregate::Center) => ("AlignHorizontalCenter", "Align Horizontal Center"),
+					(AlignAxis::X, AlignAggregate::Max) => ("AlignRight", "Align Right"),
+					(AlignAxis::Y, AlignAggregate::Min) => ("AlignTop", "Align Top"),
+					(AlignAxis::Y, AlignAggregate::Center) => ("AlignVerticalCenter", "Align Vertical Center"),
+					(AlignAxis::Y, AlignAggregate::Max) => ("AlignBottom", "Align Bottom"),
+				};
+				IconButton::new(icon, 24)
+					.tooltip(tooltip)
+					.on_update(move |_| DocumentMessage::AlignSelectedLayers { axis, aggregate }.into())
+					.disabled(disabled)
+					.widget_holder()
+			})
+	}
+
+	fn flip_widgets(&self, disabled: bool) -> impl Iterator<Item = WidgetHolder> + use<> {
+		[(FlipAxis::X, "Horizontal"), (FlipAxis::Y, "Vertical")].into_iter().map(move |(flip_axis, name)| {
+			IconButton::new("Flip".to_string() + name, 24)
+				.tooltip("Flip ".to_string() + name)
+				.on_update(move |_| DocumentMessage::FlipSelectedLayers { flip_axis }.into())
+				.disabled(disabled)
+				.widget_holder()
+		})
+	}
+
+	fn turn_widgets(&self, disabled: bool) -> impl Iterator<Item = WidgetHolder> + use<> {
+		[(-90., "TurnNegative90", "Turn -90°"), (90., "TurnPositive90", "Turn 90°")]
+			.into_iter()
+			.map(move |(degrees, icon, name)| {
+				IconButton::new(icon, 24)
+					.tooltip(name)
+					.on_update(move |_| DocumentMessage::RotateSelectedLayers { degrees }.into())
+					.disabled(disabled)
+					.widget_holder()
+			})
+	}
+
+	fn boolean_widgets(&self, selected_count: usize) -> impl Iterator<Item = WidgetHolder> + use<> {
+		let list = <BooleanOperation as graphene_std::choice_type::ChoiceTypeStatic>::list();
+		list.iter().flat_map(|i| i.iter()).map(move |(operation, info)| {
+			let mut tooltip = info.label.to_string();
+			if let Some(doc) = info.docstring.as_deref() {
+				tooltip.push_str("\n\n");
+				tooltip.push_str(doc);
+			}
+			IconButton::new(info.icon.as_deref().unwrap(), 24)
+				.tooltip(tooltip)
+				.disabled(selected_count == 0)
+				.on_update(move |_| {
+					let group_folder_type = GroupFolderType::BooleanOperation(*operation);
+					DocumentMessage::GroupSelectedLayers { group_folder_type }.into()
+				})
+				.widget_holder()
+		})
+	}
+
+	pub fn update_tool_options(&mut self, option_update: &SelectOptionsUpdate, responses: &mut VecDeque<Message>) {
+		match option_update {
+			SelectOptionsUpdate::NestedSelectionBehavior(nested_selection_behavior) => {
+				self.tool_data.nested_selection_behavior = *nested_selection_behavior;
+				responses.add(ToolMessage::UpdateHints);
+			}
+			SelectOptionsUpdate::PivotGizmoType(gizmo_type) => {
+				if !self.tool_data.pivot_gizmo.state.disabled {
+					self.tool_data.pivot_gizmo.state.gizmo_type = *gizmo_type;
+					responses.add(ToolMessage::UpdateHints);
+					let pivot_gizmo = self.tool_data.pivot_gizmo();
+					responses.add(TransformLayerMessage::SetPivotGizmo { pivot_gizmo });
+					responses.add(NodeGraphMessage::RunDocumentGraph);
+					self.tool_data.pivot_changed = true;
+				}
+			}
+			SelectOptionsUpdate::TogglePivotGizmoType(state) => {
+				self.tool_data.pivot_gizmo.state.disabled = !state;
+				responses.add(ToolMessage::UpdateHints);
+				responses.add(NodeGraphMessage::RunDocumentGraph);
+				self.tool_data.pivot_changed = true;
+			}
+
+			SelectOptionsUpdate::TogglePivotPinned => {
+				self.tool_data.pivot_gizmo.pivot.pinned = !self.tool_data.pivot_gizmo.pivot.pinned;
+				responses.add(ToolMessage::UpdateHints);
+				responses.add(NodeGraphMessage::RunDocumentGraph);
+				self.tool_data.pivot_changed = true;
+			}
+		}
+	}
+}
+
+impl LayoutHolder for SelectTool {
+	fn layout(&self) -> Layout {
+		let mut widgets = Vec::new();
+
+		// Select mode (Deep/Shallow)
+		widgets.push(self.deep_selection_widget());
+
+		// Pivot gizmo type (checkbox + dropdown for pivot/origin)
+		widgets.push(Separator::new(SeparatorType::Unrelated).widget_holder());
+		widgets.extend(pivot_gizmo_type_widget(self.tool_data.pivot_gizmo.state, PivotToolSource::Select));
+
+		if self.tool_data.pivot_gizmo.state.is_pivot_type() {
+			// Nine-position reference point widget
+			widgets.push(Separator::new(SeparatorType::Related).widget_holder());
+			widgets.push(pivot_reference_point_widget(
+				self.tool_data.selected_layers_count == 0 || !self.tool_data.pivot_gizmo.state.is_pivot(),
+				self.tool_data.pivot_gizmo.pivot.to_pivot_position(),
+				PivotToolSource::Select,
+			));
+
+			// Pivot pin button
+			widgets.push(Separator::new(SeparatorType::Related).widget_holder());
+
+			let pin_active = self.tool_data.pivot_gizmo.pin_active();
+			let pin_enabled = self.tool_data.pivot_gizmo.pivot.old_pivot_position == ReferencePoint::None && !self.tool_data.pivot_gizmo.state.disabled;
+
+			if pin_active || pin_enabled {
+				widgets.push(pin_pivot_widget(pin_active, pin_enabled, PivotToolSource::Select));
+			}
+		}
+
+		// Align
+		let disabled = self.tool_data.selected_layers_count < 2;
+		widgets.push(Separator::new(SeparatorType::Unrelated).widget_holder());
+		widgets.extend(self.alignment_widgets(disabled));
+		// widgets.push(
+		// 	PopoverButton::new()
+		// 		.popover_layout(vec![
+		// 			LayoutGroup::Row {
+		// 				widgets: vec![TextLabel::new("Align").bold(true).widget_holder()],
+		// 			},
+		// 			LayoutGroup::Row {
+		// 				widgets: vec![TextLabel::new("Coming soon").widget_holder()],
+		// 			},
+		// 		])
+		// 		.disabled(disabled)
+		// 		.widget_holder(),
+		// );
+
+		// Flip
+		let disabled = self.tool_data.selected_layers_count == 0;
+		widgets.push(Separator::new(SeparatorType::Unrelated).widget_holder());
+		widgets.extend(self.flip_widgets(disabled));
+
+		// Turn
+		widgets.push(Separator::new(SeparatorType::Unrelated).widget_holder());
+		widgets.extend(self.turn_widgets(disabled));
+
+		// Boolean
+		widgets.push(Separator::new(SeparatorType::Unrelated).widget_holder());
+		widgets.extend(self.boolean_widgets(self.tool_data.selected_layers_count));
+
+		Layout::WidgetLayout(WidgetLayout::new(vec![LayoutGroup::Row { widgets }]))
+	}
+}

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -450,7 +450,7 @@ impl Fsm for SplineToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			SplineToolFsmState::Ready => HintData(vec![HintGroup(vec![
 				HintInfo::mouse(MouseMotion::Lmb, "Draw Spline"),
@@ -467,7 +467,7 @@ impl Fsm for SplineToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 	}
 }

--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -886,7 +886,7 @@ impl Fsm for TextToolFsmState {
 		}
 	}
 
-	fn update_hints(&self, responses: &mut VecDeque<Message>) {
+	fn update_hints(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let hint_data = match self {
 			TextToolFsmState::Ready => HintData(vec![
 				HintGroup(vec![HintInfo::mouse(MouseMotion::Lmb, "Place Text")]),
@@ -915,7 +915,7 @@ impl Fsm for TextToolFsmState {
 		responses.add(FrontendMessage::UpdateInputHints { hint_data });
 	}
 
-	fn update_cursor(&self, responses: &mut VecDeque<Message>) {
+	fn update_cursor(&self, _: &Self::ToolData, _: &ToolActionMessageContext, _: &Self::ToolOptions, responses: &mut VecDeque<Message>) {
 		let cursor = match self {
 			TextToolFsmState::Placing => MouseCursorIcon::Crosshair,
 			_ => MouseCursorIcon::Text,

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -290,7 +290,7 @@ impl NodeGraphExecutor {
 					} else {
 						self.process_node_graph_output(node_graph_output, transform, responses)?
 					}
-					responses.add_front(DeferMessage::TriggerGraphRun(execution_id, execution_context.document_id));
+					responses.add(DeferMessage::TriggerGraphRun(execution_id, execution_context.document_id));
 
 					// Update the spreadsheet on the frontend using the value of the inspect result.
 					if self.old_inspect_node.is_some() {

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -83,6 +83,13 @@ impl NodeGraphExecutor {
 		};
 		(node_runtime, node_executor)
 	}
+
+	/// It is useful to get the current execution id for tests to check if any more exeuctions have been queued.
+	#[cfg(test)]
+	pub(crate) fn current_execution_id(&self) -> u64 {
+		self.current_execution_id
+	}
+
 	/// Execute the network by flattening it and creating a borrow stack.
 	fn queue_execution(&mut self, render_config: RenderConfig) -> u64 {
 		let execution_id = self.current_execution_id;


### PR DESCRIPTION
Closes #3028
Depends on #2983

Improvements:
- Separate some of the functionality of the select tool into separate files (only partially done).

Fixes:
- <kbd>alt</kbd> duplicating in the select tool sometimes applies an offset.
- `update_hints` didn't have access to the `tool_data` so was implemented in a hacky way in the select tool and path tool
- Offsets when drawing on non-origin artboard in:
  - line tool
  - freehand tool
  - pen tool
  - text tool
- Gradient tool double click insert stop #3028