### PR TITLE
Refactor: Move line gizmos into GizmoManager

### DIFF
--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/circle_arc_radius_handle.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/circle_arc_radius_handle.rs
@@ -1,11 +1,10 @@
 use crate::consts::GIZMO_HIDE_THRESHOLD;
-use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::message::Message;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::network_interface::InputConnector;
+use crate::messages::prelude::Responses;
 use crate::messages::prelude::{DocumentMessageHandler, InputPreprocessorMessageHandler, NodeGraphMessage};
-use crate::messages::prelude::{FrontendMessage, Responses};
 use crate::messages::tool::common_functionality::graph_modification_utils::{self, get_arc_id, get_stroke_width};
 use crate::messages::tool::common_functionality::shapes::shape_utility::{extract_arc_parameters, extract_circle_radius};
 use glam::{DAffine2, DVec2};
@@ -77,7 +76,7 @@ impl RadiusHandle {
 		stroke_width + extra_spacing
 	}
 
-	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, mouse_position: DVec2, responses: &mut VecDeque<Message>) {
+	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, mouse_position: DVec2) {
 		match &self.handle_state {
 			RadiusHandleState::Inactive => {
 				let Some(radius) = extract_circle_radius(layer, document).or(extract_arc_parameters(Some(layer), document).map(|(r, _, _, _)| r)) else {
@@ -99,8 +98,6 @@ impl RadiusHandle {
 					self.angle = angle;
 
 					self.update_state(RadiusHandleState::Hover);
-
-					responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::EWResize });
 				}
 			}
 			RadiusHandleState::Dragging | RadiusHandleState::Hover => {}

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/line_endpoint_handle.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/line_endpoint_handle.rs
@@ -1,0 +1,139 @@
+use crate::consts::BOUNDS_SELECT_THRESHOLD;
+use crate::messages::message::Message;
+use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::portfolio::document::utility_types::network_interface::InputConnector;
+use crate::messages::prelude::Responses;
+use crate::messages::prelude::{DocumentMessageHandler, InputPreprocessorMessageHandler, NodeGraphMessage};
+use crate::messages::tool::common_functionality::graph_modification_utils::{self};
+use crate::messages::tool::common_functionality::shapes::LineEnd;
+use crate::messages::tool::common_functionality::shapes::shape_utility::{extract_line_parameters, generate_line};
+use crate::messages::tool::common_functionality::snapping::{SnapData, SnapManager};
+use crate::messages::tool::tool_messages::tool_prelude::Key;
+use glam::DVec2;
+use graph_craft::document::NodeInput;
+use graph_craft::document::value::TaggedValue;
+use std::collections::VecDeque;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum LineEndPointHandleState {
+	#[default]
+	Inactive,
+	Hover,
+	Dragging,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct LineEndPointHandle {
+	pub layer: Option<LayerNodeIdentifier>,
+	pub handle_state: LineEndPointHandleState,
+	end_point: LineEnd,
+	drag_start: DVec2,
+	drag_current: DVec2,
+	angle: f64,
+}
+
+impl LineEndPointHandle {
+	pub fn cleanup(&mut self) {
+		self.handle_state = LineEndPointHandleState::Inactive;
+		self.layer = None;
+	}
+
+	pub fn hovered(&self) -> bool {
+		self.handle_state == LineEndPointHandleState::Hover
+	}
+
+	pub fn is_dragging(&self) -> bool {
+		self.handle_state == LineEndPointHandleState::Dragging
+	}
+
+	pub fn update_state(&mut self, state: LineEndPointHandleState) {
+		self.handle_state = state;
+	}
+
+	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, mouse_position: DVec2) {
+		match &self.handle_state {
+			LineEndPointHandleState::Inactive => {
+				if self.clicked_on_line_endpoints(layer, document, mouse_position) {
+					self.drag_current = mouse_position;
+					self.update_state(LineEndPointHandleState::Hover);
+				}
+			}
+			_ => {}
+		}
+	}
+
+	pub fn overlays(&self, selected_line_layer: Option<LayerNodeIdentifier>, document: &DocumentMessageHandler, overlay_context: &mut OverlayContext) {
+		let Some(layer) = selected_line_layer.or(self.layer) else { return };
+		let Some((start, end)) = extract_line_parameters(Some(layer), document) else { return };
+
+		let [viewport_start, viewport_end] = [start, end].map(|point| document.metadata().transform_to_viewport(layer).transform_point2(point));
+		overlay_context.line(viewport_start, viewport_end, None, None);
+		if !start.abs_diff_eq(end, f64::EPSILON * 1000.) {
+			overlay_context.square(viewport_start, Some(6.), None, None);
+			overlay_context.square(viewport_end, Some(6.), None, None);
+		}
+	}
+
+	pub fn update_endpoint_position(&mut self, document: &DocumentMessageHandler, snap: &mut SnapManager, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+		let Some(layer) = self.layer else { return };
+
+		self.drag_current = input.mouse.position;
+		let ignore = [layer];
+		let snap_data = SnapData::ignore(document, input, &ignore);
+		let to_document = document.metadata().transform_to_document(layer);
+		let (mut document_points, angle) = generate_line(
+			self.angle,
+			to_document.transform_point2(self.drag_start),
+			input.mouse.position,
+			snap,
+			snap_data,
+			input.keyboard.key(Key::Shift),
+			input.keyboard.key(Key::Control),
+			input.keyboard.key(Key::Alt),
+		);
+
+		self.angle = angle;
+
+		if self.end_point == LineEnd::Start {
+			document_points.swap(0, 1);
+		}
+		let Some(node_id) = graph_modification_utils::get_line_id(layer, &document.network_interface) else {
+			return;
+		};
+		responses.add(NodeGraphMessage::SetInput {
+			input_connector: InputConnector::node(node_id, 1),
+			input: NodeInput::value(TaggedValue::DVec2(to_document.inverse().transform_point2(document_points[0])), false),
+		});
+		responses.add(NodeGraphMessage::SetInput {
+			input_connector: InputConnector::node(node_id, 2),
+			input: NodeInput::value(TaggedValue::DVec2(to_document.inverse().transform_point2(document_points[1])), false),
+		});
+		responses.add(NodeGraphMessage::RunDocumentGraph);
+	}
+
+	pub fn clicked_on_line_endpoints(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, drag_start: DVec2) -> bool {
+		let Some((document_start, document_end)) = extract_line_parameters(Some(layer), document) else {
+			return false;
+		};
+
+		let transform = document.metadata().transform_to_viewport(layer);
+		let viewport_x = transform.transform_vector2(DVec2::X).normalize_or_zero() * BOUNDS_SELECT_THRESHOLD;
+		let viewport_y = transform.transform_vector2(DVec2::Y).normalize_or_zero() * BOUNDS_SELECT_THRESHOLD;
+		let threshold_x = transform.inverse().transform_vector2(viewport_x).length();
+		let threshold_y = transform.inverse().transform_vector2(viewport_y).length();
+
+		let [start, end] = [document_start, document_end].map(|point| transform.transform_point2(point));
+
+		let start_click = (drag_start.y - start.y).abs() < threshold_y && (drag_start.x - start.x).abs() < threshold_x;
+		let end_click = (drag_start.y - end.y).abs() < threshold_y && (drag_start.x - end.x).abs() < threshold_x;
+
+		if start_click || end_click {
+			self.end_point = if end_click { LineEnd::End } else { LineEnd::Start };
+			self.drag_start = if end_click { document_start } else { document_end };
+			self.layer = Some(layer);
+			return true;
+		}
+		false
+	}
+}

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/mod.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/mod.rs
@@ -1,4 +1,5 @@
 pub mod circle_arc_radius_handle;
+pub mod line_endpoint_handle;
 pub mod number_of_points_dial;
 pub mod point_radius_handle;
 pub mod sweep_angle_gizmo;

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/number_of_points_dial.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/number_of_points_dial.rs
@@ -1,11 +1,10 @@
 use crate::consts::{GIZMO_HIDE_THRESHOLD, NUMBER_OF_POINTS_DIAL_SPOKE_EXTENSION, NUMBER_OF_POINTS_DIAL_SPOKE_LENGTH, POINT_RADIUS_HANDLE_SEGMENT_THRESHOLD};
-use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::message::Message;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::network_interface::InputConnector;
 use crate::messages::prelude::Responses;
-use crate::messages::prelude::{DocumentMessageHandler, FrontendMessage, InputPreprocessorMessageHandler, NodeGraphMessage};
+use crate::messages::prelude::{DocumentMessageHandler, InputPreprocessorMessageHandler, NodeGraphMessage};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::common_functionality::shapes::shape_utility::{extract_polygon_parameters, inside_polygon, inside_star, polygon_outline, polygon_vertex_position, star_outline};
@@ -49,7 +48,7 @@ impl NumberOfPointsDial {
 		self.handle_state == NumberOfPointsDialState::Dragging
 	}
 
-	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler) {
 		match &self.handle_state {
 			NumberOfPointsDialState::Inactive => {
 				// Star
@@ -63,7 +62,6 @@ impl NumberOfPointsDial {
 						self.layer = Some(layer);
 						self.initial_points = sides;
 						self.update_state(NumberOfPointsDialState::Hover);
-						responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::EWResize });
 					}
 				}
 
