### PR TITLE
Fix a regression with G/R/S in the Path tool applying to the whole object instead of the selected points

### DIFF
--- a/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
+++ b/editor/src/messages/tool/transform_layer/transform_layer_message_handler.rs
@@ -119,7 +119,7 @@ impl MessageHandler<TransformLayerMessage, TransformLayerMessageContext<'_>> for
 				return;
 			}
 
-			if !using_path_tool || !using_shape_tool {
+			if !using_path_tool {
 				self.pivot_gizmo.recalculate_transform(document);
 				*selected.pivot = self.pivot_gizmo.position(document);
 				self.local_pivot = document.metadata().document_to_viewport.inverse().transform_point2(*selected.pivot);


### PR DESCRIPTION
fixed regression in #2803  - G/R/S with the Path tool is no longer targeting the selected point(s), it is instead applying to the whole object like it does with the Select tool.