### PR TITLE
Add teardrop and heard shape to the predefined shapes 

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -1750,9 +1750,17 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 				let is_stroke_node = reference.as_ref().is_some_and(|r| *r == DefinitionIdentifier::ProtoNode(graphene_std::vector::stroke::IDENTIFIER));
 				let is_fill_node = reference.as_ref().is_some_and(|r| *r == DefinitionIdentifier::ProtoNode(graphene_std::vector::fill::IDENTIFIER));
 				let is_shape_generator_node = reference.as_ref().is_some_and(|r| {
-					[regular_polygon::IDENTIFIER, star::IDENTIFIER, arc::IDENTIFIER, spiral::IDENTIFIER, grid::IDENTIFIER, arrow::IDENTIFIER]
-						.into_iter()
-						.any(|id| *r == DefinitionIdentifier::ProtoNode(id))
+					[
+						regular_polygon::IDENTIFIER,
+						star::IDENTIFIER,
+						arc::IDENTIFIER,
+						spiral::IDENTIFIER,
+						grid::IDENTIFIER,
+						arrow::IDENTIFIER,
+						teardrop::IDENTIFIER,
+					]
+					.into_iter()
+					.any(|id| *r == DefinitionIdentifier::ProtoNode(id))
 				});
 
 				let input = NodeInput::value(value, false);

--- a/editor/src/messages/tool/common_functionality/gizmos/gizmo_manager.rs
+++ b/editor/src/messages/tool/common_functionality/gizmos/gizmo_manager.rs
@@ -12,6 +12,8 @@ use crate::messages::tool::common_functionality::shapes::polygon_shape::PolygonG
 use crate::messages::tool::common_functionality::shapes::shape_utility::ShapeGizmoHandler;
 use crate::messages::tool::common_functionality::shapes::spiral_shape::SpiralGizmoHandler;
 use crate::messages::tool::common_functionality::shapes::star_shape::StarGizmoHandler;
+use crate::messages::tool::common_functionality::shapes::teardrop_shape::TeardropGizmoHandler;
+
 use glam::DVec2;
 use std::collections::VecDeque;
 
@@ -32,6 +34,7 @@ pub enum ShapeGizmoHandlers {
 	Circle(CircleGizmoHandler),
 	Grid(GridGizmoHandler),
 	Spiral(SpiralGizmoHandler),
+	Teardrop(TeardropGizmoHandler),
 }
 
 impl ShapeGizmoHandlers {
@@ -45,6 +48,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(_) => "circle",
 			Self::Grid(_) => "grid",
 			Self::Spiral(_) => "spiral",
+			Self::Teardrop(_) => "teardrop",
 			Self::None => "none",
 		}
 	}
@@ -58,6 +62,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.handle_state(layer, mouse_position, document, responses),
 			Self::Grid(h) => h.handle_state(layer, mouse_position, document, responses),
 			Self::Spiral(h) => h.handle_state(layer, mouse_position, document, responses),
+			Self::Teardrop(h) => h.handle_state(layer, mouse_position, document, responses),
 			Self::None => {}
 		}
 	}
@@ -71,6 +76,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.is_any_gizmo_hovered(),
 			Self::Grid(h) => h.is_any_gizmo_hovered(),
 			Self::Spiral(h) => h.is_any_gizmo_hovered(),
+			Self::Teardrop(h) => h.is_any_gizmo_hovered(),
 			Self::None => false,
 		}
 	}
@@ -84,6 +90,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.handle_click(),
 			Self::Grid(h) => h.handle_click(),
 			Self::Spiral(h) => h.handle_click(),
+			Self::Teardrop(h) => h.handle_click(),
 			Self::None => {}
 		}
 	}
@@ -97,6 +104,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.handle_update(drag_start, document, input, responses),
 			Self::Grid(h) => h.handle_update(drag_start, document, input, responses),
 			Self::Spiral(h) => h.handle_update(drag_start, document, input, responses),
+			Self::Teardrop(h) => h.handle_update(drag_start, document, input, responses),
 			Self::None => {}
 		}
 	}
