### PR TITLE
Shaders: Explicitly destroy WGPU images instead of waiting on GC

### DIFF
--- a/node-graph/gcore/src/raster_types.rs
+++ b/node-graph/gcore/src/raster_types.rs
@@ -134,10 +134,11 @@ pub use gpu::GPU;
 mod gpu {
 	use super::*;
 	use crate::raster_types::__private::Sealed;
+	use std::sync::Arc;
 
 	#[derive(Clone, Debug, PartialEq, Hash)]
 	pub struct GPU {
-		pub texture: wgpu::Texture,
+		pub texture: Arc<InnerTexture>,
 	}
 
 	impl Sealed for Raster<GPU> {}
@@ -150,7 +151,9 @@ mod gpu {
 
 	impl Raster<GPU> {
 		pub fn new_gpu(texture: wgpu::Texture) -> Self {
-			Self::new(GPU { texture })
+			Self::new(GPU {
+				texture: Arc::new(InnerTexture(texture)),
+			})
 		}
 
 		pub fn data(&self) -> &wgpu::Texture {
@@ -158,9 +161,20 @@ mod gpu {
 		}
 	}
 
-	impl Drop for GPU {
+	#[derive(Debug, PartialEq, Hash)]
+	pub struct InnerTexture(wgpu::Texture);
+
+	impl Deref for InnerTexture {
+		type Target = wgpu::Texture;
+
+		fn deref(&self) -> &Self::Target {
+			&self.0
+		}
+	}
+
+	impl Drop for InnerTexture {
 		fn drop(&mut self) {
-			self.texture.destroy();
+			self.0.destroy();
 		}
 	}
 }

--- a/node-graph/gcore/src/raster_types.rs
+++ b/node-graph/gcore/src/raster_types.rs
@@ -157,6 +157,12 @@ mod gpu {
 			&self.texture
 		}
 	}
+
+	impl Drop for GPU {
+		fn drop(&mut self) {
+			self.texture.destroy();
+		}
+	}
 }
 
 #[cfg(not(feature = "wgpu"))]
@@ -173,6 +179,10 @@ mod gpu {
 		fn is_empty(&self) -> bool {
 			true
 		}
+	}
+
+	impl Drop for GPU {
+		fn drop(&mut self) {}
 	}
 }
 

--- a/node-graph/gsvg-renderer/src/renderer.rs
+++ b/node-graph/gsvg-renderer/src/renderer.rs
@@ -153,7 +153,7 @@ impl Default for SvgRender {
 #[derive(Clone, Debug, Default)]
 pub struct RenderContext {
 	#[cfg(feature = "vello")]
-	pub resource_overrides: Vec<(peniko::Image, wgpu::Texture)>,
+	pub resource_overrides: Vec<(peniko::Image, Raster<GPU>)>,
 }
 
 /// Static state used whilst rendering
@@ -1326,7 +1326,7 @@ impl Render for Table<Raster<GPU>> {
 			.with_extend(peniko::Extend::Repeat);
 			let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
 			scene.draw_image(&image, kurbo::Affine::new(image_transform.to_cols_array()));
-			context.resource_overrides.push((image, row.element.data().clone()));
+			context.resource_overrides.push((image, row.element.clone()));
 
 			if layer {
 				scene.pop_layer()

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -140,7 +140,7 @@ impl WgpuExecutor {
 			let mut renderer = self.vello_renderer.lock().await;
 			for (image, texture) in context.resource_overrides.iter() {
 				let texture_view = wgpu::TexelCopyTextureInfoBase {
-					texture: texture.clone(),
+					texture: texture.texture.clone(),
 					mip_level: 0,
 					origin: Origin3d::ZERO,
 					aspect: TextureAspect::All,

--- a/node-graph/wgpu-executor/src/lib.rs
+++ b/node-graph/wgpu-executor/src/lib.rs
@@ -140,7 +140,7 @@ impl WgpuExecutor {
 			let mut renderer = self.vello_renderer.lock().await;
 			for (image, texture) in context.resource_overrides.iter() {
 				let texture_view = wgpu::TexelCopyTextureInfoBase {
-					texture: texture.texture.clone(),
+					texture: wgpu::Texture::clone(&texture.texture),
 					mip_level: 0,
 					origin: Origin3d::ZERO,
 					aspect: TextureAspect::All,

--- a/node-graph/wgpu-executor/src/shader_runtime/per_pixel_adjust_runtime.rs
+++ b/node-graph/wgpu-executor/src/shader_runtime/per_pixel_adjust_runtime.rs
@@ -230,7 +230,7 @@ impl PerPixelAdjustGraphicsPipeline {
 				rp.draw(0..3, 0..1);
 
 				TableRow {
-					element: Raster::new(GPU { texture: tex_out }),
+					element: Raster::new_gpu(tex_out),
 					transform: *instance.transform,
 					alpha_blending: *instance.alpha_blending,
 					source_node_id: *instance.source_node_id,


### PR DESCRIPTION
Issue:
> Pasting a 720p image (isometric fountain exported as png) causes excessive CPU utilization and allocator pressure on dev, has caused a wgpu OOM error (not shown here). Same firefox nightly in different tabs.

![](https://cdn.discordapp.com/attachments/881073965047636018/1414192326024368200/image.png?ex=68beacbc&is=68bd5b3c&hm=b02baf1191088558d8d226bd37145aac9d254fc922df615f3bfd99c46bbd529a)

This is a fix towards that by explicitly destroying wgpu images instead of waiting for js gc to do it for us. However, it currently breaks the vello renderer when used with GPU nodes.