### PR TITLE
Desktop: Update cef to 139.0.1

### DIFF
--- a/.nix/flake.nix
+++ b/.nix/flake.nix
@@ -40,10 +40,10 @@
         };
 
         libcef = pkgs.libcef.overrideAttrs (finalAttrs: previousAttrs: {
-          version = "138.0.26";
-          gitRevision = "84f2d27";
-          chromiumVersion = "138.0.7204.158";
-          srcHash = "sha256-d9jQJX7rgdoHfROD3zmOdMSesRdKE3slB5ZV+U2wlbQ=";
+          version = "139.0.17";
+          gitRevision = "6c347eb";
+          chromiumVersion = "139.0.7258.31";
+          srcHash = "sha256-kRMO8DP4El1qytDsAZBdHvR9AAHXce90nPdyfJailBg=";
 
           __intentionallyOverridingVersion = true;
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,19 +683,20 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "138.5.0+138.0.26"
+version = "139.0.1+139.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfa138b538b29584b02e990a631ef44261d9a70d35a77ce4ef624410046fe91"
+checksum = "39b749cfc4124f9505b3fbe32279c0e93f30831f1ecf3c2cf85863179319cd7b"
 dependencies = [
  "cef-dll-sys",
+ "libloading",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "cef-dll-sys"
-version = "138.5.0+138.0.26"
+version = "139.0.1+139.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658450855d0ef25af50420b95fbdfacb5df17c7eb20a1615ec995470c26ed643"
+checksum = "fc42adb0adc477860b705e967d9f899be05ba3775fe4d6dc4d844a1391ffa3dd"
 dependencies = [
  "anyhow",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ iai-callgrind = { version = "0.12.3" }
 ndarray = "0.16.1"
 strum = { version = "0.26.3", features = ["derive"] }
 dirs = "6.0"
-cef = "138.5.0"
+cef = "139.0.1"
 include_dir = "0.7.4"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing = "0.1.41"


### PR DESCRIPTION
Follows chromium 139 release

Checked chromium, cef and cef-rs changelog.
- dropped support for mac os 11, mac os 12+ is now required to build. 
- other breaking changes **do not effect us**.

Build works in nix dev shell.
Tested basic functionality.
