### PR TITLE
make pen/pencil/spline stroke weight match shape tools and fix stroke weight change behaviour during transformation

### DIFF
--- a/editor/src/messages/tool/tool_messages/freehand_tool.rs
+++ b/editor/src/messages/tool/tool_messages/freehand_tool.rs
@@ -9,7 +9,7 @@ use crate::messages::tool::common_functionality::color_selector::{ToolColorOptio
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use crate::messages::tool::common_functionality::utility_functions::should_extend;
 use glam::DVec2;
-use graph_craft::document::NodeId;
+use graph_craft::document::{NodeId, NodeInput};
 use graphene_std::Color;
 use graphene_std::vector::VectorModificationType;
 use graphene_std::vector::{PointId, SegmentId};
@@ -294,7 +294,8 @@ impl Fsm for FreehandToolFsmState {
 
 				let node_type = resolve_network_node_type("Path").expect("Path node does not exist");
 				let node = node_type.default_node_template();
-				let nodes = vec![(NodeId(0), node)];
+				let transform_node_type = resolve_network_node_type("Transform").expect("Transform node does not exist");
+				let nodes = vec![(NodeId(1), node), (NodeId(0), transform_node_type.node_template_input_override([Some(NodeInput::node(NodeId(1), 0))]))];
 
 				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -12,7 +12,7 @@ use crate::messages::tool::common_functionality::graph_modification_utils::{self
 use crate::messages::tool::common_functionality::shape_editor::ShapeState;
 use crate::messages::tool::common_functionality::snapping::{SnapCache, SnapCandidatePoint, SnapConstraint, SnapData, SnapManager, SnapTypeConfiguration};
 use crate::messages::tool::common_functionality::utility_functions::{calculate_segment_angle, closest_point, should_extend};
-use graph_craft::document::NodeId;
+use graph_craft::document::{NodeId, NodeInput};
 use graphene_std::Color;
 use graphene_std::subpath::pathseg_points;
 use graphene_std::vector::misc::{HandleId, ManipulatorPointId, dvec2_to_point};
@@ -1287,7 +1287,11 @@ impl PenToolData {
 
 		// New path layer
 		let node_type = resolve_network_node_type("Path").expect("Path node does not exist");
-		let nodes = vec![(NodeId(0), node_type.default_node_template())];
+		let transform_node_type = resolve_network_node_type("Transform").expect("Transform node does not exist");
+		let nodes = vec![
+			(NodeId(1), node_type.default_node_template()),
+			(NodeId(0), transform_node_type.node_template_input_override([Some(NodeInput::node(NodeId(1), 0))])),
+		];
 
 		let parent = document.new_layer_bounding_artboard(input, viewport);
 		let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);

--- a/editor/src/messages/tool/tool_messages/spline_tool.rs
+++ b/editor/src/messages/tool/tool_messages/spline_tool.rs
@@ -396,8 +396,10 @@ impl Fsm for SplineToolFsmState {
 				let path_node_type = resolve_network_node_type("Path").expect("Path node does not exist");
 				let path_node = path_node_type.default_node_template();
 				let spline_node_type = resolve_proto_node_type(graphene_std::vector::spline::IDENTIFIER).expect("Spline node does not exist");
-				let spline_node = spline_node_type.node_template_input_override([Some(NodeInput::node(NodeId(1), 0))]);
-				let nodes = vec![(NodeId(1), path_node), (NodeId(0), spline_node)];
+				let spline_node = spline_node_type.node_template_input_override([Some(NodeInput::node(NodeId(2), 0))]);
+				let transform_node_type = resolve_network_node_type("Transform").expect("Transform node does not exist");
+				let transform_node = transform_node_type.node_template_input_override([Some(NodeInput::node(NodeId(1), 0))]);
+				let nodes = vec![(NodeId(2), path_node), (NodeId(1), spline_node), (NodeId(0), transform_node)];
 
 				let layer = graph_modification_utils::new_custom(NodeId::new(), nodes, parent, responses);
 				tool_options.stroke.apply_stroke(tool_data.weight, layer, responses);


### PR DESCRIPTION
Fixes #3893
-Insert Transform before Stroke when creating pen, pencil, and spline layers
-Prevent post stroke transform insertion from changing apparent stroke width
-Fix moved value ownership issue in spline/path node construction