### PR TITLE
Desktop: Support triple-click inputs

### DIFF
--- a/desktop/src/cef/input/state.rs
+++ b/desktop/src/cef/input/state.rs
@@ -148,17 +148,17 @@ impl ClickTracker {
 		match state {
 			ElementState::Pressed if record.down_count == ClickCount::Triple => {
 				*record = ClickRecord {
-					down_count: ClickCount::Single,
+					down_count: ClickCount::Double,
 					..*record
 				};
-				return ClickCount::Single;
+				return ClickCount::Double;
 			}
 			ElementState::Released if record.up_count == ClickCount::Triple => {
 				*record = ClickRecord {
-					up_count: ClickCount::Single,
+					up_count: ClickCount::Double,
 					..*record
 				};
-				return ClickCount::Single;
+				return ClickCount::Double;
 			}
 			_ => {}
 		}


### PR DESCRIPTION
#### Before
https://github.com/user-attachments/assets/e22f7ff2-8872-4d18-aab4-a7589818c429

#### After
https://github.com/user-attachments/assets/55bbbcce-2791-4507-b9e2-f706fa646be9

This PR fixes triple-clicking text not selecting the entire paragraph on desktop.

Closes #3596