### PR TITLE
Fix incorrect flattening behavior for hidden nodes

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions/document_node_derive.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions/document_node_derive.rs
@@ -55,7 +55,7 @@ pub(super) fn post_process_nodes(custom: Vec<DocumentNodeDefinition>) -> HashMap
 						inputs,
 						call_argument: input_type.clone(),
 						implementation: DocumentNodeImplementation::ProtoNode(id.clone()),
-						visible: Visible::Passthrough,
+						visible: None,
 						skip_deduplication: false,
 						context_features: ContextDependencies::from(context_features.as_slice()),
 						..Default::default()

--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions/document_node_derive.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions/document_node_derive.rs
@@ -55,7 +55,7 @@ pub(super) fn post_process_nodes(custom: Vec<DocumentNodeDefinition>) -> HashMap
 						inputs,
 						call_argument: input_type.clone(),
 						implementation: DocumentNodeImplementation::ProtoNode(id.clone()),
-						visible: true,
+						visible: Visible::Passthrough,
 						skip_deduplication: false,
 						context_features: ContextDependencies::from(context_features.as_slice()),
 						..Default::default()

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -2585,7 +2585,7 @@ impl NodeGraphMessageHandler {
 			return Vec::new();
 		};
 		let mut nodes = Vec::new();