@@ -110,6 +118,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.cleanup(),
 			Self::Grid(h) => h.cleanup(),
 			Self::Spiral(h) => h.cleanup(),
+			Self::Teardrop(h) => h.cleanup(),
 			Self::None => {}
 		}
 	}
@@ -131,6 +140,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.overlays(document, layer, input, shape_editor, mouse_position, overlay_context),
 			Self::Grid(h) => h.overlays(document, layer, input, shape_editor, mouse_position, overlay_context),
 			Self::Spiral(h) => h.overlays(document, layer, input, shape_editor, mouse_position, overlay_context),
+			Self::Teardrop(h) => h.overlays(document, layer, input, shape_editor, mouse_position, overlay_context),
 			Self::None => {}
 		}
 	}
@@ -151,6 +161,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.dragging_overlays(document, input, shape_editor, mouse_position, overlay_context),
 			Self::Grid(h) => h.dragging_overlays(document, input, shape_editor, mouse_position, overlay_context),
 			Self::Spiral(h) => h.dragging_overlays(document, input, shape_editor, mouse_position, overlay_context),
+			Self::Teardrop(h) => h.dragging_overlays(document, input, shape_editor, mouse_position, overlay_context),
 			Self::None => {}
 		}
 	}
@@ -163,6 +174,7 @@ impl ShapeGizmoHandlers {
 			Self::Circle(h) => h.mouse_cursor_icon(),
 			Self::Grid(h) => h.mouse_cursor_icon(),
 			Self::Spiral(h) => h.mouse_cursor_icon(),
+			Self::Teardrop(h) => h.mouse_cursor_icon(),
 			Self::None => None,
 		}
 	}
@@ -213,6 +225,10 @@ impl GizmoManager {
 		// Spiral
 		if graph_modification_utils::get_spiral_id(layer, &document.network_interface).is_some() {
 			return Some(ShapeGizmoHandlers::Spiral(SpiralGizmoHandler::default()));
+		}
+		// Teardrop
+		if graph_modification_utils::get_teardrop_id(layer, &document.network_interface).is_some() {
+			return Some(ShapeGizmoHandlers::Teardrop(TeardropGizmoHandler::default()));
 		}
 
 		None

--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -423,6 +423,10 @@ pub fn get_spiral_id(layer: LayerNodeIdentifier, network_interface: &NodeNetwork
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::spiral::IDENTIFIER))
 }
 
+pub fn get_teardrop_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
+	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector::generator_nodes::teardrop::IDENTIFIER))
+}
+
 pub fn get_text_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::text::text::IDENTIFIER))
 }

--- a/editor/src/messages/tool/common_functionality/shapes/mod.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/mod.rs
@@ -9,9 +9,11 @@ pub mod rectangle_shape;
 pub mod shape_utility;
 pub mod spiral_shape;
 pub mod star_shape;
+pub mod teardrop_shape;
 
 pub use super::shapes::arrow_shape::Arrow;
 pub use super::shapes::ellipse_shape::Ellipse;
 pub use super::shapes::line_shape::{Line, LineEnd};
 pub use super::shapes::rectangle_shape::Rectangle;
+pub use super::shapes::teardrop_shape::Teardrop;
 pub use crate::messages::tool::tool_messages::shape_tool::ShapeToolData;

