### PR TITLE
Fix path tool overlays

### DIFF
--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -293,11 +293,11 @@ impl RenderMetadata {
 			clip_targets,
 			vector_data,
 		} = self;
-		upstream_footprints.extend(other.upstream_footprints.iter().map(|(k, v)| (*k, *v)));
-		local_transforms.extend(other.local_transforms.iter().map(|(k, v)| (*k, *v)));
-		first_element_source_id.extend(other.first_element_source_id.iter().map(|(k, v)| (*k, *v)));
+		upstream_footprints.extend(other.upstream_footprints.iter());
+		local_transforms.extend(other.local_transforms.iter());
+		first_element_source_id.extend(other.first_element_source_id.iter());
 		click_targets.extend(other.click_targets.iter().map(|(k, v)| (*k, v.clone())));
-		clip_targets.extend(other.clip_targets.iter().copied());
+		clip_targets.extend(other.clip_targets.iter());
 		vector_data.extend(other.vector_data.iter().map(|(id, data)| (*id, data.clone())));
 	}
 }


### PR DESCRIPTION
A change to the document metadata struct in #3727 added a new field which was then not part of the new metadata merge function introduced in render output caching pr and was missed during the rebase process. To avoid issues like this in the future, we are now destructuring the metadata struct so we get compiler warnings if the fields are modified again.
Fixes: #3807 
<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
