### PR TITLE
fix: populate colinear_manipulators for Circle, Arc, and Spiral (#3891)

### DIFF
--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -52,8 +52,7 @@ fn circle(
     // 1. Create the vector
     let mut circle = Vector::from_subpath(subpath::Subpath::new_ellipse(DVec2::splat(-radius), DVec2::splat(radius)));
 
-    // 2. Register the 4 pairs of colinear handles
-    // 2. Register the 4 pairs of colinear handles
+    // Created the collinear_manipulators so that all handles are linked, making it easier to edit the circle as a circle instead of a 4 point shape.
     let ids = circle.segment_domain.ids();
     let len = ids.len();
     for i in 0..len {
@@ -80,7 +79,6 @@ fn arc(
     sweep_angle: Angle,
     arc_type: ArcType,
 ) -> Table<Vector> {
-    // 1. Create the arc vector
     let mut arc_vector = Vector::from_subpath(subpath::Subpath::new_arc(
         radius,
         start_angle / 360. * std::f64::consts::TAU,
@@ -118,7 +116,7 @@ fn spiral(
 	#[default(25)] outer_radius: f64,
 	#[default(90.)] angular_resolution: f64,
 ) -> Table<Vector> {
-	// 1. Create the spiral vector
+
 	let mut spiral_vector = Vector::from_subpath(subpath::Subpath::new_spiral(
 		inner_radius,
 		outer_radius,
@@ -128,7 +126,7 @@ fn spiral(
 		spiral_type,
 	));
 
-	// 2. NEW: Link consecutive curved segments
+
 	let len = spiral_vector.segment_domain.ids().len();
 	for i in 0..len.saturating_sub(1) {
 		// Ensure both segments meeting at the anchor point are cubic beziers

--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -42,42 +42,69 @@ impl CornerRadius for [f64; 4] {
 /// Generates a circle shape with a chosen radius.
 #[node_macro::node(category("Vector: Shape"))]
 fn circle(
-	_: impl Ctx,
-	_primary: (),
-	#[unit(" px")]
-	#[default(50.)]
-	radius: f64,
+    _: impl Ctx,
+    _primary: (),
+    #[unit(" px")]
+    #[default(50.)]
+    radius: f64,
 ) -> Table<Vector> {
-	let radius = radius.abs();
-	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_ellipse(DVec2::splat(-radius), DVec2::splat(radius))))
+    let radius = radius.abs();
+    // 1. Create the vector
+    let mut circle = Vector::from_subpath(subpath::Subpath::new_ellipse(DVec2::splat(-radius), DVec2::splat(radius)));
+
+    // 2. Register the 4 pairs of colinear handles
+    let len = circle.segment_domain.ids().len();
+    for i in 0..len {
+        circle.colinear_manipulators.push([
+            HandleId::end(circle.segment_domain.ids()[i]), 
+            HandleId::primary(circle.segment_domain.ids()[(i + 1) % len])
+        ]);
+    }
+
+    Table::new_from_element(circle)
 }
 
 /// Generates an arc shape forming a portion of a circle which may be open, closed, or a pie slice.
 #[node_macro::node(category("Vector: Shape"))]
 fn arc(
-	_: impl Ctx,
-	_primary: (),
-	#[unit(" px")]
-	#[default(50.)]
-	radius: f64,
-	start_angle: Angle,
-	#[default(270.)]
-	#[range((0., 360.))]
-	sweep_angle: Angle,
-	arc_type: ArcType,
+    _: impl Ctx,
+    _primary: (),
+    #[unit(" px")]
+    #[default(50.)]
+    radius: f64,
+    start_angle: Angle,
+    #[default(270.)]
+    #[range((0., 360.))]
+    sweep_angle: Angle,
+    arc_type: ArcType,
 ) -> Table<Vector> {
-	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_arc(
-		radius,
-		start_angle / 360. * std::f64::consts::TAU,
-		sweep_angle / 360. * std::f64::consts::TAU,
-		match arc_type {
-			ArcType::Open => subpath::ArcType::Open,
-			ArcType::Closed => subpath::ArcType::Closed,
-			ArcType::PieSlice => subpath::ArcType::PieSlice,
-		},
-	)))
+    // 1. Create the arc vector
+    let mut arc_vector = Vector::from_subpath(subpath::Subpath::new_arc(
+        radius,
+        start_angle / 360. * std::f64::consts::TAU,
+        sweep_angle / 360. * std::f64::consts::TAU,
+        match arc_type {
+            ArcType::Open => subpath::ArcType::Open,
+            ArcType::Closed => subpath::ArcType::Closed,
+            ArcType::PieSlice => subpath::ArcType::PieSlice,
+        },
+    ));
+
+    // 2. Link handles only if both adjacent segments are cubic beziers
+    let len = arc_vector.segment_domain.ids().len();
+    for i in 0..len.saturating_sub(1) {
+        if arc_vector.segment_domain.handles()[i].is_cubic() && arc_vector.segment_domain.handles()[i + 1].is_cubic() {
+            arc_vector.colinear_manipulators.push([
+                HandleId::end(arc_vector.segment_domain.ids()[i]), 
+                HandleId::primary(arc_vector.segment_domain.ids()[i + 1])
+            ]);
+        }
+    }
+
+    Table::new_from_element(arc_vector)
 }
 
+/// Generates a spiral shape that winds from an inner to an outer radius.
 /// Generates a spiral shape that winds from an inner to an outer radius.
 #[node_macro::node(category("Vector: Shape"), properties("spiral_properties"))]
 fn spiral(
@@ -90,14 +117,29 @@ fn spiral(
 	#[default(25)] outer_radius: f64,
 	#[default(90.)] angular_resolution: f64,
 ) -> Table<Vector> {
-	Table::new_from_element(Vector::from_subpath(subpath::Subpath::new_spiral(
+	// 1. Create the spiral vector
+	let mut spiral_vector = Vector::from_subpath(subpath::Subpath::new_spiral(
 		inner_radius,
 		outer_radius,
 		turns,
 		start_angle.to_radians(),
 		angular_resolution.to_radians(),
 		spiral_type,
-	)))
+	));
+
+	// 2. NEW: Link consecutive curved segments
+	let len = spiral_vector.segment_domain.ids().len();
+	for i in 0..len.saturating_sub(1) {
+		// Ensure both segments meeting at the anchor point are cubic beziers
+		if spiral_vector.segment_domain.handles()[i].is_cubic() && spiral_vector.segment_domain.handles()[i + 1].is_cubic() {
+			spiral_vector.colinear_manipulators.push([
+				HandleId::end(spiral_vector.segment_domain.ids()[i]), 
+				HandleId::primary(spiral_vector.segment_domain.ids()[i + 1])
+			]);
+		}
+	}
+
+	Table::new_from_element(spiral_vector)
 }
 
 /// Generates an ellipse shape (an oval or stretched circle) with the chosen radii.

--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -105,7 +105,6 @@ fn arc(
 }
 
 /// Generates a spiral shape that winds from an inner to an outer radius.
-/// Generates a spiral shape that winds from an inner to an outer radius.
 #[node_macro::node(category("Vector: Shape"), properties("spiral_properties"))]
 fn spiral(
 	_: impl Ctx,

--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -53,11 +53,13 @@ fn circle(
     let mut circle = Vector::from_subpath(subpath::Subpath::new_ellipse(DVec2::splat(-radius), DVec2::splat(radius)));
 
     // 2. Register the 4 pairs of colinear handles
-    let len = circle.segment_domain.ids().len();
+    // 2. Register the 4 pairs of colinear handles
+    let ids = circle.segment_domain.ids();
+    let len = ids.len();
     for i in 0..len {
         circle.colinear_manipulators.push([
-            HandleId::end(circle.segment_domain.ids()[i]), 
-            HandleId::primary(circle.segment_domain.ids()[(i + 1) % len])
+            HandleId::end(ids[i]),
+            HandleId::primary(ids[(i + 1) % len]),
         ]);
     }
 


### PR DESCRIPTION
Fixes #3891

I have fixed the issue 3891, by using collinear_manipulators for circle, spirals and arc. 

related to this discussion:  https://discord.com/channels/731730685944922173/731738914812854303/1482256235339186196

