### PR TITLE
Shaders: Provide Wgpu Executor via Scope Input

### DIFF
--- a/node-graph/interpreted-executor/src/util.rs
+++ b/node-graph/interpreted-executor/src/util.rs
@@ -8,6 +8,7 @@ use graphene_std::Context;
 use graphene_std::ContextFeatures;
 use graphene_std::uuid::NodeId;
 use std::sync::Arc;
+use wgpu_executor::WgpuExecutor;
 
 pub fn wrap_network_in_scope(mut network: NodeNetwork, editor_api: Arc<WasmEditorApi>) -> NodeNetwork {
 	network.generate_node_paths(&[]);
@@ -68,7 +69,7 @@ pub fn wrap_network_in_scope(mut network: NodeNetwork, editor_api: Arc<WasmEdito
 	};
 
 	// wrap the inner network in a scope
-	let nodes = vec![
+	let mut nodes = vec![
 		inner_network,
 		render_node,
 		DocumentNode {
@@ -77,11 +78,21 @@ pub fn wrap_network_in_scope(mut network: NodeNetwork, editor_api: Arc<WasmEdito
 			..Default::default()
 		},
 	];
+	let mut scope_injections = vec![("editor-api".to_string(), (NodeId(2), concrete!(&WasmEditorApi)))];
+
+	if cfg!(feature = "gpu") {
+		nodes.push(DocumentNode {
+			implementation: DocumentNodeImplementation::ProtoNode(ProtoNodeIdentifier::from("graphene_core::ops::IntoNode<&WgpuExecutor>")),
+			inputs: vec![NodeInput::node(NodeId(2), 0)],
+			..Default::default()
+		});
+		scope_injections.push(("wgpu-executor".to_string(), (NodeId(3), concrete!(&WgpuExecutor))));
+	}
 
 	NodeNetwork {
 		exports: vec![NodeInput::node(NodeId(1), 0)],
 		nodes: nodes.into_iter().enumerate().map(|(id, node)| (NodeId(id as u64), node)).collect(),
-		scope_injections: [("editor-api".to_string(), (NodeId(2), concrete!(&WasmEditorApi)))].into_iter().collect(),
+		scope_injections: scope_injections.into_iter().collect(),
 		// TODO(TrueDoctor): check if it makes sense to set `generated` to `true`
 		generated: false,
 	}

--- a/node-graph/node-macro/src/shader_nodes/per_pixel_adjust.rs
+++ b/node-graph/node-macro/src/shader_nodes/per_pixel_adjust.rs
@@ -1,5 +1,5 @@
 use crate::crate_ident::CrateIdent;
-use crate::parsing::{Input, NodeFnAttributes, ParsedField, ParsedFieldType, ParsedNodeFn, RegularParsedField};
+use crate::parsing::{Input, NodeFnAttributes, ParsedField, ParsedFieldType, ParsedNodeFn, ParsedValueSource, RegularParsedField};
 use crate::shader_nodes::{SHADER_NODES_FEATURE_GATE, ShaderCodegen, ShaderNodeType, ShaderTokens};
 use convert_case::{Case, Casing};
 use proc_macro2::{Ident, Span, TokenStream};
@@ -231,8 +231,8 @@ impl PerPixelAdjustCodegen<'_> {
 			widget_override: Default::default(),
 			ty: ParsedFieldType::Regular(RegularParsedField {
 				ty: parse_quote!(&'a WgpuExecutor),
-				exposed: false,
-				value_source: Default::default(),
+				exposed: true,
+				value_source: ParsedValueSource::Scope(LitStr::new("wgpu-executor", Span::call_site())),
 				number_soft_min: None,
 				number_soft_max: None,
 				number_hard_min: None,


### PR DESCRIPTION
# Requires https://github.com/GraphiteEditor/Graphite/pull/3109

automatically connect the wgpu-executor, now GPU nodes look like regular nodes