### PR TITLE
Fix Enter fails to confirm in the New Document dialog after editing values 

### DIFF
--- a/frontend/src/components/floating-menus/Dialog.svelte
+++ b/frontend/src/components/floating-menus/Dialog.svelte
@@ -24,7 +24,7 @@
 		emphasizedOrFirstButton?.focus();
 
 		// Add an event to handle enter press on all focusable fields(inputs) inside the popup
-		const floatingMenu = (self?.div?.()?.querySelector("[data-floating-menu-content]") || self?.div?.()?.querySelector("[data-floating-menu-content]") || undefined) as HTMLButtonElement | undefined;
+		const floatingMenu = (self?.div?.()?.querySelector("[data-floating-menu-content]") || undefined) as HTMLDivElement | undefined;
 		floatingMenu?.addEventListener("keydown", function (event) {
 			if (event.key == "Enter") {
 				emphasizedOrFirstButton?.click();


### PR DESCRIPTION
Fixes: #3601

Now it behaves normally:

https://github.com/user-attachments/assets/6225e70c-41b3-431f-8d9e-b41ae697a1a5

