### PR TITLE
Add workaround for a Safari bug where our number input fields can't be released from click-and-drag

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -365,6 +365,11 @@
 			cumulativeDragDelta = 0;
 
 			document.exitPointerLock();
+
+			// Fallback for Safari in case pointerlockchange never fires
+			setTimeout(() => {
+				if (!document.pointerLockElement) pointerLockChange();
+			}, 0);
 		};
 		const pointerMove = (e: PointerEvent) => {
 			// Abort the drag if right click is down. This works here because a "pointermove" event is fired when right clicking even if the cursor didn't move.


### PR DESCRIPTION
Closes #2038

I found a way to put a fallback into our `pointerUp` const (where we exit the pointerlock) to fire a `pointerLockChange` explicitly when this event is not triggered automatically (in our case when using Safari).

I've tested this on Safari, Firefox and Chrome and it seems this fallback both fixes/keeps the intended functionality without breaking the functionality of inputting per keyboard into the NumberInputs. Below a Safari demo.


https://github.com/user-attachments/assets/aa0221ff-b167-4496-aa21-8b3268822ca9



