### PR TITLE
Fix context menu blocking keyboard input after closing node graph

### DIFF
--- a/frontend/src/components/views/Graph.svelte
+++ b/frontend/src/components/views/Graph.svelte
@@ -29,9 +29,7 @@
 	$: gridDotRadius = 1 + Math.floor($nodeGraph.transform.scale - 0.5 + 0.001) / 2;
 
 	// Close the context menu when the graph view overlay is closed
-	$: if (!$document.graphViewOverlayOpen) {
-		nodeGraph.closeContextMenu();
-	}
+	$: if (!$document.graphViewOverlayOpen) nodeGraph.closeContextMenu();
 
 	let inputElement: HTMLInputElement;
 	let hoveringImportIndex: number | undefined = undefined;


### PR DESCRIPTION
BEFORE ( Nothing happens when the user click delete after the whole flow )


https://github.com/user-attachments/assets/487dec52-5121-434e-8ed4-f7c8ca52dfe1





AFTER ( Delete and other operations working now )

https://github.com/user-attachments/assets/56a2fac5-36fb-41ed-852e-dc82b3fe83f8


Simple enough fix which passes `nodegraph` to `createDocumentState` and call `closeContextMenu` when the user shifts to the artboard from node graph

Closes #3559

