### PR TITLE
Include path endpoints as extrema in the Extrude node

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,9 +46,11 @@
 				animation: spinning-loading-indicator 1s linear infinite;
 
 				@media (prefers-reduced-motion) {
+					border: none;
 					animation: none;
 					content: "Loading…";
-					border: none;
+					font-family: Arial, sans-serif;
+					font-size: 24px;
 				}
 			}
 

--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -712,7 +712,7 @@ pub mod extrude_algorithms {
 
 		let mut next_segment = vector.segment_domain.next_id();
 		for (index, &point) in points.iter().enumerate().take(first_half_points) {
-			// Extrema are single connected points or points with both psotive and negative values
+			// Extrema are single connected points or points with both positive and negative values
 			if !matches!(point, Found::Both | Found::Positive | Found::Negative) {
 				continue;
 			}


### PR DESCRIPTION
As suggested by «Neumond» in [discord here](https://discord.com/channels/731730685944922173/1134981447539761273/1448666502260854946).

<img width="1399" height="831" alt="Screenshot of graphite editor showing an extruded 'S' like shape, with joins between the end points of the 'S'." src="https://github.com/user-attachments/assets/821ce91b-61f4-4019-8d8d-2823eda125e3" />
