### PR TITLE
Replace deprecated criterion::black_box with std::hint::black_box

### DIFF
--- a/libraries/math-parser/benches/bench.rs
+++ b/libraries/math-parser/benches/bench.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use math_parser::{ast, context::EvalContext};
 
 macro_rules! generate_benchmarks {

--- a/libraries/path-bool/benches/painted_dreams.rs
+++ b/libraries/path-bool/benches/painted_dreams.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use path_bool::*;
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/libraries/path-bool/benches/path_segment_intersection.rs
+++ b/libraries/path-bool/benches/path_segment_intersection.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use glam::DVec2;
 use path_bool::*;
 

--- a/node-graph/graph-craft/benches/compile_demo_art_criterion.rs
+++ b/node-graph/graph-craft/benches/compile_demo_art_criterion.rs
@@ -1,6 +1,6 @@
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use graph_craft::util::DEMO_ART;
 
 fn compile_to_proto(c: &mut Criterion) {


### PR DESCRIPTION
Ran this command ` cargo bench --no-run` and it passes

<img width="1005" height="846" alt="Screenshot 2026-03-05 at 8 48 00 PM" src="https://github.com/user-attachments/assets/c9dbbaba-ffcf-4048-8436-ae947822e96f" />
