### PR TITLE
Fix:  Ctrl+Z on 'Edit > Convert to Infinite Canvas' creates leftover merge nodes

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -311,6 +311,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 				}
 			}
 			DocumentMessage::RemoveArtboards => {
+				responses.add(DocumentMessage::AddTransaction);
 				responses.add(GraphOperationMessage::RemoveArtboards);
 			}
 			DocumentMessage::ClearLayersPanel => {

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -232,6 +232,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageContext<'_>> for
 			}
 			GraphOperationMessage::RemoveArtboards => {
 				if network_interface.all_artboards().is_empty() {
+					responses.add(DocumentMessage::AbortTransaction);
 					return;
 				}
 

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -1,6 +1,7 @@
 use super::transform_utils;
 use super::utility_types::ModifyInputsContext;
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
+use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::network_interface::{InputConnector, NodeNetworkInterface, OutputConnector};
 use crate::messages::portfolio::document::utility_types::nodes::CollapsedLayers;
@@ -234,12 +235,6 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageContext<'_>> for
 					return;
 				}
 
-				responses.add(DocumentMessage::AddTransaction);
-				responses.add(NodeGraphMessage::DeleteNodes {
-					node_ids: network_interface.all_artboards().iter().map(|layer_node| layer_node.to_node()).collect(),
-					delete_children: false,
-				});
-
 				let mut artboard_data: HashMap<NodeId, ArtboardInfo> = HashMap::new();
 
 				// Go through all artboards and create merge nodes
@@ -264,8 +259,8 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageContext<'_>> for
 						},
 					);
 
-					let mut modify_inputs = ModifyInputsContext::new(network_interface, responses);
-					modify_inputs.create_layer(node_id);
+					let new_merge_node = resolve_document_node_type("Merge").expect("Merge node").default_node_template();
+					network_interface.insert_node(node_id, new_merge_node, &[]);
 
 					responses.add(NodeGraphMessage::SetDisplayName {
 						node_id,
@@ -310,6 +305,10 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageContext<'_>> for
 					});
 				}
 
+				responses.add(NodeGraphMessage::DeleteNodes {
+					node_ids: network_interface.all_artboards().iter().map(|layer_node| layer_node.to_node()).collect(),
+					delete_children: false,
+				});
 				responses.add(NodeGraphMessage::RunDocumentGraph);
 				responses.add(NodeGraphMessage::SelectedNodesUpdated);
 				responses.add(NodeGraphMessage::SendGraph);

--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -1,7 +1,7 @@
 use super::transform_utils;
 use super::utility_types::ModifyInputsContext;
 use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
-use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_document_node_type;
+use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_network_node_type;
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::network_interface::{InputConnector, NodeNetworkInterface, OutputConnector};
 use crate::messages::portfolio::document::utility_types::nodes::CollapsedLayers;
@@ -259,7 +259,7 @@ impl MessageHandler<GraphOperationMessage, GraphOperationMessageContext<'_>> for
 						},
 					);
 
-					let new_merge_node = resolve_document_node_type("Merge").expect("Merge node").default_node_template();
+					let new_merge_node = resolve_network_node_type("Merge").expect("Merge node").default_node_template();
 					network_interface.insert_node(node_id, new_merge_node, &[]);
 
 					responses.add(NodeGraphMessage::SetDisplayName {


### PR DESCRIPTION
changed the flow of transaction 
Closes #2258



https://github.com/user-attachments/assets/dbe6c90e-f822-4763-b483-17011eec2353

