### PR TITLE
Replace Table<Table<Graphic>> with Table<Artboard> where Artboard is a type boundary newtype

### DIFF
--- a/editor/src/messages/portfolio/document/data_panel/data_panel_message_handler.rs
+++ b/editor/src/messages/portfolio/document/data_panel/data_panel_message_handler.rs
@@ -6,9 +6,6 @@ use crate::messages::prelude::*;
 use crate::messages::tool::tool_messages::tool_prelude::*;
 use glam::{Affine2, DAffine2, Vec2};
 use graph_craft::document::NodeId;
-use graphene_std::Color;
-use graphene_std::Context;
-use graphene_std::Graphic;
 use graphene_std::blending::BlendMode;
 use graphene_std::gradient::GradientStops;
 use graphene_std::memo::IORecord;
@@ -16,6 +13,7 @@ use graphene_std::raster_types::{CPU, GPU, Raster};
 use graphene_std::table::Table;
 use graphene_std::vector::Vector;
 use graphene_std::vector::style::{Fill, FillChoice};
+use graphene_std::{Artboard, Color, Context, Graphic};
 use std::any::Any;
 use std::sync::Arc;
 
@@ -183,7 +181,7 @@ fn generate_layout(introspected_data: &Arc<dyn std::any::Any + Send + Sync + 'st
 		return Some(table_node_id_path_layout_with_breadcrumb(&io.output, data));
 	}
 	generate_layout_downcast!(introspected_data, data, [
-		Table<Table<Graphic>>,
+		Table<Artboard>,
 		Table<Graphic>,
 		Table<Vector>,
 		Table<Raster<CPU>>,
@@ -298,6 +296,22 @@ impl<T: TableRowLayout> TableRowLayout for Table<T> {
 		rows.insert(0, column_headings(&column_names));
 
 		vec![LayoutGroup::table(rows, false)]
+	}
+}
+
+impl TableRowLayout for Artboard {
+	fn type_name() -> &'static str {
+		"Artboard"
+	}
+	fn identifier(&self) -> String {
+		self.as_graphic_table().identifier()
+	}
+	// Don't put a breadcrumb for Artboard
+	fn layout_with_breadcrumb(&self, data: &mut LayoutData) -> Vec<LayoutGroup> {
+		self.value_page(data)
+	}
+	fn value_page(&self, data: &mut LayoutData) -> Vec<LayoutGroup> {
+		self.as_graphic_table().layout_with_breadcrumb(data)
 	}
 }
 
