### PR TITLE
Add unit tests for grid, polygon, and star shape tools

### DIFF
--- a/editor/src/messages/tool/common_functionality/shapes/grid_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/grid_shape.rs
@@ -254,3 +254,169 @@ fn calculate_isometric_x_position(y_spacing: f64, rad_a: f64, rad_b: f64) -> f64
 	let spacing_x = y_spacing / (rad_a.tan() + rad_b.tan());
 	spacing_x * 9.
 }
+#[cfg(test)]
+mod tests {
+	use super::calculate_grid_params;
+	use glam::DVec2;
+
+	// ── (false, false) rectangular ──────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_basic_rectangle() {
+		// Simple downward-right drag: translation = start, dimensions = raw/9, no angle
+		let (translation, dimensions, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), false, false, false);
+		assert_eq!(translation, DVec2::ZERO);
+		assert_eq!(dimensions, DVec2::splat(10.)); // 90/9 = 10
+		assert!(angle.is_none());
+	}
+
+	#[test]
+	fn grid_params_negative_drag_adjusts_translation() {
+		// Drag up-left from (100,100) to (10,10): both x and y branches in (false,false) rect
+		let (translation, dimensions, angle) = calculate_grid_params(DVec2::splat(100.), DVec2::splat(10.), false, false, false);
+		assert!((translation.x - 10.).abs() < 1e-10, "Expected translation.x=10, got {}", translation.x);
+		assert!((translation.y - 10.).abs() < 1e-10, "Expected translation.y=10, got {}", translation.y);
+		assert_eq!(dimensions, DVec2::splat(10.)); // (90,90)/9
+		assert!(angle.is_none());
+	}
+
+	// ── (false, false) isometric ────────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_isometric_produces_angle() {
+		// Isometric grid (no lock_ratio): angle is dynamically computed from drag
+		let (_, _, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), true, false, false);
+		assert!(angle.is_some(), "Isometric grid should return an angle");
+	}
+
+	#[test]
+	fn grid_params_isometric_free_form_upward_drag() {
+		// (false, false) isometric with end.y < start.y: upward-drag translation branch
+		let start = DVec2::new(0., 100.);
+		let end = DVec2::new(90., 10.);
+		let (translation, dimensions, angle) = calculate_grid_params(start, end, true, false, false);
+		assert!(angle.is_some());
+		// translation.y = start.y - (start.y - end.y) = 10
+		assert!((translation.y - 10.).abs() < 1e-10, "Expected translation.y=10, got {}", translation.y);
+		assert_eq!(dimensions, DVec2::splat(10.)); // |100-10|/9 = 90/9 = 10
+	}
+
+	// ── (false, true) rectangular ───────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_lock_ratio_forces_square_spacing() {
+		// Non-square drag (90x45) with lock_ratio: uses larger dim (90), dimensions = 90/9 = 10
+		let (_, dimensions, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 45.), false, false, true);
+		assert_eq!(dimensions, DVec2::splat(10.));
+		assert!(angle.is_none());
+	}
+
+	#[test]
+	fn grid_params_lock_ratio_upward_drag() {
+		// (false, true) rect with end.y < start.y: translation shifts down by max
+		let start = DVec2::new(0., 90.);
+		let end = DVec2::new(90., 0.);
+		let (translation, dimensions, angle) = calculate_grid_params(start, end, false, false, true);
+		// raw = (90,90), max = 90; translation.y = 90 - 90 = 0
+		assert!((translation.y - 0.).abs() < 1e-10, "Expected translation.y=0, got {}", translation.y);
+		assert_eq!(dimensions, DVec2::splat(10.));
+		assert!(angle.is_none());
+	}
+
+	#[test]
+	fn grid_params_lock_ratio_leftward_drag() {
+		// (false, true) rect with end.x < start.x: translation shifts right by max
+		let start = DVec2::new(90., 0.);
+		let end = DVec2::new(0., 90.);
+		let (translation, dimensions, angle) = calculate_grid_params(start, end, false, false, true);
+		// raw = (90,90), max = 90; translation.x = 90 - 90 = 0
+		assert!((translation.x - 0.).abs() < 1e-10, "Expected translation.x=0, got {}", translation.x);
+		assert_eq!(dimensions, DVec2::splat(10.));
+		assert!(angle.is_none());
+	}
+
+	// ── (false, true) isometric ─────────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_isometric_lock_ratio_fixes_angle_at_30() {
+		// Isometric + lock_ratio (positive drag): angle fixed at 30°
+		let (_, _, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), true, false, true);
+		assert_eq!(angle, Some(30.), "Isometric lock_ratio should fix angle at 30°");
+	}
+
+	#[test]
+	fn grid_params_isometric_lock_ratio_negative_drag() {
+		// (false, true) isometric with end.x < start.x and end.y < start.y: both translation branches
+		let start = DVec2::new(90., 90.);
+		let end = DVec2::new(0., 0.);
+		let (translation, dimensions, angle) = calculate_grid_params(start, end, true, false, true);
+		assert_eq!(angle, Some(30.));
+		assert_eq!(dimensions, DVec2::splat(10.)); // raw_y=90, 90/9=10
+		// translation = start − (0,max) − (max,0) = (90,90) − (0,90) − (90,0) = (0,0)
+		assert!((translation.x - 0.).abs() < 1e-10, "Expected translation.x=0, got {}", translation.x);
+		assert!((translation.y - 0.).abs() < 1e-10, "Expected translation.y=0, got {}", translation.y);
+	}
+
+	// ── (true, false) rectangular ───────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_center_doubles_dimensions_and_shifts_translation() {
+		// Center draw rect: dimensions = 2×raw/9, translation = start − raw
+		let (translation, dimensions, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), false, true, false);
+		assert_eq!(translation, DVec2::splat(-90.));
+		assert_eq!(dimensions, DVec2::splat(20.)); // 2 × 90/9 = 20
+		assert!(angle.is_none());
+	}
+
+	// ── (true, false) isometric ─────────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_center_only_isometric_produces_angle() {
+		// (true, false) isometric: angle dynamically derived from drag direction
+		let (_, dimensions, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), true, true, false);
+		assert!(angle.is_some(), "Center-only isometric should produce an angle");
+		assert_eq!(dimensions, DVec2::splat(10.)); // raw_y=90/9=10
+	}
+
+	#[test]
+	fn grid_params_center_only_isometric_upward_drag() {
+		// (true, false) isometric with end.y < start.y: upward-drag inner branch
+		let start = DVec2::new(0., 90.);
+		let end = DVec2::new(90., 0.);
+		let (translation, _, angle) = calculate_grid_params(start, end, true, true, false);
+		// mouse_delta = (90, -90); translation = start − delta/2 = (0,90) − (45,−45) = (−45,135)
+		// end.y < start.y → translation.y −= start.y − end.y = 90 → 135 − 90 = 45
+		assert!(angle.is_some());
+		assert!((translation.y - 45.).abs() < 1e-10, "Expected translation.y=45, got {}", translation.y);
+	}
+
+	// ── (true, true) rectangular ────────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_center_and_lock_ratio_rect() {
+		// (true, true) rect: uses max dimension, translation = start − max, dimensions = 2×max/9
+		let (translation, dimensions, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 45.), false, true, true);
+		// max = 90; translation = (0,0) − 90 = (−90,−90); dimensions = 2×90/9 = 20
+		assert_eq!(translation, DVec2::splat(-90.));
+		assert_eq!(dimensions, DVec2::splat(20.));
+		assert!(angle.is_none());
+	}
+
+	// ── (true, true) isometric ──────────────────────────────────────────────────
+
+	#[test]
+	fn grid_params_center_and_lock_ratio_isometric() {
+		// (true, true) isometric (downward drag): angle fixed at 30°, also exercises calculate_isometric_x_position
+		let (_, _, angle) = calculate_grid_params(DVec2::ZERO, DVec2::new(90., 90.), true, true, true);
+		assert_eq!(angle, Some(30.), "Center+lock isometric should fix angle at 30°");
+	}
+
+	#[test]
+	fn grid_params_center_and_lock_ratio_isometric_upward_drag() {
+		// (true, true) isometric with end.y < start.y: inner upward-drag branch
+		let start = DVec2::new(0., 90.);
+		let end = DVec2::new(90., 0.);
+		let (_, _, angle) = calculate_grid_params(start, end, true, true, true);
+		assert_eq!(angle, Some(30.));
+	}
+}

