### PR TITLE
Ignore out-of-range mouse button values using from_bits_truncate

### DIFF
--- a/editor/src/messages/input_mapper/utility_types/input_mouse.rs
+++ b/editor/src/messages/input_mapper/utility_types/input_mouse.rs
@@ -76,7 +76,7 @@ pub struct EditorMouseState {
 
 impl EditorMouseState {
 	pub fn from_keys_and_editor_position(keys: u8, editor_position: EditorPosition) -> Self {
-        // TODO: Some graphic tablets send key codes not mentioned in the spec. In the future we would like to support these as well.
+		// TODO: Some graphic tablets send key codes not mentioned in the spec. In the future we would like to support these as well.
 		let mouse_keys = MouseKeys::from_bits_truncate(keys);
 
 		Self {


### PR DESCRIPTION
<!-- Please reference any relevant issue number below, optionally with a "Closes"/"Resolves"/"Fixes" prefix -->

Have'nt tested this locally since I don't have a tablet on me . But like [0HyperCube](https://github.com/0HyperCube) suggested, using the from_bits_truncate here . Don't see any other or better approach to this as well

Closes #3521