@@ -871,7 +885,7 @@ impl TableRowLayout for NodeId {
 macro_rules! known_table_row_types {
 	($apply:ident) => {
 		$apply!(
-			Table<Table<Graphic>>,
+			Table<Artboard>,
 			Table<Graphic>,
 			Table<Vector>,
 			Table<Raster<CPU>>,
@@ -900,6 +914,7 @@ macro_rules! known_table_row_types {
 			Raster<CPU>,
 			Raster<GPU>,
 			Graphic,
+			Artboard,
 		);
 	};
 }

--- a/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
+++ b/editor/src/messages/portfolio/document/node_graph/document_node_definitions.rs
@@ -394,7 +394,7 @@ fn document_node_definitions() -> HashMap<DefinitionIdentifier, DocumentNodeDefi
 							},
 							DocumentNode {
 								inputs: vec![
-									NodeInput::import(graphene_std::Type::Fn(Box::new(concrete!(Context)), Box::new(concrete!(Table<Table<Graphic>>))), 0),
+									NodeInput::import(graphene_std::Type::Fn(Box::new(concrete!(Context)), Box::new(concrete!(Table<Artboard>))), 0),
 									NodeInput::node(NodeId(3), 0),
 								],
 								implementation: DocumentNodeImplementation::ProtoNode(graphic::extend::IDENTIFIER),

--- a/editor/src/messages/tool/tool_messages/artboard_tool.rs
+++ b/editor/src/messages/tool/tool_messages/artboard_tool.rs
@@ -611,18 +611,15 @@ impl Fsm for ArtboardToolFsmState {
 #[cfg(test)]
 mod test_artboard {
 	pub use crate::test_utils::test_prelude::*;
-	use graphene_std::Graphic;
+	use graphene_std::Artboard;
 	use graphene_std::table::Table;
 
-	async fn get_artboards(editor: &mut EditorTestUtils) -> Table<Table<Graphic>> {
+	async fn get_artboards(editor: &mut EditorTestUtils) -> Table<Artboard> {
 		let instrumented = match editor.eval_graph().await {
 			Ok(instrumented) => instrumented,
 			Err(e) => panic!("Failed to evaluate graph: {e}"),
 		};
-		instrumented
-			.grab_all_input::<graphene_std::graphic::extend::NewInput<Table<graphene_std::Graphic>>>(&editor.runtime)
-			.flatten()
-			.collect()
+		instrumented.grab_all_input::<graphene_std::graphic::extend::NewInput<Artboard>>(&editor.runtime).flatten().collect()
 	}
 
 	#[derive(Debug, PartialEq)]

--- a/editor/src/node_graph_executor/runtime.rs
+++ b/editor/src/node_graph_executor/runtime.rs
@@ -20,7 +20,7 @@ use graphene_std::text::FontCache;
 use graphene_std::transform::RenderQuality;
 use graphene_std::vector::Vector;
 use graphene_std::vector::style::RenderMode;
-use graphene_std::{Context, Graphic};
+use graphene_std::{Artboard, Context, Graphic};
 use interpreted_executor::dynamic_executor::{DynamicExecutor, IntrospectError, ResolvedDocumentNodeTypesDelta};
 use interpreted_executor::util::wrap_network_in_scope;
 use spin::Mutex;
@@ -441,7 +441,7 @@ impl NodeRuntime {
 			}
 			// Artboard thumbnail bounds come from the clipping rectangles, not the content union, since the renderer
 			// clips content to those rectangles so anything outside isn't visible
-			else if let Some(io) = introspected_data.downcast_ref::<IORecord<Context, Table<Table<Graphic>>>>() {
+			else if let Some(io) = introspected_data.downcast_ref::<IORecord<Context, Table<Artboard>>>() {
 				if update_thumbnails {
 					let bounds = artboard_clip_bounds(&io.output);
 					Self::render_thumbnail(&mut self.thumbnail_renders, parent_network_node_id, &io.output, bounds, responses)
@@ -522,7 +522,7 @@ impl NodeRuntime {
 
 /// Returns the union of the artboards' clipping rectangles, used as the thumbnail bounds for an artboard layer so the
 /// framing matches what's actually visible after clipping rather than the unclipped content extents.
-fn artboard_clip_bounds(artboards: &Table<Table<Graphic>>) -> RenderBoundingBox {
+fn artboard_clip_bounds(artboards: &Table<Artboard>) -> RenderBoundingBox {
 	let mut combined: Option<[DVec2; 2]> = None;
 	for index in 0..artboards.len() {
 		let location: DVec2 = artboards.attribute_cloned_or_default(graphene_std::ATTR_LOCATION, index);

--- a/node-graph/graph-craft/src/document/value.rs
+++ b/node-graph/graph-craft/src/document/value.rs
@@ -14,7 +14,7 @@ pub use glam::{DAffine2, DVec2, IVec2, UVec2};
 use graphic_types::raster_types::{CPU, Image, Raster};
 use graphic_types::vector_types::vector::style::{Fill, Gradient, GradientStops, Stroke};
 use graphic_types::vector_types::vector::{self, ReferencePoint};
-use graphic_types::{Graphic, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use raster_nodes::curve::Curve;
 use rendering::RenderMetadata;
 use std::fmt::Display;
@@ -184,7 +184,7 @@ tagged_value! {
 	Graphic(Table<Graphic>),
 	#[serde(deserialize_with = "graphic_types::artboard::migrate_artboard")] // TODO: Eventually remove this migration document upgrade code
 	#[serde(alias = "ArtboardGroup")]
-	Artboard(Table<Table<Graphic>>),
+	Artboard(Table<Artboard>),
 	#[serde(deserialize_with = "core_types::misc::migrate_color")] // TODO: Eventually remove this migration document upgrade code
 	#[serde(alias = "ColorTable", alias = "OptionalColor", alias = "ColorNotInTable")]
 	Color(Table<Color>),

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -21,7 +21,7 @@ use graphene_std::table::Table;
 use graphene_std::transform::Footprint;
 use graphene_std::uuid::NodeId;
 use graphene_std::vector::Vector;
-use graphene_std::{Context, Graphic, NodeIO, NodeIOTypes, ProtoNodeIdentifier, concrete, fn_type_fut, future};
+use graphene_std::{Artboard, Context, Graphic, NodeIO, NodeIOTypes, ProtoNodeIdentifier, concrete, fn_type_fut, future};
 use node_registry_macros::{async_node, convert_node, into_node};
 use std::collections::HashMap;
 #[cfg(feature = "gpu")]
@@ -63,7 +63,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		// MONITOR NODES
 		// =============
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => ()]),
-		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => Table<Table<Graphic>>]),
+		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => Table<Artboard>]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => Table<Graphic>]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => Table<Vector>]),
 		async_node!(graphene_core::memo::MonitorNode<_, _, _>, input: Context, fn_params: [Context => Table<Raster<CPU>>]),
@@ -145,7 +145,7 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		// ==========
 		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => ()]),
 		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => bool]),
-		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => Table<Table<Graphic>>]),
+		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => Table<Artboard>]),
 		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => Table<Graphic>]),
 		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => Table<Vector>]),
 		async_node!(graphene_core::memo::MemoNode<_, _>, input: Context, fn_params: [Context => Table<Raster<CPU>>]),

