### PR TITLE
fix : Sync Make Path Editable state between path tool and menu bar

### DIFF
--- a/editor/src/messages/menu_bar/menu_bar_message.rs
+++ b/editor/src/messages/menu_bar/menu_bar_message.rs
@@ -5,4 +5,5 @@ use crate::messages::prelude::*;
 pub enum MenuBarMessage {
 	// Messages
 	SendLayout,
+	UpdateMakePathEditableState { allowed: bool },
 }

--- a/editor/src/messages/menu_bar/menu_bar_message_handler.rs
+++ b/editor/src/messages/menu_bar/menu_bar_message_handler.rs
@@ -30,6 +30,10 @@ impl MessageHandler<MenuBarMessage, ()> for MenuBarMessageHandler {
 			MenuBarMessage::SendLayout => {
 				self.send_layout(responses, LayoutTarget::MenuBar);
 			}
+			MenuBarMessage::UpdateMakePathEditableState { allowed } => {
+				self.make_path_editable_is_allowed = allowed;
+				self.send_layout(responses, LayoutTarget::MenuBar);
+			}
 		}
 	}
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1575,6 +1575,11 @@ impl Fsm for PathToolFsmState {
 
 				shape_editor.set_selected_layers(target_layers);
 
+				tool_data.make_path_editable_is_allowed = make_path_editable_is_allowed(&mut document.network_interface).is_some();
+				responses.add(MenuBarMessage::UpdateMakePathEditableState { 
+					allowed: tool_data.make_path_editable_is_allowed 
+				});
+
 				responses.add(OverlaysMessage::Draw);
 				self
 			}
@@ -3127,6 +3132,11 @@ impl Fsm for PathToolFsmState {
 
 				tool_data.make_path_editable_is_allowed = make_path_editable_is_allowed(&mut document.network_interface).is_some();
 				tool_data.update_selection_status(shape_editor, document);
+
+				responses.add(MenuBarMessage::UpdateMakePathEditableState { 
+					allowed: tool_data.make_path_editable_is_allowed 
+				});
+
 				self
 			}
 			(_, PathToolMessage::ManipulatorMakeHandlesColinear) => {


### PR DESCRIPTION
## Summary
Fix an issue where the “Make Path Editable” menu item could get stuck in a disabled state while the Path tool correctly allowed the action.

## Problem
The Menu Bar and Path tool each tracked their own `make_path_editable_is_allowed` state. The Path tool updated correctly, but the Menu Bar was never notified, leaving the menu item out of sync.

## Solution
Add a message-based update flow so the Path tool notifies the Menu Bar whenever the allowed state changes. The Menu Bar updates its state and redraws, keeping both UI entry points in sync.

## Code todo list
- https://discord.com/channels/731730685944922173/881073965047636018/1415971652470181984

## Demo
https://github.com/user-attachments/assets/8674eae2-6831-4fc0-aa39-49c8f4692742
