### PR TITLE
Fix a regression where G/R/S stayed active after switching from Pen or Shape tool 

### DIFF
--- a/editor/src/messages/tool/tool_message_handler.rs
+++ b/editor/src/messages/tool/tool_message_handler.rs
@@ -141,7 +141,7 @@ impl MessageHandler<ToolMessage, ToolMessageContext<'_>> for ToolMessageHandler 
 
 					// If a G/R/S transform is active while using Path, Select, Pen, or Shape,
 					// and the user switches to a different tool, cancel the current transform
-					// operation to avoid leaving it in an inconsistent stat
+					// operation to avoid leaving it in an inconsistent state
 					if matches!(old_tool, ToolType::Path | ToolType::Select | ToolType::Pen | ToolType::Shape) {
 						responses.add(TransformLayerMessage::CancelTransformOperation);
 					}


### PR DESCRIPTION
With the Pen tool active, we don't have regular G/R/S, but if you hit one of those keys then hit a key to switch to another tool such as V for the Select tool, you'll actually be in the G/R/S state you previously triggered with the Pen tool active.

Fixes https://discord.com/channels/731730685944922173/881073965047636018/1415787243930386584