### PR TITLE
Add G/S shortcut handling to Artboard tool

### DIFF
--- a/editor/src/messages/input_mapper/input_mappings.rs
+++ b/editor/src/messages/input_mapper/input_mappings.rs
@@ -148,6 +148,8 @@ pub fn input_mappings(zoom_with_scroll: bool) -> Mapping {
 		entry!(KeyDown(ArrowRight); action_dispatch=ArtboardToolMessage::NudgeSelected { delta_x: NUDGE_AMOUNT, delta_y: 0., resize: Alt, resize_opposite: Control }),
 		entry!(KeyDown(MouseRight); action_dispatch=ArtboardToolMessage::Abort),
 		entry!(KeyDown(Escape); action_dispatch=ArtboardToolMessage::Abort),
+		entry!(KeyDown(KeyG); action_dispatch=ArtboardToolMessage::GS { grab: KeyG, scale: KeyS }),
+		entry!(KeyDown(KeyS); action_dispatch=ArtboardToolMessage::GS { grab: KeyG, scale: KeyS }),
 		//
 		// NavigateToolMessage
 		entry!(KeyDown(MouseLeft); action_dispatch=NavigateToolMessage::ZoomCanvasBegin),

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -35,6 +35,7 @@ pub enum ArtboardToolMessage {
 	PointerMove { constrain_axis_or_aspect: Key, center: Key },
 	PointerOutsideViewport { constrain_axis_or_aspect: Key, center: Key },
 	PointerUp,
+	GS { grab: Key, scale: Key },
 }
 
 impl ToolMetadata for ArtboardTool {
@@ -63,7 +64,7 @@ impl<'a> MessageHandler<ToolMessage, &mut ToolActionMessageContext<'a>> for Artb
 		);
 
 		let additional = match self.fsm_state {
-			ArtboardToolFsmState::Ready { .. } => actions!(ArtboardToolMessageDiscriminant; PointerDown),
+			ArtboardToolFsmState::Ready { .. } => actions!(ArtboardToolMessageDiscriminant; PointerDown, GS),
 			_ => actions!(ArtboardToolMessageDiscriminant; PointerUp, Abort),
 		};
 		common.extend(additional);
@@ -291,6 +292,26 @@ impl Fsm for ArtboardToolFsmState {
 				tool_data.draw.snap_manager.draw_overlays(SnapData::new(document, input, viewport), &mut overlay_context);
 
 				self
+			}
+			(ArtboardToolFsmState::Ready { .. }, ArtboardToolMessage::GS { grab, scale }) => {
+				let to_viewport = document.metadata().document_to_viewport;
+				let to_document = to_viewport.inverse();
+				tool_data.drag_start = to_document.transform_point2(input.mouse.position);
+				tool_data.drag_current = to_document.transform_point2(input.mouse.position);
+
+				if input.keyboard.key(grab) && tool_data.selected_artboard.is_some() {
+					tool_data.get_snap_candidates(document, input);
+
+					responses.add(DocumentMessage::StartTransaction);
+
+					ArtboardToolFsmState::Dragging
+				} else if input.keyboard.key(scale) && tool_data.selected_artboard.is_some() {
+					//tool_data.start_resizing(selected_edges, document, input);
+					tool_data.get_snap_candidates(document, input);
+					ArtboardToolFsmState::ResizingBounds
+				} else {
+					ArtboardToolFsmState::Ready { hovered }
+				}
 			}
 			(ArtboardToolFsmState::Ready { .. }, ArtboardToolMessage::PointerDown) => {
 				let to_viewport = document.metadata().document_to_viewport;
@@ -540,6 +561,7 @@ impl Fsm for ArtboardToolFsmState {
 			ArtboardToolFsmState::Ready { .. } => HintData(vec![
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Draw Artboard")]),
 				HintGroup(vec![HintInfo::mouse(MouseMotion::LmbDrag, "Move Artboard")]),
+				HintGroup(vec![HintInfo::multi_keys([[Key::KeyG], [Key::KeyS]], "Grab/Scale Selected")]),
 				HintGroup(vec![HintInfo::keys([Key::Backspace], "Delete Artboard")]),
 			]),
 			ArtboardToolFsmState::Dragging => HintData(vec![

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -145,6 +145,16 @@ impl ArtboardToolData {
 		}
 	}
 
+	fn start_resizing_force_select_edges(&mut self, _selected_edges: (bool, bool, bool, bool), _document: &DocumentMessageHandler, _input: &InputPreprocessorMessageHandler) {
+		if let Some(bounds) = &mut self.bounding_box_manager {
+			let (top, bottom, left, right) = _selected_edges;
+			let selected_edges = SelectedEdges::new(top, bottom, left, right, bounds.bounds);
+			bounds.selected_edges = Some(selected_edges);
+		}
+
+		self.start_resizing(_selected_edges, _document, _input);
+	}
+
 	fn hovered_artboard(document: &DocumentMessageHandler, input: &InputPreprocessorMessageHandler, viewport: &ViewportMessageHandler) -> Option<LayerNodeIdentifier> {
 		document.click_xray(input, viewport).find(|&layer| document.network_interface.is_artboard(&layer.to_node(), &[]))
 	}
@@ -306,7 +316,8 @@ impl Fsm for ArtboardToolFsmState {
 
 					ArtboardToolFsmState::Dragging
 				} else if input.keyboard.key(scale) && tool_data.selected_artboard.is_some() {
-					//tool_data.start_resizing(selected_edges, document, input);
+					let bottom_left_selected_edges = (false, true, false, true);
+					tool_data.start_resizing_force_select_edges(bottom_left_selected_edges, document, input);
 					tool_data.get_snap_candidates(document, input);
 					ArtboardToolFsmState::ResizingBounds
 				} else {


### PR DESCRIPTION
Adds support G/S (grab and scale) keyboard shortcut handling to the Artboard tool.

Closes https://github.com/GraphiteEditor/Graphite/issues/4026