### PR TITLE
Fix regression when rotating a group, resulting in an incorrect transform cage bounding box

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -154,7 +154,21 @@ impl DocumentMetadata {
 	pub fn bounding_box_with_transform(&self, layer: LayerNodeIdentifier, transform: DAffine2) -> Option<[DVec2; 2]> {
 		self.click_targets(layer)?
 			.iter()
-			.filter_map(|click_target| click_target.bounding_box_with_transform(transform))
+			.filter_map(|click_target| match click_target.target_type() {
+				ClickTargetType::Subpath(subpath) => subpath.bounding_box_with_transform(transform),
+				ClickTargetType::FreePoint(_) => click_target.bounding_box_with_transform(transform),
+			})
+			.reduce(Quad::combine_bounds)
+	}
+
+	/// Get the loose bounding box of the click target of the specified layer in the specified transform space
+	pub fn loose_bounding_box_with_transform(&self, layer: LayerNodeIdentifier, transform: DAffine2) -> Option<[DVec2; 2]> {
+		self.click_targets(layer)?
+			.iter()
+			.filter_map(|click_target| match click_target.target_type() {
+				ClickTargetType::Subpath(subpath) => subpath.loose_bounding_box_with_transform(transform),
+				ClickTargetType::FreePoint(_) => click_target.bounding_box_with_transform(transform),
+			})
 			.reduce(Quad::combine_bounds)
 	}
 

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -3506,7 +3506,8 @@ impl NodeNetworkInterface {
 		}
 
 		self.document_metadata
-			.click_targets(layer)
+			.click_targets
+			.get(&layer)
 			.map(|click| click.iter().map(ClickTarget::target_type))
 			.map(|target_types| Vector::from_target_types(target_types, true))
 	}

--- a/editor/src/messages/tool/common_functionality/snapping.rs
+++ b/editor/src/messages/tool/common_functionality/snapping.rs
@@ -333,7 +333,7 @@ impl SnapManager {
 			return;
 		}
 		// We use a loose bounding box here since these are potential candidates which will be filtered later anyway
-		let Some(bounds) = document.metadata().bounding_box_with_transform(layer, DAffine2::IDENTITY) else {
+		let Some(bounds) = document.metadata().loose_bounding_box_with_transform(layer, DAffine2::IDENTITY) else {
 			return;
 		};
 		let layer_bounds = document.metadata().transform_to_document(layer) * Quad::from_box(bounds);

--- a/node-graph/gcore/src/vector/click_target.rs
+++ b/node-graph/gcore/src/vector/click_target.rs
@@ -40,7 +40,7 @@ pub struct ClickTarget {
 
 impl ClickTarget {
 	pub fn new_with_subpath(subpath: Subpath<PointId>, stroke_width: f64) -> Self {
-		let bounding_box = subpath.bounding_box();
+		let bounding_box = subpath.loose_bounding_box();
 		Self {
 			target_type: ClickTargetType::Subpath(subpath),
 			stroke_width,


### PR DESCRIPTION
This reverts commit d9e8a71cd095971008b2e24fe90bbab9d6467115.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #3181

As pointed out by @0HyperCube we can't reuse the cached bounding box for the click target if we apply a downstream transform later on since this might add a rotation. Until we can handle this properly, we can revert this change