### PR TITLE
New nodes: 'Reset Transform', 'Replace Transform', 'Count Points', 'Index Points'

### DIFF
--- a/editor/src/messages/portfolio/document/data_panel/data_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/data_panel/data_panel_message_handler.rs
@@ -502,10 +502,17 @@ impl TableRowLayout for Raster<CPU> {
 		format!("Raster ({}x{})", self.width, self.height)
 	}
 	fn element_page(&self, _data: &mut LayoutData) -> Vec<LayoutGroup> {
-		let base64_string = self.data().base64_string.clone().unwrap_or_else(|| {
+		let raster = self.data();
+
+		if raster.width == 0 || raster.height == 0 {
+			let widgets = vec![TextLabel::new("Image has no area").widget_holder()];
+			return vec![LayoutGroup::Row { widgets }];
+		}
+
+		let base64_string = raster.base64_string.clone().unwrap_or_else(|| {
 			use base64::Engine;
 
-			let output = self.data().to_png();
+			let output = raster.to_png();
 			let preamble = "data:image/png;base64,";
 			let mut base64_string = String::with_capacity(preamble.len() + output.len() * 4);
 			base64_string.push_str(preamble);

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -154,6 +154,7 @@ pub(crate) fn property_from_type(
 				Some("PixelLength") => number_widget(default_info, number_input.min(min(0.)).unit(unit.unwrap_or(" px"))).into(),
 				Some("Length") => number_widget(default_info, number_input.min(min(0.))).into(),
 				Some("Fraction") => number_widget(default_info, number_input.mode_range().min(min(0.)).max(max(1.))).into(),
+				Some("SignedInteger") => number_widget(default_info, number_input.int()).into(),
 				Some("IntegerCount") => number_widget(default_info, number_input.int().min(min(1.))).into(),
 				Some("SeedValue") => number_widget(default_info, number_input.int().min(min(0.))).into(),
 				Some("PixelSize") => vec2_widget(default_info, "X", "Y", unit.unwrap_or(" px"), None, false),

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -848,7 +848,7 @@ impl NodeNetwork {
 						// If the input to self is a node, connect the corresponding output of the inner network to it
 						NodeInput::Node { node_id, output_index } => {
 							nested_node.populate_first_network_input(node_id, output_index, nested_input_index, node.original_location.inputs(*import_index), 1);
-							let input_node = self.nodes.get_mut(&node_id).unwrap_or_else(|| panic!("unable find input node {node_id:?}"));
+							let input_node = self.nodes.get_mut(&node_id).unwrap_or_else(|| panic!("Unable to find input node {node_id:?}"));
 							input_node.original_location.dependants[output_index].push(nested_node_id);
 						}
 						NodeInput::Import { import_index, .. } => {

--- a/node-graph/libraries/core-types/src/ops.rs
+++ b/node-graph/libraries/core-types/src/ops.rs
@@ -79,6 +79,8 @@ impl Convert<DVec2, ()> for DVec2 {
 	}
 }
 
+// TODO: Add a DVec2 to Table<Vector> anchor point conversion implementation to replace the 'Vec2 to Point' node
+
 /// Implements the [`Convert`] trait for conversion between the cartesian product of Rust's primitive numeric types.
 macro_rules! impl_convert {
 	($from:ty, $to:ty) => {

--- a/node-graph/libraries/no-std-types/src/registry.rs
+++ b/node-graph/libraries/no-std-types/src/registry.rs
@@ -19,6 +19,8 @@ pub mod types {
 	pub type Length = f64;
 	/// 0 to 1
 	pub type Fraction = f64;
+	/// Signed integer that's actually a float because we don't handle type conversions very well yet
+	pub type SignedInteger = f64;
 	/// Unsigned integer
 	pub type IntegerCount = u32;
 	/// Unsigned integer to be used for random seeds


### PR DESCRIPTION
- Add the 'Reset Transform' and 'Replace Transform' nodes
- Add the 'Count Points' and 'Index Points' nodes
- Make the 'Index Elements' node support negative indexing from the end
- Make the 'Flatten Vector' node's implementation reusable
- Fix crash displaying 0x0 raster image in the Data panel
- Fix the 'Points to Polyline' node not working on two-point objects