### PR TITLE
Swap the default placement order of Fill and Stroke nodes in layers

### DIFF
--- a/.github/workflows/build-linux-bundle.yml
+++ b/.github/workflows/build-linux-bundle.yml
@@ -65,11 +65,11 @@ jobs:
 
           flatpak-builder --user --force-clean --install-deps-from=flathub --repo=repo build ./manifest.json
 
-          flatpak build-bundle repo graphite.flatpak art.graphite.Graphite --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+          flatpak build-bundle repo Graphite.flatpak art.graphite.Graphite --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Upload Flatpak
         uses: actions/upload-artifact@v4
         with:
           name: graphite-flatpak
-          path: .flatpak/graphite.flatpak
+          path: .flatpak/Graphite.flatpak
           compression-level: 0

--- a/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
@@ -170,15 +170,6 @@ impl<'a> ModifyInputsContext<'a> {
 			self.network_interface.move_node_to_chain_start(&transform_id, layer, &[]);
 		}
 
-		if include_fill {
-			let fill = resolve_proto_node_type(graphene_std::vector_nodes::fill::IDENTIFIER)
-				.expect("Fill node does not exist")
-				.default_node_template();
-			let fill_id = NodeId::new();
-			self.network_interface.insert_node(fill_id, fill, &[]);
-			self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
-		}
-
 		if include_stroke {
 			let stroke = resolve_proto_node_type(graphene_std::vector_nodes::stroke::IDENTIFIER)
 				.expect("Stroke node does not exist")
@@ -187,16 +178,18 @@ impl<'a> ModifyInputsContext<'a> {
 			self.network_interface.insert_node(stroke_id, stroke, &[]);
 			self.network_interface.move_node_to_chain_start(&stroke_id, layer, &[]);
 		}
+
+		if include_fill {
+			let fill = resolve_proto_node_type(graphene_std::vector_nodes::fill::IDENTIFIER)
+				.expect("Fill node does not exist")
+				.default_node_template();
+			let fill_id = NodeId::new();
+			self.network_interface.insert_node(fill_id, fill, &[]);
+			self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
+		}
 	}
 
 	pub fn insert_text(&mut self, text: String, font: Font, typesetting: TypesettingConfig, layer: LayerNodeIdentifier) {
-		let stroke = resolve_proto_node_type(graphene_std::vector_nodes::stroke::IDENTIFIER)
-			.expect("Stroke node does not exist")
-			.default_node_template();
-		let fill = resolve_proto_node_type(graphene_std::vector_nodes::fill::IDENTIFIER)
-			.expect("Fill node does not exist")
-			.default_node_template();
-		let transform = resolve_network_node_type("Transform").expect("Transform node does not exist").default_node_template();
 		let text = resolve_proto_node_type(graphene_std::text::text::IDENTIFIER)
 			.expect("Text node does not exist")
 			.node_template_input_override([
@@ -213,6 +206,13 @@ impl<'a> ModifyInputsContext<'a> {
 				Some(NodeInput::value(TaggedValue::F64(typesetting.tilt), false)),
 				Some(NodeInput::value(TaggedValue::TextAlign(typesetting.align), false)),
 			]);
+		let transform = resolve_network_node_type("Transform").expect("Transform node does not exist").default_node_template();
+		let stroke = resolve_proto_node_type(graphene_std::vector_nodes::stroke::IDENTIFIER)
+			.expect("Stroke node does not exist")
+			.default_node_template();
+		let fill = resolve_proto_node_type(graphene_std::vector_nodes::fill::IDENTIFIER)
+			.expect("Fill node does not exist")
+			.default_node_template();
 
 		let text_id = NodeId::new();
 		self.network_interface.insert_node(text_id, text, &[]);
@@ -222,13 +222,13 @@ impl<'a> ModifyInputsContext<'a> {
 		self.network_interface.insert_node(transform_id, transform, &[]);
 		self.network_interface.move_node_to_chain_start(&transform_id, layer, &[]);
 
-		let fill_id = NodeId::new();
-		self.network_interface.insert_node(fill_id, fill, &[]);
-		self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
-
 		let stroke_id = NodeId::new();
 		self.network_interface.insert_node(stroke_id, stroke, &[]);
 		self.network_interface.move_node_to_chain_start(&stroke_id, layer, &[]);
+
+		let fill_id = NodeId::new();
+		self.network_interface.insert_node(fill_id, fill, &[]);
+		self.network_interface.move_node_to_chain_start(&fill_id, layer, &[]);
 	}
 
 	pub fn insert_image_data(&mut self, image_frame: Table<Raster<CPU>>, layer: LayerNodeIdentifier) {

--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -290,8 +290,8 @@ impl Fsm for FreehandToolFsmState {
 				let nodes = vec![(NodeId(0), node)];
 
 				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
-				tool_options.fill.apply_fill(layer, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);
+				tool_options.fill.apply_fill(layer, responses);
 				tool_data.layer = Some(layer);
 
 				FreehandToolFsmState::Drawing

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2836,14 +2836,15 @@ impl Fsm for PathToolFsmState {
 
 							let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 
-							let fill_color = Color::WHITE;
+							// Defaults chosen because the pasted geometry has no inherent associated style
 							let stroke_color = Color::BLACK;
-
-							let fill = graphene_std::vector::style::Fill::solid(fill_color.to_gamma_srgb());
-							responses.add(GraphOperationMessage::FillSet { layer, fill });
+							let fill_color = Color::WHITE;
 
 							let stroke = graphene_std::vector::style::Stroke::new(Some(stroke_color.to_gamma_srgb()), DEFAULT_STROKE_WIDTH);
 							responses.add(GraphOperationMessage::StrokeSet { layer, stroke });
+
+							let fill = graphene_std::vector::style::Fill::solid(fill_color.to_gamma_srgb());
+							responses.add(GraphOperationMessage::FillSet { layer, fill });
 
 							new_layers.push(layer);
 

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -1288,8 +1288,8 @@ impl PenToolData {
 		let parent = document.new_layer_bounding_artboard(input, viewport);
 		let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 		self.current_layer = Some(layer);
-		tool_options.fill.apply_fill(layer, responses);
 		tool_options.stroke.apply_stroke(tool_options.line_weight, layer, responses);
+		tool_options.fill.apply_fill(layer, responses);
 		self.prior_segment = None;
 		self.prior_segments = None;
 		responses.add(NodeGraphMessage::SelectedNodesSet { nodes: vec![layer.to_node()] });

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -941,6 +941,8 @@ impl Fsm for ShapeToolFsmState {
 
 				let defered_responses = &mut VecDeque::new();
 
+				tool_options.stroke.apply_stroke(tool_options.line_weight, layer, defered_responses);
+
 				match tool_data.current_shape {
 					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
 						defered_responses.add(GraphOperationMessage::TransformSet {
@@ -962,9 +964,7 @@ impl Fsm for ShapeToolFsmState {
 						tool_data.line_data.editing_layer = Some(layer);
 					}
 				}
-				tool_options.stroke.apply_stroke(tool_options.line_weight, layer, defered_responses);
 
-				tool_options.stroke.apply_stroke(tool_options.line_weight, layer, defered_responses);
 				tool_data.data.layer = Some(layer);
 
 				responses.add(DeferMessage::AfterGraphRun {

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -395,8 +395,8 @@ impl Fsm for SplineToolFsmState {
 				let nodes = vec![(NodeId(1), path_node), (NodeId(0), spline_node)];
 
 				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
-				tool_options.fill.apply_fill(layer, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);
+				tool_options.fill.apply_fill(layer, responses);
 				tool_data.current_layer = Some(layer);
 
 				SplineToolFsmState::Drawing

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -550,6 +550,7 @@ fn clamp<T: std::cmp::PartialOrd>(
 	min: T,
 	/// The right (greater) side of the range. The output is never greater than this number.
 	#[implementations(f64, f32, u32, &str)]
+	#[default(1)]
 	max: T,
 ) -> T {
 	let (min, max) = if min < max { (min, max) } else { (max, min) };


### PR DESCRIPTION
Now the Fill, which is the more commonly needed option and the one that takes up less vertical space due to its simpler set of parameters, appears above Stroke in the Properties panel which helps avoid the confusion of accidentally setting the Stroke color when intending to set the Fill color.