### PR TITLE
Desktop: Fix drag followed by a click causing a double click

### DIFF
--- a/desktop/src/cef/input/state.rs
+++ b/desktop/src/cef/input/state.rs
@@ -149,7 +149,9 @@ impl ClickTracker {
 			ElementState::Released => (record.up_count, record.up_position),
 		};
 
-		let within_dist = position.x.abs_diff(prev_position.x) <= MULTICLICK_ALLOWED_TRAVEL && position.y.abs_diff(prev_position.y) <= MULTICLICK_ALLOWED_TRAVEL;
+		let dx = position.x.abs_diff(prev_position.x);
+		let dy = position.y.abs_diff(prev_position.y);
+		let within_dist = dx <= MULTICLICK_ALLOWED_TRAVEL && dy <= MULTICLICK_ALLOWED_TRAVEL;
 
 		let count = match (prev_count, within_time, within_dist) {
 			(ClickCount::Single, true, true) => ClickCount::Double,


### PR DESCRIPTION
### Before
https://github.com/user-attachments/assets/d10dc173-94f3-4262-9f06-20ce027095fd

### After
https://github.com/user-attachments/assets/dfdd37e0-2cfc-4df5-a2e7-0762b54e1264



Closes #3714 