### PR TITLE
New node: Remap

### DIFF
--- a/node-graph/gmath-nodes/src/lib.rs
+++ b/node-graph/gmath-nodes/src/lib.rs
@@ -325,7 +325,6 @@ impl TangentInverse for DVec2 {
 	}
 }
 
-/// The Remap function linearly maps a number from one range to another. If the input range is zero, the output will be the output minimum.
 #[node_macro::node(category("Math: Numeric"))]
 fn remap<U: num_traits::float::Float>(
 	_: impl Ctx,


### PR DESCRIPTION
Adds a simple remap node, we consistently do this via math nodes manually. This improves workflows that need to handle number ranges.
