### PR TITLE
Reduce editor message size by 67% and fix simple clippy warnings

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1542,7 +1542,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					.default_node_template();
 				responses.add(NodeGraphMessage::InsertNode {
 					node_id,
-					node_template: new_artboard_node,
+					node_template: Box::new(new_artboard_node),
 				});
 				responses.add(NodeGraphMessage::ShiftNodePosition { node_id, x: 15, y: -3 });
 				responses.add(GraphOperationMessage::ResizeArtboard {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message.rs
@@ -75,7 +75,8 @@ pub enum NodeGraphMessage {
 	},
 	InsertNode {
 		node_id: NodeId,
-		node_template: NodeTemplate,
+		// Boxed to reduce size of enum (1120 bytes to 8 bytes)
+		node_template: Box<NodeTemplate>,
 	},
 	InsertNodeBetween {
 		node_id: NodeId,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -264,7 +264,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 
 				responses.add(NodeGraphMessage::InsertNode {
 					node_id,
-					node_template: node_template.clone(),
+					node_template: Box::new(node_template.clone()),
 				});
 				responses.add(NodeGraphMessage::ShiftNodePosition { node_id, x, y });
 				// Only auto connect to the dragged wire if the node is being added to the currently opened network
@@ -507,7 +507,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 				responses.add(NodeGraphMessage::UpdateImportsExports);
 			}
 			NodeGraphMessage::InsertNode { node_id, node_template } => {
-				network_interface.insert_node(node_id, node_template, selection_network_path);
+				network_interface.insert_node(node_id, *node_template, selection_network_path);
 			}
 			NodeGraphMessage::InsertNodeBetween {
 				node_id,
@@ -624,7 +624,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 				responses.add(DocumentMessage::AddTransaction);
 				responses.add(NodeGraphMessage::InsertNode {
 					node_id: encapsulating_node_id,
-					node_template: default_node_template,
+					node_template: Box::new(default_node_template),
 				});
 				responses.add(NodeGraphMessage::SetDisplayNameImpl {
 					node_id: encapsulating_node_id,

--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -77,7 +77,7 @@ pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIde
 		.default_node_template();
 	responses.add(NodeGraphMessage::InsertNode {
 		node_id: merge_node_id,
-		node_template: merge_node,
+		node_template: Box::new(merge_node),
 	});
 	responses.add(NodeGraphMessage::SetToNodeOrLayer {
 		node_id: merge_node_id,
@@ -103,7 +103,7 @@ pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIde
 		.default_node_template();
 	responses.add(NodeGraphMessage::InsertNode {
 		node_id: flatten_node_id,
-		node_template: flatten_node,
+		node_template: Box::new(flatten_node),
 	});
 	responses.add(NodeGraphMessage::MoveNodeToChainStart {
 		node_id: flatten_node_id,
@@ -117,7 +117,7 @@ pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIde
 		.default_node_template();
 	responses.add(NodeGraphMessage::InsertNode {
 		node_id: path_node_id,
-		node_template: path_node,
+		node_template: Box::new(path_node),
 	});
 	responses.add(NodeGraphMessage::MoveNodeToChainStart {
 		node_id: path_node_id,
@@ -132,7 +132,7 @@ pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIde
 			.default_node_template();
 		responses.add(NodeGraphMessage::InsertNode {
 			node_id: spline_node_id,
-			node_template: spline_node,
+			node_template: Box::new(spline_node),
 		});
 		responses.add(NodeGraphMessage::MoveNodeToChainStart {
 			node_id: spline_node_id,
@@ -147,7 +147,7 @@ pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIde
 		.default_node_template();
 	responses.add(NodeGraphMessage::InsertNode {
 		node_id: transform_node_id,
-		node_template: transform_node,
+		node_template: Box::new(transform_node),
 	});
 	responses.add(NodeGraphMessage::MoveNodeToChainStart {
 		node_id: transform_node_id,

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1214,7 +1214,7 @@ impl PathToolData {
 
 			// Check if that segment exists or it has been removed
 			if let Some(vector_data) = document.network_interface.compute_modified_vector(layer)
-				&& !(vector_data.segment_domain.ids().iter().any(|segment| *segment == segment_id))
+				&& !(vector_data.segment_domain.ids().contains(&segment_id))
 			{
 				self.segment = None;
 			}

--- a/node-graph/node-macro/src/buffer_struct.rs
+++ b/node-graph/node-macro/src/buffer_struct.rs
@@ -205,7 +205,7 @@ impl VisitMut for GenericsVisitor<'_> {
 	}
 
 	fn visit_path_segment_mut(&mut self, i: &mut PathSegment) {
-		if i.ident.to_string() == "Self" {
+		if i.ident == "Self" {
 			i.ident = self.self_ident.clone();
 		}
 		visit_mut::visit_path_segment_mut(self, i);

--- a/node-graph/node-macro/src/codegen.rs
+++ b/node-graph/node-macro/src/codegen.rs
@@ -287,7 +287,7 @@ pub(crate) fn generate_node_code(crate_ident: &CrateIdent, parsed: &ParsedNodeFn
 	let properties = &attributes.properties_string.as_ref().map(|value| quote!(Some(#value))).unwrap_or(quote!(None));
 
 	let cfg = crate::shader_nodes::modify_cfg(attributes);
-	let node_input_accessor = generate_node_input_references(parsed, fn_generics, &field_idents, &graphene_core, &identifier, &cfg);
+	let node_input_accessor = generate_node_input_references(parsed, fn_generics, &field_idents, graphene_core, &identifier, &cfg);
 	let ShaderTokens { shader_entry_point, gpu_node } = attributes.shader_node.as_ref().map(|n| n.codegen(crate_ident, parsed)).unwrap_or(Ok(ShaderTokens::default()))?;
 
 	Ok(quote! {

--- a/node-graph/node-macro/src/crate_ident.rs
+++ b/node-graph/node-macro/src/crate_ident.rs
@@ -30,16 +30,11 @@ impl Default for CrateIdent {
 				let name = format_ident!("{}", name);
 				Ok(quote!(::#name))
 			}
-			Err(e) => Err(syn::Error::new(Span::call_site(), &format!("Could not find dependency on `{orig_name}`:\n{e}"))),
+			Err(e) => Err(syn::Error::new(Span::call_site(), format!("Could not find dependency on `{orig_name}`:\n{e}"))),
 		};
 
 		let gcore = find_crate("graphene-core");
-		let gcore_shaders = find_crate("graphene-core-shaders").or_else(|eshaders| {
-			gcore
-				.as_ref()
-				.map(Clone::clone)
-				.map_err(|ecore| syn::Error::new(Span::call_site(), &format!("{ecore}\n\nFallback: {eshaders}")))
-		});
+		let gcore_shaders = find_crate("graphene-core-shaders").or_else(|eshaders| gcore.clone().map_err(|ecore| syn::Error::new(Span::call_site(), format!("{ecore}\n\nFallback: {eshaders}"))));
 		let wgpu_executor = find_crate("wgpu-executor");
 		Self { gcore, gcore_shaders, wgpu_executor }
 	}

--- a/node-graph/node-macro/src/lib.rs
+++ b/node-graph/node-macro/src/lib.rs
@@ -37,5 +37,5 @@ pub fn derive_choice_type(input_item: TokenStream) -> TokenStream {
 #[proc_macro_derive(BufferStruct)]
 pub fn derive_buffer_struct(input_item: TokenStream) -> TokenStream {
 	let crate_ident = CrateIdent::default();
-	TokenStream::from(buffer_struct::derive_buffer_struct(&crate_ident, input_item.into()).unwrap_or_else(|err| err.to_compile_error()))
+	TokenStream::from(buffer_struct::derive_buffer_struct(&crate_ident, input_item).unwrap_or_else(|err| err.to_compile_error()))
 }


### PR DESCRIPTION
Reduces the size of every editor message (`graphite_editor::messages::message::Message`) from 1136 bytes to 368 bytes by boxing `PortfolioMessage` -> `DocumentMessage` -> `NodeGraphMessage::InsertNode`'s `node_template` field.

Also fixes these simple clippy warnings:
```
warning: this creates an owned instance just for comparison
   --> node-graph/node-macro/src/buffer_struct.rs:208:6

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> node-graph/node-macro/src/codegen.rs:290:95

warning: the borrowed expression implements the required traits
  --> node-graph/node-macro/src/crate_ident.rs:33:53

warning: the borrowed expression implements the required traits
  --> node-graph/node-macro/src/crate_ident.rs:41:57

warning: this call to `as_ref.map(...)` does nothing
  --> node-graph/node-macro/src/crate_ident.rs:38:4

warning: useless conversion to the same type: `proc_macro::TokenStream`
  --> node-graph/node-macro/src/lib.rs:40:70

warning: using `contains()` instead of `iter().any()` is more efficient
  --> editor/src/messages/tool/tool_messages/path_tool.rs:1217:9
```
