### PR TITLE
Respect artboard clipping when computing canvas scrollbars

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1028,7 +1028,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 				let viewport_size = viewport.size().into_dvec2();
 				let viewport_mid = viewport.center_in_viewport_space().into_dvec2();
 				let [bounds1, bounds2] = if !self.graph_view_overlay_open {
-					self.metadata().document_bounds_viewport_space().unwrap_or([viewport_mid; 2])
+					self.network_interface.document_bounds_viewport_space(true).unwrap_or([viewport_mid; 2])
 				} else {
 					self.network_interface.graph_bounds_viewport_space(&self.breadcrumb_network_path).unwrap_or([viewport_mid; 2])
 				};

--- a/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message_handler.rs
@@ -239,7 +239,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageContext<'_>> for Navigat
 				}
 				let document_bounds = if !graph_view_overlay_open {
 					// TODO: Cache this in node graph coordinates and apply the transform to the rectangle to get viewport coordinates
-					network_interface.document_metadata().document_bounds_viewport_space()
+					network_interface.document_bounds_viewport_space(true)
 				} else {
 					network_interface.graph_bounds_viewport_space(breadcrumb_network_path)
 				};
@@ -257,7 +257,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageContext<'_>> for Navigat
 			NavigationMessage::CanvasZoomSet { zoom_factor } => {
 				let document_bounds = if !graph_view_overlay_open {
 					// TODO: Cache this in node graph coordinates and apply the transform to the rectangle to get viewport coordinates
-					network_interface.document_metadata().document_bounds_viewport_space()
+					network_interface.document_bounds_viewport_space(true)
 				} else {
 					network_interface.graph_bounds_viewport_space(breadcrumb_network_path)
 				};
@@ -454,7 +454,7 @@ impl MessageHandler<NavigationMessage, NavigationMessageContext<'_>> for Navigat
 
 							let document_bounds = if !graph_view_overlay_open {
 								// TODO: Cache this in node graph coordinates and apply the transform to the rectangle to get viewport coordinates
-								network_interface.document_metadata().document_bounds_viewport_space()
+								network_interface.document_bounds_viewport_space(true)
 							} else {
 								network_interface.graph_bounds_viewport_space(breadcrumb_network_path)
 							};

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -1210,6 +1210,13 @@ impl NodeNetworkInterface {
 			.reduce(Quad::combine_bounds)
 	}
 
+	pub fn document_bounds_viewport_space(&self, include_artboards: bool) -> Option<[DVec2; 2]> {
+		let [min, max] = self.document_bounds_document_space(include_artboards)?;
+		let quad = Quad::from_box([min, max]);
+		let transformed = self.document_metadata.document_to_viewport * quad;
+		Some(transformed.bounding_box())
+	}
+
 	/// Calculates the selected layer bounds in document space
 	pub fn selected_bounds_document_space(&self, include_artboards: bool, network_path: &[NodeId]) -> Option<[DVec2; 2]> {
 		let Some(selected_nodes) = self.selected_nodes_in_nested_network(network_path) else {


### PR DESCRIPTION
 Fixes #2846 
 
Added `NetworkInterface::document_bounds_viewport_space(include_artboards)` that converts clipping‑aware document bounds into viewport space, and updated `RenderScrollbars` to use the new helper so scroll extents respect artboard clipping. 

Please check if this is the intended behaviour.

https://github.com/user-attachments/assets/02ee37ea-9287-4d48-9e45-864e9034c9f9