--- a/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
@@ -35,6 +35,7 @@ pub enum ShapeType {
 	Spiral,
 	Grid,
 	Arrow,
+	Teardrop,
 	Line,      // KEEP THIS AT THE END
 	Rectangle, // KEEP THIS AT THE END
 	Ellipse,   // KEEP THIS AT THE END
@@ -70,6 +71,7 @@ impl ShapeType {
 			Self::Spiral => "Spiral",
 			Self::Grid => "Grid",
 			Self::Arrow => "Arrow",
+			Self::Teardrop => "Teardrop",
 			Self::Line => "Line",           // KEEP THIS AT THE END
 			Self::Rectangle => "Rectangle", // KEEP THIS AT THE END
 			Self::Ellipse => "Ellipse",     // KEEP THIS AT THE END

--- a/editor/src/messages/tool/common_functionality/shapes/teardrop_shape.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/teardrop_shape.rs
@@ -1,0 +1,158 @@
+use super::shape_utility::{ShapeToolModifierKey, update_radius_sign};
+use super::*;
+use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
+use crate::messages::portfolio::document::node_graph::document_node_definitions::{DefinitionIdentifier, resolve_document_node_type};
+use crate::messages::portfolio::document::overlays::utility_types::OverlayContext;
+use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::portfolio::document::utility_types::network_interface::{InputConnector, NodeTemplate};
+use crate::messages::tool::common_functionality::gizmos::shape_gizmos::number_of_points_dial::{NumberOfPointsDial, NumberOfPointsDialState};
+use crate::messages::tool::common_functionality::gizmos::shape_gizmos::point_radius_handle::{PointRadiusHandle, PointRadiusHandleState};
+use crate::messages::tool::common_functionality::graph_modification_utils;
+use crate::messages::tool::common_functionality::shape_editor::ShapeState;
+use crate::messages::tool::common_functionality::shapes::shape_utility::ShapeGizmoHandler;
+use crate::messages::tool::tool_messages::tool_prelude::*;
+use glam::DAffine2;
+use graph_craft::document::NodeInput;
+use graph_craft::document::value::TaggedValue;
+use std::collections::VecDeque;
+
+#[derive(Clone, Debug, Default)]
+pub struct TeardropGizmoHandler {
+	number_of_points_dial: NumberOfPointsDial,
+	point_radius_handle: PointRadiusHandle,
+}
+
+impl ShapeGizmoHandler for TeardropGizmoHandler {
+	fn is_any_gizmo_hovered(&self) -> bool {
+		self.number_of_points_dial.is_hovering() || self.point_radius_handle.hovered()
+	}
+
+	fn handle_state(&mut self, selected_teardrop_layer: LayerNodeIdentifier, mouse_position: DVec2, document: &DocumentMessageHandler, responses: &mut VecDeque<Message>) {
+		self.number_of_points_dial.handle_actions(selected_teardrop_layer, mouse_position, document, responses);
+		self.point_radius_handle.handle_actions(selected_teardrop_layer, document, mouse_position, responses);
+	}
+
+	fn handle_click(&mut self) {
+		if self.number_of_points_dial.is_hovering() {
+			self.number_of_points_dial.update_state(NumberOfPointsDialState::Dragging);
+			return;
+		}
+
+		if self.point_radius_handle.hovered() {
+			self.point_radius_handle.update_state(PointRadiusHandleState::Dragging);
+		}
+	}
+
+	fn handle_update(&mut self, drag_start: DVec2, document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, responses: &mut VecDeque<Message>) {
+		if self.number_of_points_dial.is_dragging() {
+			self.number_of_points_dial.update_number_of_sides(document, input, responses, drag_start);
+		}
+
+		if self.point_radius_handle.is_dragging_or_snapped() {
+			self.point_radius_handle.update_inner_radius(document, input, responses, drag_start);
+		}
+	}
+
+	fn overlays(
+		&self,
+		document: &DocumentMessageHandler,
+		selected_teardrop_layer: Option<LayerNodeIdentifier>,
+		_input: &InputPreprocessorMessageHandler,
+		shape_editor: &mut &mut ShapeState,
+		mouse_position: DVec2,
+		overlay_context: &mut OverlayContext,
+	) {
+		self.number_of_points_dial.overlays(document, selected_teardrop_layer, shape_editor, mouse_position, overlay_context);
+		self.point_radius_handle.overlays(selected_teardrop_layer, document, overlay_context);
+	}
+
+	fn dragging_overlays(
+		&self,
+		document: &DocumentMessageHandler,
+		_input: &InputPreprocessorMessageHandler,
+		shape_editor: &mut &mut ShapeState,
+		mouse_position: DVec2,
+		overlay_context: &mut OverlayContext,
+	) {
+		if self.number_of_points_dial.is_dragging() {
+			self.number_of_points_dial.overlays(document, None, shape_editor, mouse_position, overlay_context);
+		}
+
+		if self.point_radius_handle.is_dragging_or_snapped() {
+			self.point_radius_handle.overlays(None, document, overlay_context);
+		}
+	}
+
+	fn cleanup(&mut self) {
+		self.number_of_points_dial.cleanup();
+		self.point_radius_handle.cleanup();
+	}
+
+	fn mouse_cursor_icon(&self) -> Option<MouseCursorIcon> {
+		if self.number_of_points_dial.is_dragging() || self.number_of_points_dial.is_hovering() {
+			return Some(MouseCursorIcon::EWResize);
+		}
+
+		if self.point_radius_handle.is_dragging_or_snapped() || self.point_radius_handle.hovered() {
+			return Some(MouseCursorIcon::Default);
+		}
+
+		None
+	}
+}
+
+#[derive(Default)]
+pub struct Teardrop;
+
+impl Teardrop {
+	pub fn create_node(_vertices: u32) -> NodeTemplate {
+		let identifier = DefinitionIdentifier::ProtoNode(graphene_std::vector::generator_nodes::teardrop::IDENTIFIER);
+		let node_type = resolve_document_node_type(&identifier).expect("Teardrop node can't be found");
+		node_type.node_template_input_override([None, Some(NodeInput::value(TaggedValue::F64(50.), false)), Some(NodeInput::value(TaggedValue::F64(50.), false))])
+	}
+
+	pub fn update_shape(
+		document: &DocumentMessageHandler,
+		ipp: &InputPreprocessorMessageHandler,
+		viewport: &ViewportMessageHandler,
+		layer: LayerNodeIdentifier,
+		shape_tool_data: &mut ShapeToolData,
+		modifier: ShapeToolModifierKey,
+		responses: &mut VecDeque<Message>,
+	) {
+		let [center, lock_ratio, _] = modifier;
+
+		if let Some([start, end]) = shape_tool_data.data.calculate_points(document, ipp, viewport, center, lock_ratio) {
+			update_radius_sign(end, start, layer, document, responses);
+
+			let dimensions = (start - end).abs();
+			let radius = dimensions.x / 2.0;
+			let spike_radius = (dimensions.y - radius).max(0.0);
+
+			let Some(node_id) = graph_modification_utils::get_teardrop_id(layer, &document.network_interface) else {
+				return;
+			};
+
+			responses.add(NodeGraphMessage::SetInput {
+				input_connector: InputConnector::node(node_id, 1),
+				input: NodeInput::value(TaggedValue::F64(radius), false),
+			});
+
+			responses.add(NodeGraphMessage::SetInput {
+				input_connector: InputConnector::node(node_id, 2),
+				input: NodeInput::value(TaggedValue::F64(spike_radius), false),
+			});
+
+			let top = start.y.min(end.y);
+			let center_x = (start.x + end.x) / 2.0;
+			let center_y = top + spike_radius;
+
+			responses.add(GraphOperationMessage::TransformSet {
+				layer,
+				transform: DAffine2::from_translation(DVec2::new(center_x, center_y)),
+				transform_in: TransformIn::Viewport,
+				skip_rerender: false,
+			});
+		}
+	}
+}

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -21,6 +21,7 @@ use crate::messages::tool::common_functionality::shapes::polygon_shape::Polygon;
 use crate::messages::tool::common_functionality::shapes::shape_utility::{ShapeToolModifierKey, ShapeType, anchor_overlays, clicked_on_shape_endpoints, transform_cage_overlays};
 use crate::messages::tool::common_functionality::shapes::spiral_shape::Spiral;
 use crate::messages::tool::common_functionality::shapes::star_shape::Star;
+use crate::messages::tool::common_functionality::shapes::teardrop_shape::Teardrop;
 use crate::messages::tool::common_functionality::shapes::{Ellipse, Line, Rectangle};
 use crate::messages::tool::common_functionality::snapping::{self, SnapCandidatePoint, SnapData, SnapTypeConfiguration};
 use crate::messages::tool::common_functionality::stroke_options::{StrokeOptionsUpdate, apply_stroke_option, create_stroke_options_popover_widget};
@@ -209,6 +210,12 @@ fn create_shape_option_widget(shape_type: ShapeType) -> WidgetInstance {
 		MenuListEntry::new("Arrow").label("Arrow").on_commit(move |_| {
 			ShapeToolMessage::UpdateOptions {
 				options: ShapeOptionsUpdate::ShapeType(ShapeType::Arrow),
+			}
+			.into()
+		}),
+		MenuListEntry::new("Teardrop").label("Teardrop").on_commit(move |_| {
+			ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::ShapeType(ShapeType::Teardrop),
 			}
 			.into()
 		}),
@@ -430,7 +437,8 @@ fn sync_shape_options_from_selection(options: &mut ShapeToolOptions, tool_data: 
 				changed = true;
 			}
 		}
-		ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle => {}
+
+		ShapeType::Teardrop | ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle => {}
 	}
 
 	changed
