### PR TITLE
Fix node graph export sometimes not sticking to right edge of graph

### DIFF
--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -590,6 +590,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 				responses.add(DocumentMessage::RenderScrollbars);
 				if opened {
 					responses.add(NodeGraphMessage::UnloadWires);
+					responses.add(NodeGraphMessage::UpdateNodeGraphWidth);
 				}
 				if open {
 					responses.add(ToolMessage::DeactivateTools);


### PR DESCRIPTION
Regression caused by commit 5b472a6

Before : 

https://github.com/user-attachments/assets/712a6b14-d28f-4de9-916e-4a8368043890


After :

https://github.com/user-attachments/assets/805addca-fc09-496c-b4f9-30d019e437b3



