### PR TITLE
Fix history steps not being given to Line tool endpoint movements

### DIFF
--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -789,6 +789,7 @@ impl Fsm for ShapeToolFsmState {
 				) && clicked_on_line_endpoints(layer, document, input, tool_data)
 					&& !input.keyboard.key(Key::Control)
 				{
+					responses.add(DocumentMessage::StartTransaction);
 					return ShapeToolFsmState::DraggingLineEndpoints;
 				}
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/b3f605ca-ed42-43ed-acb0-c3d7a9960ab7


Fixes the issue from this discussion here

https://discord.com/channels/731730685944922173/731738914812854303/1469746043167051959