### PR TITLE
Fix using Esc to abort box selection and wire dragging causing the graph to close

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -325,7 +325,7 @@ pub fn input_mappings() -> Mapping {
 		//
 		// DocumentMessage
 		entry!(KeyDown(Space); modifiers=[Control], action_dispatch=DocumentMessage::GraphViewOverlayToggle),
-		entry!(KeyUp(Escape); action_dispatch=DocumentMessage::Escape),
+		entry!(KeyDownNoRepeat(Escape); action_dispatch=DocumentMessage::Escape),
 		entry!(KeyDown(Delete); action_dispatch=DocumentMessage::DeleteSelectedLayers),
 		entry!(KeyDown(Backspace); action_dispatch=DocumentMessage::DeleteSelectedLayers),
 		entry!(KeyDown(KeyO); modifiers=[Alt], action_dispatch=DocumentMessage::ToggleOverlaysVisibility),

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -72,11 +72,12 @@ pub struct NodeGraphMessageHandler {
 	initial_disconnecting: bool,
 	/// Node to select on pointer up if multiple nodes are selected and they were not dragged.
 	select_if_not_dragged: Option<NodeId>,
-	/// The start of the dragged line (cannot be moved), stored in node graph coordinates
+	/// The start of the dragged line (cannot be moved), stored in node graph coordinates.
 	pub wire_in_progress_from_connector: Option<DVec2>,
-	pub wire_in_progress_type: FrontendGraphDataType,
-	/// The end point of the dragged line (cannot be moved), stored in node graph coordinates
+	/// The end point of the dragged line (cannot be moved), stored in node graph coordinates.
 	pub wire_in_progress_to_connector: Option<DVec2>,
+	/// The data type determining the color of the wire being dragged.
+	pub wire_in_progress_type: FrontendGraphDataType,
 	/// State for the context menu popups.
 	pub context_menu: Option<ContextMenuInformation>,
 	/// Index of selected node to be deselected on pointer up when shift clicking an already selected node
@@ -295,8 +296,8 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					}
 
 					self.wire_in_progress_from_connector = None;
-					self.wire_in_progress_type = FrontendGraphDataType::General;
 					self.wire_in_progress_to_connector = None;
+					self.wire_in_progress_type = FrontendGraphDataType::General;
 				}
 				responses.add(FrontendMessage::UpdateWirePathInProgress { wire_path: None });
 				responses.add(FrontendMessage::UpdateContextMenuInformation {
@@ -768,8 +769,9 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					// Abort dragging a wire
 					if self.wire_in_progress_from_connector.is_some() {
 						self.wire_in_progress_from_connector = None;
-						self.wire_in_progress_type = FrontendGraphDataType::General;
 						self.wire_in_progress_to_connector = None;
+						self.wire_in_progress_type = FrontendGraphDataType::General;
+
 						responses.add(DocumentMessage::AbortTransaction);
 						responses.add(FrontendMessage::UpdateWirePathInProgress { wire_path: None });
 						return;
@@ -850,8 +852,9 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 				if self.context_menu.is_some() {
 					self.context_menu = None;
 					self.wire_in_progress_from_connector = None;
-					self.wire_in_progress_type = FrontendGraphDataType::General;
 					self.wire_in_progress_to_connector = None;
+					self.wire_in_progress_type = FrontendGraphDataType::General;
+
 					responses.add(FrontendMessage::UpdateContextMenuInformation {
 						context_menu_information: self.context_menu.clone(),
 					});
@@ -1388,14 +1391,18 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					});
 					responses.add(DocumentMessage::EndTransaction);
 				}
+
 				self.drag_start = None;
 				self.begin_dragging = false;
 				self.box_selection_start = None;
+
 				self.wire_in_progress_from_connector = None;
-				self.wire_in_progress_type = FrontendGraphDataType::General;
 				self.wire_in_progress_to_connector = None;
+				self.wire_in_progress_type = FrontendGraphDataType::General;
+
 				self.reordering_export = None;
 				self.reordering_import = None;
+
 				responses.add(DocumentMessage::EndTransaction);
 				responses.add(FrontendMessage::UpdateWirePathInProgress { wire_path: None });
 				responses.add(FrontendMessage::UpdateBox { box_selection: None });


### PR DESCRIPTION
## Description

This PR implements proper node graph interaction aborting when pressing the Escape key (Esc) or the right mouse button (RMB). Specifically:
- Pressing Esc or RMB during wire-dragging will now restore the original connection.
- Pressing Esc or RMB during box selection will now restore the previous selection.
- In both cases, pressing Esc or RMB will not exit the node graph mode. 

_Note: the aborting behavior using RMB is already implemented. This PR extends that functionality to the Escape key._ 

## Code Change

In the NodeGraphMessageHandler struct, the following fields are now public to enable access from `document_message_handler.rs`:
- `box_selection_start`
- `selection_before_pointer_down`
- `wire_in_progress_type`

I made this decision since existing fields such as `drag_start` is already public and used in `document_message_handler.rs`     in a similar way. 

In the `Escape` key handler in `document_message_handler.rs`, I add special handling for wire dragging and box selection aborting. The logic mirrors the existing implementation for right click in [node_graph_message_handler.rs (lines 760–776).](https://github.com/GraphiteEditor/Graphite/blob/master/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs#L760-L776).

## Demo Video

[Google Drive link](https://drive.google.com/file/d/1h90C04c-YRHT0sAVMVLf1PVvN1ZNJHRe/view) to the demo video. Unfortunately the video is too large to attach directly in the description.

Closes #2336 