@@ -78,7 +76,6 @@ impl NumberOfPointsDial {
 						self.layer = Some(layer);
 						self.initial_points = sides;
 						self.update_state(NumberOfPointsDialState::Hover);
-						responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::EWResize });
 					}
 				}
 			}
@@ -91,7 +88,6 @@ impl NumberOfPointsDial {
 				if mouse_position.distance(center) > NUMBER_OF_POINTS_DIAL_SPOKE_LENGTH && matches!(&self.handle_state, NumberOfPointsDialState::Hover) {
 					self.update_state(NumberOfPointsDialState::Inactive);
 					self.layer = None;
-					responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 				}
 			}
 		}

--- a/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/point_radius_handle.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/shape_gizmos/point_radius_handle.rs
@@ -1,10 +1,8 @@
 use crate::consts::GIZMO_HIDE_THRESHOLD;
 use crate::consts::{COLOR_OVERLAY_RED, POINT_RADIUS_HANDLE_SNAP_THRESHOLD};
-use crate::messages::frontend::utility_types::MouseCursorIcon;
 use crate::messages::message::Message;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::{overlays::utility_types::OverlayContext, utility_types::network_interface::InputConnector};
-use crate::messages::prelude::FrontendMessage;
 use crate::messages::prelude::Responses;
 use crate::messages::prelude::{DocumentMessageHandler, InputPreprocessorMessageHandler, NodeGraphMessage};
 use crate::messages::tool::common_functionality::graph_modification_utils::{self, NodeGraphLayer};
