### PR TITLE
fixed issue where pen tool would create a second anchor when closing

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -1844,6 +1844,7 @@ impl Fsm for PenToolFsmState {
 				} else {
 					if tool_data.handle_end.is_some() {
 						responses.add(DocumentMessage::StartTransaction);
+						return PenToolFsmState::PlacingAnchor;
 					}
 					// Merge two layers if the point is connected to the end point of another path
 


### PR DESCRIPTION
https://discord.com/channels/731730685944922173/881073965047636018/1419542672623931512

the pen tool now early returns if closing a loop, instead of creating a new point