### PR TITLE
Fix Path tool not displaying its hints during G/R/S modes

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -1879,6 +1879,7 @@ impl ShapeState {
 			_ => self.sorted_selected_layers(network_interface.document_metadata()).find_map(closest_seg),
 		}
 	}
+
 	pub fn get_dragging_state(&self, network_interface: &NodeNetworkInterface) -> PointSelectState {
 		for &layer in self.selected_shape_state.keys() {
 			let Some(vector) = network_interface.compute_modified_vector(layer) else { continue };

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -3663,4 +3663,5 @@ fn update_dynamic_hints(
 		PathToolFsmState::SlidingPoint => HintData(vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Rmb, ""), HintInfo::keys([Key::Escape], "Cancel").prepend_slash()])]),
 	};
 	hint_data.send_layout(responses);
+	responses.add(ToolMessage::UpdateHints);
 }

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -3182,10 +3182,9 @@ impl Fsm for PathToolFsmState {
 				PathToolFsmState::Ready
 			}
 			(_, PathToolMessage::SelectedPointUpdated) => {
-				let colinear = shape_editor.selected_manipulator_angles(&document.network_interface);
 				tool_data.dragging_state = DraggingState {
 					point_select_state: shape_editor.get_dragging_state(&document.network_interface),
-					colinear,
+					colinear: shape_editor.selected_manipulator_angles(&document.network_interface),
 				};
 
 				let old = tool_data.make_path_editable_is_allowed;


### PR DESCRIPTION
Closes #3537, also reported at https://discord.com/channels/731730685944922173/881073965047636018/1419968518086197269

Previously the path tool hints would override the hints from other operations (Eg GRS's hints would not show. This was the case for everything but the drag) It was just an order of operations issue. When "update_dynamic_hints" was created (replacing "update_hints"), the path tool updates would always happen after the other tools' hints. This means that, when you are in GRS, the GRS hints will be written and then immediately overwrite. Sending ToolMessage::UpdateHints() after updating the path tool's hints fixes this.
