### PR TITLE
Add missing StartTransaction for ToggleSelectedVisibility

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1360,6 +1360,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 			}
 			DocumentMessage::ToggleSelectedLocked => responses.add(NodeGraphMessage::ToggleSelectedLocked),
 			DocumentMessage::ToggleSelectedVisibility => {
+									responses.add(DocumentMessage::StartTransaction);
 				responses.add(NodeGraphMessage::ToggleSelectedVisibility);
 			}
 			DocumentMessage::ToggleGridVisibility => {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Closes #3381

This PR fixes issue #3381, where hiding/unhiding a layer did not always update the document's saved state correctly.

The issue was that the ToggleSelectedVisibility action did not start a transaction.