### PR TITLE
Fix click target metadata not propagating through intermediate wrapper table rows

### DIFF
--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -730,11 +730,14 @@ impl Render for Table<Graphic> {
 
 	fn collect_metadata(&self, metadata: &mut RenderMetadata, footprint: Footprint, element_id: Option<NodeId>) {
 		for row in self.iter() {
-			if let Some(element_id) = row.source_node_id {
-				let mut footprint = footprint;
-				footprint.transform *= *row.transform;
+			let mut footprint = footprint;
+			footprint.transform *= *row.transform;
 
+			if let Some(element_id) = row.source_node_id {
 				row.element.collect_metadata(metadata, footprint, Some(*element_id));
+			} else {
+				// Recurse through anonymous wrapper rows to reach nested content with source_node_ids
+				row.element.collect_metadata(metadata, footprint, None);
 			}
 		}
 
@@ -1229,12 +1232,20 @@ impl Render for Table<Vector> {
 		}
 	}
 
-	fn collect_metadata(&self, metadata: &mut RenderMetadata, mut footprint: Footprint, element_id: Option<NodeId>) {
+	fn collect_metadata(&self, metadata: &mut RenderMetadata, footprint: Footprint, caller_element_id: Option<NodeId>) {
 		for row in self.iter() {
 			let transform = *row.transform;
 			let vector = row.element;
 
-			if let Some(element_id) = element_id {
+			if let Some(element_id) = caller_element_id.or(*row.source_node_id) {
+				// When recovering element_id from the row's source_node_id (because the caller
+				// passed None), also store the transform metadata that Graphic::collect_metadata
+				// normally provides but skipped due to the None element_id.
+				if caller_element_id.is_none() {
+					metadata.upstream_footprints.entry(element_id).or_insert(footprint);
+					metadata.local_transforms.entry(element_id).or_insert(transform);
+				}
+
 				let stroke_width = vector.style.stroke().as_ref().map_or(0., Stroke::effective_width);
 				let filled = vector.style.fill() != &Fill::None;
 				let fill = |mut subpath: Subpath<_>| {
@@ -1269,8 +1280,9 @@ impl Render for Table<Vector> {
 			}
 
 			if let Some(upstream_nested_layers) = &vector.upstream_data {
-				footprint.transform *= transform;
-				upstream_nested_layers.collect_metadata(metadata, footprint, None);
+				let mut upstream_footprint = footprint;
+				upstream_footprint.transform *= transform;
+				upstream_nested_layers.collect_metadata(metadata, upstream_footprint, None);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the Blend Shapes not being unable to select click targets for its group layer's children:

https://github.com/user-attachments/assets/c723c757-bb8f-48ea-9e9c-bea240fcf766

