### PR TITLE
fix: move save state updates to SavedDocument handler

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1046,11 +1046,6 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					self.path = None;
 				}
 
-				self.set_save_state(true);
-				responses.add(PortfolioMessage::AutoSaveActiveDocument);
-				// Update the save status of the just saved document
-				responses.add(PortfolioMessage::UpdateOpenDocumentsList);
-
 				responses.add(FrontendMessage::TriggerSaveDocument {
 					document_id,
 					name: format!("{}.{}", self.name.clone(), FILE_EXTENSION),
@@ -1061,7 +1056,12 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 			DocumentMessage::SavedDocument { path } => {
 				self.path = path;
 
+				// Mark the document as saved now that the file has actually been written
+				self.set_save_state(true);
+				self.set_auto_save_state(true);
 				responses.add(PortfolioMessage::AutoSaveActiveDocument);
+				// Update the save status of the just saved document
+				responses.add(PortfolioMessage::UpdateOpenDocumentsList);
 
 				// Update the name to match the file stem
 				let document_name_from_path = self.path.as_ref().and_then(|path| {


### PR DESCRIPTION
Fixes #3558 

### Problem

Previously, `set_save_state(true)` was called in the `SaveDocument` handler before the save dialog even appeared. This caused the document to be marked as saved even if the user cancelled the save dialog, leading to:
- Loss of the unsaved indicator (asterisk) in the document tab
- Users thinking their document was saved when it wasn't
- Potential loss of modifications if the user closed the document

### Solution

Moved the save state updates (`set_save_state`, `set_auto_save_state`) from the `SaveDocument` handler to the `SavedDocument` handler, which only executes after the file has actually been written to disk.

### Changes

- Removed premature `set_save_state(true)` and related calls from `SaveDocument` handler
- Added `set_save_state(true)` and `set_auto_save_state(true)` to `SavedDocument` handler
- Moved `UpdateOpenDocumentsList` response to `SavedDocument` handler

### Testing

- Verified compilation with `cargo check`
- The asterisk indicator now correctly remains visible when save is cancelled
- Document is only marked as saved after successful file write

---