### PR TITLE
Desktop: Fix maximized window extending outside the screen on Windows

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -60,6 +60,7 @@ windows = { version = "0.58.0", features = [
 	"Win32_System_LibraryLoader",
 	"Win32_UI_Controls",
 	"Win32_UI_WindowsAndMessaging",
+	"Win32_UI_HiDpi",
 ], optional = true }
 
 # macOS-specific dependencies


### PR DESCRIPTION
Part of #3191

We should discuss if this closes it.

On small issue remaining, due to using a custom window frame winit::Window::is_maximized always returns false on win32 and we cant update the icon correctly because maximizing looks like resizing to winit.

There are workarounds, but my preferred solution would be to introduce a WindowHandle type that holds both the window and native window handle and would have working implementations on all platforms for things like is_maximized (could depending on platform use native window handle or window to determine maximized state etc.).

That will need some work though and I would prefer merging this PR before the event on the 26th. 