### PR TITLE
Exclude procedural-string-lights from cached execution ci benchmarks

### DIFF
--- a/node-graph/interpreted-executor/benches/run_cached_iai.rs
+++ b/node-graph/interpreted-executor/benches/run_cached_iai.rs
@@ -17,7 +17,7 @@ fn setup_run_cached(name: &str) -> DynamicExecutor {
 }
 
 #[library_benchmark]
-#[benches::with_setup(args = ["isometric-fountain", "painted-dreams", "procedural-string-lights", "parametric-dunescape", "red-dress", "valley-of-spires"], setup = setup_run_cached)]
+#[benches::with_setup(args = ["isometric-fountain", "painted-dreams", "parametric-dunescape", "red-dress", "valley-of-spires"], setup = setup_run_cached)]
 pub fn run_cached(executor: DynamicExecutor) {
 	let context = RenderConfig::default();
 	black_box(futures::executor::block_on(executor.tree().eval_tagged_value(executor.output(), black_box(context))).unwrap());


### PR DESCRIPTION
This benchmark seem to have been really flaky in our CI so we remove it

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