--- a/node-graph/libraries/graphic-types/src/artboard.rs
+++ b/node-graph/libraries/graphic-types/src/artboard.rs
@@ -1,25 +1,71 @@
 use crate::graphic::Graphic;
 use core_types::blending::BlendMode;
+use core_types::bounds::{BoundingBox, RenderBoundingBox};
+use core_types::graphene_hash::CacheHash;
+use core_types::render_complexity::RenderComplexity;
 use core_types::table::{Table, TableRow};
 use core_types::uuid::NodeId;
 use core_types::{ATTR_BACKGROUND, ATTR_CLIP, ATTR_DIMENSIONS, ATTR_LOCATION, Color};
 use dyn_any::DynAny;
 use glam::{DAffine2, IVec2};
 
-// An artboard table is `Table<Table<Graphic>>`: each row's element is the artboard's content
-// (a `Table<Graphic>`), with the artboard's metadata stored alongside on the row as attributes
-// (see `ATTR_LOCATION`, `ATTR_DIMENSIONS`, `ATTR_BACKGROUND`, `ATTR_CLIP`).
-//
-// The artboard's user-visible name is the parent layer's display name (resolved live from the
-// network interface via the row's `ATTR_EDITOR_LAYER_PATH` attribute) — not stored here, so it
-// can never go stale.
-//
-// These metadata attributes are populated at runtime by the `Artboard` proto node from its
-// inputs and therefore aren't persisted in document files; the proto node's input values are
-// what get serialized.
+/// Nominal wrapper around `Table<Graphic>` representing a single artboard's content.
+///
+/// Per-artboard metadata (location, dimensions, background, clip) lives as row attributes on the
+/// enclosing `Table<Artboard>`, not as fields here. This keeps `Artboard` a pure type-system boundary
+/// that prevents arbitrary `Table<Table<...<Graphic>>>` nesting.
+#[derive(Clone, Debug, Default, CacheHash, PartialEq, DynAny)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Artboard(Table<Graphic>);
+
+impl Artboard {
+	pub fn new(content: Table<Graphic>) -> Self {
+		Self(content)
+	}
+
+	pub fn as_graphic_table(&self) -> &Table<Graphic> {
+		&self.0
+	}
+
+	pub fn as_graphic_table_mut(&mut self) -> &mut Table<Graphic> {
+		&mut self.0
+	}
+
+	pub fn into_graphic_table(self) -> Table<Graphic> {
+		self.0
+	}
+}
+
+impl From<Table<Graphic>> for Artboard {
+	fn from(content: Table<Graphic>) -> Self {
+		Self(content)
+	}
+}
+
+impl From<Artboard> for Table<Graphic> {
+	fn from(artboard: Artboard) -> Self {
+		artboard.0
+	}
+}
+
+impl BoundingBox for Artboard {
+	fn bounding_box(&self, transform: DAffine2, include_stroke: bool) -> RenderBoundingBox {
+		self.0.bounding_box(transform, include_stroke)
+	}
+
+	fn thumbnail_bounding_box(&self, transform: DAffine2, include_stroke: bool) -> RenderBoundingBox {
+		self.0.thumbnail_bounding_box(transform, include_stroke)
+	}
+}
+
+impl RenderComplexity for Artboard {
+	fn render_complexity(&self) -> usize {
+		self.0.render_complexity()
+	}
+}
 
 // TODO: Eventually remove this migration document upgrade code
