### PR TITLE
Fix insertion or creation of layers at top of a stack with multiple top output wires

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -5524,55 +5524,8 @@ impl NodeNetworkInterface {
 			let _ = self.selected_nodes_mut(network_path).unwrap().replace_with(old_selected_nodes);
 		}
 
-		// If inserting into a stack with a parent, ensure the parent stack has enough space for the child stack
-		if parent != LayerNodeIdentifier::ROOT_PARENT
-			&& let Some(upstream_sibling) = parent.next_sibling(&self.document_metadata)
-		{
-			let Some(parent_position) = self.position(&parent.to_node(), network_path) else {
-				log::error!("Could not get parent position in move_layer_to_stack");
-				return;
-			};
-			let last_child = parent.last_child(&self.document_metadata).unwrap_or(parent);
-
-			let Some(mut last_child_position) = self.position(&last_child.to_node(), network_path) else {
-				log::error!("Could not get last child position in move_layer_to_stack");
-				return;
-			};
-
-			if self.is_layer(&last_child.to_node(), network_path) {
-				last_child_position.y += 3;
-			} else {
-				last_child_position.y += 2;
-			}
-
-			// If inserting below the current last child, then the last child is layer to move
-			if post_node.node_id() == Some(last_child.to_node()) {
-				last_child_position += height_above_layer + 3 + height_below_layer;
-			}
-
-			let Some(upstream_sibling_position) = self.position(&upstream_sibling.to_node(), network_path) else {
-				log::error!("Could not get upstream sibling position in move_layer_to_stack");
-				return;
-			};
-
-			let target_gap = last_child_position.y - parent_position.y + 3;
-			let current_gap = upstream_sibling_position.y - parent_position.y;
-
-			let upstream_nodes = self
-				.upstream_flow_back_from_nodes(vec![upstream_sibling.to_node()], network_path, FlowType::UpstreamFlow)
-				.collect::<Vec<_>>();
-			let Some(selected_nodes) = self.selected_nodes_mut(network_path) else {
-				log::error!("Could not get selected nodes in move_layer_to_stack");
-				return;
-			};
-			let old_selected_nodes = selected_nodes.replace_with(upstream_nodes);
-
-			for _ in 0..(target_gap - current_gap).max(0) {
-				self.shift_selected_nodes(Direction::Down, true, network_path);
-			}
-
-			let _ = self.selected_nodes_mut(network_path).unwrap().replace_with(old_selected_nodes);
-		}
+		// If true, this node should be inserted before the post node (toward root from the layer), and all outward wires from the pre node should be moved to its output.
+		let mut insert_node_after_post = false;
 
 		// Connect the layer to a parent layer/node at the top of the stack, or a non layer node midway down the stack
 		if !inserting_into_stack {
@@ -5595,7 +5548,7 @@ impl NodeNetworkInterface {
 					let final_layer_position = IVec2::new(stack_top_position.x, after_move_post_layer_position.y + 3 + height_above_layer);
 					let shift = final_layer_position - previous_layer_position;
 					self.shift_absolute_node_position(&layer.to_node(), shift, network_path);
-					self.insert_node_between(&layer.to_node(), &post_node, 0, network_path);
+					insert_node_after_post = true;
 				}
 				NodeInput::Import { .. } => {
 					log::error!("Cannot move post node to parent which connects to the imports")
@@ -5614,11 +5567,35 @@ impl NodeNetworkInterface {
 					let final_layer_position = after_move_post_layer_position + IVec2::new(0, 3 + height_above_layer);
 					let shift = final_layer_position - previous_layer_position;
 					self.shift_absolute_node_position(&layer.to_node(), shift, network_path);
-					self.insert_node_between(&layer.to_node(), &post_node, 0, network_path);
+					insert_node_after_post = true;
 				}
 				NodeInput::Import { .. } => {
 					log::error!("Cannot move post node to parent which connects to the imports")
 				}
+			}
+		}
+
+		if insert_node_after_post {
+			self.insert_node_between(&layer.to_node(), &post_node, 0, network_path);
+
+			// Get the other wires which need to be moved to the output of the moved layer
+			let layer_input_connector = InputConnector::node(layer.to_node(), 0);
+			let other_outward_wires = self
+				.upstream_output_connector(&layer_input_connector, network_path)
+				.and_then(|pre_node_output| self.outward_wires(network_path).and_then(|wires| wires.get(&pre_node_output)))
+				.map(|other| {
+					other
+						.iter()
+						.filter(|other_input_connector| **other_input_connector != layer_input_connector)
+						.cloned()
+						.collect::<Vec<_>>()
+				})
+				.unwrap_or_default();
+
+			// Disconnect and reconnect
+			for other_outward_wire in &other_outward_wires {
+				self.disconnect_input(other_outward_wire, network_path);
+				self.create_wire(&OutputConnector::node(layer.to_node(), 0), other_outward_wire, network_path);
 			}
 		}
 		self.unload_upstream_node_click_targets(vec![layer.to_node()], network_path);


### PR DESCRIPTION
Remove faulty logic for expanding layer stacks
Fix inserting layers to the top of a stack with multiple outputs
