### PR TITLE
Fix/multiply alpha for table color

### DIFF
--- a/node-graph/nodes/blending/src/lib.rs
+++ b/node-graph/nodes/blending/src/lib.rs
@@ -1,4 +1,4 @@
-use core_types::color::Alpha;
+use core_types::color::{AlphaMut};
 use core_types::registry::types::Percentage;
 use core_types::table::Table;
 use core_types::{BlendMode, Color, Ctx};
@@ -40,7 +40,7 @@ impl MultiplyAlpha for Table<Raster<CPU>> {
 impl MultiplyAlpha for Table<Color> {
 	fn multiply_alpha(&mut self, factor: f64) {
 		for row in self.iter_mut() {
-			*row.element = row.element.multiplied_alpha(factor as f32);
+			row.element.set_alpha(factor as f32);
 			row.alpha_blending.opacity *= factor as f32;
 		}
 	}


### PR DESCRIPTION
Fixes #3205 
The main problem was in 
`MultiplyAlpha for Table<Color>`, where only the alpha_blending.opacity was changing but not the color opacity as mentioned itself in the issue

I changed the color alpha itself with the function `multiplied_alpha` under the `AlphaMut` trait.
My fix is this:
```rust
impl MultiplyAlpha for Table<Color> {
	fn multiply_alpha(&mut self, factor: f64) {
		for row in self.iter_mut() {
			row.element.set_alpha(factor as f32);
			row.alpha_blending.opacity *= factor as f32;
		}
	}
}
```


**Faulty behavior**

<img width="1233" height="307" alt="image" src="https://github.com/user-attachments/assets/53dbdc00-ca22-4181-82a9-5ec1047c9b57" />

Change in opacity node before the fill value does not changes anything. The opacity is always full

---

**Corrected behaviour**
<img width="1242" height="360" alt="image" src="https://github.com/user-attachments/assets/4a0ee950-75c2-4410-96cf-7e81ece4a842" />

Now changing the opacity changes the color opacity


