### PR TITLE
Fix Vello canvas on web not being transparent by using premultiplied alpha mode

### DIFF
--- a/editor/src/node_graph_executor/runtime.rs
+++ b/editor/src/node_graph_executor/runtime.rs
@@ -351,7 +351,7 @@ impl NodeRuntime {
 									width: physical_resolution.x,
 									height: physical_resolution.y,
 									present_mode: surface_caps.present_modes[0],
-									alpha_mode: vello::wgpu::CompositeAlphaMode::Opaque,
+									alpha_mode: vello::wgpu::CompositeAlphaMode::PreMultiplied,
 									view_formats: vec![],
 									desired_maximum_frame_latency: 2,
 								},


### PR DESCRIPTION
Important note the surface caps doesn't report `PreMultiplied`, wasn't able to find out why. But this seems to work for all browsers I was able to test.

before

<img width="1178" height="1071" alt="image" src="https://github.com/user-attachments/assets/9499b16c-d3ae-49cd-ad76-3e119e462fd6" />

after

<img width="1178" height="1071" alt="image" src="https://github.com/user-attachments/assets/9a890252-5edc-481a-9e00-68bfad7c291f" />


