### PR TITLE
Prevent tooltips from showing when mouse leaves the window over a widget with a tooltip

### DIFF
--- a/frontend/src/state-providers/tooltip.ts
+++ b/frontend/src/state-providers/tooltip.ts
@@ -63,6 +63,7 @@ export function createTooltipState(editor: Editor) {
 
 	document.addEventListener("mousedown", closeTooltip);
 	document.addEventListener("keydown", closeTooltip);
+	document.addEventListener("wheel", closeTooltip);
 
 	editor.subscriptions.subscribeJsMessage(SendShortcutShiftClick, async (data) => {
 		update((state) => {


### PR DESCRIPTION
Fix #3593 , added mouseleave event listener . 
Before:-
<img width="744" height="279" alt="Screenshot 2026-01-12 164624" src="https://github.com/user-attachments/assets/925e531e-fd37-4db2-b491-336fab10c857" />
After:-
<img width="422" height="330" alt="Screenshot 2026-01-12 170440" src="https://github.com/user-attachments/assets/d309c98f-8322-4f7d-b645-3095b659c35c" />

