### PR TITLE
fix: Path tool requires a double click to insert a new point after having dragged another point

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2628,6 +2628,7 @@ impl Fsm for PathToolFsmState {
 				responses.add(PathToolMessage::SelectedPointUpdated);
 				tool_data.snap_manager.cleanup(responses);
 				tool_data.opposite_handle_position = None;
+				tool_data.molding_segment = false;
 
 				PathToolFsmState::Ready
 			}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2630,6 +2630,7 @@ impl Fsm for PathToolFsmState {
 				tool_data.opposite_handle_position = None;
 				tool_data.molding_segment = false;
 				tool_data.molding_info = None;
+				tool_data.temporary_adjacent_handles_while_molding = None;
 
 				PathToolFsmState::Ready
 			}

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2629,6 +2629,7 @@ impl Fsm for PathToolFsmState {
 				tool_data.snap_manager.cleanup(responses);
 				tool_data.opposite_handle_position = None;
 				tool_data.molding_segment = false;
+				tool_data.molding_info = None;
 
 				PathToolFsmState::Ready
 			}


### PR DESCRIPTION
closes https://discord.com/channels/731730685944922173/881073965047636018/1419544936986185838 

supercede #3631 