-pub fn migrate_artboard<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Table<Table<Graphic>>, D::Error> {
+pub fn migrate_artboard<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<Table<Artboard>, D::Error> {
 	use serde::Deserialize;
 
 	/// Mirrors the removed `AlphaBlending` struct for legacy document deserialization.
@@ -33,9 +79,7 @@ pub fn migrate_artboard<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Re
 		pub clip: bool,
 	}
 
-	/// Pre-migration shape of the artboard's stored data: the struct that used to live as the element
-	/// of `Table<Artboard>`. Kept as a private type so we can deserialize legacy documents into the new
-	/// `Table<Table<Graphic>>` (element = `content`, other fields → row attributes).
+	/// Legacy artboard struct shape, kept for deserializing old documents into `Table<Artboard>`.
 	#[derive(Clone, Debug, DynAny)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 	pub struct LegacyArtboard {
@@ -68,14 +112,14 @@ pub fn migrate_artboard<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Re
 		ArtboardGroup(LegacyArtboardGroup),
 		OldArtboardTable(OldTable<LegacyArtboard>),
 		LegacyArtboardTable(Table<LegacyArtboard>),
-		// Note: this variant must come last so older formats above are tried first; an empty
-		// `Table<Table<Graphic>>` would otherwise match (since `Table<T>` has the same shell across `T`).
-		ArtboardTable(Table<Table<Graphic>>),
+		// NOTE: Must come last so older tagged formats above are tried first.
+		// Also covers the intermediate `Table<Table<Graphic>>` shape since `Artboard` deserializes transparently.
+		ArtboardTable(Table<Artboard>),
 	}
 
