### PR TITLE
Exit sub-network via Escape key

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -496,6 +496,9 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					self.node_graph_handler.wire_in_progress_from_connector = None;
 					self.node_graph_handler.wire_in_progress_to_connector = None;
 					responses.add(FrontendMessage::UpdateWirePathInProgress { wire_path: None });
+				} else if !self.breadcrumb_network_path.is_empty() {
+					// Exit one level up if inside a nested network
+					responses.add(DocumentMessage::ExitNestedNetwork { steps_back: 1 });
 				} else {
 					responses.add(DocumentMessage::GraphViewOverlay { open: false });
 				}


### PR DESCRIPTION
Problem
Previously, pressing the Escape key while inside a sub-network would close the entire node graph overlay, forcing users to lose their navigation context and start over from the beginning. This was frustrating when working with deeply nested networks.

Solution
Modified the DocumentMessage::Escape handler in document_message_handler.rs to check if the user is currently inside a nested network before closing the graph overlay:

If inside a sub-network (breadcrumb path is not empty): Exit one level up using ExitNestedNetwork { steps_back: 1 }
If at the root level (breadcrumb path is empty): Close the graph overlay as before
Changes
Updated document_message_handler.rs - Modified the Escape message handler to conditionally navigate up one level or close the overlay based on the current navigation depth
Testing
The fix can be tested by:

Opening the node graph
Entering a sub-network (double-clicking a node)
Pressing Escape - should return to the parent network
Pressing Escape again at the root level - should close the graph overlay
Benefits
More intuitive navigation behavior
Preserves user context when working with nested networks
Consistent with common UI patterns where Escape means "go back one step"

Closes #3283