### PR TITLE
Desktop: Enable manual trigger for Mac and Windows builds

### DIFF
--- a/.github/workflows/build-mac-bundle.yml
+++ b/.github/workflows/build-mac-bundle.yml
@@ -1,6 +1,7 @@
 name: Build Mac Bundle
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - master
@@ -82,6 +83,7 @@ jobs:
           path: target/artifacts
 
       - name: Sign and Notarize Mac Bundle Preparation
+        if: github.ref == 'refs/heads/master'
         env:
           APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
           APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
@@ -115,6 +117,7 @@ jobs:
           EOF
 
       - name: Sign and Notarize Mac Bundle
+        if: github.ref == 'refs/heads/master'
         env:
           APPLE_EMAIL: ${{ secrets.APPLE_EMAIL }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -147,6 +150,7 @@ jobs:
           spctl -a -vv "$APP_PATH"
 
       - name: Upload Mac Bundle Signed
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v4
         with:
           name: graphite-mac-bundle-signed

--- a/.github/workflows/build-win-bundle.yml
+++ b/.github/workflows/build-win-bundle.yml
@@ -1,6 +1,7 @@
 name: Build Windows Bundle
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - master
@@ -87,6 +88,7 @@ jobs:
           path: target/artifacts
 
       - name: Azure login
+        if: github.ref == 'refs/heads/master'
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -95,6 +97,7 @@ jobs:
           enable-AzPSSession: true
 
       - name: Sign
+        if: github.ref == 'refs/heads/master'
         uses: azure/artifact-signing-action@v1
         with:
           endpoint: https://eus.codesigning.azure.net/
@@ -115,6 +118,7 @@ jobs:
           correlation-id: ${{ github.sha }}
 
       - name: Verify Signatures
+        if: github.ref == 'refs/heads/master'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -161,6 +165,7 @@ jobs:
           }
 
       - name: Upload Windows Bundle Signed
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v4
         with:
           name: graphite-windows-bundle-signed


### PR DESCRIPTION
allow members to start desktop builds manually on any branch
only builds on master are signed