### PR TITLE
Path tool box selection creates small square upon mousedown when animation is playing

### DIFF
--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -1888,6 +1888,11 @@ impl Fsm for PathToolFsmState {
 						}
 					}
 					Self::Drawing { selection_shape } => {
+						let previous_mouse = document.metadata().document_to_viewport.transform_point2(tool_data.previous_mouse_position);
+						if tool_data.drag_start_pos.distance(previous_mouse) < 1e-8 {
+							return self;
+						}
+
 						let mut fill_color = graphene_std::Color::from_rgb_str(COLOR_OVERLAY_BLUE.strip_prefix('#').unwrap())
 							.unwrap()
 							.with_alpha(0.05)


### PR DESCRIPTION
closes #2595 

https://github.com/user-attachments/assets/a190c4a1-9bfe-4bcd-966e-ab9240a582af


