### PR TITLE
Fix regression breaking Into/Convert node type coercion

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -648,7 +648,7 @@ impl NodeNetworkInterface {
 
 				let export_name = if !export_name.is_empty() {
 					export_name
-				} else if let Some(export_type_name) = input_type.compiled_nested_type().map(|nested| nested.to_string()) {
+				} else if let Some(export_type_name) = input_type.compiled_nested_type().map(ToString::to_string) {
 					export_type_name
 				} else {
 					format!("Export #{}", export_index)
@@ -658,12 +658,19 @@ impl NodeNetworkInterface {
 			}
 		};
 
+		let valid_types = self.potential_valid_input_types(input_connector, network_path).iter().map(ToString::to_string).collect::<Vec<_>>();
+		let valid_types = {
+			// Dedupe while preserving order
+			let mut found = HashSet::new();
+			valid_types.into_iter().filter(|s| found.insert(s.clone())).collect::<Vec<_>>()
+		};
+
 		Some(FrontendGraphInput {
 			data_type,
 			resolved_type,
 			name,
 			description,
-			valid_types: self.potential_valid_input_types(input_connector, network_path).iter().map(|ty| ty.to_string()).collect(),
+			valid_types,
 			connected_to,
 		})
 	}
@@ -698,7 +705,7 @@ impl NodeNetworkInterface {
 
 				let import_name = if !import_name.is_empty() {
 					import_name
-				} else if let Some(import_type_name) = output_type.compiled_nested_type().map(|nested| nested.to_string()) {
+				} else if let Some(import_type_name) = output_type.compiled_nested_type().map(ToString::to_string) {
 					import_type_name
 				} else {
 					format!("Import #{}", import_index)

--- a/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
@@ -91,8 +91,8 @@ impl TypeSource {
 	/// The type to display in the tooltip label.
 	pub fn resolved_type_tooltip_string(&self) -> String {
 		match self {
-			TypeSource::Compiled(compiled_type) => format!("Data Type: {:?}", compiled_type.nested_type().to_string()),
-			TypeSource::TaggedValue(value_type) => format!("Data Type: {:?}", value_type.nested_type().to_string()),
+			TypeSource::Compiled(compiled_type) => format!("Data Type: {}", compiled_type.nested_type()),
+			TypeSource::TaggedValue(value_type) => format!("Data Type: {}", value_type.nested_type()),
 			TypeSource::Unknown => "Unknown Data Type".to_string(),
 			TypeSource::Invalid => "Invalid Type Combination".to_string(),
 			TypeSource::Error(_) => "Error Getting Data Type".to_string(),
@@ -180,7 +180,7 @@ impl NodeNetworkInterface {
 		self.input_type_not_invalid(input_connector, network_path)
 	}
 
-	// Gets the default tagged value for an input. If its not compiled, then it tries to get a valid type. If there are no valid types, then it picks a random implementation
+	/// Gets the default tagged value for an input. If its not compiled, then it tries to get a valid type. If there are no valid types, then it picks a random implementation.
 	pub fn tagged_value_from_input(&mut self, input_connector: &InputConnector, network_path: &[NodeId]) -> TaggedValue {
 		let guaranteed_type = match self.input_type(input_connector, network_path) {
 			TypeSource::Compiled(compiled) => compiled,
@@ -190,12 +190,12 @@ impl NodeNetworkInterface {
 				// TODO: Add a NodeInput::Indeterminate which can be resolved at compile time to be any type that prevents an error. This may require bidirectional typing.
 				self.complete_valid_input_types(input_connector, network_path)
 					.into_iter()
-					.min_by_key(|ty| ty.nested_type().to_string())
+					.min_by_key(|ty| ty.nested_type().identifier_name())
 					// Pick a random type from the potential valid types
 					.or_else(|| {
 						self.potential_valid_input_types(input_connector, network_path)
 							.into_iter()
-							.min_by_key(|ty| ty.nested_type().to_string())
+							.min_by_key(|ty| ty.nested_type().identifier_name())
 					}).unwrap_or(concrete!(()))
 			}
 			TypeSource::Error(e) => {

--- a/node-graph/graph-craft/src/proto.rs
+++ b/node-graph/graph-craft/src/proto.rs
@@ -794,7 +794,14 @@ impl TypingContext {
 					.into_iter()
 					.chain(&inputs)
 					.enumerate()
-					.filter_map(|(i, t)| if i == 0 { None } else { Some(format!("• Input {}: {t}", i + convert_node_index_offset)) })
+					.filter_map(|(i, t)| {
+						if i == 0 {
+							None
+						} else {
+							let number = i + convert_node_index_offset;
+							Some(format!("• Input {number}: {t}"))
+						}
+					})
 					.collect::<Vec<_>>()
 					.join("\n");
 				Err(vec![GraphError::new(node, GraphErrorType::InvalidImplementations { inputs, error_inputs })])
@@ -821,13 +828,13 @@ impl TypingContext {
 						return Ok(node_io.clone());
 					}
 				}
-				let inputs = [call_argument].into_iter().chain(&inputs).map(|t| t.to_string()).collect::<Vec<_>>().join(", ");
+				let inputs = [call_argument].into_iter().chain(&inputs).map(ToString::to_string).collect::<Vec<_>>().join(", ");
 				let valid = valid_output_types.into_iter().cloned().collect();
 				Err(vec![GraphError::new(node, GraphErrorType::MultipleImplementations { inputs, valid })])
 			}
 
 			_ => {
-				let inputs = [call_argument].into_iter().chain(&inputs).map(|t| t.to_string()).collect::<Vec<_>>().join(", ");
+				let inputs = [call_argument].into_iter().chain(&inputs).map(ToString::to_string).collect::<Vec<_>>().join(", ");
 				let valid = valid_output_types.into_iter().cloned().collect();
 				Err(vec![GraphError::new(node, GraphErrorType::MultipleImplementations { inputs, valid })])
 			}
@@ -871,9 +878,7 @@ fn check_generic(types: &NodeIOTypes, input: &Type, parameters: &[Type], generic
 /// Returns a list of all generic types used in the node
 fn replace_generics(types: &mut NodeIOTypes, lookup: &HashMap<String, Type>) {
 	let replace = |ty: &Type| {
-		let Type::Generic(ident) = ty else {
-			return None;
-		};
+		let Type::Generic(ident) = ty else { return None };
 		lookup.get(ident.as_ref()).cloned()
 	};
 	types.call_argument.replace_nested(replace);

--- a/node-graph/preprocessor/src/lib.rs
+++ b/node-graph/preprocessor/src/lib.rs
@@ -36,7 +36,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 		let id = id.clone();
 
 		let NodeMetadata { fields, .. } = metadata;
-		let Some(implementations) = &node_registry.get(&id) else { continue };
+		let Some(implementations) = node_registry.get(&id) else { continue };
 		let valid_call_args: HashSet<_> = implementations.iter().map(|(_, node_io)| node_io.call_argument.clone()).collect();
 		let first_node_io = implementations.first().map(|(_, node_io)| node_io).unwrap_or(const { &NodeIOTypes::empty() });
 		let mut node_io_types = vec![HashSet::new(); fields.len()];
@@ -69,8 +69,8 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 							let input_ty = input.nested_type();
 							let mut inputs = vec![NodeInput::import(input.clone(), i)];
 
-							let into_node_identifier = ProtoNodeIdentifier::with_owned_string(format!("graphene_core::ops::IntoNode<{}>", input_ty.clone()));
-							let convert_node_identifier = ProtoNodeIdentifier::with_owned_string(format!("graphene_core::ops::ConvertNode<{}>", input_ty.clone()));
+							let into_node_identifier = ProtoNodeIdentifier::with_owned_string(format!("graphene_core::ops::IntoNode<{}>", input_ty.identifier_name()));
+							let convert_node_identifier = ProtoNodeIdentifier::with_owned_string(format!("graphene_core::ops::ConvertNode<{}>", input_ty.identifier_name()));
 
 							let proto_node = if into_node_registry.keys().any(|ident: &ProtoNodeIdentifier| ident.as_str() == into_node_identifier.as_str()) {
 								generated_nodes += 1;


### PR DESCRIPTION
Fixes a regression from #3662. Closes #3677.

This also refactors some code messiness around how we did `Display` vs. `Debug` printing of type representations.