### PR TITLE
Fix Pen tool anchor point overlays disappearing forever after viewing the node graph

### DIFF
--- a/editor/src/messages/portfolio/document/overlays/utility_functions.rs
+++ b/editor/src/messages/portfolio/document/overlays/utility_functions.rs
@@ -137,11 +137,9 @@ pub fn path_overlays(document: &DocumentMessageHandler, draw_handles: DrawHandle
 
 		let selected_shape_state = shape_editor.selected_shape_state.entry(layer).or_default();
 		// Get the selected segments and then add a bold line overlay on them
-		if selected_shape_state.selected_points().next().is_some() {
-			for (segment_id, bezier, _, _) in vector.segment_iter() {
-				if selected_shape_state.is_segment_selected(segment_id) {
-					overlay_context.outline_select_bezier(bezier, transform);
-				}
+		for (segment_id, bezier, _, _) in vector.segment_iter() {
+			if selected_shape_state.is_segment_selected(segment_id) {
+				overlay_context.outline_select_bezier(bezier, transform);
 			}
 		}
 


### PR DESCRIPTION
@Keavon please review this
fixed the issue of pen tool loosing its ability to produce anchor points after open/close of node graph

https://github.com/user-attachments/assets/1b67bbdd-9445-4dca-8335-0e746f88c9c3




Closes #3505 
