### PR TITLE
Fix PNG exports being off by 1 pixel

### DIFF
--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -201,7 +201,7 @@ impl NodeGraphExecutor {
 			ExportBounds::Artboard(id) => document.metadata().bounding_box_document(id),
 		}
 		.ok_or_else(|| "No bounding box".to_string())?;
-		let resolution = (bounds[1] - bounds[0]).as_uvec2();
+		let resolution = (bounds[1] - bounds[0]).round().as_uvec2();
 		let transform = DAffine2::from_translation(bounds[0]).inverse();
 
 		let render_config = RenderConfig {


### PR DESCRIPTION


Before 


https://github.com/user-attachments/assets/de66fa36-9ba4-49e2-88df-17a47348b710


After


https://github.com/user-attachments/assets/7069e783-2c79-4279-b700-6724d3b8f159


Closes #3574 