### PR TITLE
fix: prevent geometry shift in Auto-Tangents when spread is 0

### DIFF
--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -903,6 +903,13 @@ async fn auto_tangents(
 
 				for i in 0..manipulators_list.len() {
 					let curr = &manipulators_list[i];
+                   
+					// Changes to the original logic:
+					if preserve_existing && spread == 0.0
+					{
+						new_manipulators_list.push(*curr);
+						continue;
+					}
 
 					if preserve_existing {
 						// Check if this point has handles that are meaningfully different from the anchor


### PR DESCRIPTION
Fixes #3822 

Here is the fix to Spread==0 error and the AutoTangents error. 
Based on the discussion : https://discord.com/channels/731730685944922173/731738914812854303/1481764902266736660

