### PR TITLE
Adds a Toggle for Inner Radius in Polygon tool (#3484)

### DIFF
--- a/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
@@ -18,6 +18,7 @@ use graph_craft::document::NodeInput;
 use graph_craft::document::value::TaggedValue;
 use graphene_std::NodeInputDecleration;
 use graphene_std::subpath::{self, Subpath};
+use graphene_std::vector::calculate_effective_radius;
 use graphene_std::vector::click_target::ClickTargetType;
 use graphene_std::vector::misc::{ArcType, GridType, SpiralType, dvec2_to_point};
 use kurbo::{BezPath, PathEl, Shape};
@@ -300,15 +301,26 @@ pub fn extract_star_parameters(layer: Option<LayerNodeIdentifier>, document: &Do
 
 /// Extract the node input values of Polygon.
 /// Returns an option of (sides, radius).
-pub fn extract_polygon_parameters(layer: Option<LayerNodeIdentifier>, document: &DocumentMessageHandler) -> Option<(u32, f64)> {
+pub fn extract_polygon_parameters(layer: Option<LayerNodeIdentifier>, document: &DocumentMessageHandler) -> Option<(u32, f64, bool)> {
 	let node_inputs =
 		NodeGraphLayer::new(layer?, &document.network_interface).find_node_inputs(&DefinitionIdentifier::ProtoNode(graphene_std::vector::generator_nodes::regular_polygon::IDENTIFIER))?;
 
-	let (Some(&TaggedValue::U32(n)), Some(&TaggedValue::F64(radius))) = (node_inputs.get(1)?.as_value(), node_inputs.get(2)?.as_value()) else {
+	let (Some(&TaggedValue::U32(n)), Some(&TaggedValue::F64(radius)), Some(&TaggedValue::Bool(is_inner_radius))) =
+		(node_inputs.get(1)?.as_value(), node_inputs.get(2)?.as_value(), node_inputs.get(3)?.as_value())
+	else {
 		return None;
 	};
 
-	Some((n, radius))
+	Some((n, radius, is_inner_radius))
+}
+
+pub fn polygon_edge_midpoint(viewport: DAffine2, edge_index: i32, n: u32, radius: f64) -> DVec2 {
+	let angle = ((edge_index as f64 + 0.5) * TAU) / (n as f64);
+
+	viewport.transform_point2(DVec2 {
+		x: radius * angle.sin(),
+		y: -radius * angle.cos(),
+	})
 }
 
 /// Extract the node input values of an arc.
@@ -434,14 +446,14 @@ pub fn star_outline(layer: Option<LayerNodeIdentifier>, document: &DocumentMessa
 /// Outlines the geometric shape made by polygon-node
 pub fn polygon_outline(layer: Option<LayerNodeIdentifier>, document: &DocumentMessageHandler, overlay_context: &mut OverlayContext) {
 	let Some(layer) = layer else { return };
-	let Some((sides, radius)) = extract_polygon_parameters(Some(layer), document) else {
+	let Some((sides, radius, is_inner_radius)) = extract_polygon_parameters(Some(layer), document) else {
 		return;
 	};
 
 	let viewport = document.metadata().transform_to_viewport(layer);
 
 	let points = sides as u64;
-	let radius: f64 = radius * 2.;
+	let radius: f64 = calculate_effective_radius(radius, sides, is_inner_radius) * 2.;
 
 	let subpath: Vec<ClickTargetType> = vec![ClickTargetType::Subpath(Subpath::new_regular_polygon(DVec2::splat(-radius), points, radius))];
 

--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -158,10 +158,20 @@ fn regular_polygon<T: AsU64>(
 	#[unit(" px")]
 	#[default(50)]
 	radius: f64,
+	#[default(false)] is_inner_radius: bool,
 ) -> Table<Vector> {
 	let points = sides.as_u64();
-	let radius: f64 = radius * 2.;
-	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_regular_polygon(DVec2::splat(-radius), points, radius)))
+	let effective_radius = calculate_effective_radius(radius, sides.as_u64() as u32, is_inner_radius) * 2.;
+	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_regular_polygon(DVec2::splat(-effective_radius), points, effective_radius)))
+}
+
+pub fn calculate_effective_radius(radius: f64, sides: u32, is_inner: bool) -> f64 {
+	if is_inner {
+		let cosine = (std::f64::consts::PI / sides as f64).cos();
+		if cosine.abs() > 1e-6 { radius / cosine } else { radius }
+	} else {
+		radius
+	}
 }
 
 /// Generates an n-pointed star shape with inner and outer points at chosen radii from the center.


### PR DESCRIPTION
### Description
- Adds a Toggle to switch between inner and outer radius in a polygon

### Issue
Closes #3484 

### Notes For Maintainer
- Umm, I wasn't sure if it was better to overwrite the default radius with the improvised one or create a new var. For now, at most places I created a variable as `effective_radius`, let me know if I go with overwriting approach
- Also, the toggle could use a better name...

### Preview

https://github.com/user-attachments/assets/9f061df2-8bd0-4e0c-8772-a67674be945b