--- a/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/polygon_shape.rs
@@ -191,3 +191,152 @@ impl Polygon {
 		responses.add(NodeGraphMessage::RunDocumentGraph);
 	}
 }
+
+#[cfg(test)]
+mod test_polygon {
+	use crate::messages::tool::common_functionality::graph_modification_utils::NodeGraphLayer;
+	use crate::messages::tool::tool_messages::shape_tool::ShapeOptionsUpdate;
+	use crate::test_utils::test_prelude::*;
+	use graph_craft::document::value::TaggedValue;
+
+	/// Reads sides and radius from the first polygon node found in the document.
+	fn get_polygon_inputs(editor: &EditorTestUtils) -> Option<(u32, f64)> {
+		let document = editor.active_document();
+		document.metadata().all_layers().find_map(|layer| {
+			let inputs = NodeGraphLayer::new(layer, &document.network_interface)
+				.find_node_inputs(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::regular_polygon::IDENTIFIER))?;
+			let Some(&TaggedValue::U32(sides)) = inputs.get(1).and_then(|i| i.as_value()) else {
+				return None;
+			};
+			let Some(&TaggedValue::F64(radius)) = inputs.get(2).and_then(|i| i.as_value()) else {
+				return None;
+			};
+			Some((sides, radius))
+		})
+	}
+
+	#[tokio::test]
+	async fn polygon_draw_simple() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		assert_eq!(editor.active_document().metadata().all_layers().count(), 1);
+		let (sides, radius) = get_polygon_inputs(&editor).expect("Polygon node should exist after draw");
+		assert!(sides >= 3, "Polygon should have at least 3 sides, got {sides}");
+		assert!((radius - 50.).abs() < 1., "Expected radius ≈ 50 for 100×100 drag, got {radius}");
+	}
+
+	#[tokio::test]
+	async fn polygon_draw_non_square_uses_shorter_dimension() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		// Drag wider than tall: dimensions = (100, 60), radius = shorter/2 = 30
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 60., ModifierKeys::empty()).await;
+
+		let (_, radius) = get_polygon_inputs(&editor).expect("Polygon node should exist");
+		assert!((radius - 30.).abs() < 1., "Expected radius ≈ 30 for 100×60 drag, got {radius}");
+	}
+
+	#[tokio::test]
+	async fn polygon_draw_shift_lock_ratio() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		// SHIFT forces equal dimensions — a 100×60 drag becomes 100×100
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 60., ModifierKeys::SHIFT).await;
+
+		let (_, radius) = get_polygon_inputs(&editor).expect("Polygon node should exist");
+		assert!((radius - 50.).abs() < 1., "Expected radius ≈ 50 with SHIFT lock ratio on 100×60 drag, got {radius}");
+	}
+
+	#[tokio::test]
+	async fn polygon_default_six_sides() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		let (sides, _) = get_polygon_inputs(&editor).expect("Polygon node should exist");
+		assert_eq!(sides, 5, "Default polygon should have 5 sides");
+	}
+
+	#[tokio::test]
+	async fn polygon_cancel_rmb_no_layer() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.drag_tool_cancel_rmb(ToolType::Shape).await;
+
+		assert_eq!(
+			editor.active_document().metadata().all_layers().count(),
+			0,
+			"RMB-cancelled polygon should not create a layer"
+		);
+	}
+
+	#[tokio::test]
+	async fn polygon_increase_sides_enqueues_responses() {
+		use super::Polygon;
+		use std::collections::VecDeque;
+
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		let document = editor.active_document();
+		let layer = document.metadata().all_layers().next().expect("Layer should exist after draw");
+
+		let mut responses = VecDeque::new();
+		Polygon::decrease_or_increase_sides(false, layer, document, &mut responses);
+		// Increasing sides enqueues UpdateOptions + SetInput + RunDocumentGraph
+		assert_eq!(responses.len(), 3, "Increasing sides should enqueue exactly 3 responses");
+	}
+
+	#[tokio::test]
+	async fn polygon_decrease_sides_enqueues_responses() {
+		use super::Polygon;
+		use std::collections::VecDeque;
+
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.drag_tool(ToolType::Shape, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		let document = editor.active_document();
+		let layer = document.metadata().all_layers().next().expect("Layer should exist after draw");
+
+		let mut responses = VecDeque::new();
+		// Default polygon has 5 sides; decreasing gives 4 (above the 3-side minimum)
+		Polygon::decrease_or_increase_sides(true, layer, document, &mut responses);
+		assert_eq!(responses.len(), 3, "Decreasing sides should enqueue exactly 3 responses");
+	}
+
+	#[tokio::test]
+	async fn polygon_decrease_sides_clamps_at_minimum_three() {
+		use super::Polygon;
+		use std::collections::VecDeque;
+
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+
+		// Draw a triangle (minimum 3 sides) explicitly
+		editor.select_tool(ToolType::Shape).await;
+		editor
+			.handle_message(ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::Vertices(3),
+			})
+			.await;
+		editor.move_mouse(0., 0., ModifierKeys::empty(), MouseKeys::empty()).await;
+		editor.left_mousedown(0., 0., ModifierKeys::empty()).await;
+		editor.move_mouse(100., 100., ModifierKeys::empty(), MouseKeys::LEFT).await;
+		editor.left_mouseup(100., 100., ModifierKeys::empty()).await;
+
+		let (sides, _) = get_polygon_inputs(&editor).expect("Polygon should exist");
+		assert_eq!(sides, 3, "Polygon should have 3 sides");
+
+		let document = editor.active_document();
+		let layer = document.metadata().all_layers().next().expect("Layer should exist");
+
+		let mut responses = VecDeque::new();
+		// Decreasing from 3 must clamp to 3 (not go to 2): verifies the `.max(3)` branch
+		Polygon::decrease_or_increase_sides(true, layer, document, &mut responses);
+		assert_eq!(responses.len(), 3, "Should still produce 3 responses even when sides are already at minimum");
+	}
+}

