### PR TITLE
Fix dragging range-style integer number inputs not accumulating slow mouse movements

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -469,7 +469,7 @@
 		cumulativeDragDelta += dragDelta;
 
 		const combined = initialValue + cumulativeDragDelta;
-		const combineSnapped = snapping ? Math.round(combined) : combined;
+		const combineSnapped = snapping || isInteger ? Math.round(combined) : combined;
 
 		const newValue = updateValue(combineSnapped);
 


### PR DESCRIPTION
Closes #3674
Fixes a bug where slow mouse movements were ignored for integer inputs or when snapping is enabled.
