### PR TITLE
fix undo for checkboxes

### DIFF
--- a/frontend/src/io-managers/input.ts
+++ b/frontend/src/io-managers/input.ts
@@ -514,5 +514,16 @@ export function createInputManager(editor: Editor, dialog: DialogState, portfoli
 }
 
 function targetIsTextField(target: EventTarget | HTMLElement | undefined): boolean {
-	return target instanceof HTMLElement && (target.nodeName === "INPUT" || target.nodeName === "TEXTAREA" || target.isContentEditable);
+	if (!(target instanceof HTMLElement)) return false;
+
+	// Handle textarea and contenteditable elements
+	if (target.nodeName === "TEXTAREA" || target.isContentEditable) return true;
+
+	// For input elements, only treat text-like inputs as text fields (not checkboxes )
+	if (target instanceof HTMLInputElement) {
+		const textInputTypes = ["text", "password", "email", "number", "search", "tel", "url"];
+		return textInputTypes.includes(target.type);
+	}
+
+	return false;
 }


### PR DESCRIPTION

Bug : Keyboard shortcuts like Cmd+Z were blocked when a checkbox had focus because targetIsTextField() treated all <input> elements as text fields.

Fix : Only treat text-like input types (text, password, email, etc.) as text fields, not checkboxes or radio buttons.




https://github.com/user-attachments/assets/4f675948-ecea-4233-a7dd-2ebcdb71a3ec

Fixes : https://discord.com/channels/731730685944922173/731738914812854303/1479627959127117924