### PR TITLE
fix undo for checkboxes

### DIFF
--- a/frontend/src/utility-functions/input.ts
+++ b/frontend/src/utility-functions/input.ts
@@ -344,7 +344,15 @@ function detectShake(e: PointerEvent | MouseEvent): boolean {
 }
 
 function targetIsTextField(target: EventTarget | HTMLElement | undefined): boolean {
-	return target instanceof HTMLElement && (target.nodeName === "INPUT" || target.nodeName === "TEXTAREA" || target.isContentEditable);
+	if (!(target instanceof HTMLElement)) return false;
+	if (target.nodeName === "TEXTAREA" || target.isContentEditable) return true;
+	if (target instanceof HTMLInputElement) {
+		const inputType = target.type.toLowerCase();
+		// Only consider actual text-entry input types as text fields, not checkboxes, radio buttons, etc.
+		const textInputTypes = ["text", "password", "email", "number", "search", "tel", "url", "date", "datetime-local", "month", "time", "week"];
+		return textInputTypes.includes(inputType);
+	}
+	return false;
 }
 
 function potentiallyRestoreCanvasFocus(e: Event) {


### PR DESCRIPTION
Replaces #3866 (branch was force-pushed after file location changed in master)

---

Bug: Keyboard shortcuts like Cmd+Z were blocked when a checkbox had focus because targetIsTextField() treated all <input> elements as text fields.

Fix: Only treat text-like input types (text, password, email, etc.) as text fields, not checkboxes or radio buttons.

https://github.com/user-attachments/assets/4f675948-ecea-4233-a7dd-2ebcdb71a3ec

Fixes: https://discord.com/channels/731730685944922173/731738914812854303/1479627959127117924