### PR TITLE
Paste nodes at cursor position in the node graph

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -6351,6 +6351,14 @@ impl NodePersistentMetadata {
 	pub fn new(position: NodePosition) -> Self {
 		Self { position }
 	}
+
+	pub fn position(&self) -> &NodePosition {
+		&self.position
+	}
+
+	pub fn position_mut(&mut self) -> &mut NodePosition {
+		&mut self.position
+	}
 }
 
 /// A layer can either be position as Absolute or in a Stack


### PR DESCRIPTION
## Summary
- When pasting nodes with the graph view open, repositions pasted nodes so their bounding box center aligns with the cursor's position in graph space, instead of using the fixed 2x2 grid offset from the original location
- Handles both single and multi-node pastes by computing the center of all absolute-positioned nodes and shifting them as a group, preserving relative positions
- Adds `position()` and `position_mut()` public accessors to `NodePersistentMetadata` for accessing the private position field outside the `network_interface` module

Closes #3798

## Test plan
- [ ] Open the node graph view
- [ ] Copy one or more nodes (Ctrl+C)
- [ ] Move cursor to a different location in the graph
- [ ] Paste (Ctrl+V) and verify nodes appear centered at cursor position
- [ ] Test with multiple nodes to verify relative positions are preserved
- [ ] Test pasting when graph view is closed to verify original behavior is unchanged