### PR TITLE
Revert real time playback being enabled by default

### DIFF
--- a/editor/src/messages/animation/animation_message_handler.rs
+++ b/editor/src/messages/animation/animation_message_handler.rs
@@ -99,11 +99,13 @@ impl MessageHandler<AnimationMessage, ()> for AnimationMessageHandler {
 				}
 			}
 			AnimationMessage::UpdateTime => {
-				responses.add(PortfolioMessage::SubmitActiveGraphRender);
-				if self.is_playing() && self.live_preview_recently_zero {
-					// Update the restart and pause/play buttons
-					responses.add(PortfolioMessage::UpdateDocumentWidgets);
-					self.live_preview_recently_zero = false;
+				if self.is_playing() {
+					responses.add(PortfolioMessage::SubmitActiveGraphRender);
+					if self.live_preview_recently_zero {
+						// Update the restart and pause/play buttons
+						responses.add(PortfolioMessage::UpdateDocumentWidgets);
+						self.live_preview_recently_zero = false;
+					}
 				}
 			}
 			AnimationMessage::RestartAnimation => {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

This fixes message spam for message debugging introduced in #2500. Eventually we can re-enable this after addressing the other issues this causes.