@@ -1116,7 +1124,15 @@ impl Fsm for ShapeToolFsmState {
 				};
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::Teardrop => {
 						tool_data.data.start(document, input, viewport);
 					}
 					ShapeType::Arrow | ShapeType::Line => {
@@ -1139,6 +1155,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::create_node(tool_options.spiral_type, tool_options.turns),
 					ShapeType::Grid => Grid::create_node(tool_options.grid_type),
 					ShapeType::Arrow => Arrow::create_node(tool_options.arrow_shaft_width, tool_options.arrow_head_width, tool_options.arrow_head_length),
+					ShapeType::Teardrop => Teardrop::create_node(tool_options.vertices), // FIXME
 					ShapeType::Line => Line::create_node(),
 					ShapeType::Rectangle => Rectangle::create_node(),
 					ShapeType::Ellipse => Ellipse::create_node(),
@@ -1150,7 +1167,15 @@ impl Fsm for ShapeToolFsmState {
 				let defered_responses = &mut VecDeque::new();
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::Teardrop => {
 						defered_responses.add(GraphOperationMessage::TransformSet {
 							layer,
 							transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
@@ -1212,6 +1237,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::update_shape(document, input, viewport, layer, tool_data, responses),
 					ShapeType::Grid => Grid::update_shape(document, input, layer, tool_options.grid_type, tool_data, modifier, responses),
 					ShapeType::Arrow => Arrow::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
+					ShapeType::Teardrop => Teardrop::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Line => Line::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Rectangle => Rectangle::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Ellipse => Ellipse::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
@@ -1464,6 +1490,11 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
 					HintInfo::keys([Key::Control], "Lock Angle").prepend_plus(),
 				])],
+				ShapeType::Teardrop => vec![HintGroup(vec![
+					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Teardrop"),
+					HintInfo::keys([Key::Shift], "Constrain Regular").prepend_plus(),
+					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
+				])],
 				ShapeType::Line => vec![HintGroup(vec![
 					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Line"),
 					HintInfo::keys([Key::Shift], "15° Increments").prepend_plus(),
@@ -1495,6 +1526,7 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 					HintInfo::keys([Key::Alt], "From Center"),
 					HintInfo::keys([Key::Control], "Lock Angle"),
 				]),
+				ShapeType::Teardrop => HintGroup(vec![HintInfo::keys([Key::Shift], "Constrain Regular"), HintInfo::keys([Key::Alt], "From Center")]),
 				ShapeType::Line => HintGroup(vec![
 					HintInfo::keys([Key::Shift], "15° Increments"),
 					HintInfo::keys([Key::Alt], "From Center"),

--- a/node-graph/libraries/vector-types/src/subpath/consts.rs
+++ b/node-graph/libraries/vector-types/src/subpath/consts.rs
@@ -2,3 +2,6 @@
 
 /// Constant used to determine if `f64`s are equivalent.
 pub const MAX_ABSOLUTE_DIFFERENCE: f64 = 1e-3;
+
+// Constant to approximate a quarter circle with a cubic Bézier curve, from https://pomax.github.io/bezierinfo/#circles_cubic
+pub const HANDLE_OFFSET_FACTOR: f64 = 0.551784777779014;

--- a/node-graph/libraries/vector-types/src/subpath/core.rs
+++ b/node-graph/libraries/vector-types/src/subpath/core.rs
@@ -341,6 +341,27 @@ impl<PointId: Identifier> Subpath<PointId> {
 		Self::from_anchors(anchors, true)
 	}
 
+	pub fn new_teardrop(center: DVec2, radius: f64, spike_radius: f64) -> Self {
+		let radius = radius.abs();
+		let spike_radius = spike_radius.max(0.0);
+
+		let tip = center + DVec2::new(0.0, -spike_radius);
+		let left = center + DVec2::new(-radius, 0.0);
+		let right = center + DVec2::new(radius, 0.0);
+		let bottom = center + DVec2::new(0.0, radius);
+
+		let handle_offset = radius * HANDLE_OFFSET_FACTOR;
+
+		let manipulator_groups = vec![
+			ManipulatorGroup::new(tip, None, None),
+			ManipulatorGroup::new(right, Some(right - handle_offset * DVec2::Y), Some(right + handle_offset * DVec2::Y)),
+			ManipulatorGroup::new(bottom, Some(bottom + handle_offset * DVec2::X), Some(bottom - handle_offset * DVec2::X)),
+			ManipulatorGroup::new(left, Some(left + handle_offset * DVec2::Y), Some(left - handle_offset * DVec2::Y)),
+		];
+
+		Subpath::new(manipulator_groups, true)
+	}
+
 	pub fn new_spiral(a: f64, outer_radius: f64, turns: f64, start_angle: f64, delta_theta: f64, spiral_type: SpiralType) -> Self {
 		let mut manipulator_groups = Vec::new();
 		let mut prev_in_handle = None;

--- a/node-graph/libraries/vector-types/src/subpath/core.rs
+++ b/node-graph/libraries/vector-types/src/subpath/core.rs
@@ -180,8 +180,6 @@ impl<PointId: Identifier> Subpath<PointId> {
 				return vec![ManipulatorGroup::new_anchor(point1), ManipulatorGroup::new_anchor(point2)];
 			}
 
-			// Constant from https://pomax.github.io/bezierinfo/#circles_cubic
-			const HANDLE_OFFSET_FACTOR: f64 = 0.551784777779014;
 			let handle_offset = radius * HANDLE_OFFSET_FACTOR;
 			vec![
 				ManipulatorGroup::new(point1, None, Some(point1 + handle_offset * (corner - point1).normalize())),
@@ -209,8 +207,6 @@ impl<PointId: Identifier> Subpath<PointId> {
 		let left = DVec2::new(corner1.x, center.y);
 		let right = DVec2::new(corner2.x, center.y);
 
-		// Based on https://pomax.github.io/bezierinfo/#circles_cubic
-		const HANDLE_OFFSET_FACTOR: f64 = 0.551784777779014;
 		let handle_offset = size * HANDLE_OFFSET_FACTOR * 0.5;
 
 		let manipulator_groups = vec![

--- a/node-graph/nodes/vector/src/generator_nodes.rs
+++ b/node-graph/nodes/vector/src/generator_nodes.rs
@@ -201,6 +201,20 @@ fn star<T: AsU64>(
 
 	List::new_from_element(Vector::from_subpath(subpath::Subpath::new_star_polygon(DVec2::splat(-diameter), points, diameter, inner_diameter)))
 }
+/// Generates a teardrop shape with a round body and a pointed tail
+#[node_macro::node(category("Vector: Shape"))]
+fn teardrop(
+	_: impl Ctx,
+	_primary: (),
+	#[unit(" px")]
+	#[default(50.)]
+	radius: f64,
+	#[unit(" px")]
+	#[default(100.)]
+	spike_radius: f64,
+) -> List<Vector> {
+	List::new_from_element(Vector::from_subpath(subpath::Subpath::new_teardrop(DVec2::ZERO, radius, spike_radius)))
+}
 
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, CacheHash, DynAny, node_macro::ChoiceType)]


### PR DESCRIPTION
Closes #3419

https://github.com/user-attachments/assets/950cb0f8-6b36-4299-8735-45702fb40ea7

- This PR adds teardrop and heart shapes to the shape tool options. It fully integrates both shapes and implements them in core.rs.

- Additionally, the HANDLE_OFFSET_FACTOR constant is extracted and properly documented.