### PR TITLE
Remove sample based image hashing to avoid false equalities

### DIFF
--- a/node-graph/libraries/raster-types/src/image.rs
+++ b/node-graph/libraries/raster-types/src/image.rs
@@ -109,8 +109,6 @@ impl<P: Copy + Pixel> BitmapMut for Image<P> {
 	}
 }
 
-// TODO: Evaluate if this will be a problem for our use case.
-/// Warning: This is an approximation of a hash, and is not guaranteed to not collide.
 impl<P: Hash + Pixel> Hash for Image<P> {
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.width.hash(state);


### PR DESCRIPTION
This was originally introduced to improve the performance of working with image data, but since the memo hash wrapper got introduced this should no longer be really necessary.

<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
