### PR TITLE
fix: prevent unbounded window.imageCanvases growth in SVG render mode

### DIFF
--- a/frontend/wasm/src/editor_api.rs
+++ b/frontend/wasm/src/editor_api.rs
@@ -1103,4 +1103,18 @@ fn render_image_data_to_canvases(image_data: &[(u64, Image<Color>)]) {
 			error!("Failed to set canvas '{canvas_name}' on imageCanvases object");
 		}
 	}
+
+	// Evict canvases for images no longer present in the current render, freeing their pixel memory
+	let current_ids: std::collections::HashSet<String> = image_data.iter().map(|(id, _)| id.to_string()).collect();
+	let existing_keys = Object::keys(&canvases_obj);
+	for i in 0..existing_keys.length() {
+		let key = existing_keys.get(i);
+		if let Some(key_str) = key.as_string() {
+			if !current_ids.contains(&key_str) {
+				if Reflect::delete_property(&canvases_obj.clone().into(), &key).is_err() {
+					error!("Failed to delete stale canvas '{key_str}'");
+				}
+			}
+		}
+	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1304,7 +1304,14 @@ impl Render for Table<Raster<CPU>> {
 			if render_params.to_canvas() {
 				let mut image_copy = image.clone();
 				image_copy.data_mut().map_pixels(|p| p.to_unassociated_alpha());
-				let id = *render.image_data.entry(image_copy.into_data()).or_insert_with(generate_uuid);
+				let image_data = image_copy.into_data();
+				let content_id = {
+					use std::collections::hash_map::DefaultHasher;
+					let mut hasher = DefaultHasher::new();
+					image_data.hash(&mut hasher);
+					hasher.finish()
+				};
+				let id = *render.image_data.entry(image_data).or_insert(content_id);
 
 				render.parent_tag(
 					"foreignObject",


### PR DESCRIPTION
## **Summary**

This PR fixes a critical memory leak in the SVG rendering pipeline affecting raster images.

The issue originates from how image canvas IDs are generated and managed across render cycles. In `renderer.rs`, raster image IDs were generated using a per-render random UUID:

```rust
let id = *render.image_data
    .entry(image_copy.into_data())
    .or_insert_with(generate_uuid);
```

Since `SvgRender` is reinitialized on every render, this caused **new IDs to be generated for identical image data on every frame**.

On the frontend side (`editor_api.rs`), canvases are stored in `window.imageCanvases` and only reused if the key already exists:

```rust
if Reflect::has(&canvases_obj, &js_key).unwrap_or(false) {
    continue;
}
```

Because IDs were always new, this check never matched, leading to **unbounded accumulation of `HtmlCanvasElement` instances**, each retaining full pixel buffers.

Additionally, the deduplication guard based on hashing:

```rust
let new_hash = calculate_hash(image_data);
```

was ineffective because it included these random IDs, causing it to **always detect changes even when image data was identical**.

---

## **Fix**

This PR introduces two key changes:

### 1. Stable Content-Based Image IDs

Replaced per-render UUID generation with a deterministic hash derived from image data:

```rust
let image_data = image_copy.into_data();

let content_id = {
    use std::collections::hash_map::DefaultHasher;
    let mut hasher = DefaultHasher::new();
    image_data.hash(&mut hasher);
    hasher.finish()
};

let id = *render.image_data.entry(image_data).or_insert(content_id);
```

This ensures:

* Identical images produce the same ID across renders
* Deduplication logic works correctly
* No redundant canvas creation

---

### 2. Stale Canvas Eviction

Added cleanup logic in `render_image_data_to_canvases` to remove canvases no longer present in the current render:

```rust
let current_ids: std::collections::HashSet<String> =
    image_data.iter().map(|(id, _)| id.to_string()).collect();

let existing_keys = Object::keys(&canvases_obj);

for i in 0..existing_keys.length() {
    let key = existing_keys.get(i);
    if let Some(key_str) = key.as_string() {
        if !current_ids.contains(&key_str) {
            Reflect::delete_property(&canvases_obj.clone().into(), &key).ok();
        }
    }
}
```

This guarantees:

* `window.imageCanvases` stays bounded
* Old canvases are released and eligible for GC
* Memory usage reflects only active images

---

## **Verification**

The fix was validated using realistic SVG preview workflows:

### Steps:

1. Open Graphite in SVG Preview mode (or without WebGPU)
2. Import a large raster image (e.g., 1000×1000+)
3. Perform repeated edits or play animations
4. Monitor:

   * `Object.keys(window.imageCanvases).length`
   * Chrome DevTools → Memory (Heap snapshots)

### Before Fix:

* Canvas count increased with every render
* Hundreds/thousands of `HTMLCanvasElement` instances retained
* Rapid memory growth → browser tab crash

### After Fix:

* Canvas count remains stable (bounded by active images)
* No duplicate canvases created for identical data
* Memory usage plateaus even under continuous interaction

---

## **Impact**

* Eliminates unbounded memory growth in SVG preview mode
* Prevents browser OOM crashes in raster-heavy workflows
* Restores effectiveness of render deduplication
* Makes SVG fallback path production-safe (especially on non-WebGPU environments)