### PR TITLE
Add a workaround for flickering vector mesh rendering produced by the Boolean Operation node

### DIFF
--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -854,13 +854,9 @@ impl Render for Table<Vector> {
 				(id, mask_type, vector_row)
 			});
 
-			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.
-			// Branching vectors with regions (e.g. boolean operation results) use even-odd fill
-			// on the main stroke path instead, since face decomposition can't determine which
-			// bounded faces should vs. shouldn't be filled in boolean results.
-			let use_face_fill = vector.is_branching() && !vector.has_regions();
+			let use_face_fill = vector.use_face_fill();
 			if use_face_fill {
-				for mut face_path in vector.construct_faces().filter(|face| !(face.area() < 0.0)) {
+				for mut face_path in vector.construct_faces().filter(|face| face.area() >= 0.) {
 					face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
 
 					let face_d = face_path.to_svg();
@@ -934,8 +930,7 @@ impl Render for Table<Vector> {
 				}
 				attributes.push_val(fill_and_stroke);
 
-				// Branching vectors with regions use even-odd fill on the main path
-				if vector.is_branching() && vector.has_regions() {
+				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
 				}
 
@@ -1095,14 +1090,10 @@ impl Render for Table<Vector> {
 			};
 
 			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.
-			// Branching vectors with regions (e.g. boolean operation results) use even-odd fill
-			// on the main stroke path instead, since face decomposition can't determine which
-			// bounded faces should vs. shouldn't be filled in boolean results.
-			let use_face_fill = row.element.is_branching() && !row.element.has_regions();
+			let use_face_fill = row.element.use_face_fill();
 			let do_fill = |scene: &mut Scene| {
 				if use_face_fill {
-					// For branching paths without regions (meshes), fill each face separately
-					for mut face_path in row.element.construct_faces().filter(|face| !(face.area() < 0.0)) {
+					for mut face_path in row.element.construct_faces().filter(|face| face.area() >= 0.) {
 						face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
 						let mut kurbo_path = kurbo::BezPath::new();
 						for element in face_path {
@@ -1110,11 +1101,9 @@ impl Render for Table<Vector> {
 						}
 						do_fill_path(scene, &kurbo_path, peniko::Fill::NonZero);
 					}
-				} else if row.element.is_branching() && row.element.has_regions() {
-					// For branching paths with regions (boolean ops), use even-odd fill
+				} else if row.element.is_branching() {
 					do_fill_path(scene, &path, peniko::Fill::EvenOdd);
 				} else {
-					// Simple fill of the entire path
 					do_fill_path(scene, &path, peniko::Fill::NonZero);
 				}
 			};

--- a/node-graph/libraries/vector-types/src/vector/vector_attributes.rs
+++ b/node-graph/libraries/vector-types/src/vector/vector_attributes.rs
@@ -1110,6 +1110,15 @@ impl<Upstream> Vector<Upstream> {
 		!self.region_domain.id.is_empty()
 	}
 
+	/// Determines if face-by-face fill rendering should be used.
+	/// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.
+	/// Branching vectors with regions (e.g. boolean operation results) use even-odd fill
+	/// on the main stroke path instead, since face decomposition can't determine which
+	/// bounded faces should vs. shouldn't be filled in boolean results.
+	pub fn use_face_fill(&self) -> bool {
+		self.is_branching() && !self.has_regions()
+	}
+
 	pub fn construct_faces(&self) -> FaceIterator<'_, Upstream> {
 		let mut adjacency: Vec<Vec<FaceSide>> = vec![Vec::new(); self.point_domain.len()];
 		for (segment_index, (&start, &end)) in self.segment_domain.start_point.iter().zip(&self.segment_domain.end_point).enumerate() {


### PR DESCRIPTION
Fixes #3657

Right now, the Grid node produces a vector mesh without any `region_domain` entries due to its inability to represent non-contiguous ranges of segment indices (that would require `Vec<SegmentId>`), while Boolean Operation nodes do produce contiguous segment strings and do populate the `region_domain`. This is a somewhat hacky workaround for the flickering on boolean op outputs where we avoid the sub-region building in those cases where regions are already specified, while we only attempt to build regions when they are not specified in the `region_domain`. This isn't a permanent solution, but it seems reasonable for now until the whole way that we handle vector meshes and regions is replaced with a properly designed system.

<details><summary>But to be more precise...</summary>

> We're not actually rendering individual regions — the current code renders the full combined stroke path (from stroke_bezpath_iter, which traverses every edge of the graph once). For branching vectors where merge_by_distance_spatial has welded contour endpoints together, that traversal produces a single complex path with arbitrary winding direction. With the default nonzero fill, the winding direction determines what's filled, so the result would be unpredictable. Even-odd ignores winding direction and just counts boundary crossings, which gives correct results regardless of traversal order.

</details> 