### PR TITLE
Add tooltip documentation to web request and brush related nodes

### DIFF
--- a/node-graph/nodes/brush/src/brush.rs
+++ b/node-graph/nodes/brush/src/brush.rs
@@ -59,7 +59,7 @@ impl<P: Pixel + Alpha> Sample for BrushStampGenerator<P> {
 
 /// Controls the brush shape with diameter and hardness, plus color and opacity (via flow).
 /// The feather exponent is calculated from hardness to determine edge softness.
-/// Used internally to create the individual brush texture before stamping it repeatedly along a stroke path.
+/// Used internally to create the brush texture before stamping it repeatedly along a stroke path.
 #[node_macro::node(skip_impl)]
 fn brush_stamp_generator(#[unit(" px")] diameter: f64, color: Color, hardness: f64, flow: f64) -> BrushStampGenerator<Color> {
 	// Diameter
@@ -79,7 +79,7 @@ fn brush_stamp_generator(#[unit(" px")] diameter: f64, color: Color, hardness: f
 	BrushStampGenerator { color, feather_exponent, transform }
 }
 
-/// Used to efficiently paint brush strokes: applies the same texture repeatedly at different positions with proper blending and boundary handling.
+/// Used to efficiently paint brush strokes. Applies the same texture repeatedly at different positions with proper blending and boundary handling.
 #[node_macro::node(skip_impl)]
 fn blit<BlendFn>(mut target: Table<Raster<CPU>>, texture: Raster<CPU>, positions: Vec<DVec2>, blend_mode: BlendFn) -> Table<Raster<CPU>>
 where

--- a/node-graph/nodes/gstd/src/text.rs
+++ b/node-graph/nodes/gstd/src/text.rs
@@ -3,9 +3,6 @@ use graph_craft::wasm_application_io::WasmEditorApi;
 use graphic_types::Vector;
 pub use text_nodes::*;
 
-/// Converts text into editable vector shapes with customizable styling.
-/// Parameters control font, size, spacing, alignment, and layout.
-
 #[node_macro::node(category(""))]
 fn text<'i: 'n>(
 	_: impl Ctx,
@@ -28,9 +25,7 @@ fn text<'i: 'n>(
 	#[default(0.)]
 	tilt: f64,
 	align: TextAlign,
-    /// When disabled, outputs a single vector element containing all characters combined.
-	/// When enabled, outputs a table with one vector element per character,
-	/// allowing individual character manipulation by subsequent operations.
+	/// Splits each text glyph into its own row in the table of vector geometry.
 	#[default(false)]
 	per_glyph_instances: bool,
 ) -> Table<Vector> {

--- a/node-graph/nodes/gstd/src/wasm_application_io.rs
+++ b/node-graph/nodes/gstd/src/wasm_application_io.rs
@@ -27,16 +27,24 @@ use wasm_bindgen::JsCast;
 #[cfg(target_family = "wasm")]
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
 
-/// Allocates GPU memory and rendering context for vector-to-raster conversion. Must be paired with the Rasterize node.
+/// Allocates GPU memory and a rendering context for vector-to-raster conversion.
 #[cfg(feature = "wgpu")]
 #[node_macro::node(category("Debug: GPU"))]
 async fn create_surface<'a: 'n>(_: impl Ctx, editor: &'a WasmEditorApi) -> Arc<WasmSurfaceHandle> {
 	Arc::new(editor.application_io.as_ref().unwrap().create_window())
 }
 
-/// "Discard Result" runs asynchronously in the background without waiting. Useful for triggering webhooks or analytics without blocking.
+/// Sends an HTTP GET request to a specified URL and optionally waits for the response (unless discarded) which is output as a string.
 #[node_macro::node(category("Web Request"))]
-async fn get_request(_: impl Ctx, _primary: (), #[name("URL")] url: String, discard_result: bool) -> String {
+async fn get_request(
+	_: impl Ctx,
+	_primary: (),
+	/// The web address to send the GET request to.
+	#[name("URL")]
+	url: String,
+	/// Makes the request run in the background without waiting on a response. This is useful for triggering webhooks without blocking the continued execution of the graph.
+	discard_result: bool,
+) -> String {
 	#[cfg(target_family = "wasm")]
 	{
 		if discard_result {
@@ -65,9 +73,19 @@ async fn get_request(_: impl Ctx, _primary: (), #[name("URL")] url: String, disc
 	response.text().await.ok().unwrap_or_default()
 }
 
-/// Sends binary data to a URL via HTTP POST. When "Discard Result" is enabled, runs asynchronously without waiting for a response.
+/// Sends an HTTP POST request to a specified URL with the provided binary data and optionally waits for the response (unless discarded) which is output as a string.
 #[node_macro::node(category("Web Request"))]
-async fn post_request(_: impl Ctx, _primary: (), #[name("URL")] url: String, body: Vec<u8>, discard_result: bool) -> String {
+async fn post_request(
+	_: impl Ctx,
+	_primary: (),
+	/// The web address to send the POST request to.
+	#[name("URL")]
+	url: String,
+	/// The binary data to include in the body of the POST request.
+	body: Vec<u8>,
+	/// Makes the request run in the background without waiting on a response. This is useful for triggering webhooks without blocking the continued execution of the graph.
+	discard_result: bool,
+) -> String {
 	#[cfg(target_family = "wasm")]
 	{
 		if discard_result {
@@ -100,23 +118,23 @@ async fn post_request(_: impl Ctx, _primary: (), #[name("URL")] url: String, bod
 	response.text().await.ok().unwrap_or_default()
 }
 
-/// Prepare text for transmission over HTTP or storage in binary file formats.
+/// Converts a text string to raw binary data. Useful for transmission over HTTP or writing to files.
 #[node_macro::node(category("Web Request"), name("String to Bytes"))]
 fn string_to_bytes(_: impl Ctx, string: String) -> Vec<u8> {
 	string.into_bytes()
 }
 
-/// Extracts raw pixel data in RGBA format. Each pixel becomes 4 sequential bytes. Use before sending images over HTTP or writing to files.
+/// Converts extracted raw RGBA pixel data from an input image. Each pixel becomes 4 sequential bytes. Useful for transmission over HTTP or writing to files.
 #[node_macro::node(category("Web Request"), name("Image to Bytes"))]
 fn image_to_bytes(_: impl Ctx, image: Table<Raster<CPU>>) -> Vec<u8> {
 	let Some(image) = image.iter().next() else { return vec![] };
 	image.element.data.iter().flat_map(|color| color.to_rgb8_srgb().into_iter()).collect::<Vec<u8>>()
 }
 
-/// Supports loading from URLs and local asset paths. Returns a transparent placeholder if the resource fails to load, allowing workflows to continue.
+/// Loads binary from URLs and local asset paths. Returns a transparent placeholder if the resource fails to load, allowing workflows to continue.
 #[node_macro::node(category("Web Request"))]
-async fn load_resource<'a: 'n>(_: impl Ctx, _primary: (), #[scope("editor-api")] editor: &'a WasmEditorApi, #[name("URL")] url: String) -> Arc<[u8]> {
-	let Some(api) = editor.application_io.as_ref() else {
+async fn load_resource<'a: 'n>(_: impl Ctx, _primary: (), #[scope("editor-api")] editor_resources: &'a WasmEditorApi, #[name("URL")] url: String) -> Arc<[u8]> {
+	let Some(api) = editor_resources.application_io.as_ref() else {
 		return Arc::from(include_bytes!("../../../graph-craft/src/null.png").to_vec());
 	};
 	let Ok(data) = api.load_resource(url) else {
@@ -129,7 +147,9 @@ async fn load_resource<'a: 'n>(_: impl Ctx, _primary: (), #[scope("editor-api")]
 	data
 }
 
-/// Works with any standard image format (PNG, JPEG, WebP, etc.). Automatically converts color space to linear sRGB for accurate compositing.
+/// Converts raw binary data to a raster image.
+///
+/// Works with standard image format (PNG, JPEG, WebP, etc.). Automatically converts the color space to linear sRGB for accurate compositing.
 #[node_macro::node(category("Web Request"))]
 fn decode_image(_: impl Ctx, data: Arc<[u8]>) -> Table<Raster<CPU>> {
 	let Some(image) = image::load_from_memory(data.as_ref()).ok() else {
@@ -149,7 +169,7 @@ fn decode_image(_: impl Ctx, data: Arc<[u8]>) -> Table<Raster<CPU>> {
 	Table::new_from_element(Raster::new_cpu(image))
 }
 
-/// Renders with the resolution and transform defined by the footprint. Output respects vector strokes, gradients, and other styling details.
+/// Renders a view of the input graphic within an area defined by the *Footprint*.
 #[cfg(target_family = "wasm")]
 #[node_macro::node(category(""))]
 async fn rasterize<T: WasmNotSend + 'n>(


### PR DESCRIPTION
  - Add descriptive tooltips to web request nodes (GET/POST, string/image conversion, resource loading, image decoding)
  - Add tooltip to GPU rasterization node explaining footprint usage
  - Add tooltips to brush stamp generator and blit operations explaining their internal roles
  - Fix typos in tooltip and variable names