### PR TITLE
Pan and Zoom on Document when in Node Graph

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -414,8 +414,9 @@ pub fn input_mappings(zoom_with_scroll: bool) -> Mapping {
 		// NavigationMessage
 		entry!(KeyDown(MouseMiddle); modifiers=[Alt], action_dispatch=NavigationMessage::BeginCanvasTilt { was_dispatched_from_menu: false }),
 		entry!(KeyDown(MouseLeft); modifiers=[Alt, Space], action_dispatch=NavigationMessage::BeginCanvasTilt { was_dispatched_from_menu: false }),
-		entry!(KeyDown(MouseMiddle); modifiers=[Control], action_dispatch=NavigationMessage::BeginCanvasZoom),
-		entry!(KeyDown(MouseLeft); modifiers=[Control, Space], action_dispatch=NavigationMessage::BeginCanvasZoom),
+		entry!(KeyDown(MouseMiddle); modifiers=[Control, Alt], action_dispatch=NavigationMessage::BeginCanvasZoom { document_ptz_override: true }),
+		entry!(KeyDown(MouseMiddle); modifiers=[Control], action_dispatch=NavigationMessage::BeginCanvasZoom { document_ptz_override: false }),
+		entry!(KeyDown(MouseLeft); modifiers=[Control, Space], action_dispatch=NavigationMessage::BeginCanvasZoom { document_ptz_override: false }),
 		entry!(KeyDown(MouseMiddle); action_dispatch=NavigationMessage::BeginCanvasPan),
 		entry!(KeyDown(MouseLeft); modifiers=[Space], action_dispatch=NavigationMessage::BeginCanvasPan),
 		entry!(KeyDown(NumpadAdd); modifiers=[Accel], action_dispatch=NavigationMessage::CanvasZoomIncrease { center_on_mouse: false }),

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -218,7 +218,9 @@ pub enum DocumentMessage {
 	UngroupLayer {
 		layer: LayerNodeIdentifier,
 	},
-	PTZUpdate,
+	PTZUpdate {
+		document_ptz_override: bool,
+	},
 	SelectionStepBack,
 	SelectionStepForward,
 	WrapContentInArtboard {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -524,7 +524,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 				}
 				responses.add(NodeGraphMessage::UnloadWires);
 				responses.add(NodeGraphMessage::SendGraph);
-				responses.add(DocumentMessage::PTZUpdate);
+				responses.add(DocumentMessage::PTZUpdate { document_ptz_override: false });
 				responses.add(NodeGraphMessage::UpdateNodeGraphWidth);
 			}
 			DocumentMessage::FlipSelectedLayers { flip_axis } => {
@@ -1512,8 +1512,8 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 				responses.add(NodeGraphMessage::SelectedNodesUpdated);
 				responses.add(NodeGraphMessage::SendGraph);
 			}
-			DocumentMessage::PTZUpdate => {
-				if !self.graph_view_overlay_open {
+			DocumentMessage::PTZUpdate { document_ptz_override } => {
+				if !self.graph_view_overlay_open || document_ptz_override {
 					let transform = self.navigation_handler.calculate_offset_transform(viewport.center_in_viewport_space().into(), &self.document_ptz);
 					self.network_interface.set_document_to_viewport_transform(transform);
 					// Ensure selection box is kept in sync with the pointer when the PTZ changes

--- a/editor/src/messages/portfolio/document/navigation/navigation_message.rs
+++ b/editor/src/messages/portfolio/document/navigation/navigation_message.rs
@@ -8,7 +8,7 @@ pub enum NavigationMessage {
 	// Messages
 	BeginCanvasPan,
 	BeginCanvasTilt { was_dispatched_from_menu: bool },
-	BeginCanvasZoom,
+	BeginCanvasZoom { document_ptz_override: bool },
 	CanvasPan { delta: DVec2 },
 	CanvasPanAbortPrepare { x_not_y_axis: bool },
 	CanvasPanAbort { x_not_y_axis: bool },

--- a/editor/src/messages/portfolio/portfolio_message_handler.rs
+++ b/editor/src/messages/portfolio/portfolio_message_handler.rs
@@ -446,7 +446,7 @@ impl MessageHandler<PortfolioMessage, PortfolioMessageContext<'_>> for Portfolio
 				let mut new_document = DocumentMessageHandler::default();
 				new_document.name = name;
 
-				responses.add(DocumentMessage::PTZUpdate);
+				responses.add(DocumentMessage::PTZUpdate { document_ptz_override: false });
 
 				let document_id = DocumentId(generate_uuid());
 				if self.active_document().is_some() {

--- a/editor/src/messages/tool/tool_messages/navigate_tool.rs
+++ b/editor/src/messages/tool/tool_messages/navigate_tool.rs
@@ -117,7 +117,7 @@ impl Fsm for NavigateToolFsmState {
 			}
 			NavigateToolMessage::PointerMove { snap } => {
 				if self == NavigateToolFsmState::ZoomOrClickZooming {
-					responses.add_front(NavigationMessage::BeginCanvasZoom);
+					responses.add_front(NavigationMessage::BeginCanvasZoom { document_ptz_override: false });
 					NavigateToolFsmState::Zooming
 				} else {
 					responses.add_front(NavigationMessage::PointerMove { snap });


### PR DESCRIPTION

https://github.com/user-attachments/assets/e773a7aa-2062-4789-b208-1804168e51e0


Adds:  Alt+MMB dragging to pan the artwork canvas in node graph
           Ctrl+Alt+MMB drag to zoom the artwork canvas in node graph
           
Resolves: https://discord.com/channels/731730685944922173/881073965047636018/1364204626433409046