### PR TITLE
Fix crash when selecting "Brightness/Contrast classic" node

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -1713,6 +1713,7 @@ pub static NODE_OVERRIDES: once_cell::sync::Lazy<NodeProperties> = once_cell::sy
 fn static_node_properties() -> NodeProperties {
 	let mut map: NodeProperties = HashMap::new();
 	map.insert("brightness_contrast_properties".to_string(), Box::new(node_properties::brightness_contrast_properties));
+	map.insert("brightness_contrast_classic_properties".to_string(), Box::new(node_properties::brightness_contrast_classic_properties));
 	map.insert("channel_mixer_properties".to_string(), Box::new(node_properties::channel_mixer_properties));
 	map.insert("fill_properties".to_string(), Box::new(node_properties::fill_properties));
 	map.insert("stroke_properties".to_string(), Box::new(node_properties::stroke_properties));

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -1074,6 +1074,12 @@ pub fn query_assign_colors_randomize(node_id: NodeId, context: &NodePropertiesCo
 	})
 }
 
+pub(crate) fn brightness_contrast_classic_properties(node_id: NodeId, context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
+	use graphene_std::raster::brightness_contrast_classic::*;
+
+	brightness_contrast_properties_common(node_id, context, BrightnessInput::INDEX, ContrastInput::INDEX, true)
+}
+
 pub(crate) fn brightness_contrast_properties(node_id: NodeId, context: &mut NodePropertiesContext) -> Vec<LayoutGroup> {
 	use graphene_std::raster::brightness_contrast::*;
 
@@ -1092,9 +1098,22 @@ pub(crate) fn brightness_contrast_properties(node_id: NodeId, context: &mut Node
 		_ => false,
 	};
 
+	let mut layout = brightness_contrast_properties_common(node_id, context, BrightnessInput::INDEX, ContrastInput::INDEX, use_classic_value);
+	layout.extend([LayoutGroup::Row { widgets: use_classic }]);
+
+	layout
+}
+
+fn brightness_contrast_properties_common(
+	node_id: NodeId,
+	context: &mut NodePropertiesContext,
+	brightness_input_index: usize,
+	contrast_input_index: usize,
+	use_classic_value: bool,
+) -> Vec<LayoutGroup> {
 	// Brightness
 	let brightness = number_widget(
-		ParameterWidgetsInfo::new(node_id, BrightnessInput::INDEX, true, context),
+		ParameterWidgetsInfo::new(node_id, brightness_input_index, true, context),
 		NumberInput::default()
 			.unit("%")
 			.mode_range()
@@ -1105,7 +1124,7 @@ pub(crate) fn brightness_contrast_properties(node_id: NodeId, context: &mut Node
 
 	// Contrast
 	let contrast = number_widget(
-		ParameterWidgetsInfo::new(node_id, ContrastInput::INDEX, true, context),
+		ParameterWidgetsInfo::new(node_id, contrast_input_index, true, context),
 		NumberInput::default()
 			.unit("%")
 			.mode_range()
@@ -1114,11 +1133,7 @@ pub(crate) fn brightness_contrast_properties(node_id: NodeId, context: &mut Node
 			.range_max(Some(100.)),
 	);
 
-	let layout = vec![
-		LayoutGroup::Row { widgets: brightness },
-		LayoutGroup::Row { widgets: contrast },
-		LayoutGroup::Row { widgets: use_classic },
-	];
+	let layout = vec![LayoutGroup::Row { widgets: brightness }, LayoutGroup::Row { widgets: contrast }];
 
 	layout
 }

--- a/node-graph/graster-nodes/src/adjustments.rs
+++ b/node-graph/graster-nodes/src/adjustments.rs
@@ -145,7 +145,7 @@ fn make_opaque<T: Adjust<Color>>(
 #[node_macro::node(
 	name("Brightness/Contrast classic"),
 	category("Raster: Adjustment"),
-	properties("brightness_contrast_properties"),
+	properties("brightness_contrast_classic_properties"),
 	shader_node(PerPixelAdjust)
 )]
 fn brightness_contrast_classic<T: Adjust<Color>>(


### PR DESCRIPTION
Resolves #3206

The crash was because both the normal and classic brightness/contrast nodes were using the same `brightness_contrast_properties` function and that function used input indexes from the normal node rather than the classic one. Since the classic node didn't have the `use_classic` input that the normal brightness/contrast node has, there was an OOB when `brightness_contrast_properties` tried to read it.