### PR TITLE
Fix scaling while export

### DIFF
--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -244,25 +244,8 @@ impl NodeGraphExecutor {
 			ExportBounds::Artboard(id) => document.metadata().bounding_box_document(id),
 		}
 		.ok_or_else(|| "No bounding box".to_string())?;
-
-		// Calculate base resolution from bounds
-		let base_size = bounds[1] - bounds[0];
-
-		// For raster exports (PNG/JPG), apply scale factor to resolution for GPU rendering
-		// For SVG exports, keep original resolution (scaling happens during SVG-to-raster conversion on frontend)
-		let resolution = if export_format == graphene_std::application_io::ExportFormat::Raster {
-			(base_size * export_config.scale_factor).round().as_uvec2()
-		} else {
-			base_size.round().as_uvec2()
-		};
-
-		// Transform from document space to viewport space
-		// First translate to origin, then scale if doing raster export
-		let transform = if export_format == graphene_std::application_io::ExportFormat::Raster {
-			DAffine2::from_scale(DVec2::splat(export_config.scale_factor)) * DAffine2::from_translation(-bounds[0])
-		} else {
-			DAffine2::from_translation(bounds[0]).inverse()
-		};
+		let resolution = (bounds[1] - bounds[0]).round().as_uvec2();
+		let transform = DAffine2::from_translation(bounds[0]).inverse();
 
 		let render_config = RenderConfig {
 			viewport: Footprint {

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -253,7 +253,8 @@ impl NodeGraphExecutor {
 				transform,
 				..Default::default()
 			},
-			scale: export_config.scale_factor,
+			// For exports, keep the internal render scale at 1.0 and apply the user scale factor only to the bitmap size later
+			scale: 1.,
 			time: Default::default(),
 			pointer: DVec2::ZERO,
 			export_format,

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -244,8 +244,25 @@ impl NodeGraphExecutor {
 			ExportBounds::Artboard(id) => document.metadata().bounding_box_document(id),
 		}
 		.ok_or_else(|| "No bounding box".to_string())?;
-		let resolution = (bounds[1] - bounds[0]).round().as_uvec2();
-		let transform = DAffine2::from_translation(bounds[0]).inverse();
+
+		// Calculate base resolution from bounds
+		let base_size = bounds[1] - bounds[0];
+
+		// For raster exports (PNG/JPG), apply scale factor to resolution for GPU rendering
+		// For SVG exports, keep original resolution (scaling happens during SVG-to-raster conversion on frontend)
+		let resolution = if export_format == graphene_std::application_io::ExportFormat::Raster {
+			(base_size * export_config.scale_factor).round().as_uvec2()
+		} else {
+			base_size.round().as_uvec2()
+		};
+
+		// Transform from document space to viewport space
+		// First translate to origin, then scale if doing raster export
+		let transform = if export_format == graphene_std::application_io::ExportFormat::Raster {
+			DAffine2::from_scale(DVec2::splat(export_config.scale_factor)) * DAffine2::from_translation(-bounds[0])
+		} else {
+			DAffine2::from_translation(bounds[0]).inverse()
+		};
 
 		let render_config = RenderConfig {
 			viewport: Footprint {


### PR DESCRIPTION
Closes #3588 

Earlier, using the scale factor of export configuration inside RenderConfig caused the viewBox to shrink.This meant the renderer produced artwork in a smaller logical coordinate space. Then It drew this small content in a large canvas , scaled up. Thats why we saw only the zoomed-in top-left corner. Now we use scale 1. instead of scale_factor. So the SVG viewBox matches the artwork’s true bounds.scale_factor is only used during calculation of frontend size

Before:

https://github.com/user-attachments/assets/a91d0cc6-bb09-4cef-a29a-7cc56edac54b

After:

https://github.com/user-attachments/assets/4eac0155-b8e7-4856-9bbb-a54ea3e0aabf

