### PR TITLE
Unify menu bar with standard layout/diff system

### DIFF
--- a/editor/src/messages/frontend/frontend_message.rs
+++ b/editor/src/messages/frontend/frontend_message.rs
@@ -281,7 +281,10 @@ pub enum FrontendMessage {
 	UpdateMenuBarLayout {
 		#[serde(rename = "layoutTarget")]
 		layout_target: LayoutTarget,
-		layout: Vec<MenuBarEntry>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		layout: Option<Vec<MenuBarEntry>>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		diff: Option<Vec<WidgetDiff>>,
 	},
 	UpdateMouseCursor {
 		cursor: MouseCursorIcon,

--- a/frontend/src/components/Editor.svelte
+++ b/frontend/src/components/Editor.svelte
@@ -16,6 +16,7 @@
 	import { createFullscreenState } from "@graphite/state-providers/fullscreen";
 	import { createNodeGraphState } from "@graphite/state-providers/node-graph";
 	import { createPortfolioState } from "@graphite/state-providers/portfolio";
+	import { createMenuBarState } from "@graphite/state-providers/menu-bar";
 	import { operatingSystem } from "@graphite/utility-functions/platform";
 
 	import MainWindow from "@graphite/components/window/MainWindow.svelte";
@@ -39,6 +40,9 @@
 	setContext("portfolio", portfolio);
 	let appWindow = createAppWindowState(editor);
 	setContext("appWindow", appWindow);
+    
+		let menuBar = createMenuBarState(editor);
+		setContext("menuBar", menuBar);
 
 	// Initialize managers, which are isolated systems that subscribe to backend messages to link them to browser API functionality (like JS events, IndexedDB, etc.)
 	createClipboardManager(editor);

--- a/frontend/src/messages.ts
+++ b/frontend/src/messages.ts
@@ -1593,9 +1593,11 @@ export class UpdateLayersPanelBottomBarLayout extends WidgetDiffUpdate {}
 export class UpdateMenuBarLayout extends JsMessage {
 	layoutTarget!: unknown;
 
-	// TODO: Replace `any` with correct typing
 	@Transform(({ value }: { value: any }) => createMenuLayout(value))
-	layout!: MenuBarEntry[];
+	layout?: MenuBarEntry[];
+
+	@Transform(({ value }: { value: any }) => createWidgetDiff(value))
+	diff?: WidgetDiff[];
 }
 
 export class UpdateNodeGraphControlBarLayout extends WidgetDiffUpdate {}

--- a/frontend/src/state-providers/menu-bar.ts
+++ b/frontend/src/state-providers/menu-bar.ts
@@ -1,0 +1,40 @@
+import { writable } from "svelte/store";
+import type { Editor } from "@graphite/editor";
+import { defaultWidgetLayout, patchWidgetLayout, type WidgetLayout, type MenuListEntry, UpdateMenuBarLayout } from "@graphite/messages";
+
+export function createMenuBarState(editor: Editor) {
+    const state = writable({
+        // Legacy entries used by the old menu bar renderer
+        entries: [] as MenuListEntry[],
+        // When true the frontend should render the WidgetLayout instead of `entries`
+        useWidgetLayout: false,
+        // The widget-backed layout (diffed)
+        layout: defaultWidgetLayout() as WidgetLayout,
+    });
+
+    const { subscribe, update } = state;
+
+    editor.subscriptions.subscribeJsMessage(UpdateMenuBarLayout, (updateMenuBarLayout) => {
+        update((s) => {
+            if ((updateMenuBarLayout as any).layout) {
+                s.useWidgetLayout = false;
+                s.entries = (updateMenuBarLayout as any).layout as MenuListEntry[];
+                return s;
+            }
+
+            if ((updateMenuBarLayout as any).diff) {
+                s.useWidgetLayout = true;
+                patchWidgetLayout(s.layout, updateMenuBarLayout as any);
+                // trigger reactivity by shallow copy
+                s.layout = { ...s.layout } as WidgetLayout;
+                return s;
+            }
+
+            return s;
+        });
+    });
+
+    return { subscribe };
+}
+
+export type MenuBarState = ReturnType<typeof createMenuBarState>;


### PR DESCRIPTION
Migrates the menu bar from a special-cased MenuLayout system to the unified WidgetLayout diff system used by all other UI panels.

### Frontend Changes
- Update UpdateMenuBarLayout message to accept both legacy layout and new diff fields for backwards compatibility
- Modify TitleBar.svelte to render either legacy TextButtons or WidgetLayout based on message type
- Add centralized menu bar state provider for cross-component access
- Ensure Svelte reactivity when patching widget layout diffs

### Backend Changes
- Remove MenuLayout variant from Layout enum
- Convert MenuBarEntry structures to TextButton widgets with MenuListEntry children in MenuBarMessageHandler
- Update diffing system to handle all layouts uniformly
- Remove special-case handling in diff_and_send_layout_to_frontend
- Enable LayoutTarget::MenuBar in send_diff to use standard diff flow
- Preserve menu actions through MenuListEntry callbacks

### Benefits
- Menu bar now supports proper diff updates for dynamic state changes (checkbox states, shortcuts, nested menu updates)
- Eliminates special-case code paths and consolidates layout logic
- Maintains backwards compatibility during transition
- Enables consistent behavior across all UI panels

Nested menus, keyboard shortcuts, and action callbacks continue to work through the standard widget system. The menu bar seamlessly integrates with the existing layout diff architecture while preserving all functionality.

<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #
