### PR TITLE
Fix regular polygon radius using inner radius correctly

### DIFF
--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -159,8 +159,9 @@ fn regular_polygon<T: AsU64>(
 	radius: f64,
 ) -> Table<Vector> {
 	let points = sides.as_u64();
-	let radius: f64 = radius * 2.;
-	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_regular_polygon(DVec2::splat(-radius), points, radius)))
+	let sides = points as f64;
+	let outer_radius = radius / (std::f64::consts::PI / sides).cos();
+	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_regular_polygon(DVec2::splat(-outer_radius), points, outer_radius),))
 }
 
 /// Generates an n-pointed star shape with inner and outer points at chosen radii from the center.


### PR DESCRIPTION
### Description
Fixes an issue where the regular polygon node treated the radius input as an outer radius.
The radius is now interpreted as the inner radius (apothem) and correctly converted to the outer radius before generating the polygon.

###Related Issue
Fixes #3484

### Changes
- Correctly convert inner radius (apothem) to outer radius (circumradius) for regular polygons
- Remove incorrect radius scaling

### Testing
- `cargo build`
- Mathematical verification of apothem → circumradius conversion