### PR TITLE
Simplify node graph type error diagnostic message text

### DIFF
--- a/node-graph/libraries/core-types/src/types.rs
+++ b/node-graph/libraries/core-types/src/types.rs
@@ -369,7 +369,7 @@ impl std::fmt::Debug for Type {
 			Self::Concrete(ty) => format!("Concrete<{}, {:?}>", ty.name, ty.id),
 			#[cfg(not(feature = "type_id_logging"))]
 			Self::Concrete(ty) => format_type(&ty.name),
-			Self::Fn(call_arg, return_value) => format!("{return_value:?} called with {call_arg:?}"),
+			Self::Fn(_, return_value) => format!("{return_value:?}"),
 			Self::Future(ty) => format!("{ty:?}"),
 		};
 		let result = result.replace("Option<Arc<OwnedContextImpl>>", "Context");
@@ -382,7 +382,7 @@ impl std::fmt::Display for Type {
 		let result = match self {
 			Type::Generic(name) => name.to_string(),
 			Type::Concrete(ty) => format_type(&ty.name),
-			Type::Fn(call_arg, return_value) => format!("{return_value} called with {call_arg}"),
+			Type::Fn(_, return_value) => format!("{return_value}"),
 			Type::Future(ty) => ty.to_string(),
 		};
 		let result = result.replace("Option<Arc<OwnedContextImpl>>", "Context");


### PR DESCRIPTION
Old vs new
<img width="248" height="523" alt="image" src="https://github.com/user-attachments/assets/3c58dcc1-8185-4abd-90d7-0e35ecd7e61a" />
<img width="302" height="493" alt="image" src="https://github.com/user-attachments/assets/789f702b-4ca5-4dda-96cb-064e9efc4cb1" />

Potential further change: Hide error until clicked but show it on all erroring nodes. Not a single large error that jumps from node to node.
<img width="540" height="387" alt="image" src="https://github.com/user-attachments/assets/9186ee17-79d0-490d-b6ad-172e3356b10a" />