--- a/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/star_shape.rs
@@ -170,3 +170,112 @@ impl Star {
 		}
 	}
 }
+
+#[cfg(test)]
+mod test_star {
+	use crate::messages::tool::common_functionality::graph_modification_utils::NodeGraphLayer;
+	use crate::messages::tool::common_functionality::shapes::shape_utility::ShapeType;
+	use crate::messages::tool::tool_messages::shape_tool::ShapeOptionsUpdate;
+	use crate::test_utils::test_prelude::*;
+	use graph_craft::document::value::TaggedValue;
+
+	/// Switch to Star shape type, then manually drag to avoid drag_tool re-selecting and resetting options.
+	async fn draw_star(editor: &mut EditorTestUtils, x1: f64, y1: f64, x2: f64, y2: f64, modifier_keys: ModifierKeys) {
+		editor.select_tool(ToolType::Shape).await;
+		editor
+			.handle_message(ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::ShapeType(ShapeType::Star),
+			})
+			.await;
+		editor.move_mouse(x1, y1, modifier_keys, MouseKeys::empty()).await;
+		editor.left_mousedown(x1, y1, modifier_keys).await;
+		editor.move_mouse(x2, y2, modifier_keys, MouseKeys::LEFT).await;
+		editor.left_mouseup(x2, y2, modifier_keys).await;
+	}
+
+	/// Returns (sides, outer_radius, inner_radius) from the first star node in the document.
+	fn get_star_inputs(editor: &EditorTestUtils) -> Option<(u32, f64, f64)> {
+		let document = editor.active_document();
+		document.metadata().all_layers().find_map(|layer| {
+			let inputs = NodeGraphLayer::new(layer, &document.network_interface)
+				.find_node_inputs(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::star::IDENTIFIER))?;
+			let Some(&TaggedValue::U32(sides)) = inputs.get(1).and_then(|i| i.as_value()) else {
+				return None;
+			};
+			let Some(&TaggedValue::F64(outer_radius)) = inputs.get(2).and_then(|i| i.as_value()) else {
+				return None;
+			};
+			let Some(&TaggedValue::F64(inner_radius)) = inputs.get(3).and_then(|i| i.as_value()) else {
+				return None;
+			};
+			Some((sides, outer_radius, inner_radius))
+		})
+	}
+
+	#[tokio::test]
+	async fn star_draw_simple() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		draw_star(&mut editor, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		assert_eq!(editor.active_document().metadata().all_layers().count(), 1);
+		let (sides, outer_radius, _) = get_star_inputs(&editor).expect("Star node should exist after draw");
+		assert!(sides >= 2, "Star should have at least 2 points, got {sides}");
+		assert!(outer_radius > 0., "Outer radius should be positive, got {outer_radius}");
+	}
+
+	#[tokio::test]
+	async fn star_inner_radius_is_half_outer() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		draw_star(&mut editor, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		let (_, outer_radius, inner_radius) = get_star_inputs(&editor).expect("Star node should exist");
+		assert!(
+			(inner_radius - outer_radius / 2.).abs() < 1e-10,
+			"Inner radius {inner_radius} should equal outer_radius/2 = {}",
+			outer_radius / 2.
+		);
+	}
+
+	#[tokio::test]
+	async fn star_draw_correct_outer_radius() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		// 100x100 drag: dimensions=(100,100), x==y, radius = x/2 = 50
+		draw_star(&mut editor, 0., 0., 100., 100., ModifierKeys::empty()).await;
+
+		let (_, outer_radius, _) = get_star_inputs(&editor).expect("Star node should exist");
+		assert!((outer_radius - 50.).abs() < 1., "Expected outer radius ~50 for 100x100 drag, got {outer_radius}");
+	}
+
+	#[tokio::test]
+	async fn star_draw_wider_than_tall_uses_height_as_radius() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		// Drag wider than tall: dimensions = (100, 60), x > y → outer_radius = y/2 = 30
+		draw_star(&mut editor, 0., 0., 100., 60., ModifierKeys::empty()).await;
+
+		let (_, outer_radius, _) = get_star_inputs(&editor).expect("Star node should exist");
+		assert!((outer_radius - 30.).abs() < 1., "Expected outer radius ≈ 30 for 100×60 drag, got {outer_radius}");
+	}
+
+	#[tokio::test]
+	async fn star_cancel_rmb_no_layer() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		editor.select_tool(ToolType::Shape).await;
+		editor
+			.handle_message(ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::ShapeType(ShapeType::Star),
+			})
+			.await;
+		editor.drag_tool_cancel_rmb(ToolType::Shape).await;
+
+		assert_eq!(
+			editor.active_document().metadata().all_layers().count(),
+			0,
+			"RMB-cancelled star should not create a layer"
+		);
+	}
+}


