### PR TITLE
Desktop: add missing txt file mime type mapping

### DIFF
--- a/desktop/src/cef/scheme_handler.rs
+++ b/desktop/src/cef/scheme_handler.rs
@@ -87,6 +87,7 @@ impl<'a> GraphiteFrontendResourceHandler<'a> {
 			match ext {
 				"html" => Some("text/html".to_string()),
 				"css" => Some("text/css".to_string()),
+				"txt" => Some("text/plain".to_string()),
 				"wasm" => Some("application/wasm".to_string()),
 				"js" => Some("application/javascript".to_string()),
 				"png" => Some("image/png".to_string()),


### PR DESCRIPTION
Missing mapping caused license dialog that loads txt file to fail and report no network connection.

Partly closes #3041. Fixup after #3079.
