### PR TITLE
Render raster images as outlines in Outline mode

### DIFF
--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1375,6 +1375,9 @@ impl Render for Table<Raster<CPU>> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, _: &mut RenderContext, render_params: &RenderParams) {
+		use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
+		use vector_types::vector::PointId;
+		use vello::kurbo::{Cap, Join};
 		use vello::peniko;
 
 		for row in self.iter() {
@@ -1389,7 +1392,7 @@ impl Render for Table<Raster<CPU>> {
 			let opacity = alpha_blending.opacity(render_params.for_mask);
 			let mut layer = false;
 
-			if (opacity < 1. || alpha_blending.blend_mode != BlendMode::default())
+			if (opacity < 1. || (render_params.render_mode != RenderMode::Outline && alpha_blending.blend_mode != BlendMode::default()))
 				&& let RenderBoundingBox::Rectangle(bounds) = self.bounding_box(transform, false)
 			{
 				let blending = peniko::BlendMode::new(blend_mode, peniko::Compose::SrcOver);
@@ -1398,17 +1401,41 @@ impl Render for Table<Raster<CPU>> {
 				layer = true;
 			}
 
-			let image_brush = peniko::ImageBrush::new(peniko::ImageData {
-				data: image.to_flat_u8().0.into(),
-				format: peniko::ImageFormat::Rgba8,
-				width: image.width,
-				height: image.height,
-				alpha_type: peniko::ImageAlphaType::Alpha,
-			})
-			.with_extend(peniko::Extend::Repeat);
-			let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
+			match render_params.render_mode {
+				RenderMode::Outline => {
+					let outline_transform = transform * *row.transform;
 
-			scene.draw_image(&image_brush, kurbo::Affine::new(image_transform.to_cols_array()));
+					let outline_stroke = kurbo::Stroke {
+						width: LAYER_OUTLINE_STROKE_WEIGHT,
+						miter_limit: 4.,
+						join: Join::Miter,
+						start_cap: Cap::Butt,
+						end_cap: Cap::Butt,
+						dash_pattern: Default::default(),
+						dash_offset: 0.,
+					};
+					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
+					let outline_color = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
+					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
+
+					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color, None, &outline_path);
+				}
+				_ => {
+					let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
+
+					let image_brush = peniko::ImageBrush::new(peniko::ImageData {
+						data: image.to_flat_u8().0.into(),
+						format: peniko::ImageFormat::Rgba8,
+						width: image.width,
+						height: image.height,
+						alpha_type: peniko::ImageAlphaType::Alpha,
+					})
+					.with_extend(peniko::Extend::Repeat);
+
+					scene.draw_image(&image_brush, kurbo::Affine::new(image_transform.to_cols_array()));
+				}
+			}
 
 			if layer {
 				scene.pop_layer();
@@ -1441,34 +1468,63 @@ impl Render for Table<Raster<GPU>> {
 		log::warn!("tried to render texture as an svg");
 	}
 
-	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext, _render_params: &RenderParams) {
+	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
+		use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
+		use vector_types::vector::PointId;
+		use vello::kurbo::{Cap, Join};
 		use vello::peniko;
 
 		for row in self.iter() {
-			let blend_mode = *row.alpha_blending;
+			let alpha_blending = *row.alpha_blending;
+			let blend_mode = alpha_blending.blend_mode.to_peniko();
+
 			let mut layer = false;
-			if blend_mode != Default::default()
+
+			if (render_params.render_mode != RenderMode::Outline && alpha_blending != Default::default())
 				&& let RenderBoundingBox::Rectangle(bounds) = self.bounding_box(transform, true)
 			{
-				let blending = peniko::BlendMode::new(blend_mode.blend_mode.to_peniko(), peniko::Compose::SrcOver);
+				let blending = peniko::BlendMode::new(blend_mode, peniko::Compose::SrcOver);
 				let rect = kurbo::Rect::new(bounds[0].x, bounds[0].y, bounds[1].x, bounds[1].y);
-				scene.push_layer(peniko::Fill::NonZero, blending, blend_mode.opacity, kurbo::Affine::IDENTITY, &rect);
+				scene.push_layer(peniko::Fill::NonZero, blending, alpha_blending.opacity, kurbo::Affine::IDENTITY, &rect);
 				layer = true;
 			}
 
-			let width = row.element.data().width();
-			let height = row.element.data().height();
-			let image = peniko::ImageBrush::new(peniko::ImageData {
-				data: peniko::Blob::new(LAZY_ARC_VEC_ZERO_U8.deref().clone()),
-				format: peniko::ImageFormat::Rgba8,
-				width,
-				height,
-				alpha_type: peniko::ImageAlphaType::Alpha,
-			})
-			.with_extend(peniko::Extend::Repeat);
-			let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(width as f64, height as f64));
-			scene.draw_image(&image, kurbo::Affine::new(image_transform.to_cols_array()));
-			context.resource_overrides.push((image, row.element.data().clone()));
+			match render_params.render_mode {
+				RenderMode::Outline => {
+					let outline_transform = transform * *row.transform;
+
+					let outline_stroke = kurbo::Stroke {
+						width: LAYER_OUTLINE_STROKE_WEIGHT,
+						miter_limit: 4.,
+						join: Join::Miter,
+						start_cap: Cap::Butt,
+						end_cap: Cap::Butt,
+						dash_pattern: Default::default(),
+						dash_offset: 0.,
+					};
+					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
+					let outline_color = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
+					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
+
+					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color, None, &outline_path);
+				}
+				_ => {
+					let width = row.element.data().width();
+					let height = row.element.data().height();
+					let image = peniko::ImageBrush::new(peniko::ImageData {
+						data: peniko::Blob::new(LAZY_ARC_VEC_ZERO_U8.deref().clone()),
+						format: peniko::ImageFormat::Rgba8,
+						width,
+						height,
+						alpha_type: peniko::ImageAlphaType::Alpha,
+					})
+					.with_extend(peniko::Extend::Repeat);
+					let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(width as f64, height as f64));
+					scene.draw_image(&image, kurbo::Affine::new(image_transform.to_cols_array()));
+					context.resource_overrides.push((image, row.element.data().clone()));
+				}
+			}
 
 			if layer {
 				scene.pop_layer()

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1401,41 +1401,44 @@ impl Render for Table<Raster<CPU>> {
 				layer = true;
 			}
 
-			match render_params.render_mode {
-				RenderMode::Outline => {
-					let outline_transform = transform * *row.transform;
+			if let RenderMode::Outline = render_params.render_mode {
+				let outline_transform = transform * *row.transform;
 
-					let outline_stroke = kurbo::Stroke {
-						width: LAYER_OUTLINE_STROKE_WEIGHT,
-						miter_limit: 4.,
-						join: Join::Miter,
-						start_cap: Cap::Butt,
-						end_cap: Cap::Butt,
-						dash_pattern: Default::default(),
-						dash_offset: 0.,
-					};
-					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
-					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
-					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
+				let outline_stroke = kurbo::Stroke {
+					width: LAYER_OUTLINE_STROKE_WEIGHT,
+					miter_limit: 4.,
+					join: Join::Miter,
+					start_cap: Cap::Butt,
+					end_cap: Cap::Butt,
+					dash_pattern: Default::default(),
+					dash_offset: 0.,
+				};
+				let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
+				let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+				let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
+				outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
 
-					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+				scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+
+				if layer {
+					scene.pop_layer();
 				}
-				_ => {
-					let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
 
-					let image_brush = peniko::ImageBrush::new(peniko::ImageData {
-						data: image.to_flat_u8().0.into(),
-						format: peniko::ImageFormat::Rgba8,
-						width: image.width,
-						height: image.height,
-						alpha_type: peniko::ImageAlphaType::Alpha,
-					})
-					.with_extend(peniko::Extend::Repeat);
-
-					scene.draw_image(&image_brush, kurbo::Affine::new(image_transform.to_cols_array()));
-				}
+				continue;
 			}
+
+			let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
+
+			let image_brush = peniko::ImageBrush::new(peniko::ImageData {
+				data: image.to_flat_u8().0.into(),
+				format: peniko::ImageFormat::Rgba8,
+				width: image.width,
+				height: image.height,
+				alpha_type: peniko::ImageAlphaType::Alpha,
+			})
+			.with_extend(peniko::Extend::Repeat);
+
+			scene.draw_image(&image_brush, kurbo::Affine::new(image_transform.to_cols_array()));
 
 			if layer {
 				scene.pop_layer();
@@ -1489,42 +1492,45 @@ impl Render for Table<Raster<GPU>> {
 				layer = true;
 			}
 
-			match render_params.render_mode {
-				RenderMode::Outline => {
-					let outline_transform = transform * *row.transform;
+			if let RenderMode::Outline = render_params.render_mode {
+				let outline_transform = transform * *row.transform;
 
-					let outline_stroke = kurbo::Stroke {
-						width: LAYER_OUTLINE_STROKE_WEIGHT,
-						miter_limit: 4.,
-						join: Join::Miter,
-						start_cap: Cap::Butt,
-						end_cap: Cap::Butt,
-						dash_pattern: Default::default(),
-						dash_offset: 0.,
-					};
-					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
-					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
-					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
+				let outline_stroke = kurbo::Stroke {
+					width: LAYER_OUTLINE_STROKE_WEIGHT,
+					miter_limit: 4.,
+					join: Join::Miter,
+					start_cap: Cap::Butt,
+					end_cap: Cap::Butt,
+					dash_pattern: Default::default(),
+					dash_offset: 0.,
+				};
+				let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
+				let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+				let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
+				outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
 
-					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+				scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+
+				if layer {
+					scene.pop_layer();
 				}
-				_ => {
-					let width = row.element.data().width();
-					let height = row.element.data().height();
-					let image = peniko::ImageBrush::new(peniko::ImageData {
-						data: peniko::Blob::new(LAZY_ARC_VEC_ZERO_U8.deref().clone()),
-						format: peniko::ImageFormat::Rgba8,
-						width,
-						height,
-						alpha_type: peniko::ImageAlphaType::Alpha,
-					})
-					.with_extend(peniko::Extend::Repeat);
-					let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(width as f64, height as f64));
-					scene.draw_image(&image, kurbo::Affine::new(image_transform.to_cols_array()));
-					context.resource_overrides.push((image, row.element.data().clone()));
-				}
+
+				continue;
 			}
+
+			let width = row.element.data().width();
+			let height = row.element.data().height();
+			let image = peniko::ImageBrush::new(peniko::ImageData {
+				data: peniko::Blob::new(LAZY_ARC_VEC_ZERO_U8.deref().clone()),
+				format: peniko::ImageFormat::Rgba8,
+				width,
+				height,
+				alpha_type: peniko::ImageAlphaType::Alpha,
+			})
+			.with_extend(peniko::Extend::Repeat);
+			let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(width as f64, height as f64));
+			scene.draw_image(&image, kurbo::Affine::new(image_transform.to_cols_array()));
+			context.resource_overrides.push((image, row.element.data().clone()));
 
 			if layer {
 				scene.pop_layer()

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1469,7 +1469,10 @@ impl Render for Table<Raster<GPU>> {
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
 		for row in self.iter() {
 			let alpha_blending = *row.alpha_blending;
-			let blend_mode = alpha_blending.blend_mode.to_peniko();
+			let blend_mode = match render_params.render_mode {
+				RenderMode::Outline => peniko::Mix::Normal,
+				_ => alpha_blending.blend_mode.to_peniko(),
+			};
 
 			let mut layer = false;
 

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -18,8 +18,7 @@ use graphic_types::vector_types::subpath::Subpath;
 use graphic_types::vector_types::vector::click_target::{ClickTarget, FreePoint};
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, Stroke, StrokeAlign};
 use graphic_types::{Artboard, Graphic};
-use kurbo::Affine;
-use kurbo::Shape;
+use kurbo::{Affine, Cap, Join, Shape};
 use num_traits::Zero;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -260,6 +259,36 @@ pub fn black_or_white_for_best_contrast(background: Option<Color>) -> Color {
 pub fn to_transform(transform: DAffine2) -> usvg::Transform {
 	let cols = transform.to_cols_array();
 	usvg::Transform::from_row(cols[0] as f32, cols[1] as f32, cols[2] as f32, cols[3] as f32, cols[4] as f32, cols[5] as f32)
+}
+
+fn get_outline_styles(render_params: &RenderParams) -> (kurbo::Stroke, peniko::Color) {
+	use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
+
+	let outline_stroke = kurbo::Stroke {
+		width: LAYER_OUTLINE_STROKE_WEIGHT / if render_params.viewport_zoom > 0. { render_params.viewport_zoom } else { 1. },
+		miter_limit: 4.,
+		join: Join::Miter,
+		start_cap: Cap::Butt,
+		end_cap: Cap::Butt,
+		dash_pattern: Default::default(),
+		dash_offset: 0.,
+	};
+
+	let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
+	let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+
+	(outline_stroke, outline_color_peniko)
+}
+
+fn draw_raster_outline(scene: &mut Scene, outline_transform: &DAffine2, render_params: &RenderParams) {
+	use graphic_types::vector_types::vector::PointId;
+
+	let (outline_stroke, outline_color_peniko) = get_outline_styles(render_params);
+
+	let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
+	outline_path.apply_affine(Affine::new(outline_transform.to_cols_array()));
+
+	scene.stroke(&outline_stroke, Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 }
 
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
@@ -935,10 +964,7 @@ impl Render for Table<Vector> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, _context: &mut RenderContext, render_params: &RenderParams) {
-		use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
 		use graphic_types::vector_types::vector::style::{GradientType, StrokeCap, StrokeJoin};
-		use vello::kurbo::{Cap, Join};
-		use vello::peniko;
 
 		for row in self.iter() {
 			use graphic_types::vector_types::vector;
@@ -1111,18 +1137,7 @@ impl Render for Table<Vector> {
 			// Render the path
 			match render_params.render_mode {
 				RenderMode::Outline => {
-					let outline_stroke = kurbo::Stroke {
-						width: LAYER_OUTLINE_STROKE_WEIGHT / if render_params.viewport_zoom > 0. { render_params.viewport_zoom } else { 1. },
-						miter_limit: 4.,
-						join: Join::Miter,
-						start_cap: Cap::Butt,
-						end_cap: Cap::Butt,
-						dash_pattern: Default::default(),
-						dash_offset: 0.,
-					};
-
-					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let (outline_stroke, outline_color_peniko) = get_outline_styles(render_params);
 
 					scene.stroke(&outline_stroke, kurbo::Affine::new(element_transform.to_cols_array()), outline_color_peniko, None, &path);
 				}
@@ -1375,11 +1390,6 @@ impl Render for Table<Raster<CPU>> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, _: &mut RenderContext, render_params: &RenderParams) {
-		use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
-		use vector_types::vector::PointId;
-		use vello::kurbo::{Cap, Join};
-		use vello::peniko;
-
 		for row in self.iter() {
 			let image = &row.element;
 			if image.data.is_empty() {
@@ -1403,22 +1413,7 @@ impl Render for Table<Raster<CPU>> {
 
 			if let RenderMode::Outline = render_params.render_mode {
 				let outline_transform = transform * *row.transform;
-
-				let outline_stroke = kurbo::Stroke {
-					width: LAYER_OUTLINE_STROKE_WEIGHT,
-					miter_limit: 4.,
-					join: Join::Miter,
-					start_cap: Cap::Butt,
-					end_cap: Cap::Butt,
-					dash_pattern: Default::default(),
-					dash_offset: 0.,
-				};
-				let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-				let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
-				let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
-				outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
-
-				scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+				draw_raster_outline(scene, &outline_transform, render_params);
 
 				if layer {
 					scene.pop_layer();
@@ -1472,11 +1467,6 @@ impl Render for Table<Raster<GPU>> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
-		use core_types::consts::LAYER_OUTLINE_STROKE_WEIGHT;
-		use vector_types::vector::PointId;
-		use vello::kurbo::{Cap, Join};
-		use vello::peniko;
-
 		for row in self.iter() {
 			let alpha_blending = *row.alpha_blending;
 			let blend_mode = alpha_blending.blend_mode.to_peniko();
@@ -1494,22 +1484,7 @@ impl Render for Table<Raster<GPU>> {
 
 			if let RenderMode::Outline = render_params.render_mode {
 				let outline_transform = transform * *row.transform;
-
-				let outline_stroke = kurbo::Stroke {
-					width: LAYER_OUTLINE_STROKE_WEIGHT,
-					miter_limit: 4.,
-					join: Join::Miter,
-					start_cap: Cap::Butt,
-					end_cap: Cap::Butt,
-					dash_pattern: Default::default(),
-					dash_offset: 0.,
-				};
-				let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-				let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
-				let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
-				outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
-
-				scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
+				draw_raster_outline(scene, &outline_transform, render_params);
 
 				if layer {
 					scene.pop_layer();

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1122,9 +1122,9 @@ impl Render for Table<Vector> {
 					};
 
 					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
 
-					scene.stroke(&outline_stroke, kurbo::Affine::new(element_transform.to_cols_array()), outline_color, None, &path);
+					scene.stroke(&outline_stroke, kurbo::Affine::new(element_transform.to_cols_array()), outline_color_peniko, None, &path);
 				}
 				_ => {
 					if use_layer {
@@ -1415,11 +1415,11 @@ impl Render for Table<Raster<CPU>> {
 						dash_offset: 0.,
 					};
 					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
 					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
 					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
 
-					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color, None, &outline_path);
+					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 				}
 				_ => {
 					let image_transform = transform * *row.transform * DAffine2::from_scale(1. / DVec2::new(image.width as f64, image.height as f64));
@@ -1503,11 +1503,11 @@ impl Render for Table<Raster<GPU>> {
 						dash_offset: 0.,
 					};
 					let outline_color = black_or_white_for_best_contrast(render_params.artboard_background);
-					let outline_color = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
+					let outline_color_peniko = peniko::Color::new([outline_color.r(), outline_color.g(), outline_color.b(), outline_color.a()]);
 					let mut outline_path = Subpath::<PointId>::new_rectangle(DVec2::ZERO, DVec2::ONE).to_bezpath();
 					outline_path.apply_affine(kurbo::Affine::new(outline_transform.to_cols_array()));
 
-					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color, None, &outline_path);
+					scene.stroke(&outline_stroke, kurbo::Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 				}
 				_ => {
 					let width = row.element.data().width();


### PR DESCRIPTION
Closes #2888

## Screencasts

### Before

https://github.com/user-attachments/assets/61ff9dd2-39d9-4c98-9c45-f4e5496183cb

### After

https://github.com/user-attachments/assets/57665066-8e3b-4fa6-85ed-f8a7c4114007


## What changed
- If `RenderMode::Outline`, create a rectangle then apply the same transform as the other modes but without the image scaling factor as the rectangle is already an identity. 
- Added a check to avoid creating unnecessary blending layer for the outline mode.
- Apply the above changes for the vello renderer of `Raster<CPU>` and `Raster<GPU>`.
- Organize a code bit for the GPU one to use the same variable names as the CPU one.

## Small notes
Just a tiny thing, but I kept the duplicated outline code for now for readability, happy to extract it into a shared helper if preferred.