### PR TITLE
Improve robustness when panning/tilting/zooming during dragging actions

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -2,7 +2,7 @@
 
 use super::tool_prelude::*;
 use crate::consts::*;
-use crate::messages::input_mapper::utility_types::input_mouse::ViewportPosition;
+use crate::messages::input_mapper::utility_types::input_mouse::{ViewportPosition, MouseKeys};
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
 use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
 use crate::messages::portfolio::document::utility_types::document_metadata::{DocumentMetadata, LayerNodeIdentifier};
@@ -606,6 +606,7 @@ impl Fsm for SelectToolFsmState {
 
 		let ToolMessage::Select(event) = event else { return self };
 		match (self, event) {
+			(SelectToolFsmState::Dragging { .. }, SelectToolMessage::Overlays { .. }) => self,
 			(_, SelectToolMessage::Overlays { context: mut overlay_context }) => {
 				tool_data.snap_manager.draw_overlays(SnapData::new(document, input, viewport), &mut overlay_context);
 
@@ -1393,8 +1394,11 @@ impl Fsm for SelectToolFsmState {
 
 				state
 			}
-			(SelectToolFsmState::Dragging { has_dragged, remove, deepest, .. }, SelectToolMessage::DragStop { remove_from_selection }) => {
+			(SelectToolFsmState::Dragging { has_dragged, remove, deepest, axis, using_compass }, SelectToolMessage::DragStop { remove_from_selection }) => {
 				// Deselect layer if not snap dragging
+				if input.mouse.mouse_keys.contains(MouseKeys::LEFT) {
+					return SelectToolFsmState::Dragging { has_dragged, remove, deepest, axis, using_compass };
+				}
 				responses.add(DocumentMessage::EndTransaction);
 				tool_data.axis_align = false;
 


### PR DESCRIPTION
### Description
This PR improves aims to improve the robustness when panning/tilting/zooming during dragging actions

### Changes
Sometimes during multi-finger actions like tilting or zooming,  `PointerUp` event was sent (even though we are still pressing the button), I Added a check for this within the `DragStop` handler for `SelectToolFsmState` which ensures the left mouse button is not released before a transformation is committed by ignoring `PointerUp` events received while we are still dragging

Viewport Redraw Stability: Implemented an Overlays message handler for the `Dragging` state. Now, whenever the editor sends a redraw message while dragging, it is prevented from dropping out of Dragging mode.

I will be working on related Paper Cut issues within this PR.
https://github.com/user-attachments/assets/30d4d338-9ffb-409e-b3a1-29b749fbbde8

Part of #3500 (drag offset)
