### PR TITLE
Remove cargo-about timeout to make builds work on slow machines

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -262,7 +262,6 @@ function generateRustLicenses(): LicenseInfo[] | undefined {
 		const { stdout, stderr, status } = spawnSync("cargo", ["about", "generate", "about.hbs"], {
 			cwd: path.join(__dirname, ".."),
 			encoding: "utf8",
-			timeout: 60000, // One minute
 			shell: true,
 			windowsHide: true, // Hide the terminal on Windows
 		});


### PR DESCRIPTION
Otherwise nixpkgs-review in github actions and builds on my build server fail with a cargo-about not installed error.

cargo-about takes +2 min on my build server


See https://github.com/timon-schelling/run-nixpkgs-review/actions/runs/16827851557/attempts/1#summary-47669462248