### PR TITLE
fix breadcrumb connection element ui scaling issue

### DIFF
--- a/frontend/src/components/widgets/buttons/BreadcrumbTrailButtons.svelte
+++ b/frontend/src/components/widgets/buttons/BreadcrumbTrailButtons.svelte
@@ -27,10 +27,10 @@
 			position: relative;
 
 			&:not(:first-child) {
-				margin-left: 0px;
+				margin-left: -2px;
 			}
 
-			clip-path: polygon(0% 0%, calc(100% - 4px) 0%, 100% 50%, calc(100% - 4px) 100%, 0% 100%, 4px 50%);
+			clip-path: polygon(2px 0%, calc(100% - 4px) 0%, 100% 50%, calc(100% - 4px) 100%, 2px 100%, 6px 50%);
 			padding-left: 12px;
 			padding-right: 12px;
 
@@ -41,7 +41,7 @@
 			}
 
 			&:last-of-type {
-				clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 4px 50%);
+				clip-path: polygon(2px 0%, 100% 0%, 100% 100%, 2px 100%, 6px 50%);
 				padding-left: 12px;
 				padding-right: 8px;
 


### PR DESCRIPTION
Discord link to issue:- https://discord.com/channels/731730685944922173/881073965047636018/1458467402743287973

This issue can be reproduced by going into the node graph and then clicking on a sub element. 
The issue lies on the Breadcrumb menu showing the user where they currently are in the graph
such as Document->Layer.

The issue arises due to non integer scaling on certain scales.
I have taken a few screenshots before my fix to show this.

### Before
Zoom (110%)
<img width="450" height="223" alt="image" src="https://github.com/user-attachments/assets/6e3c47bc-0939-40f0-9473-68f9859156a4" />
Zoom (150%)
<img width="760" height="232" alt="image" src="https://github.com/user-attachments/assets/9112c2e4-13aa-423e-b1a5-ca8a8df3db69" />

I narrowed it down the issue to `frontend/src/components/widgets/buttons/BreadcrumbTrailButtons.svelte`
specifically in the way it was drawn. The `.text-button`, and i seem to understand its a block element, and whenever the scale changes (like 110%) the browser might possibly calculate the dimensions of the border(which seems to be the way the arrow was drawn) and make some rounding error which seems to misalign the ui as seen in the Before pictures.

I wrote a fix by drawing the text button using clip-path so it stays stable across all ui scales as its recalculated perfectly and does not seem to cause any misalignment.

### After
Zoom (110%)
<img width="461" height="133" alt="image" src="https://github.com/user-attachments/assets/aae258e1-c9c3-4a4d-9dcc-42aecec899e8" />
Zoom(150%)
<img width="591" height="187" alt="image" src="https://github.com/user-attachments/assets/41f3efc6-d057-4d77-8487-079bb37b1f54" />

The ui might have been altered slightly visually but the misalignment issue does not seem to be there anymore