-		for (node_id, visible) in network.nodes.iter().map(|(node_id, node)| (*node_id, node.visible)).collect::<Vec<_>>() {
+		for (node_id, visible) in network.nodes.iter().map(|(node_id, node)| (*node_id, node.visible.is_visible())).collect::<Vec<_>>() {
 			let primary_input_connector = InputConnector::node(node_id, 0);
 
 			let primary_input = if network_interface
@@ -2735,7 +2735,7 @@ impl NodeGraphMessageHandler {
 
 				let parents_visible = layer.ancestors(network_interface.document_metadata()).filter(|&ancestor| ancestor != layer).all(|layer| {
 					if layer != LayerNodeIdentifier::ROOT_PARENT {
-						network_interface.document_node(&layer.to_node(), &[]).map(|node| node.visible).unwrap_or_default()
+						network_interface.document_node(&layer.to_node(), &[]).map(|node| node.visible.is_visible()).unwrap_or_default()
 					} else {
 						true
 					}

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -2571,7 +2571,7 @@ impl NodeGraphMessageHandler {
 			return Vec::new();
 		};
 		let mut nodes = Vec::new();
-		for (node_id, visible) in network.nodes.iter().map(|(node_id, node)| (*node_id, node.visible.is_visible())).collect::<Vec<_>>() {
+		for (node_id, visible) in network.nodes.iter().map(|(node_id, node)| (*node_id, node.visible.is_none())).collect::<Vec<_>>() {
 			let primary_input_connector = InputConnector::node(node_id, 0);
 
 			let primary_input = if network_interface
@@ -2721,7 +2721,7 @@ impl NodeGraphMessageHandler {
 
 				let parents_visible = layer.ancestors(network_interface.document_metadata()).filter(|&ancestor| ancestor != layer).all(|layer| {
 					if layer != LayerNodeIdentifier::ROOT_PARENT {
-						network_interface.document_node(&layer.to_node(), &[]).map(|node| node.visible.is_visible()).unwrap_or_default()
+						network_interface.document_node(&layer.to_node(), &[]).map(|node| node.visible.is_none()).unwrap_or_default()
 					} else {
 						true
 					}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
@@ -203,7 +203,7 @@ impl NodeNetworkInterface {
 				concrete!(())
 			}
 		};
-		TaggedValue::from_type_or_none(&guaranteed_type)
+		TaggedValue::from_type(&guaranteed_type).expect("Failed to construct TaggedValue for identity type")
 	}
 
 	/// A list of all valid input types for this specific node.

--- a/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface/resolved_types.rs
@@ -182,28 +182,39 @@ impl NodeNetworkInterface {
 
 	/// Gets the default tagged value for an input. If its not compiled, then it tries to get a valid type. If there are no valid types, then it picks a random implementation.
 	pub fn tagged_value_from_input(&mut self, input_connector: &InputConnector, network_path: &[NodeId]) -> TaggedValue {
-		let guaranteed_type = match self.input_type(input_connector, network_path) {
-			TypeSource::Compiled(compiled) => compiled,
-			TypeSource::TaggedValue(value) => value,
+		match self.input_type(input_connector, network_path) {
+			TypeSource::Compiled(compiled) | TypeSource::TaggedValue(compiled) => {
+				let tagged_value = TaggedValue::from_type_or_none(&compiled);
+				if matches!(tagged_value, TaggedValue::None) {
+					log::error!("Failed to construct TaggedValue for {compiled:?} in tagged_value_from_input");
+				}
+				tagged_value
+			}
 			TypeSource::Unknown | TypeSource::Invalid => {
-				// Pick a random type from the complete valid types
-				// TODO: Add a NodeInput::Indeterminate which can be resolved at compile time to be any type that prevents an error. This may require bidirectional typing.
-				self.complete_valid_input_types(input_connector, network_path)
-					.into_iter()
-					.min_by_key(|ty| ty.nested_type().identifier_name())
-					// Pick a random type from the potential valid types
-					.or_else(|| {
-						self.potential_valid_input_types(input_connector, network_path)
-							.into_iter()
-							.min_by_key(|ty| ty.nested_type().identifier_name())
-					}).unwrap_or(concrete!(()))
+				// Try complete valid types first, then potential valid types
+				let mut candidate_types = self.complete_valid_input_types(input_connector, network_path);
+				if candidate_types.is_empty() {
+					candidate_types = self.potential_valid_input_types(input_connector, network_path);
+				}
+				candidate_types.sort_by_key(|ty| ty.nested_type().identifier_name());
+
+				// Try each candidate type in order until we find one that works
+				if let Some(tagged_value) = candidate_types.iter().find_map(|ty| {
+					let tagged = TaggedValue::from_type_or_none(ty);
+					(!matches!(tagged, TaggedValue::None)).then_some(tagged)
+				}) {
+					return tagged_value;
+				}
+
+				let fallback_type = candidate_types.first().cloned().unwrap_or(concrete!(()));
+				log::error!("Failed to construct TaggedValue for any valid type on {input_connector:?}; fallback type: {fallback_type:?}");
+				TaggedValue::from_type_or_none(&fallback_type)
 			}
 			TypeSource::Error(e) => {
 				log::error!("Error getting tagged_value_from_input for {input_connector:?} {e}");
-				concrete!(())
+				TaggedValue::None
 			}
-		};
-		TaggedValue::from_type(&guaranteed_type).expect("Failed to construct TaggedValue for identity type")
+		}
 	}
 
 	/// A list of all valid input types for this specific node.

--- a/node-graph/README.md
+++ b/node-graph/README.md
@@ -14,7 +14,7 @@ pub struct DocumentNode {
 	pub call_argument: Type,
 	pub implementation: DocumentNodeImplementation,
 	pub skip_deduplication: bool,
-	pub visible: Visible,
+	pub visible: Option<Hidden>,
 	pub original_location: OriginalLocation,
 }
 ```

--- a/node-graph/README.md
+++ b/node-graph/README.md
@@ -14,7 +14,7 @@ pub struct DocumentNode {
 	pub call_argument: Type,
 	pub implementation: DocumentNodeImplementation,
 	pub skip_deduplication: bool,
-	pub visible: bool,
+	pub visible: Visible,
 	pub original_location: OriginalLocation,
 }
 ```

--- a/node-graph/graph-craft/src/document.rs
+++ b/node-graph/graph-craft/src/document.rs
@@ -31,28 +31,15 @@ fn return_true() -> bool {
 
 #[derive(Clone, Debug, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct HiddenNodeInput {
+	pub node_id: NodeId,
 	pub input_index: usize,
 	pub tagged_value: TaggedValue,
 }
 
 #[derive(Clone, Debug, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum Visible {
+pub enum Hidden {
 	Passthrough,
-	Value(Type), //kept for backward compatibility
 	TaggedValues(Vec<HiddenNodeInput>),
-}
-impl Visible {
-	pub fn is_visible(&self) -> bool {
-		matches!(self, Visible::Passthrough)
-	}
-
-	pub fn is_hidden(&self) -> bool {
-		!self.is_visible()
-	}
-}
-
-fn return_visible_true() -> Visible {
-	Visible::Passthrough
 }
 
 /// An instance of a [`DocumentNodeDefinition`] that has been instantiated in a [`NodeNetwork`].
@@ -76,8 +63,8 @@ pub struct DocumentNode {
 	// A nested document network or a proto-node identifier.
 	pub implementation: DocumentNodeImplementation,
 	/// Represents the eye icon for hiding/showing the node in the graph UI. When hidden, a node gets replaced with an identity node during the graph flattening step.
-	#[serde(default = "return_visible_true")]
-	pub visible: Visible,
+	#[serde(default)]
+	pub visible: Option<Hidden>,
 	/// When two different proto nodes hash to the same value (e.g. two value nodes each containing `2_u32` or two multiply nodes that have the same node IDs as input), the duplicates are removed.
 	/// See [`ProtoNetwork::generate_stable_node_ids`] for details.
 	/// However sometimes this is not desirable, for example in the case of a [`graphene_core::memo::MonitorNode`] that needs to be accessed outside of the graph.
@@ -120,7 +107,7 @@ impl Default for DocumentNode {
 			inputs: Default::default(),
 			call_argument: concrete!(Context),
 			implementation: Default::default(),
-			visible: Visible::Passthrough,
+			visible: None,
 			skip_deduplication: Default::default(),
 			original_location: OriginalLocation::default(),
 			context_features: Default::default(),
@@ -812,79 +799,42 @@ impl NodeNetwork {
 		};
 
 		match node.visible.clone() {
-			Visible::Passthrough => {}
-
-			Visible::Value(output_type) => {
-				let matching_input = node
-					.inputs
-					.iter()
-					.find_map(|input| match input {
-						NodeInput::Import { import_type, .. } if *import_type == output_type => Some(input.clone()),
-						NodeInput::Value { tagged_value, .. } if tagged_value.ty() == output_type => Some(input.clone()),
-						_ => None,
-					})
-					.or_else(|| node.inputs.iter().find(|input| matches!(input, NodeInput::Node { .. })).cloned());
-
-				if let Some(primary) = matching_input {
-					node.implementation = DocumentNodeImplementation::ProtoNode(graphene_core::ops::identity::IDENTIFIER);
-					node.call_argument = concrete!(());
-					node.inputs.clear();
-					node.inputs.push(primary);
-				} else {
-					let tagged = TaggedValue::from_type(&output_type).unwrap_or_else(|| TaggedValue::None);
-
-					node.implementation = DocumentNodeImplementation::ProtoNode(ProtoNodeIdentifier::new("core_types::value::ClonedNode"));
-					node.call_argument = concrete!(());
-					node.inputs.clear();
-					node.inputs.push(NodeInput::value(tagged, false));
+			None => {}
+			Some(Hidden::Passthrough) => {
+				node.implementation = DocumentNodeImplementation::ProtoNode(graphene_core::ops::identity::IDENTIFIER);
+				if node.inputs.len() > 1 {
+					node.inputs.drain(1..);
 				}
-
+				node.call_argument = concrete!(());
 				self.nodes.insert(id, node);
 				return;
 			}
+			Some(Hidden::TaggedValues(tagged_values)) => {
+				let mut replaced_any_downstream = false;
+				let replacement_tagged = tagged_values.first().map(|hidden_input| hidden_input.tagged_value.clone()).unwrap_or(TaggedValue::None);
 
-			Visible::TaggedValues(tagged_values) => {
-				let passthrough_input = tagged_values
-					.iter()
-					.filter(|hidden_input| hidden_input.tagged_value.ty() != concrete!(()))
-					.find_map(|hidden_input| {
-						let input = node.inputs.get(hidden_input.input_index)?;
-						match input {
-							NodeInput::Node { .. } => Some(input.clone()),
-							NodeInput::Import { import_type, .. } if *import_type == hidden_input.tagged_value.ty() => Some(input.clone()),
-							NodeInput::Value { tagged_value, .. } if tagged_value.ty() == hidden_input.tagged_value.ty() => Some(input.clone()),
-							NodeInput::Import { .. } | NodeInput::Value { .. } | NodeInput::Scope(_) | NodeInput::Reflection(_) | NodeInput::Inline(_) => None,
-						}
-					})
-					.or_else(|| {
-						tagged_values.iter().find_map(|hidden_input| {
-							let input = node.inputs.get(hidden_input.input_index)?;
-							match input {
-								NodeInput::Node { .. } | NodeInput::Import { .. } | NodeInput::Value { .. } => Some(input.clone()),
-								NodeInput::Scope(_) | NodeInput::Reflection(_) | NodeInput::Inline(_) => None,
-							}
-						})
-					});
-
-				if let Some(primary) = passthrough_input {
-					node.implementation = DocumentNodeImplementation::ProtoNode(graphene_core::ops::identity::IDENTIFIER);
-					node.call_argument = concrete!(());
-					node.inputs.clear();
-					node.inputs.push(primary);
-				} else {
-					let tagged = tagged_values
-						.iter()
-						.find(|hidden_input| hidden_input.tagged_value.ty() != concrete!(()))
-						.or_else(|| tagged_values.first())
-						.map(|hidden_input| hidden_input.tagged_value.clone())
-						.or_else(|| TaggedValue::from_type(&node.call_argument))
-						.unwrap_or(TaggedValue::None);
-
-					node.implementation = DocumentNodeImplementation::ProtoNode(ProtoNodeIdentifier::new("core_types::value::ClonedNode"));
-					node.call_argument = concrete!(());
-					node.inputs.clear();
-					node.inputs.push(NodeInput::value(tagged, false));
+				for hidden_input in &tagged_values {
+					let Some(downstream_node) = self.nodes.get_mut(&hidden_input.node_id) else {
+						continue;
+					};
+					let Some(downstream_input) = downstream_node.inputs.get_mut(hidden_input.input_index) else {
+						continue;
+					};
+					if matches!(downstream_input, NodeInput::Node { node_id, output_index } if *node_id == id && *output_index == 0) {
+						*downstream_input = NodeInput::value(hidden_input.tagged_value.clone(), false);
+						replaced_any_downstream = true;
+					}
 				}
+
+				if replaced_any_downstream {
+					self.replace_network_outputs(NodeInput::node(id, 0), NodeInput::value(replacement_tagged, false));
+					return;
+				}
+
+				node.implementation = DocumentNodeImplementation::ProtoNode(ProtoNodeIdentifier::new("core_types::value::ClonedNode"));
+				node.call_argument = concrete!(());
+				node.inputs.clear();
+				node.inputs.push(NodeInput::value(replacement_tagged, false));
 
 				self.nodes.insert(id, node);
 				return;

--- a/node-graph/preprocessor/src/lib.rs
+++ b/node-graph/preprocessor/src/lib.rs
@@ -87,7 +87,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 							DocumentNode {
 								inputs,
 								implementation: DocumentNodeImplementation::ProtoNode(proto_node),
-								visible: true,
+								visible: Visible::Passthrough,
 								original_location,
 								..Default::default()
 							}
@@ -95,7 +95,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 						_ => DocumentNode {
 							inputs: vec![NodeInput::import(generic!(X), i)],
 							implementation: DocumentNodeImplementation::ProtoNode(identity_node.clone()),
-							visible: false,
+							visible: Visible::Passthrough,
 							..Default::default()
 						},
 					},
@@ -111,7 +111,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 			inputs: network_inputs,
 			call_argument: input_type.clone(),
 			implementation: DocumentNodeImplementation::ProtoNode(id.clone()),
-			visible: true,
+			visible: Visible::Passthrough,
 			skip_deduplication: false,
 			context_features: ContextDependencies::from(metadata.context_features.as_slice()),
 			..Default::default()
@@ -131,7 +131,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 				scope_injections: Default::default(),
 				generated: true,
 			}),
-			visible: true,
+			visible: Visible::Passthrough,
 			skip_deduplication: false,
 			..Default::default()
 		};

--- a/node-graph/preprocessor/src/lib.rs
+++ b/node-graph/preprocessor/src/lib.rs
@@ -87,7 +87,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 							DocumentNode {
 								inputs,
 								implementation: DocumentNodeImplementation::ProtoNode(proto_node),
-								visible: Visible::Passthrough,
+								visible: None,
 								original_location,
 								..Default::default()
 							}
@@ -95,7 +95,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 						_ => DocumentNode {
 							inputs: vec![NodeInput::import(generic!(X), i)],
 							implementation: DocumentNodeImplementation::ProtoNode(identity_node.clone()),
-							visible: Visible::Passthrough,
+							visible: None,
 							..Default::default()
 						},
 					},
@@ -111,7 +111,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 			inputs: network_inputs,
 			call_argument: input_type.clone(),
 			implementation: DocumentNodeImplementation::ProtoNode(id.clone()),
-			visible: Visible::Passthrough,
+			visible: None,
 			skip_deduplication: false,
 			context_features: ContextDependencies::from(metadata.context_features.as_slice()),
 			..Default::default()
@@ -131,7 +131,7 @@ pub fn generate_node_substitutions() -> HashMap<ProtoNodeIdentifier, DocumentNod
 				scope_injections: Default::default(),
 				generated: true,
 			}),
-			visible: Visible::Passthrough,
+			visible: None,
 			skip_deduplication: false,
 			..Default::default()
 		};


### PR DESCRIPTION
Closes #3629

When a node like **Instance Position** or **Pointer Position** is hidden, the flattening logic incorrectly replaces it with a default `()` value.  

This causes:

- Type mismatches in downstream nodes (Ex `ConvertNode<DVec2>`)
- Graph evaluation failures
- Panics such as:
  - `Cannot construct default value for hidden node`
  - `entered unreachable code: tried to resolve not flattened node`



![Before:](https://github.com/user-attachments/assets/e7409edc-7e4c-4614-b703-bbf7f3c23890)


### Expected Behavior

Hiding a node should:
- Preserve its output type
- Forward a compatible input when possible
- Never inject `()` unless the node’s real output type is `()`

---
## Solution

https://github.com/user-attachments/assets/4a53e410-a5fa-47a0-8211-d7a796a186c5


Updated `flatten_with_fns` handling for `Visible::Value(output_type)`.

### New behavior:

1. **If a compatible input exists**
   - Replace the node with an identity node
   - Forward that input directly
   - Preserve type integrity

2. **If no compatible input exists**
   - Generate a default value using:
     ```rust
     TaggedValue::from_type(&output_type)
     ```
   - Insert a correctly typed constant node

3. **Prevent incorrect `()` propagation**
   - The logic no longer defaults to `()` unless the node’s actual output type is unit.

---

## Result

- Hiding `Instance Position` no longer crashes.
- `ConvertNode<DVec2>` no longer receives `()`.

---
 
<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
