### PR TITLE
preference load message on default load

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -231,10 +231,9 @@ impl App {
 				self.persistent_data.write_preferences(preferences);
 			}
 			DesktopFrontendMessage::PersistenceLoadPreferences => {
-				if let Some(preferences) = self.persistent_data.load_preferences() {
-					let message = DesktopWrapperMessage::LoadPreferences { preferences };
-					self.dispatch_desktop_wrapper_message(message);
-				}
+				let preferences = self.persistent_data.load_preferences();
+				let message = DesktopWrapperMessage::LoadPreferences { preferences };
+				self.dispatch_desktop_wrapper_message(message);
 			}
 		}
 	}

--- a/desktop/wrapper/src/messages.rs
+++ b/desktop/wrapper/src/messages.rs
@@ -102,7 +102,7 @@ pub enum DesktopWrapperMessage {
 		id: DocumentId,
 	},
 	LoadPreferences {
-		preferences: Preferences,
+		preferences: Option<Preferences>,
 	},
 }
 

--- a/editor/src/messages/preferences/preferences_message.rs
+++ b/editor/src/messages/preferences/preferences_message.rs
@@ -6,7 +6,7 @@ use crate::messages::prelude::*;
 #[derive(PartialEq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum PreferencesMessage {
 	// Management messages
-	Load { preferences: PreferencesMessageHandler },
+	Load { preferences: Option<PreferencesMessageHandler> },
 	ResetToDefaults,
 
 	// Per-preference messages

--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -50,7 +50,9 @@ impl MessageHandler<PreferencesMessage, ()> for PreferencesMessageHandler {
 		match message {
 			// Management messages
 			PreferencesMessage::Load { preferences } => {
-				*self = preferences;
+				if let Some(preferences) = preferences {
+					*self = preferences;
+				}
 
 				responses.add(PortfolioMessage::EditorPreferences);
 				responses.add(PortfolioMessage::UpdateVelloPreference);

--- a/frontend/src/io-managers/persistence.ts
+++ b/frontend/src/io-managers/persistence.ts
@@ -147,9 +147,7 @@ export function createPersistenceManager(editor: Editor, portfolio: PortfolioSta
 
 	async function loadPreferences() {
 		const preferences = await get<Record<string, unknown>>("preferences", graphiteStore);
-		if (!preferences) return;
-
-		editor.handle.loadPreferences(JSON.stringify(preferences));
+		editor.handle.loadPreferences(preferences ? JSON.stringify(preferences) : null);
 	}
 
 	// FRONTEND MESSAGE SUBSCRIPTIONS

--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -421,14 +421,18 @@ impl EditorHandle {
 	}
 
 	#[wasm_bindgen(js_name = loadPreferences)]
-	pub fn load_preferences(&self, preferences: String) {
-		let Ok(preferences) = serde_json::from_str(&preferences) else {
-			log::error!("Failed to deserialize preferences");
-			return;
+	pub fn load_preferences(&self, preferences: Option<String>) {
+		let preferences = if let Some(preferences) = preferences {
+			let Ok(preferences) = serde_json::from_str(&preferences) else {
+				log::error!("Failed to deserialize preferences");
+				return;
+			};
+			Some(preferences)
+		} else {
+			None
 		};
 
 		let message = PreferencesMessage::Load { preferences };
-
 		self.dispatch(message);
 	}
 


### PR DESCRIPTION
Previously, when no preferences were stored, the Load Preferences message was never called. This caused issues with hole-punch setting on desktop not being set correctly. Users had to manually go into settings and toggle Vello off and back on for it to take effect.

This PR fixes the issue by always sending a Load Preferences message from both frontends, even when there are no saved preferences. In that case, preferences are set to None to explicitly indicate that nothing was loaded (default preferences will be used).