### PR TITLE
Desktop: Add window buttons for linux

### DIFF
--- a/frontend/src/components/window/title-bar/TitleBar.svelte
+++ b/frontend/src/components/window/title-bar/TitleBar.svelte
@@ -8,6 +8,7 @@
 
 	import LayoutRow from "@graphite/components/layout/LayoutRow.svelte";
 	import TextButton from "@graphite/components/widgets/buttons/TextButton.svelte";
+	import WindowButtonsLinux from "@graphite/components/window/title-bar/WindowButtonsLinux.svelte";
 	import WindowButtonsMac from "@graphite/components/window/title-bar/WindowButtonsMac.svelte";
 	import WindowButtonsWeb from "@graphite/components/window/title-bar/WindowButtonsWeb.svelte";
 	import WindowButtonsWindows from "@graphite/components/window/title-bar/WindowButtonsWindows.svelte";
@@ -82,8 +83,10 @@
 	</LayoutRow>
 	<!-- Window buttons (except on Mac) -->
 	<LayoutRow class="right">
-		{#if platform === "Windows" || platform === "Linux"}
+		{#if platform === "Windows"}
 			<WindowButtonsWindows {maximized} />
+		{:else if platform === "Linux"}
+			<WindowButtonsLinux {maximized} />
 		{:else if platform === "Web"}
 			<WindowButtonsWeb />
 		{/if}

--- a/frontend/src/components/window/title-bar/WindowButtonsLinux.svelte
+++ b/frontend/src/components/window/title-bar/WindowButtonsLinux.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { getContext } from "svelte";
+
+	import type { Editor } from "@graphite/editor";
+
+	import LayoutRow from "@graphite/components/layout/LayoutRow.svelte";
+	import IconLabel from "@graphite/components/widgets/labels/IconLabel.svelte";
+
+	export let maximized;
+
+	const editor = getContext<Editor>("editor");
+</script>
+
+<LayoutRow class="window-button linux" tooltip="Minimize" on:click={() => editor.handle.appWindowMinimize()}>
+	<IconLabel icon={"WindowButtonWinMinimize"} />
+</LayoutRow>
+<LayoutRow class="window-button linux" tooltip={maximized ? "Restore Down" : "Maximize"} on:click={() => editor.handle.appWindowMaximize()}>
+	<IconLabel icon={maximized ? "WindowButtonWinRestoreDown" : "WindowButtonWinMaximize"} />
+</LayoutRow>
+<LayoutRow class="window-button linux" tooltip="Close" on:click={() => editor.handle.appWindowClose()}>
+	<IconLabel icon={"WindowButtonWinClose"} />
+</LayoutRow>
+
+<style lang="scss" global>
+	.window-button.linux {
+		flex: 0 0 auto;
+		align-items: center;
+		padding: 0 10px;
+
+		svg {
+			fill: var(--color-e-nearwhite);
+		}
+
+		&:hover {
+			border-radius: 2px;
+			background: var(--color-6-lowergray);
+
+			svg {
+				fill: var(--color-f-white);
+			}
+		}
+	}
+</style>


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Implements basic window buttons for linux that look less out of place (on most desktops) than using Windows™ buttons
<img width="243" height="204" alt="image" src="https://github.com/user-attachments/assets/78b704bc-18fa-44e4-9f5d-f506554de3c2" />
