### PR TITLE
Revert "Add multi-level loop indexing with the 'Instance Repeat' node"

### DIFF
--- a/editor/src/messages/portfolio/document_migration.rs
+++ b/editor/src/messages/portfolio/document_migration.rs
@@ -1040,18 +1040,6 @@ fn migrate_node(node_id: &NodeId, node: &DocumentNode, network_path: &[NodeId], 
 		}
 	}
 
-	// Add the "Depth" parameter to the "Instance Index" node
-	if reference == "Instance Index" && inputs_count == 0 {
-		let mut node_template = resolve_document_node_type(reference)?.default_node_template();
-		document.network_interface.replace_implementation(node_id, network_path, &mut node_template);
-
-		let mut node_path = network_path.to_vec();
-		node_path.push(*node_id);
-
-		document.network_interface.add_import(TaggedValue::None, false, 0, "Primary", "", &node_path);
-		document.network_interface.add_import(TaggedValue::U32(0), false, 1, "Loop Level", "TODO", &node_path);
-	}
-
 	// Migrate the Transform node to use degrees instead of radians
 	if reference == "Transform" && node.inputs.get(6).is_none() {
 		// Migrate rotation from radians to degrees

--- a/node-graph/gcore/src/vector/algorithms/instance.rs
+++ b/node-graph/gcore/src/vector/algorithms/instance.rs
@@ -105,10 +105,12 @@ async fn instance_position(ctx: impl Ctx + ExtractVarArgs) -> DVec2 {
 
 // TODO: Make this return a u32 instead of an f64, but we ned to improve math-related compatibility with integer types first.
 #[node_macro::node(category("Instancing"), path(graphene_core::vector))]
-async fn instance_index(ctx: impl Ctx + ExtractIndex, _primary: (), loop_level: u32) -> f64 {
-	ctx.try_index()
-		.and_then(|indexes| indexes.get(indexes.len().wrapping_sub(1).wrapping_sub(loop_level as usize)).copied())
-		.unwrap_or_default() as f64
+async fn instance_index(ctx: impl Ctx + ExtractIndex) -> f64 {
+	match ctx.try_index() {
+		Some(index) => return index as f64,
+		None => warn!("Extracted value of incorrect type"),
+	}
+	0.
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This reverts commit 112efe88c2002485ebb6b113862d6724cfa3e87b.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Reverts #112efe8 as this is definitely not the right way to 2d indexing and would lead to future performance bottlenecks so we should revert this asap to prevent the creation of artworks using an API that is going to be deprecated at some point

