### PR TITLE
Fix integer underflow in 'Index Points' node

### DIFF
--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -2275,6 +2275,9 @@ async fn index_points(
 ) -> DVec2 {
 	let points_count = content.iter().map(|row| row.element.point_domain.positions().len()).sum::<usize>();
 
+	if points_count == 0 {
+		return DVec2::ZERO;
+	}
 	// Clamp and allow negative indexing from the end
 	let index = index as isize;
 	let index = if index < 0 {


### PR DESCRIPTION
This PR fixes an integer underflow bug in the Index Points node that caused crashes in debug builds when processing empty vectors. Closes #3621.
Before - 
<img width="1528" height="977" alt="Screenshot 2026-01-11 130856" src="https://github.com/user-attachments/assets/d9ed25b4-f819-49b4-97fb-5fdc7c81af4a" />

Now:-
<img width="1533" height="963" alt="Screenshot 2026-01-11 130909" src="https://github.com/user-attachments/assets/ebca6e46-374d-4e06-a449-0a6d67b467f0" />
