### PR TITLE
Add the re-labeled node display name to its Properties panel section header

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -174,7 +174,7 @@ fn document_node_definitions() -> HashMap<DefinitionIdentifier, DocumentNodeDefi
 			properties: Some("monitor_properties"),
 		},
 		DocumentNodeDefinition {
-			identifier: "Default Network",
+			identifier: "Custom Node",
 			category: "General",
 			node_template: NodeTemplate {
 				document_node: DocumentNode {

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -645,7 +645,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 
 				// Use the network interface to add a default node, then set the imports, exports, paste the nodes inside, and connect them to the imports/exports
 				let encapsulating_node_id = NodeId::new();
-				let mut default_node_template = resolve_network_node_type("Default Network").expect("Default Network node should exist").default_node_template();
+				let mut default_node_template = resolve_network_node_type("Custom Node").expect("Custom Node should exist").default_node_template();
 				let Some(center_of_selected_nodes) = network_interface.selected_nodes_bounding_box(breadcrumb_network_path).map(|[a, b]| (a + b) / 2.) else {
 					log::error!("Could not get center of selected_nodes");
 					return;

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -1796,7 +1796,21 @@ pub(crate) fn generate_node_properties(node_id: NodeId, context: &mut NodeProper
 	if layout.is_empty() {
 		layout = node_no_properties(node_id, context);
 	}
-	let name = context.network_interface.display_name(&node_id, context.selection_network_path);
+
+	let display_name = context
+		.network_interface
+		.node_metadata(&node_id, context.selection_network_path)
+		.map(|metadata| metadata.persistent_metadata.display_name.as_ref());
+	let implementation_name = context.network_interface.implementation_name(&node_id, context.selection_network_path);
+	let name = if let Some(display_name) = display_name
+		&& implementation_name != display_name
+		&& implementation_name != "Custom Node"
+		&& !display_name.is_empty()
+	{
+		format!("{display_name} ({implementation_name})")
+	} else {
+		implementation_name
+	};
 
 	let description = context
 		.network_interface


### PR DESCRIPTION
closes #2461

Not sure we want to do it this way forever, but it's at least an improvement in the sort term.

<img width="518" height="562" alt="image" src="https://github.com/user-attachments/assets/b2f73463-933b-487b-ae78-febd0abc942a" />
