### PR TITLE
Add "Exclude Layers" Ctrl modifier when dragging to box select in the node graph

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1986,22 +1986,29 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					}
 
 					if control {
-						let layer_nodes: Vec<_> = nodes.iter().filter(|node_id| network_interface.is_layer(node_id, selection_network_path)).cloned().collect();
-						let mut child_nodes = HashSet::new();
-						for layer_id in &layer_nodes {
-							for child_id in network_interface.upstream_flow_back_from_nodes(vec![*layer_id], selection_network_path, FlowType::LayerChildrenUpstreamFlow) {
-								if nodes.contains(&child_id) && child_id != *layer_id {
-									child_nodes.insert(child_id);
+						let mut non_layer_nodes = HashSet::new();
+
+						let layer_nodes = nodes.iter().filter(|node_id| network_interface.is_layer(node_id, selection_network_path));
+						for &layer_id in layer_nodes {
+							for child_id in network_interface.upstream_flow_back_from_nodes(vec![layer_id], selection_network_path, FlowType::LayerChildrenUpstreamFlow) {
+								if nodes.contains(&child_id) && child_id != layer_id {
+									non_layer_nodes.insert(child_id);
 								}
 							}
 						}
-						nodes = if alt {
-							previous_selection.difference(&child_nodes).cloned().collect()
-						} else if shift {
-							previous_selection.union(&child_nodes).cloned().collect()
-						} else {
-							child_nodes
-						};
+
+						// Remove non-layer nodes from selection
+						if alt {
+							nodes = previous_selection.difference(&non_layer_nodes).cloned().collect();
+						}
+						// Add non-layer nodes to selection
+						else if shift {
+							nodes = previous_selection.union(&non_layer_nodes).cloned().collect();
+						}
+						// Replace selection with non-layer nodes
+						else {
+							nodes = non_layer_nodes;
+						}
 					}
 
 					if nodes != previous_selection {
@@ -2791,7 +2798,7 @@ impl NodeGraphMessageHandler {
 				HintInfo::mouse(MouseMotion::LmbDrag, "Select Area"),
 				HintInfo::keys([Key::Shift], "Extend").prepend_plus(),
 				HintInfo::keys([Key::Alt], "Subtract").prepend_plus(),
-				HintInfo::keys([Key::Control], "Children Only").prepend_plus(),
+				HintInfo::keys([Key::Control], "Exclude Layers").prepend_plus(),
 			]),
 		]);
 		if self.has_selection {


### PR DESCRIPTION
Added Ctrl modifier that filters selection to include only child nodes . closes #3212 
video : 

https://github.com/user-attachments/assets/023f37c0-976b-4dfd-b3dd-de22a28735f0

