### PR TITLE
Fix checkbox labels becoming unclickable after first toggle

### DIFF
--- a/editor/src/messages/dialog/export_dialog/export_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/export_dialog/export_dialog_message_handler.rs
@@ -149,7 +149,7 @@ impl LayoutHolder for ExportDialogMessageHandler {
 			DropdownInput::new(entries).selected_index(Some(index as u32)).widget_holder(),
 		];
 
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("export-transparency");
 		let transparent_background = vec![
 			TextLabel::new("Transparency").table_align(true).min_width("100px").for_checkbox(checkbox_id).widget_holder(),
 			Separator::new(SeparatorType::Unrelated).widget_holder(),

--- a/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
@@ -81,7 +81,7 @@ impl LayoutHolder for NewDocumentDialogMessageHandler {
 				.widget_holder(),
 		];
 
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("new-doc-infinite-canvas");
 		let infinite = vec![
 			TextLabel::new("Infinite Canvas").table_align(true).min_width("90px").for_checkbox(checkbox_id).widget_holder(),
 			Separator::new(SeparatorType::Unrelated).widget_holder(),

--- a/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/preferences_dialog/preferences_dialog_message_handler.rs
@@ -68,7 +68,7 @@ impl PreferencesDialogMessageHandler {
 				.widget_holder(),
 		];
 
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("pref-zoom-with-scroll");
 		let zoom_with_scroll_tooltip = "Use the scroll wheel for zooming instead of vertically panning (not recommended for trackpads)";
 		let zoom_with_scroll = vec![
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
@@ -169,7 +169,7 @@ impl PreferencesDialogMessageHandler {
 			graph_wire_style,
 		];
 
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("pref-vello-renderer");
 		let vello_tooltip = "Use the experimental Vello renderer (your browser must support WebGPU)";
 		let use_vello = vec![
 			Separator::new(SeparatorType::Unrelated).widget_holder(),
@@ -188,7 +188,7 @@ impl PreferencesDialogMessageHandler {
 				.widget_holder(),
 		];
 
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("pref-vector-meshes");
 		let vector_mesh_tooltip =
 			"Allow tools to produce vector meshes, where more than two segments can connect to an anchor point.\n\nCurrently this does not properly handle stroke joins and fills.";
 		let vector_meshes = vec![

--- a/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
+++ b/editor/src/messages/layout/utility_types/widgets/input_widgets.rs
@@ -57,6 +57,17 @@ impl CheckboxId {
 	pub fn new() -> Self {
 		Self(graphene_std::uuid::generate_uuid())
 	}
+
+	/// Create a stable CheckboxId from a string identifier.
+	/// This ensures the same string always produces the same ID, preventing ID mismatches during layout updates.
+	pub fn from_string(s: &str) -> Self {
+		use std::collections::hash_map::DefaultHasher;
+		use std::hash::{Hash, Hasher};
+
+		let mut hasher = DefaultHasher::new();
+		s.hash(&mut hasher);
+		Self(hasher.finish())
+	}
 }
 impl Default for CheckboxId {
 	fn default() -> Self {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2245,7 +2245,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-artboard-name");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.artboard_name)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2263,7 +2263,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-transform-measurement");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.transform_measurement)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2284,7 +2284,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-quick-measurement");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.quick_measurement)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2302,7 +2302,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-transform-cage");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.transform_cage)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2320,7 +2320,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-compass-rose");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.compass_rose)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2338,7 +2338,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-pivot");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.pivot)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2356,7 +2356,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-origin");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.pivot)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2374,7 +2374,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-hover-outline");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.hover_outline)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2392,7 +2392,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-selection-outline");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.selection_outline)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2413,7 +2413,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-path");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.path)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2431,7 +2431,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-anchors");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.anchors)
 									.on_update(|optional_input: &CheckboxInput| {
@@ -2449,7 +2449,7 @@ impl DocumentMessageHandler {
 					},
 					LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string("overlay-handles");
 							vec![
 								CheckboxInput::new(self.overlays_visibility_settings.handles)
 									.disabled(!self.overlays_visibility_settings.anchors)
@@ -2497,7 +2497,7 @@ impl DocumentMessageHandler {
 					.into_iter()
 					.chain(SNAP_FUNCTIONS_FOR_BOUNDING_BOXES.into_iter().map(|(name, closure, tooltip)| LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string(&format!("snap-bbox-{}", name.to_lowercase().replace(' ', "-")));
 							vec![
 								CheckboxInput::new(*closure(&mut snapping_state))
 									.on_update(move |input: &CheckboxInput| {
@@ -2519,7 +2519,7 @@ impl DocumentMessageHandler {
 					}])
 					.chain(SNAP_FUNCTIONS_FOR_PATHS.into_iter().map(|(name, closure, tooltip)| LayoutGroup::Row {
 						widgets: {
-							let checkbox_id = CheckboxId::new();
+							let checkbox_id = CheckboxId::from_string(&format!("snap-path-{}", name.to_lowercase().replace(' ', "-")));
 							vec![
 								CheckboxInput::new(*closure(&mut snapping_state2))
 									.on_update(move |input: &CheckboxInput| {

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -243,7 +243,7 @@ impl LayoutHolder for PathTool {
 		})
 		// TODO: Remove `unwrap_or_default` once checkboxes are capable of displaying a mixed state
 		.unwrap_or_default();
-		let checkbox_id = CheckboxId::new();
+		let checkbox_id = CheckboxId::from_string("path-tool-colinear-handles");
 		let colinear_handle_checkbox = CheckboxInput::new(colinear_handles_state)
 			.disabled(!self.tool_data.can_toggle_colinearity)
 			.on_update(|&CheckboxInput { checked, .. }| {


### PR DESCRIPTION
Fixes #3368

Checkbox labels could only be clicked once, then stopped working because `CheckboxId::new()` generated random IDs on every layout update. It updated `CheckboxInput` widgets with new IDs but skipped updating `TextLabel` widgets. 

I added `CheckboxId::from_string()` to generate stable, hash-based IDs, so each checkbox/label pair now maintains consistent IDs across renders.


https://github.com/user-attachments/assets/00ee985a-00f2-4171-b898-a46c0c6048ad

