### PR TITLE
Fix thumbnails not being updated for layers when they become empty

### DIFF
--- a/editor/src/node_graph_executor/runtime.rs
+++ b/editor/src/node_graph_executor/runtime.rs
@@ -518,7 +518,6 @@ impl NodeRuntime {
 			RenderBoundingBox::Infinite => Some([DVec2::ZERO, DVec2::new(300., 200.)]),
 			RenderBoundingBox::Rectangle(bounds) => Some(bounds),
 		};
-		// Generate the SVG based on whether bounds exist
 		let new_thumbnail_svg = if let Some(bounds) = bounds {
 			let footprint = Footprint {
 				transform: DAffine2::from_translation(DVec2::new(bounds[0].x, bounds[0].y)),
@@ -540,13 +539,11 @@ impl NodeRuntime {
 
 			render.svg
 		} else {
-			// If there are no bounds (empty layer), return an empty SVG vector
 			Vec::new()
 		};
 
-		// UPDATE FRONTEND THUMBNAIL
+		// Update frontend thumbnail
 		let old_thumbnail_svg = thumbnail_renders.entry(parent_network_node_id).or_default();
-
 		if old_thumbnail_svg != &new_thumbnail_svg {
 			responses.push_back(FrontendMessage::UpdateNodeThumbnail {
 				id: parent_network_node_id,


### PR DESCRIPTION
fixes #3597 

changed the handling of empty bounds (empty layers) from early returning to generate a empty svg and send to frontend.

before: 


https://github.com/user-attachments/assets/09f97443-35c5-4b4b-a3c9-779ccc3e419e


after fix: 


https://github.com/user-attachments/assets/0e8c3f99-a328-47f7-9a9d-97a322695273


