### PR TITLE
Fix inability to navigate up and down with arrow keys in interactive-style menu lists

### DIFF
--- a/frontend/src/components/floating-menus/MenuList.svelte
+++ b/frontend/src/components/floating-menus/MenuList.svelte
@@ -252,9 +252,6 @@
 	/// Handles keyboard navigation for the menu.
 	// Returns a boolean indicating whether the entire menu stack should be dismissed.
 	export function keydown(e: KeyboardEvent, submenu = false): boolean {
-		// Interactive menus should keep the active entry the same as the highlighted one
-		if (interactive) highlighted = activeEntry;
-
 		const menuOpen = open;
 		const flatEntries = filteredEntries.flat().filter((entry) => !entry.disabled);
 		const openChild = (openChildValue !== undefined && flatEntries.findIndex((entry) => entry.value === openChildValue)) || -1;


### PR DESCRIPTION
Closes #3586 

While selecting font of a text, there were few issues:

### Before:

- Arrow Navigation handling was buggy, like get stuck at one item away from selected font.
- `Enter` didn't applied to highlighted font correctly.

https://github.com/user-attachments/assets/b75017b5-3afd-4c5a-83f4-0097160105dd


### After:

I removed the line that reset highlighted to activeEntry on every key press. That reset was causing the issues.

https://github.com/user-attachments/assets/e7c4cfde-4d80-41d9-b9aa-8a9f8740c33e


<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