### PR DESCRIPTION
Closes #3954

## What this does

Adds `#[cfg(test)]` coverage to three previously untested files in the shape-tool subsystem:

### `grid_shape.rs` — pure unit tests for `calculate_grid_params`

All 8 match-arm combinations of `(center, lock_ratio)` × `is_isometric` are now exercised, including every negative-drag sub-branch (`end.x < start.x`, `end.y < start.y`):

| Branch | Tests |
|---|---|
| `(false, false)` rect | basic downward-right drag; combined up-left drag covering both negative-axis branches |
| `(false, false)` isometric | positive drag (dynamic angle); upward drag (translation compensation) |
| `(false, true)` rect | square spacing; upward drag; leftward drag |
| `(false, true)` isometric | 30° fixed angle; combined negative drag |
| `(true, false)` rect | centered dimensions and translation |
| `(true, false)` isometric | dynamic angle; upward drag inner branch |
| `(true, true)` rect | max-dimension centering |
| `(true, true)` isometric | 30° fixed angle + `calculate_isometric_x_position`; upward drag |

### `polygon_shape.rs`

- Existing draw tests cover the `dimensions.x > dimensions.y` and `dimensions.x <= dimensions.y` branches of `update_shape`.
- New tests for `decrease_or_increase_sides`: increase (n+1 path), decrease above minimum (n−1 path), and decrease at minimum-3 (`.max(3)` clamp path).

### `star_shape.rs`

- New test for the `dimensions.x > dimensions.y` branch of `update_shape` (wider-than-tall drag), which was not reached by any existing test.
- Existing tests cover simple draw, inner-radius invariant, correct outer-radius, and RMB-cancel.