### PR TITLE
Hide decimals in Color Picker's RGB channel inputs

### DIFF
--- a/frontend/src/components/floating-menus/ColorPicker.svelte
+++ b/frontend/src/components/floating-menus/ColorPicker.svelte
@@ -535,6 +535,8 @@
 							min={0}
 							max={255}
 							minWidth={1}
+							step={1}
+							displayDecimalPlaces={0}
 							tooltip={`${{ r: "Red", g: "Green", b: "Blue" }[channel]} channel, integers 0–255`}
 						/>
 					{/each}


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Fixes a bug dropped in `#code-todo-list`
https://discord.com/channels/731730685944922173/881073965047636018/1444118878899671103

Test Results

https://github.com/user-attachments/assets/4a15482f-132c-4db4-8eab-4c5523b02d5d