@@ -54,7 +52,7 @@ impl PointRadiusHandle {
 		self.handle_state = state;
 	}
 
-	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, mouse_position: DVec2, responses: &mut VecDeque<Message>) {
+	pub fn handle_actions(&mut self, layer: LayerNodeIdentifier, document: &DocumentMessageHandler, mouse_position: DVec2) {
 		match &self.handle_state {
 			PointRadiusHandleState::Inactive => {
 				// Draw the point handle gizmo for the star shape
@@ -77,7 +75,6 @@ impl PointRadiusHandle {
 							self.point = i;
 							self.snap_radii = Self::calculate_snap_radii(document, layer, radius_index);
 							self.initial_radius = radius;
-							responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 							self.update_state(PointRadiusHandleState::Hover);
 
 							return;
@@ -105,7 +102,6 @@ impl PointRadiusHandle {
 							self.snap_radii.clear();
 							self.initial_radius = radius;
 							self.update_state(PointRadiusHandleState::Hover);
-							responses.add(FrontendMessage::UpdateMouseCursor { cursor: MouseCursorIcon::Default });
 							return;
 						}
 					}

--- a/editor/src/messages/tool/common_functionality/shapes/arc_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/arc_shape.rs
@@ -8,6 +8,7 @@ use crate::messages::tool::common_functionality::gizmos::shape_gizmos::circle_ar
 use crate::messages::tool::common_functionality::gizmos::shape_gizmos::sweep_angle_gizmo::{SweepAngleGizmo, SweepAngleGizmoState};
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::shapes::shape_utility::{ShapeGizmoHandler, arc_outline};
+use crate::messages::tool::common_functionality::snapping::SnapManager;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use glam::DAffine2;
 use graph_craft::document::NodeInput;
@@ -28,9 +29,9 @@ impl ArcGizmoHandler {
 }
 
 impl ShapeGizmoHandler for ArcGizmoHandler {
-	fn handle_state(&mut self, selected_shape_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+	fn handle_state(&mut self, selected_shape_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler) {
 		self.sweep_angle_gizmo.handle_actions(selected_shape_layer, document, mouse_position);
-		self.arc_radius_handle.handle_actions(selected_shape_layer, document, mouse_position, responses);
+		self.arc_radius_handle.handle_actions(selected_shape_layer, document, mouse_position);
 	}
 
 	fn is_any_gizmo_hovered(&self) -> bool {
@@ -54,7 +55,7 @@ impl ShapeGizmoHandler for ArcGizmoHandler {
 		}
 	}
 
-	fn handle_update(&mut self, drag_start: DVec2, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+	fn handle_update(&mut self, drag_start: DVec2, _snap_manager: &mut SnapManager, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
 		if self.sweep_angle_gizmo.is_dragging_or_snapped() {
 			self.sweep_angle_gizmo.update_arc(document, input, responses);
 		}

--- a/editor/src/messages/tool/common_functionality/shapes/circle_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/circle_shape.rs
@@ -7,6 +7,7 @@ use crate::messages::tool::common_functionality::gizmos::shape_gizmos::circle_ar
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::common_functionality::shapes::shape_utility::{ShapeGizmoHandler, ShapeToolModifierKey};
+use crate::messages::tool::common_functionality::snapping::SnapManager;
 use crate::messages::tool::tool_messages::shape_tool::ShapeToolData;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use glam::DAffine2;
@@ -23,8 +24,8 @@ impl ShapeGizmoHandler for CircleGizmoHandler {
 		self.circle_radius_handle.hovered()
 	}
 
-	fn handle_state(&mut self, selected_circle_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
-		self.circle_radius_handle.handle_actions(selected_circle_layer, document, mouse_position, responses);
+	fn handle_state(&mut self, selected_circle_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler) {
+		self.circle_radius_handle.handle_actions(selected_circle_layer, document, mouse_position);
 	}
 
 	fn handle_click(&mut self) {
@@ -33,7 +34,7 @@ impl ShapeGizmoHandler for CircleGizmoHandler {
 		}
 	}
 
-	fn handle_update(&mut self, drag_start: DVec2, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+	fn handle_update(&mut self, drag_start: DVec2, _snap_manager: &mut SnapManager, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
 		if self.circle_radius_handle.is_dragging() {
 			self.circle_radius_handle.update_inner_radius(document, input, responses, drag_start);
 		}

--- a/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
@@ -14,6 +14,7 @@ use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::common_functionality::shapes::shape_utility::ShapeGizmoHandler;
 use crate::messages::tool::common_functionality::shapes::shape_utility::polygon_outline;
+use crate::messages::tool::common_functionality::snapping::SnapManager;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use glam::DAffine2;
 use graph_craft::document::NodeInput;
@@ -31,9 +32,9 @@ impl ShapeGizmoHandler for PolygonGizmoHandler {
 		self.number_of_points_dial.is_hovering() || self.point_radius_handle.hovered()
 	}
 
-	fn handle_state(&mut self, selected_star_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
-		self.number_of_points_dial.handle_actions(selected_star_layer, mouse_position, document, responses);
-		self.point_radius_handle.handle_actions(selected_star_layer, document, mouse_position, responses);
+	fn handle_state(&mut self, selected_star_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler) {
+		self.number_of_points_dial.handle_actions(selected_star_layer, mouse_position, document);
+		self.point_radius_handle.handle_actions(selected_star_layer, document, mouse_position);
 	}
 
 	fn handle_click(&mut self) {
@@ -47,7 +48,7 @@ impl ShapeGizmoHandler for PolygonGizmoHandler {
 		}
 	}
 
-	fn handle_update(&mut self, drag_start: DVec2, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+	fn handle_update(&mut self, drag_start: DVec2, _snap_manager: &mut SnapManager, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
 		if self.number_of_points_dial.is_dragging() {
 			self.number_of_points_dial.update_number_of_sides(document, input, responses, drag_start);
 		}

--- a/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
@@ -10,6 +10,7 @@ use crate::messages::tool::common_functionality::gizmos::shape_gizmos::point_rad
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::common_functionality::shapes::shape_utility::{ShapeGizmoHandler, star_outline};
+use crate::messages::tool::common_functionality::snapping::SnapManager;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use core::f64;
 use glam::DAffine2;
@@ -28,9 +29,9 @@ impl ShapeGizmoHandler for StarGizmoHandler {
 		self.number_of_points_dial.is_hovering() || self.point_radius_handle.hovered()
 	}
 
-	fn handle_state(&mut self, selected_star_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
-		self.number_of_points_dial.handle_actions(selected_star_layer, mouse_position, document, responses);
-		self.point_radius_handle.handle_actions(selected_star_layer, document, mouse_position, responses);
+	fn handle_state(&mut self, selected_star_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler) {
+		self.number_of_points_dial.handle_actions(selected_star_layer, mouse_position, document);
+		self.point_radius_handle.handle_actions(selected_star_layer, document, mouse_position);
 	}
 
 	fn handle_click(&mut self) {
@@ -44,7 +45,7 @@ impl ShapeGizmoHandler for StarGizmoHandler {
 		}
 	}
 
-	fn handle_update(&mut self, drag_start: DVec2, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+	fn handle_update(&mut self, drag_start: DVec2, _snap_manager: &mut SnapManager, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
 		if self.number_of_points_dial.is_dragging() {
 			self.number_of_points_dial.update_number_of_sides(document, input, responses, drag_start);
 		}


### PR DESCRIPTION
Refactored line gizmo API which was handled by shape-tool to be managed under the new GizmoManager.