### PR TITLE
Fix images remaining opaque in outline view

### DIFF
--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -543,7 +543,7 @@
 						data-viewport
 					>
 						{#if !$appWindow.viewportHolePunch}
-							<svg class="artboards" style:width={canvasWidthCSS} style:height={canvasHeightCSS}>
+							<svg class="artboards" style:width={canvasWidthCSS} style:height={canvasHeightCSS} style:opacity={$document.graphViewOverlayOpen ? `${(100 - $document.fadeArtwork) / 100}` : '1'}>
 								{@html artworkSvg}
 							</svg>
 						{/if}


### PR DESCRIPTION
## Summary
- Apply opacity directly to SVG artwork element when graph view overlay is open
- Use fadeArtwork percentage to calculate proper opacity value
- This ensures images and all SVG content properly fade in graph view mode
- Fixes issue #2888

The previous implementation used a CSS overlay which didn't properly affect embedded images within SVG content. By applying opacity directly to the SVG element, all content including images now correctly fades when in outline/graph view mode.
## Description
Fixes #2888 - Images now properly fade when switching to graph view (outline view) mode.

## Changes
- Apply opacity directly to SVG artwork element when graph view overlay is open
- Use existing fadeArtwork percentage to calculate proper opacity value
- Ensures all SVG content including embedded images fade consistently

## Technical Details
The previous CSS overlay approach didn't properly affect embedded images within SVG content. This solution applies opacity directly to the SVG element, ensuring uniform fading behavior for all artwork content.

## Testing
- ✅ Development environment setup and tested
- ✅ Changes verified via hot reload
- ✅ Focused, minimal change with clear impact


<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #
