### PR TITLE
Pen tool: do not merge with ancestor layer as it breaks the graph

### DIFF
--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -32,7 +32,8 @@ pub fn find_spline(document: &DocumentMessageHandler, layer: LayerNodeIdentifier
 
 /// Merge `second_layer` to the `first_layer`.
 pub fn merge_layers(document: &DocumentMessageHandler, first_layer: LayerNodeIdentifier, second_layer: LayerNodeIdentifier, responses: &mut VecDeque<Message>) {
-	if first_layer == second_layer {
+	// Skip layers that are children of each other (or the same)
+	if first_layer.ancestors(document.metadata()).any(|l| l == second_layer) || second_layer.ancestors(document.metadata()).any(|l| l == first_layer) {
 		return;
 	}
 	// Calculate the downstream transforms in order to bring the other vector geometry into the same layer space


### PR DESCRIPTION
## Reproduction
- Create a path with pen tool
- Add a separate contour to the layer by using <kbd>shift</kbd> with the pen tool
- Put the single path layer into a group
- Select the original path layer
- Use the pen tool to connect up the two contours.
- Observe graph is broken as the pen tool attempts to merge the layer with itself and fails miserably leaving an uncommitted transaction and some broken state.

## Reported by
[Chambers on discord](https://discord.com/channels/731730685944922173/1134981447539761273/1435760533822246944)