### PR TITLE
Fix solidify stroke node ignoring transforms applied before stroke node

### DIFF
--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -1158,7 +1158,9 @@ async fn solidify_stroke(_: impl Ctx, content: Table<Vector>) -> Table<Vector> {
 				path.apply_affine(Affine::new(stroke.transform.to_cols_array()));
 
 				let mut solidified = kurbo::stroke(path, &stroke_style, &stroke_options, STROKE_TOLERANCE);
-				solidified.apply_affine(Affine::new(stroke.transform.inverse().to_cols_array()));
+				if stroke.transform.matrix2.determinant() != 0. {
+					solidified.apply_affine(Affine::new(stroke.transform.inverse().to_cols_array()));
+				}
 
 				result.append_bezpath(solidified);
 			}


### PR DESCRIPTION
This PR addresses the issue raised in https://discord.com/channels/731730685944922173/881073965047636018/1416281986661613669

Solidify stroke now applies the stroke's transform to the path before generating geometry and then reverses the transform. 

The rectangle on the left is 600px by 600px with transform scale at 1x and the one on the right is 100px by 100px with transform scale set to 6x on both axes.

**Before**
<img width="1245" height="842" alt="Screenshot 2026-01-26 at 3 02 49 AM" src="https://github.com/user-attachments/assets/652536cc-4523-4463-8d4c-43d5b6be90f8" />


**After**
<img width="1244" height="840" alt="Screenshot 2026-01-26 at 3 02 28 AM" src="https://github.com/user-attachments/assets/eeafa42f-f5f3-4b1d-b89e-ced7825255eb" />

<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
