### PR TITLE
Fix opacity not being included in alpha of Fill type when converted from Table<Color>

### DIFF
--- a/node-graph/libraries/vector-types/src/vector/style.rs
+++ b/node-graph/libraries/vector-types/src/vector/style.rs
@@ -124,7 +124,7 @@ impl From<Option<Color>> for Fill {
 
 impl From<Table<Color>> for Fill {
 	fn from(color: Table<Color>) -> Fill {
-		let alpha = color.get(0).unwrap().alpha_blending.opacity;
+		let alpha = color.get(0).map(|c| c.alpha_blending.opacity).unwrap_or(1.);
 		let color: Option<Color> = color.into();
 		Fill::solid_or_none(color.map(|c| c.with_alpha(c.alpha() * alpha)))
 	}


### PR DESCRIPTION
Closes #3205.