-	fn legacy_to_row(legacy: LegacyArtboard) -> TableRow<Table<Graphic>> {
-		// Legacy `label` field is dropped — the artboard's name now comes from its parent layer's display name.
-		TableRow::new_from_element(legacy.content)
+	fn legacy_to_row(legacy: LegacyArtboard) -> TableRow<Artboard> {
+		// Legacy `label` field is dropped (the artboard's name comes from its parent layer's display name)
+		TableRow::new_from_element(Artboard::new(legacy.content))
 			.with_attribute(ATTR_LOCATION, legacy.location.as_dvec2())
 			.with_attribute(ATTR_DIMENSIONS, legacy.dimensions.as_dvec2())
 			.with_attribute(ATTR_BACKGROUND, legacy.background)

--- a/node-graph/libraries/graphic-types/src/lib.rs
+++ b/node-graph/libraries/graphic-types/src/lib.rs
@@ -7,6 +7,7 @@ pub use raster_types;
 pub use vector_types;
 
 // Re-export commonly used types at the crate root
+pub use artboard::Artboard;
 pub use graphic::{Graphic, IntoGraphicTable, TryFromGraphic, Vector};
 
 pub mod migrations {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -17,13 +17,12 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::Graphic;
-use graphic_types::Vector;
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
 use graphic_types::vector_types::vector::click_target::{ClickTarget, FreePoint};
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, Stroke, StrokeAlign};
+use graphic_types::{Artboard, Graphic, Vector};
 use kurbo::{Affine, Cap, Join, Shape};
 use num_traits::Zero;
 use std::collections::{HashMap, HashSet};
@@ -514,8 +513,8 @@ impl Render for Graphic {
 	}
 }
 
-/// Reads the artboard metadata for the row at `index` from a `Table<Table<Graphic>>` of artboards.
-fn read_artboard_attributes(table: &Table<Table<Graphic>>, index: usize) -> (DVec2, DVec2, Color, bool) {
+/// Reads the artboard metadata for the row at `index` from a `Table<Artboard>`.
+fn read_artboard_attributes(table: &Table<Artboard>, index: usize) -> (DVec2, DVec2, Color, bool) {
 	let location: DVec2 = table.attribute_cloned_or_default(ATTR_LOCATION, index);
 	let dimensions: DVec2 = table.attribute_cloned_or_default(ATTR_DIMENSIONS, index);
 	let background: Color = table.attribute_cloned_or_default(ATTR_BACKGROUND, index);
@@ -523,10 +522,10 @@ fn read_artboard_attributes(table: &Table<Table<Graphic>>, index: usize) -> (DVe
 	(location, dimensions, background, clip)
 }
 
-impl Render for Table<Table<Graphic>> {
+impl Render for Table<Artboard> {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams) {
 		for index in 0..self.len() {
-			let Some(content) = self.element(index) else { continue };
+			let Some(content) = self.element(index).map(Artboard::as_graphic_table) else { continue };
 			let (location, dimensions, background, clip) = read_artboard_attributes(self, index);
 
 			let x = location.x.min(location.x + dimensions.x);
@@ -584,7 +583,7 @@ impl Render for Table<Table<Graphic>> {
 		use vello::peniko;
 
 		for index in 0..self.len() {
-			let Some(content) = self.element(index) else { continue };
+			let Some(content) = self.element(index).map(Artboard::as_graphic_table) else { continue };
 			let (location, dimensions, background, clip) = read_artboard_attributes(self, index);
 
 			let [a, b] = [location, location + dimensions];
@@ -614,7 +613,7 @@ impl Render for Table<Table<Graphic>> {
 
 	fn collect_metadata(&self, metadata: &mut RenderMetadata, footprint: Footprint, _element_id: Option<NodeId>) {
 		for index in 0..self.len() {
-			let Some(content) = self.element(index) else { continue };
+			let Some(content) = self.element(index).map(Artboard::as_graphic_table) else { continue };
 			let (location, dimensions, _background, clip) = read_artboard_attributes(self, index);
 
 			let layer_path: Table<NodeId> = self.attribute_cloned_or_default(ATTR_EDITOR_LAYER_PATH, index);

--- a/node-graph/nodes/gcore/src/animation.rs
+++ b/node-graph/nodes/gcore/src/animation.rs
@@ -3,7 +3,7 @@ use core_types::transform::Footprint;
 use core_types::{CacheHash, CloneVarArgs, Color, Context, Ctx, ExtractAll, ExtractAnimationTime, ExtractPointerPosition, ExtractRealTime, OwnedContextImpl};
 use glam::{DAffine2, DVec2};
 use graphic_types::vector_types::GradientStops;
-use graphic_types::{Graphic, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use raster_types::{CPU, GPU, Raster};
 
 const DAY: f64 = 1000. * 3600. * 24.;
@@ -78,7 +78,7 @@ async fn quantize_real_time<T>(
 		Context -> Table<Raster<CPU>>,
 		Context -> Table<Raster<GPU>>,
 		Context -> Table<Color>,
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<GradientStops>,
 		Context -> Table<String>,
 		Context -> Table<f64>,
@@ -118,7 +118,7 @@ async fn quantize_animation_time<T>(
 		Context -> Table<Raster<CPU>>,
 		Context -> Table<Raster<GPU>>,
 		Context -> Table<Color>,
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<GradientStops>,
 		Context -> Table<String>,
 		Context -> Table<f64>,

--- a/node-graph/nodes/gcore/src/context_modification.rs
+++ b/node-graph/nodes/gcore/src/context_modification.rs
@@ -6,7 +6,7 @@ use core_types::uuid::NodeId;
 use core_types::{Color, OwnedContextImpl};
 use glam::{DAffine2, DVec2};
 use graphic_types::vector_types::GradientStops;
-use graphic_types::{Graphic, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use raster_types::{CPU, GPU, Raster};
 
 /// Filters out what should be unused components of the context based on the specified requirements.
@@ -35,7 +35,7 @@ async fn context_modification<T>(
 		Context -> Table<Raster<CPU>>,
 		Context -> Table<Raster<GPU>>,
 		Context -> Table<Color>,
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<GradientStops>,
 	)]
 	value: impl Node<Context<'static>, Output = T>,

--- a/node-graph/nodes/graphic/src/artboard.rs
+++ b/node-graph/nodes/graphic/src/artboard.rs
@@ -1,19 +1,13 @@
-use core_types::{
-	ATTR_BACKGROUND, ATTR_CLIP, ATTR_DIMENSIONS, ATTR_LOCATION, CloneVarArgs, Color, Context, Ctx, ExtractAll, OwnedContextImpl,
-	table::{Table, TableRow},
-	transform::TransformMut,
-};
+use core_types::table::{Table, TableRow};
+use core_types::transform::TransformMut;
+use core_types::{ATTR_BACKGROUND, ATTR_CLIP, ATTR_DIMENSIONS, ATTR_LOCATION, CloneVarArgs, Color, Context, Ctx, ExtractAll, OwnedContextImpl};
 use glam::{DAffine2, DVec2};
-use graphic_types::{
-	Vector,
-	graphic::{Graphic, IntoGraphicTable},
-};
+use graphic_types::graphic::{Graphic, IntoGraphicTable};
+use graphic_types::{Artboard, Vector};
 use raster_types::{CPU, GPU, Raster};
 use vector_types::GradientStops;
 
-/// Constructs a new single-item `Table<Table<Graphic>>` (an artboard table) where the row's element is
-/// the artboard's content and the metadata (label, location, dimensions, background, clip) is stored as
-/// per-row attributes.
+/// Constructs a single-row `Table<Artboard>` with the given content and metadata stored as row attributes.
 #[node_macro::node(category(""))]
 pub async fn create_artboard<T: IntoGraphicTable + 'n>(
 	ctx: impl ExtractAll + CloneVarArgs + Ctx,
@@ -37,7 +31,7 @@ pub async fn create_artboard<T: IntoGraphicTable + 'n>(
 	/// Whether to cut off the contained content that extends outside the artboard, or keep it visible.
 	#[default(true)]
 	clip: bool,
-) -> Table<Table<Graphic>> {
+) -> Table<Artboard> {
 	let footprint = ctx.try_footprint().copied();
 	let mut new_ctx = OwnedContextImpl::from(ctx);
 	if let Some(mut footprint) = footprint {
@@ -54,11 +48,9 @@ pub async fn create_artboard<T: IntoGraphicTable + 'n>(
 
 	let background = background.element(0).copied().unwrap_or(Color::WHITE);
 
-	// The artboard's user-visible name is its parent layer's display name; not stored as an attribute here so
-	// it can't go stale. The data panel resolves it live from the row's `editor:layer_path` NodeId via the network
-	// interface, so renaming the layer reflects everywhere on the next refresh.
+	// Name is not stored here, it's resolved live from the parent layer's display name
 	Table::new_from_row(
-		TableRow::new_from_element(content)
+		TableRow::new_from_element(Artboard::new(content))
 			.with_attribute(ATTR_LOCATION, normalized_location)
 			.with_attribute(ATTR_DIMENSIONS, normalized_dimensions)
 			.with_attribute(ATTR_BACKGROUND, background)

--- a/node-graph/nodes/graphic/src/graphic.rs
+++ b/node-graph/nodes/graphic/src/graphic.rs
@@ -4,8 +4,8 @@ use core_types::table::{Table, TableRow};
 use core_types::uuid::NodeId;
 use core_types::{ATTR_EDITOR_LAYER_PATH, ATTR_TRANSFORM, AnyHash, CacheHash, CloneVarArgs, Color, Context, Ctx, ExtractAll, OwnedContextImpl};
 use glam::{DAffine2, DVec2};
-use graphic_types::Vector;
 use graphic_types::graphic::{Graphic, IntoGraphicTable};
+use graphic_types::{Artboard, Vector};
 use raster_types::{CPU, GPU, Raster};
 use vector_types::{GradientStop, GradientStops, ReferencePoint};
 
@@ -16,7 +16,7 @@ pub fn index_elements<T: graphic_types::graphic::AtIndex + Clone + Default>(
 	_: impl Ctx,
 	/// The list of data.
 	#[implementations(
-		Table<Table<Graphic>>,
+		Table<Artboard>,
 		Table<Graphic>,
 		Table<Vector>,
 		Table<Raster<CPU>>,
@@ -48,7 +48,7 @@ pub fn omit_element<T: graphic_types::graphic::OmitIndex + Clone + Default>(
 	/// The list of data.
 	#[implementations(
 		Table<String>,
-		Table<Table<Graphic>>,
+		Table<Artboard>,
 		Table<Graphic>,
 		Table<Vector>,
 		Table<Raster<CPU>>,
@@ -86,7 +86,7 @@ pub fn extract_element<T: Clone + Default + Send + Sync + 'static>(
 		Table<Vector>,
 		Table<Raster<CPU>>,
 		Table<Graphic>,
-		Table<Table<Graphic>>,
+		Table<Artboard>,
 	)]
 	table: Table<T>,
 	/// The index of the item to retrieve, starting from 0 for the first item. Negative indices count backwards from the end of the list, starting from -1 for the last item.
@@ -225,7 +225,7 @@ async fn write_attribute<T: AnyHash + Clone + Send + Sync + CacheHash, U: Clone 
 	ctx: impl ExtractAll + CloneVarArgs + Ctx,
 	/// The `Table` whose items will gain or have replaced the named attribute.
 	#[implementations(
-		Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>, Table<Table<Graphic>>,
+		Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>, Table<Artboard>,
 		Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>, Table<Graphic>,
 		Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>, Table<Vector>,
 		Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>, Table<Raster<CPU>>,
@@ -262,11 +262,11 @@ async fn write_attribute<T: AnyHash + Clone + Send + Sync + CacheHash, U: Clone 
 pub async fn extend<T: 'n + Send + Clone>(
 	_: impl Ctx,
 	/// The `Table` whose items will appear at the start of the extended `Table`.
-	#[implementations(Table<Table<Graphic>>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
+	#[implementations(Table<Artboard>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
 	base: Table<T>,
 	/// The `Table` whose items will appear at the end of the extended `Table`.
 	#[expose]
-	#[implementations(Table<Table<Graphic>>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
+	#[implementations(Table<Artboard>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
 	new: Table<T>,
 ) -> Table<T> {
 	let mut base = base;
@@ -281,9 +281,9 @@ pub async fn extend<T: 'n + Send + Clone>(
 #[node_macro::node(category(""))]
 pub async fn legacy_layer_extend<T: 'n + Send + Clone>(
 	_: impl Ctx,
-	#[implementations(Table<Table<Graphic>>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)] base: Table<T>,
+	#[implementations(Table<Artboard>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)] base: Table<T>,
 	#[expose]
-	#[implementations(Table<Table<Graphic>>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
+	#[implementations(Table<Artboard>, Table<Graphic>, Table<Vector>, Table<Raster<CPU>>, Table<Raster<GPU>>, Table<Color>, Table<GradientStops>)]
 	new: Table<T>,
 	nested_node_path: Table<NodeId>,
 ) -> Table<T> {

--- a/node-graph/nodes/gstd/src/lib.rs
+++ b/node-graph/nodes/gstd/src/lib.rs
@@ -11,7 +11,7 @@ pub use graphene_application_io as application_io;
 pub use graphene_core;
 pub use graphene_core::debug;
 pub use graphic_nodes;
-pub use graphic_types::{Graphic, Vector};
+pub use graphic_types::{Artboard, Graphic, Vector};
 pub use math_nodes;
 pub use path_bool_nodes;
 pub use raster_nodes;

--- a/node-graph/nodes/gstd/src/render_node.rs
+++ b/node-graph/nodes/gstd/src/render_node.rs
@@ -8,7 +8,7 @@ use graph_craft::document::value::RenderOutput;
 pub use graph_craft::document::value::RenderOutputType;
 use graphene_application_io::{ApplicationIo, ExportFormat, RenderConfig};
 use graphic_types::raster_types::{CPU, Raster};
-use graphic_types::{Graphic, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use rendering::{Render, RenderMetadata, RenderOutputType as RenderOutputTypeRequest, RenderParams, SvgRender, SvgRenderOutput};
 use std::fmt::Write;
 use std::sync::Arc;
@@ -33,7 +33,7 @@ pub struct RenderIntermediate {
 async fn render_intermediate<'a: 'n, T: 'static + Render + WasmNotSend + Send + Sync>(
 	ctx: impl Ctx + ExtractVarArgs + ExtractAll + CloneVarArgs,
 	#[implementations(
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<Graphic>,
 		Context -> Table<Vector>,
 		Context -> Table<Raster<CPU>>,

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -5,7 +5,7 @@ use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
 use glam::{DAffine2, DVec2};
 use graphic_types::raster_types::{CPU, GPU, Raster};
-use graphic_types::{Graphic, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use log::warn;
 use math_parser::ast;
 use math_parser::context::{EvalContext, NothingMap, ValueProvider};
@@ -753,7 +753,7 @@ async fn switch<T, C: Send + 'n + Clone>(
 		Context -> u64,
 		Context -> DVec2,
 		Context -> DAffine2,
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<Graphic>,
 		Context -> Table<Vector>,
 		Context -> Table<Raster<CPU>>,
@@ -772,7 +772,7 @@ async fn switch<T, C: Send + 'n + Clone>(
 		Context -> u64,
 		Context -> DVec2,
 		Context -> DAffine2,
-		Context -> Table<Table<Graphic>>,
+		Context -> Table<Artboard>,
 		Context -> Table<Graphic>,
 		Context -> Table<Vector>,
 		Context -> Table<Raster<CPU>>,


### PR DESCRIPTION
This follows the same approach taken by the `Graphic` struct which is an enum over multiple wrapped types acting as a boundary for the boundless type explosion from infinite nestings of `Table<Table<...<all graphical types>>>`. Now, `Artboard` is a newtype script that wraps `Table<Graphic>` just as `Graphic` has arms that wrap `Table<all graphical types>`. This represents an explicit loss of data purity that takes the form of a new named base type, not simply an extra nesting level of the base type.


Followup to #4077. Partly closes #3779.