### PR TITLE
fix: prevent text editor flash at origin

### DIFF
--- a/frontend/src/components/panels/Document.svelte
+++ b/frontend/src/components/panels/Document.svelte
@@ -32,7 +32,7 @@
 	// Interactive text editing
 	let textInput: undefined | HTMLDivElement = undefined;
 	let showTextInput: boolean;
-	let textInputMatrix: [number, number, number, number, number, number];
+	let textInputMatrix: [number, number, number, number, number, number] = [1, 0, 0, 1, 0, 0];
 
 	// Scrollbars
 	let scrollbarPos = { x: 0.5, y: 0.5 };
@@ -345,6 +345,7 @@
 	}
 
 	export async function displayEditableTextbox(data: MessageBody<"DisplayEditableTextbox">) {
+		textInputMatrix = data.transform;
 		showTextInput = true;
 
 		await tick();
@@ -373,8 +374,6 @@
 			if (!textInput) return;
 			editor.updateBounds(textInputCleanup(textInput.innerText));
 		};
-
-		textInputMatrix = data.transform;
 
 		if (data.fontData.length > 0 && data.fontData.buffer instanceof ArrayBuffer) {
 			const fontView = new Uint8Array(data.fontData.buffer, data.fontData.byteOffset, data.fontData.byteLength);


### PR DESCRIPTION
## Summary
- Initialize the editable text input transform matrix with an identity fallback.
- Apply the backend-provided transform before rendering the contenteditable text input.
- Prevents a newly created text input from briefly appearing at viewport origin before moving to the cursor location.

Fixes #4028

## Test Plan
- `python3` targeted regression check confirming `textInputMatrix = data.transform` occurs before `showTextInput = true`
- `npx eslint src/components/panels/Document.svelte`

Note: `npm run check -- --quiet` was attempted after `npm ci`, but it requires generated `/wrapper/pkg/graphite_wasm_wrapper` bindings. This environment has no `cargo`, `rustc`, or `wasm-pack`, so the wrapper package could not be generated locally.
