### PR TITLE
Fix regression with graph UI culling still on-screen nodes

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1614,7 +1614,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					return;
 				};
 
-				let viewport_bbox = [DVec2::new(0., 0.), viewport.size().into_dvec2()];
+				let viewport_bbox = [DVec2::ZERO, viewport.size().into_dvec2()];
 				let document_bbox: [DVec2; 2] = viewport_bbox.map(|p| network_metadata.persistent_metadata.navigation_metadata.node_graph_to_viewport.inverse().transform_point2(p));
 
 				let mut nodes = Vec::new();


### PR DESCRIPTION
introduced in #3331

This patch replicates the correct behavior with the new viewport api.

Without patch
<img width="452" height="280" alt="image" src="https://github.com/user-attachments/assets/c818fa86-33e9-4658-9235-06e09bfd8f62" />

With patch
<img width="555" height="270" alt="image" src="https://github.com/user-attachments/assets/77600edf-24c8-4657-8a29-074198aa8026" />
