### PR TITLE
Add renderer support for painting vector with "fill" and "stroke" attributes with graphic List<T> types

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -12,6 +12,7 @@ use crate::messages::prelude::*;
 use glam::{DAffine2, IVec2};
 use graph_craft::document::NodeId;
 use graphene_std::Color;
+use graphene_std::list::List;
 use graphene_std::raster::BlendMode;
 use graphene_std::raster::Image;
 use graphene_std::transform::Footprint;
@@ -232,8 +233,11 @@ pub enum DocumentMessage {
 	UpdateClipTargets {
 		clip_targets: HashSet<NodeId>,
 	},
+	// `Message` is only serialized at `editor_wrapper.rs`, and only inputs from JS pass through it.
+	// `UpdateVectorData` is produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
+	#[serde(skip)]
 	UpdateVectorData {
-		vector_data: HashMap<NodeId, Arc<Vector>>,
+		vector_data: HashMap<NodeId, Arc<List<Vector>>>,
 	},
 	Undo,
 	UngroupSelectedLayers,

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -12,7 +12,6 @@ use crate::messages::prelude::*;
 use glam::{DAffine2, IVec2};
 use graph_craft::document::NodeId;
 use graphene_std::Color;
-use graphene_std::list::List;
 use graphene_std::raster::BlendMode;
 use graphene_std::raster::Image;
 use graphene_std::transform::Footprint;
@@ -233,11 +232,8 @@ pub enum DocumentMessage {
 	UpdateClipTargets {
 		clip_targets: HashSet<NodeId>,
 	},
-	// `Message` is only serialized at `editor_wrapper.rs`, and only inputs from JS pass through it.
-	// `UpdateVectorData` is produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
-	#[serde(skip)]
 	UpdateVectorData {
-		vector_data: HashMap<NodeId, Arc<List<Vector>>>,
+		vector_data: HashMap<NodeId, Arc<Vector>>,
 	},
 	Undo,
 	UngroupSelectedLayers,

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -12,6 +12,8 @@ use crate::messages::prelude::*;
 use glam::{DAffine2, IVec2};
 use graph_craft::document::NodeId;
 use graphene_std::Color;
+use graphene_std::Graphic;
+use graphene_std::list::List;
 use graphene_std::raster::BlendMode;
 use graphene_std::raster::Image;
 use graphene_std::transform::Footprint;
@@ -234,6 +236,16 @@ pub enum DocumentMessage {
 	},
 	UpdateVectorData {
 		vector_data: HashMap<NodeId, Arc<Vector>>,
+	},
+	// `Message` is only serialized at `editor_wrapper.rs`, and only inputs from JS pass through it.
+	// `UpdateFillAttributes` and `UpdateStrokePaintAttributes` are produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
+	#[serde(skip)]
+	UpdateFillAttributes {
+		fill_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
+	},
+	#[serde(skip)]
+	UpdateStrokePaintAttributes {
+		stroke_paint_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
 	},
 	Undo,
 	UngroupSelectedLayers,

--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -238,14 +238,14 @@ pub enum DocumentMessage {
 		vector_data: HashMap<NodeId, Arc<Vector>>,
 	},
 	// `Message` is only serialized at `editor_wrapper.rs`, and only inputs from JS pass through it.
-	// `UpdateFillAttributes` and `UpdateStrokePaintAttributes` are produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
+	// `UpdateFillAttributes` and `UpdateStrokeAttributes` are produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
 	#[serde(skip)]
 	UpdateFillAttributes {
 		fill_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
 	},
 	#[serde(skip)]
-	UpdateStrokePaintAttributes {
-		stroke_paint_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
+	UpdateStrokeAttributes {
+		stroke_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
 	},
 	Undo,
 	UngroupSelectedLayers,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -34,9 +34,7 @@ use graph_craft::application_io::wgpu_available;
 use graph_craft::descriptor;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{NodeId, NodeInput, NodeNetwork, OldNodeNetwork};
-use graphene_std::Graphic;
-use graphene_std::graphic::{color_to_graphic_list, fill_to_graphic_list};
-use graphene_std::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
+use graphene_std::graphic::{fill_graphic_list_at, stroke_paint_graphic_list_at};
 use graphene_std::math::quad::Quad;
 use graphene_std::path_bool_nodes::boolean_intersect;
 use graphene_std::raster::BlendMode;
@@ -46,7 +44,6 @@ use graphene_std::vector::click_target::{ClickTarget, ClickTargetType};
 use graphene_std::vector::misc::dvec2_to_point;
 use graphene_std::vector::style::{RenderMode, Stroke};
 use kurbo::{Affine, BezPath, Line, PathSeg};
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2491,19 +2488,10 @@ impl DocumentMessageHandler {
 			};
 			let style = vector_list.element(0).map(|vector| &vector.style);
 
-			let fill_graphic_list = vector_list
-				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, 0)
-				.filter(|list| !list.is_empty())
-				.map(Cow::Borrowed)
-				.or_else(|| style.and_then(|style| fill_to_graphic_list(style.fill())).map(Cow::Owned));
-			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
-
-			let stroke_paint_graphic_list = vector_list
-				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, 0)
-				.filter(|list| !list.is_empty())
-				.map(Cow::Borrowed)
-				.or_else(|| color_to_graphic_list(style.and_then(|style| style.stroke().and_then(|s| s.color()))).map(Cow::Owned));
-			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+			let fill_graphic_list = fill_graphic_list_at(&vector_list, 0);
+			let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
+			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(&vector_list, 0);
+			let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
 
 			let has_fill = fill_graphic.is_some();
 

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1418,9 +1418,9 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					.collect();
 				self.network_interface.update_fill_attributes(layer_fill_attributes);
 			}
-			DocumentMessage::UpdateStrokePaintAttributes { stroke_paint_attributes } => {
+			DocumentMessage::UpdateStrokeAttributes { stroke_attributes } => {
 				// Convert NodeId keys to LayerNodeIdentifier keys, filtering to only layers
-				let layer_stroke_paint_attributes = stroke_paint_attributes
+				let layer_stroke_attributes = stroke_attributes
 					.into_iter()
 					.filter(|(node_id, _)| self.network_interface.document_network().nodes.contains_key(node_id))
 					.filter_map(|(node_id, attrs)| {
@@ -1430,7 +1430,7 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 						})
 					})
 					.collect();
-				self.network_interface.update_stroke_paint_attributes(layer_stroke_paint_attributes);
+				self.network_interface.update_stroke_attributes(layer_stroke_attributes);
 			}
 			DocumentMessage::Undo => {
 				if self.network_interface.transaction_status() != TransactionStatus::Finished {
@@ -2515,7 +2515,7 @@ impl DocumentMessageHandler {
 			};
 
 			let fill_graphic_list = self.network_interface.document_metadata().layer_fill_attributes.get(&layer);
-			let stroke_paint_graphic_list = self.network_interface.document_metadata().layer_stroke_paint_attributes.get(&layer);
+			let stroke_graphic_list = self.network_interface.document_metadata().layer_stroke_attributes.get(&layer);
 
 			let has_fill = if let Some(list) = fill_graphic_list {
 				list.element(0).is_some()
@@ -2524,13 +2524,13 @@ impl DocumentMessageHandler {
 			};
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// `ATTR_STROKE_PAINT_GRAPHIC` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
-			let stroke_paint_visible = if let Some(list) = stroke_paint_graphic_list {
+			// `ATTR_STROKE_GRAPHIC` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
+			let stroke_visible = if let Some(list) = stroke_graphic_list {
 				list.element(0).is_some_and(|g| !g.is_fully_transparent())
 			} else {
 				style.stroke.as_ref().and_then(|s| s.color()).is_some_and(|c| c.a() != 0.)
 			};
-			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke()) && stroke_paint_visible;
+			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke()) && stroke_visible;
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.
 			if !has_stroke {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2524,7 +2524,7 @@ impl DocumentMessageHandler {
 			};
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// `ATTR_STROKE` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
+			// `ATTR_STROKE` is the source of truth when set; fall back to `style.stroke.color` only when no attribute is present.
 			let stroke_visible = if let Some(list) = stroke_graphic_list {
 				list.element(0).is_some_and(|g| !g.is_fully_transparent())
 			} else {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -1404,6 +1404,34 @@ impl MessageHandler<DocumentMessage, DocumentMessageContext<'_>> for DocumentMes
 					.collect();
 				self.network_interface.update_vector_data(layer_vector_data);
 			}
+			DocumentMessage::UpdateFillAttributes { fill_attributes } => {
+				// Convert NodeId keys to LayerNodeIdentifier keys, filtering to only layers
+				let layer_fill_attributes = fill_attributes
+					.into_iter()
+					.filter(|(node_id, _)| self.network_interface.document_network().nodes.contains_key(node_id))
+					.filter_map(|(node_id, attrs)| {
+						self.network_interface.is_layer(&node_id, &[]).then(|| {
+							let layer = LayerNodeIdentifier::new(node_id, &self.network_interface);
+							(layer, attrs)
+						})
+					})
+					.collect();
+				self.network_interface.update_fill_attributes(layer_fill_attributes);
+			}
+			DocumentMessage::UpdateStrokePaintAttributes { stroke_paint_attributes } => {
+				// Convert NodeId keys to LayerNodeIdentifier keys, filtering to only layers
+				let layer_stroke_paint_attributes = stroke_paint_attributes
+					.into_iter()
+					.filter(|(node_id, _)| self.network_interface.document_network().nodes.contains_key(node_id))
+					.filter_map(|(node_id, attrs)| {
+						self.network_interface.is_layer(&node_id, &[]).then(|| {
+							let layer = LayerNodeIdentifier::new(node_id, &self.network_interface);
+							(layer, attrs)
+						})
+					})
+					.collect();
+				self.network_interface.update_stroke_paint_attributes(layer_stroke_paint_attributes);
+			}
 			DocumentMessage::Undo => {
 				if self.network_interface.transaction_status() != TransactionStatus::Finished {
 					return;
@@ -2486,11 +2514,23 @@ impl DocumentMessageHandler {
 				continue;
 			};
 
-			let has_fill = !matches!(style.fill, Fill::None);
+			let fill_graphic_list = self.network_interface.document_metadata().layer_fill_attributes.get(&layer);
+			let stroke_paint_graphic_list = self.network_interface.document_metadata().layer_stroke_paint_attributes.get(&layer);
+
+			let has_fill = if let Some(list) = fill_graphic_list {
+				list.element(0).is_some()
+			} else {
+				!matches!(style.fill, Fill::None)
+			};
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
-			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
+			// `ATTR_STROKE_PAINT_GRAPHIC` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
+			let stroke_paint_visible = if let Some(list) = stroke_paint_graphic_list {
+				list.element(0).is_some_and(|g| !g.is_fully_transparent())
+			} else {
+				style.stroke.as_ref().and_then(|s| s.color()).is_some_and(|c| c.a() != 0.)
+			};
+			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke()) && stroke_paint_visible;
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.
 			if !has_stroke {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2524,7 +2524,7 @@ impl DocumentMessageHandler {
 			};
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// `ATTR_STROKE_GRAPHIC` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
+			// `ATTR_STROKE` is the source of truth when set; fall back to `style.stroke.color` only when no row attribute is present.
 			let stroke_visible = if let Some(list) = stroke_graphic_list {
 				list.element(0).is_some_and(|g| !g.is_fully_transparent())
 			} else {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -34,6 +34,9 @@ use graph_craft::application_io::wgpu_available;
 use graph_craft::descriptor;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{NodeId, NodeInput, NodeNetwork, OldNodeNetwork};
+use graphene_std::Graphic;
+use graphene_std::graphic::{color_to_graphic_list, fill_to_graphic_list};
+use graphene_std::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
 use graphene_std::math::quad::Quad;
 use graphene_std::path_bool_nodes::boolean_intersect;
 use graphene_std::raster::BlendMode;
@@ -41,8 +44,9 @@ use graphene_std::subpath::Subpath;
 use graphene_std::vector::PointId;
 use graphene_std::vector::click_target::{ClickTarget, ClickTargetType};
 use graphene_std::vector::misc::dvec2_to_point;
-use graphene_std::vector::style::{Fill, RenderMode};
+use graphene_std::vector::style::{RenderMode, Stroke};
 use kurbo::{Affine, BezPath, Line, PathSeg};
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2480,17 +2484,32 @@ impl DocumentMessageHandler {
 		let mut resulting_layers: Vec<NodeId> = Vec::new();
 
 		for layer in selected_layers {
-			let style = self.network_interface.document_metadata().layer_vector_data.get(&layer).map(|arc| arc.style.clone());
-			let Some(style) = style else {
+			let vector_list = self.network_interface.document_metadata().layer_vector_data.get(&layer).cloned();
+			let Some(vector_list) = vector_list else {
 				resulting_layers.push(layer.to_node());
 				continue;
 			};
+			let style = vector_list.element(0).map(|vector| &vector.style);
 
-			let has_fill = !matches!(style.fill, Fill::None);
-			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
-			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
-			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
+			let fill_graphic_list = vector_list
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, 0)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| style.and_then(|style| fill_to_graphic_list(style.fill())).map(Cow::Owned));
+			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let stroke_paint_graphic_list = vector_list
+				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, 0)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| color_to_graphic_list(style.and_then(|style| style.stroke().and_then(|s| s.color()))).map(Cow::Owned));
+			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let has_fill = fill_graphic.is_some();
+
+			let stroke_renderable = style.is_some_and(|s| s.stroke.as_ref().is_some_and(Stroke::has_renderable_stroke));
+			let stroke_paint_visible = stroke_paint_graphic.is_some_and(|g| !g.is_fully_transparent());
+			let has_stroke = stroke_renderable && stroke_paint_visible;
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.
 			if !has_stroke {

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2489,6 +2489,7 @@ impl DocumentMessageHandler {
 			let has_fill = !matches!(style.fill, Fill::None);
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
+			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
 			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -34,7 +34,6 @@ use graph_craft::application_io::wgpu_available;
 use graph_craft::descriptor;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{NodeId, NodeInput, NodeNetwork, OldNodeNetwork};
-use graphene_std::graphic::{fill_graphic_list_at, stroke_paint_graphic_list_at};
 use graphene_std::math::quad::Quad;
 use graphene_std::path_bool_nodes::boolean_intersect;
 use graphene_std::raster::BlendMode;
@@ -42,7 +41,7 @@ use graphene_std::subpath::Subpath;
 use graphene_std::vector::PointId;
 use graphene_std::vector::click_target::{ClickTarget, ClickTargetType};
 use graphene_std::vector::misc::dvec2_to_point;
-use graphene_std::vector::style::{RenderMode, Stroke};
+use graphene_std::vector::style::{Fill, RenderMode};
 use kurbo::{Affine, BezPath, Line, PathSeg};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -2481,23 +2480,17 @@ impl DocumentMessageHandler {
 		let mut resulting_layers: Vec<NodeId> = Vec::new();
 
 		for layer in selected_layers {
-			let vector_list = self.network_interface.document_metadata().layer_vector_data.get(&layer).cloned();
-			let Some(vector_list) = vector_list else {
+			let style = self.network_interface.document_metadata().layer_vector_data.get(&layer).map(|arc| arc.style.clone());
+			let Some(style) = style else {
 				resulting_layers.push(layer.to_node());
 				continue;
 			};
-			let style = vector_list.element(0).map(|vector| &vector.style);
 
-			let fill_graphic_list = fill_graphic_list_at(&vector_list, 0);
-			let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
-			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(&vector_list, 0);
-			let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
-
-			let has_fill = fill_graphic.is_some();
-
-			let stroke_renderable = style.is_some_and(|s| s.stroke.as_ref().is_some_and(Stroke::has_renderable_stroke));
-			let stroke_paint_visible = stroke_paint_graphic.is_some_and(|g| !g.is_fully_transparent());
-			let has_stroke = stroke_renderable && stroke_paint_visible;
+			let has_fill = !matches!(style.fill, Fill::None);
+			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
+			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
+			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
+			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.
 			if !has_stroke {

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -44,9 +44,9 @@ pub struct DocumentMetadata {
 	/// Per-layer `ATTR_FILL_GRAPHIC` row attribute, exposed so message handlers can read paint
 	/// information that lives on the list.
 	pub layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
-	/// Per-layer `ATTR_STROKE_PAINT_GRAPHIC` row attribute, exposed so message handlers can read
+	/// Per-layer `ATTR_STROKE_GRAPHIC` row attribute, exposed so message handlers can read
 	/// stroke paint information that lives on the list.
-	pub layer_stroke_paint_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
+	pub layer_stroke_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
 	/// Transform from document space to viewport space.
 	pub document_to_viewport: DAffine2,
 }

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -6,7 +6,6 @@ use crate::messages::portfolio::document::utility_types::network_interface::Flow
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use glam::{DAffine2, DVec2};
 use graph_craft::document::NodeId;
-use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath;
 use graphene_std::transform::Footprint;
@@ -39,7 +38,7 @@ pub struct DocumentMetadata {
 	pub vector_modify: HashMap<NodeId, Vector>,
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
-	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>,
+	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
 	/// Transform from document space to viewport space.
 	pub document_to_viewport: DAffine2,
 }
@@ -226,7 +225,7 @@ impl DocumentMetadata {
 	/// stroke geometry when the layer is a vector with a stroke style. Falls back to the click-target-based
 	/// bounds for non-vector layers (groups, raster, text, color, gradient).
 	pub fn bounding_box_document_with_stroke(&self, layer: LayerNodeIdentifier) -> Option<[DVec2; 2]> {
-		if let Some(vector) = self.layer_vector_data.get(&layer).and_then(|vector_list| vector_list.element(0))
+		if let Some(vector) = self.layer_vector_data.get(&layer)
 			&& let Some(bounds) = vector.stroke_inclusive_bounding_box_with_transform(self.transform_to_document(layer))
 		{
 			return Some(bounds);

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -41,10 +41,10 @@ pub struct DocumentMetadata {
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
 	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
-	/// Per-layer `ATTR_FILL` row attribute, exposed so message handlers can read paint
+	/// Per-layer `ATTR_FILL` attribute, exposed so message handlers can read paint
 	/// information that lives on the list.
 	pub layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
-	/// Per-layer `ATTR_STROKE` row attribute, exposed so message handlers can read
+	/// Per-layer `ATTR_STROKE` attribute, exposed so message handlers can read
 	/// stroke paint information that lives on the list.
 	pub layer_stroke_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
 	/// Transform from document space to viewport space.

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -6,6 +6,8 @@ use crate::messages::portfolio::document::utility_types::network_interface::Flow
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use glam::{DAffine2, DVec2};
 use graph_craft::document::NodeId;
+use graphene_std::Graphic;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath;
 use graphene_std::transform::Footprint;
@@ -39,6 +41,12 @@ pub struct DocumentMetadata {
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
 	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
+	/// Per-layer `ATTR_FILL_GRAPHIC` row attribute, exposed so message handlers can read paint
+	/// information that lives on the list.
+	pub layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
+	/// Per-layer `ATTR_STROKE_PAINT_GRAPHIC` row attribute, exposed so message handlers can read
+	/// stroke paint information that lives on the list.
+	pub layer_stroke_paint_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
 	/// Transform from document space to viewport space.
 	pub document_to_viewport: DAffine2,
 }

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -6,6 +6,7 @@ use crate::messages::portfolio::document::utility_types::network_interface::Flow
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use glam::{DAffine2, DVec2};
 use graph_craft::document::NodeId;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath;
 use graphene_std::transform::Footprint;
@@ -38,7 +39,7 @@ pub struct DocumentMetadata {
 	pub vector_modify: HashMap<NodeId, Vector>,
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
-	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
+	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>,
 	/// Transform from document space to viewport space.
 	pub document_to_viewport: DAffine2,
 }
@@ -225,7 +226,7 @@ impl DocumentMetadata {
 	/// stroke geometry when the layer is a vector with a stroke style. Falls back to the click-target-based
 	/// bounds for non-vector layers (groups, raster, text, color, gradient).
 	pub fn bounding_box_document_with_stroke(&self, layer: LayerNodeIdentifier) -> Option<[DVec2; 2]> {
-		if let Some(vector) = self.layer_vector_data.get(&layer)
+		if let Some(vector) = self.layer_vector_data.get(&layer).and_then(|vector_list| vector_list.element(0))
 			&& let Some(bounds) = vector.stroke_inclusive_bounding_box_with_transform(self.transform_to_document(layer))
 		{
 			return Some(bounds);

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -41,10 +41,10 @@ pub struct DocumentMetadata {
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
 	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
-	/// Per-layer `ATTR_FILL_GRAPHIC` row attribute, exposed so message handlers can read paint
+	/// Per-layer `ATTR_FILL` row attribute, exposed so message handlers can read paint
 	/// information that lives on the list.
 	pub layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
-	/// Per-layer `ATTR_STROKE_GRAPHIC` row attribute, exposed so message handlers can read
+	/// Per-layer `ATTR_STROKE` row attribute, exposed so message handlers can read
 	/// stroke paint information that lives on the list.
 	pub layer_stroke_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>,
 	/// Transform from document space to viewport space.

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -3404,12 +3404,12 @@ impl NodeNetworkInterface {
 		self.document_metadata.layer_vector_data = new_layer_vector_data;
 	}
 
-	/// Update the per-layer `ATTR_FILL_GRAPHIC` snapshot.
+	/// Update the per-layer `ATTR_FILL` snapshot.
 	pub fn update_fill_attributes(&mut self, new_layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
 		self.document_metadata.layer_fill_attributes = new_layer_fill_attributes;
 	}
 
-	/// Update the per-layer `ATTR_STROKE_GRAPHIC` snapshot.
+	/// Update the per-layer `ATTR_STROKE` snapshot.
 	pub fn update_stroke_attributes(&mut self, new_layer_stroke_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
 		self.document_metadata.layer_stroke_attributes = new_layer_stroke_attributes;
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -24,7 +24,6 @@ use graph_craft::application_io::resource::ResourceId;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeId, NodeInput, NodeNetwork, OldDocumentNodeImplementation, OldNodeNetwork};
 use graphene_std::ContextDependencies;
-use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath::Subpath;
 use graphene_std::transform::Footprint;
@@ -3236,9 +3235,8 @@ impl NodeNetworkInterface {
 			}
 			return Some(modified);
 		}
-		// Only item 0 is returned since editing tools can only target a single item currently.
-		let vector_list = self.document_metadata.layer_vector_data.get(&layer).cloned();
-		vector_list.and_then(|list| list.element(0).cloned())
+
+		self.document_metadata.layer_vector_data.get(&layer).map(|arc| arc.as_ref().clone())
 	}
 
 	/// The vector geometry an upstream Path node would surface for editing.
@@ -3400,7 +3398,7 @@ impl NodeNetworkInterface {
 	}
 
 	/// Update the layer vector data (for layers without Path nodes)
-	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>) {
+	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>) {
 		self.document_metadata.layer_vector_data = new_layer_vector_data;
 	}
 }

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -24,6 +24,7 @@ use graph_craft::application_io::resource::ResourceId;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeId, NodeInput, NodeNetwork, OldDocumentNodeImplementation, OldNodeNetwork};
 use graphene_std::ContextDependencies;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath::Subpath;
 use graphene_std::transform::Footprint;
@@ -3235,8 +3236,9 @@ impl NodeNetworkInterface {
 			}
 			return Some(modified);
 		}
-
-		self.document_metadata.layer_vector_data.get(&layer).map(|arc| arc.as_ref().clone())
+		// Only item 0 is returned since editing tools can only target a single item currently.
+		let vector_list = self.document_metadata.layer_vector_data.get(&layer).cloned();
+		vector_list.and_then(|list| list.element(0).cloned())
 	}
 
 	/// The vector geometry an upstream Path node would surface for editing.
@@ -3398,7 +3400,7 @@ impl NodeNetworkInterface {
 	}
 
 	/// Update the layer vector data (for layers without Path nodes)
-	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>) {
+	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>) {
 		self.document_metadata.layer_vector_data = new_layer_vector_data;
 	}
 }

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -3409,9 +3409,9 @@ impl NodeNetworkInterface {
 		self.document_metadata.layer_fill_attributes = new_layer_fill_attributes;
 	}
 
-	/// Update the per-layer `ATTR_STROKE_PAINT_GRAPHIC` snapshot.
-	pub fn update_stroke_paint_attributes(&mut self, new_layer_stroke_paint_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
-		self.document_metadata.layer_stroke_paint_attributes = new_layer_stroke_paint_attributes;
+	/// Update the per-layer `ATTR_STROKE_GRAPHIC` snapshot.
+	pub fn update_stroke_attributes(&mut self, new_layer_stroke_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
+		self.document_metadata.layer_stroke_attributes = new_layer_stroke_attributes;
 	}
 }
 

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -24,6 +24,8 @@ use graph_craft::application_io::resource::ResourceId;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeId, NodeInput, NodeNetwork, OldDocumentNodeImplementation, OldNodeNetwork};
 use graphene_std::ContextDependencies;
+use graphene_std::Graphic;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath::Subpath;
 use graphene_std::transform::Footprint;
@@ -3400,6 +3402,16 @@ impl NodeNetworkInterface {
 	/// Update the layer vector data (for layers without Path nodes)
 	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>) {
 		self.document_metadata.layer_vector_data = new_layer_vector_data;
+	}
+
+	/// Update the per-layer `ATTR_FILL_GRAPHIC` snapshot.
+	pub fn update_fill_attributes(&mut self, new_layer_fill_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
+		self.document_metadata.layer_fill_attributes = new_layer_fill_attributes;
+	}
+
+	/// Update the per-layer `ATTR_STROKE_PAINT_GRAPHIC` snapshot.
+	pub fn update_stroke_paint_attributes(&mut self, new_layer_stroke_paint_attributes: HashMap<LayerNodeIdentifier, Arc<List<Graphic>>>) {
+		self.document_metadata.layer_stroke_paint_attributes = new_layer_stroke_paint_attributes;
 	}
 }
 

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -446,6 +446,8 @@ impl NodeGraphExecutor {
 			text_frames,
 			clip_targets,
 			vector_data,
+			fill_attributes,
+			stroke_paint_attributes,
 			backgrounds: _,
 		} = render_output.metadata;
 
@@ -460,6 +462,8 @@ impl NodeGraphExecutor {
 		responses.add(DocumentMessage::UpdateTextFrames { text_frames });
 		responses.add(DocumentMessage::UpdateClipTargets { clip_targets });
 		responses.add(DocumentMessage::UpdateVectorData { vector_data });
+		responses.add(DocumentMessage::UpdateFillAttributes { fill_attributes });
+		responses.add(DocumentMessage::UpdateStrokePaintAttributes { stroke_paint_attributes });
 		responses.add(DocumentMessage::RenderScrollbars);
 		responses.add(DocumentMessage::RenderRulers);
 		responses.add(OverlaysMessage::Draw);

--- a/editor/src/node_graph_executor.rs
+++ b/editor/src/node_graph_executor.rs
@@ -447,7 +447,7 @@ impl NodeGraphExecutor {
 			clip_targets,
 			vector_data,
 			fill_attributes,
-			stroke_paint_attributes,
+			stroke_attributes,
 			backgrounds: _,
 		} = render_output.metadata;
 
@@ -463,7 +463,7 @@ impl NodeGraphExecutor {
 		responses.add(DocumentMessage::UpdateClipTargets { clip_targets });
 		responses.add(DocumentMessage::UpdateVectorData { vector_data });
 		responses.add(DocumentMessage::UpdateFillAttributes { fill_attributes });
-		responses.add(DocumentMessage::UpdateStrokePaintAttributes { stroke_paint_attributes });
+		responses.add(DocumentMessage::UpdateStrokeAttributes { stroke_attributes });
 		responses.add(DocumentMessage::RenderScrollbars);
 		responses.add(DocumentMessage::RenderRulers);
 		responses.add(OverlaysMessage::Draw);

--- a/node-graph/interpreted-executor/src/node_registry.rs
+++ b/node-graph/interpreted-executor/src/node_registry.rs
@@ -88,6 +88,9 @@ fn node_registry() -> HashMap<ProtoNodeIdentifier, HashMap<NodeIOTypes, NodeCons
 		convert_node!(from: List<NodeId>, to: AttributeValueDyn),
 		convert_node!(from: List<Color>, to: AttributeValueDyn),
 		convert_node!(from: List<GradientStops>, to: AttributeValueDyn),
+		convert_node!(from: List<Vector>, to: AttributeValueDyn),
+		convert_node!(from: List<Raster<CPU>>, to: AttributeValueDyn),
+		convert_node!(from: List<Raster<GPU>>, to: AttributeValueDyn),
 		convert_node!(from: List<Graphic>, to: AttributeValueDyn),
 		// into_node!(from: List<Raster<CPU>>, to: List<Raster<SRGBA8>>),
 		#[cfg(feature = "gpu")]

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -77,7 +77,7 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 /// Gradient's `GradientType` (`Linear` or `Radial`).
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
-/// Table<Graphic> data for fill.
+/// List<Graphic> data for fill.
 pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
 
 // ===========================

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -661,6 +661,22 @@ impl ItemAttributeValues {
 			}
 		})
 	}
+
+	/// Moves the attribute at `from_key` to `to_key`.
+	/// Does nothing if `from_key` is absent, overwrites any existing `to_key`.
+	pub fn rename(&mut self, from_key: &str, to_key: impl Into<String>) {
+		let Some(pos) = self.0.iter().position(|(k, _)| k == from_key) else { return };
+		let (_, value) = self.0.remove(pos);
+
+		let to_key = to_key.into();
+		for (existing_key, existing_value) in &mut self.0 {
+			if *existing_key == to_key {
+				*existing_value = value;
+				return;
+			}
+		}
+		self.0.push((to_key, value));
+	}
 }
 
 // ==========

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -78,10 +78,10 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
 /// List<Graphic> data for fill.
-pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
+pub const ATTR_FILL: &str = "fill";
 
 /// List<Graphic> data for stroke.
-pub const ATTR_STROKE_GRAPHIC: &str = "stroke_graphic";
+pub const ATTR_STROKE: &str = "stroke";
 
 // ===========================
 // Implicit attribute defaults

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -77,6 +77,9 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 /// Gradient's `GradientType` (`Linear` or `Radial`).
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
+/// Table<Graphic> data for fill.
+pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
+
 // ===========================
 // Implicit attribute defaults
 // ===========================

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -81,7 +81,7 @@ pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
 
 /// List<Graphic> data for stroke.
-pub const ATTR_STROKE_PAINT_GRAPHIC: &str = "stroke_paint_graphic";
+pub const ATTR_STROKE_GRAPHIC: &str = "stroke_graphic";
 
 // ===========================
 // Implicit attribute defaults

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -80,6 +80,9 @@ pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 /// List<Graphic> data for fill.
 pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
 
+/// List<Graphic> data for stroke.
+pub const ATTR_STROKE_PAINT_GRAPHIC: &str = "stroke_paint_graphic";
+
 // ===========================
 // Implicit attribute defaults
 // ===========================

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -77,10 +77,10 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 /// Gradient's `GradientType` (`Linear` or `Radial`).
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
-/// List<Graphic> data for fill.
+/// Vector graphics object's filled area paint, of type List<T> where T is any graphic type.
 pub const ATTR_FILL: &str = "fill";
 
-/// List<Graphic> data for stroke.
+/// Vector graphics object's stroke paint, of type List<T> where T is any graphic type.
 pub const ATTR_STROKE: &str = "stroke";
 
 // ===========================

--- a/node-graph/libraries/core-types/src/ops.rs
+++ b/node-graph/libraries/core-types/src/ops.rs
@@ -56,7 +56,7 @@ impl<T: ToString + Send> Convert<String, ()> for T {
 }
 
 pub trait ListConvert<U> {
-	fn convert_row(self) -> U;
+	fn convert_item(self) -> U;
 }
 
 impl<U, T: ListConvert<U> + Send> Convert<List<U>, ()> for List<T> {
@@ -65,7 +65,7 @@ impl<U, T: ListConvert<U> + Send> Convert<List<U>, ()> for List<T> {
 			.into_iter()
 			.map(|row| {
 				let (element, attributes) = row.into_parts();
-				Item::from_parts(element.convert_row(), attributes)
+				Item::from_parts(element.convert_item(), attributes)
 			})
 			.collect();
 		list

--- a/node-graph/libraries/graphic-types/src/artboard.rs
+++ b/node-graph/libraries/graphic-types/src/artboard.rs
@@ -8,7 +8,7 @@ use glam::DAffine2;
 
 /// Nominal wrapper around `List<Graphic>` representing a single artboard's content.
 ///
-/// Per-artboard metadata (location, dimensions, background, clip) lives as row attributes on the
+/// Per-artboard metadata (location, dimensions, background, clip) lives as attributes on the
 /// enclosing `List<Artboard>`, not as fields here. This keeps `Artboard` a pure type-system boundary
 /// that prevents arbitrary `List<List<...<Graphic>>>` nesting.
 #[derive(Clone, Debug, Default, CacheHash, PartialEq, DynAny)]

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -180,7 +180,7 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 }
 
 /// Converts a `Fill` enum into the `List<Graphic>` representation used as paint storage.
-/// TODO: Remove once all paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+/// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 	match fill {
 		Fill::None => None,
@@ -195,6 +195,12 @@ pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 			Some(List::new_from_element(Graphic::Gradient(gradient_list)))
 		}
 	}
+}
+
+/// Converts a `Color` into the `List<Graphic>` representation used as paint storage.
+/// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
+pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
+	color.as_ref().map(|color| List::new_from_element((*color).into()))
 }
 
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::{ATTR_STROKE_PAINT_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -205,6 +205,29 @@ pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
 	color.as_ref().map(|color| List::new_from_element((*color).into()))
 }
 
+/// Look up the fill paint graphics for a vector row, falling back to the legacy
+/// `style.fill` when the row attribute is absent or empty.
+/// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
+	list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).filter(|l| !l.is_empty()).map(Cow::Borrowed).or_else(|| {
+		let vector = list.element(index)?;
+		fill_to_graphic_list(vector.style.fill()).map(Cow::Owned)
+	})
+}
+
+/// Look up the stroke paint graphics for a vector row, falling back to the legacy
+/// `style.stroke.color` when the row attribute is absent or empty.
+/// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
+pub fn stroke_paint_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
+	list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
+		.filter(|l| !l.is_empty())
+		.map(Cow::Borrowed)
+		.or_else(|| {
+			let vector = list.element(index)?;
+			color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
+		})
+}
+
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,
 /// enabling type-directed casting of typed `List`s from a `Graphic` value.
 pub trait TryFromGraphic: Clone + Sized {
@@ -368,12 +391,9 @@ impl Graphic {
 			Graphic::Vector(vector) => (0..vector.len()).all(|index| {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
-				let stroke_paint_graphic_list = vector
-					.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
-					.filter(|list| !list.is_empty())
-					.map(Cow::Borrowed)
-					.or_else(|| color_to_graphic_list(element.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
-				let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
+				let stroke_paint_graphic_list = stroke_paint_graphic_list_at(vector, index);
+				let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
 
 				opacity > 1. - f64::EPSILON
 					&& element.style.fill().is_opaque()
@@ -385,18 +405,48 @@ impl Graphic {
 
 	pub fn is_opaque(&self) -> bool {
 		match self {
+			Graphic::Graphic(list) => !list.is_empty() && list.iter_element_values().all(Graphic::is_opaque),
+			Graphic::Vector(list) => {
+				!list.is_empty()
+					&& list.iter_element_values().enumerate().all(|(i, vector)| {
+						let style = &vector.style;
+
+						let fill_graphic_list = fill_graphic_list_at(list, i);
+						let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
+						let stroke_paint_graphic_list = stroke_paint_graphic_list_at(list, i);
+						let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
+
+						let fill_opaque = fill_graphic.is_some_and(|g| g.is_opaque());
+						let stroke_opaque_or_invisible = style.stroke().is_none_or(|s| !s.has_renderable_stroke()) || stroke_paint_graphic.is_some_and(|g| g.is_opaque());
+
+						fill_opaque && stroke_opaque_or_invisible
+					})
+			}
 			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
 			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
-			_ => false,
+			Graphic::RasterCPU(_) | Graphic::RasterGPU(_) => false,
 		}
 	}
 
 	pub fn is_fully_transparent(&self) -> bool {
 		match self {
-			Self::Color(list) => list.element(0).is_some_and(|c| c.a() == 0.),
-			Self::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() == 0.)),
-			// FIXME: Write recursive check for other types
-			_ => false,
+			Graphic::Graphic(list) => list.iter_element_values().all(Graphic::is_fully_transparent),
+			Graphic::Vector(list) => list.iter_element_values().enumerate().all(|(i, vector)| {
+				let style = &vector.style;
+
+				let fill_graphic_list = fill_graphic_list_at(list, i);
+				let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
+				let stroke_paint_graphic_list = stroke_paint_graphic_list_at(list, i);
+				let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
+
+				let fill_invisible = fill_graphic.is_none_or(|g| g.is_fully_transparent());
+				let stroke_invisible = style.stroke().is_none_or(|s| !s.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|g| g.is_fully_transparent());
+
+				fill_invisible && stroke_invisible
+			}),
+			Graphic::Color(list) => list.iter_element_values().all(|c| c.a() == 0.),
+			Graphic::Gradient(list) => list.iter_element_values().all(|stops| stops.iter().all(|stop| stop.color.a() == 0.)),
+			Graphic::RasterCPU(_) | Graphic::RasterGPU(_) => false,
 		}
 	}
 }

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -209,7 +209,7 @@ pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
 /// `style.fill` when the row attribute is absent or empty.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).filter(|l| !l.is_empty()).map(Cow::Borrowed).or_else(|| {
+	list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
 		let vector = list.element(index)?;
 		fill_to_graphic_list(vector.style.fill()).map(Cow::Owned)
 	})
@@ -219,13 +219,70 @@ pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_,
 /// `style.stroke.color` when the row attribute is absent or empty.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn stroke_paint_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
-		.filter(|l| !l.is_empty())
-		.map(Cow::Borrowed)
-		.or_else(|| {
-			let vector = list.element(index)?;
-			color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
-		})
+	list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
+		let vector = list.element(index)?;
+		color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
+	})
+}
+
+/// Check whether the fill paint for a vector row is fully opaque, falling back to
+/// the legacy `style.fill` when the row attribute is absent.
+/// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
+/// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
+	}
+	let Some(vector) = list.element(index) else { return false };
+	match vector.style.fill() {
+		Fill::None => false,
+		Fill::Solid(color) => color.is_opaque(),
+		Fill::Gradient(gradient) => gradient.stops.iter().all(|stop| stop.color.is_opaque()),
+	}
+}
+
+/// Check whether the fill paint for a vector row is fully transparent, falling back to
+/// the legacy `style.fill` when the row attribute is absent.
+/// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
+/// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
+	}
+	let Some(vector) = list.element(index) else { return false };
+	match vector.style.fill() {
+		Fill::None => true,
+		Fill::Solid(color) => color.a() == 0.,
+		Fill::Gradient(gradient) => gradient.stops.iter().all(|stop| stop.color.a() == 0.),
+	}
+}
+
+/// Check whether the stroke paint for a vector row is fully opaque, falling back to
+/// the legacy `style.stroke.color` when the row attribute is absent.
+/// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
+/// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
+pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
+	}
+	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
+		return false;
+	};
+	color.is_opaque()
+}
+
+/// Check whether the stroke paint for a vector row is fully transparent, falling back to
+/// the legacy `style.stroke.color` when the row attribute is absent.
+/// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
+/// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
+pub fn is_stroke_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
+	}
+	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
+		return true;
+	};
+	color.a() == 0.
 }
 
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,
@@ -392,14 +449,19 @@ impl Graphic {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
 
-				let stroke_paint_graphic_list = stroke_paint_graphic_list_at(vector, index);
-				let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
-				let fill_graphic_list = fill_graphic_list_at(vector, index);
-				let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
+				let fill_opaque_or_absent = match vector.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+					Some(graphic_list) => graphic_list.element(0).is_none_or(|graphic| graphic.is_opaque()),
+					None => element.style.fill().is_opaque(),
+				};
 
-				opacity > 1. - f64::EPSILON
-					&& fill_graphic.is_none_or(|g| g.is_opaque())
-					&& (element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|graphic| graphic.is_fully_transparent()))
+				let stroke_invisible_or_transparent = element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
+					|| if let Some(graphic_list) = vector.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+						graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent())
+					} else {
+						element.style.stroke().and_then(|stroke| stroke.color()).is_none_or(|color| color.a() == 0.)
+					};
+
+				opacity > 1. - f64::EPSILON && fill_opaque_or_absent && stroke_invisible_or_transparent
 			}),
 			_ => false,
 		}
@@ -410,22 +472,15 @@ impl Graphic {
 			Graphic::Graphic(list) => !list.is_empty() && list.iter_element_values().all(Graphic::is_opaque),
 			Graphic::Vector(list) => {
 				!list.is_empty()
-					&& list.iter_element_values().enumerate().all(|(i, vector)| {
-						let style = &vector.style;
-
-						let fill_graphic_list = fill_graphic_list_at(list, i);
-						let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
-						let stroke_paint_graphic_list = stroke_paint_graphic_list_at(list, i);
-						let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
-
-						let fill_opaque = fill_graphic.is_some_and(|g| g.is_opaque());
-						let stroke_opaque_or_invisible = style.stroke().is_none_or(|s| !s.has_renderable_stroke()) || stroke_paint_graphic.is_some_and(|g| g.is_opaque());
-
+					&& (0..list.len()).all(|i| {
+						let Some(vector) = list.element(i) else { return false };
+						let fill_opaque = is_fill_opaque_at(list, i);
+						let stroke_opaque_or_invisible = vector.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || is_stroke_opaque_at(list, i);
 						fill_opaque && stroke_opaque_or_invisible
 					})
 			}
 			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
-			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
+			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.is_opaque())),
 			Graphic::RasterCPU(_) | Graphic::RasterGPU(_) => false,
 		}
 	}
@@ -433,20 +488,13 @@ impl Graphic {
 	pub fn is_fully_transparent(&self) -> bool {
 		match self {
 			Graphic::Graphic(list) => list.iter_element_values().all(Graphic::is_fully_transparent),
-			Graphic::Vector(list) => list.iter_element_values().enumerate().all(|(i, vector)| {
-				let style = &vector.style;
-
-				let fill_graphic_list = fill_graphic_list_at(list, i);
-				let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
-				let stroke_paint_graphic_list = stroke_paint_graphic_list_at(list, i);
-				let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
-
-				let fill_invisible = fill_graphic.is_none_or(|g| g.is_fully_transparent());
-				let stroke_invisible = style.stroke().is_none_or(|s| !s.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|g| g.is_fully_transparent());
-
+			Graphic::Vector(list) => (0..list.len()).all(|i| {
+				let Some(vector) = list.element(i) else { return false };
+				let fill_invisible = is_fill_fully_transparent_at(list, i);
+				let stroke_invisible = vector.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || is_stroke_fully_transparent_at(list, i);
 				fill_invisible && stroke_invisible
 			}),
-			Graphic::Color(list) => list.iter_element_values().all(|c| c.a() == 0.),
+			Graphic::Color(list) => list.iter_element_values().all(|color| color.a() == 0.),
 			Graphic::Gradient(list) => list.iter_element_values().all(|stops| stops.iter().all(|stop| stop.color.a() == 0.)),
 			Graphic::RasterCPU(_) | Graphic::RasterGPU(_) => false,
 		}

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -520,6 +520,12 @@ impl Graphic {
 		}
 	}
 
+	/// True if this paint opaquely covers the entire fill region.
+	/// Vector, Raster, and a nested Graphic may leave gaps, so they return false.
+	pub fn covers_opaquely(&self) -> bool {
+		matches!(self, Graphic::Color(_) | Graphic::Gradient(_)) && self.is_opaque()
+	}
+
 	/// Returns true if this graphic's inner list is empty.
 	pub fn is_empty(&self) -> bool {
 		match self {

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
 use core_types::list::{ATTR_FILL, ATTR_STROKE, Item, List};
@@ -10,9 +8,8 @@ use core_types::{ATTR_CLIPPING_MASK, ATTR_EDITOR_LAYER_PATH, ATTR_GRADIENT_TYPE,
 use dyn_any::DynAny;
 use glam::DAffine2;
 use raster_types::{CPU, GPU, Raster};
+use std::borrow::Cow;
 use vector_types::GradientStops;
-// use vector_types::Vector;
-
 pub use vector_types::Vector;
 use vector_types::vector::style::Fill;
 
@@ -110,21 +107,21 @@ impl From<List<GradientStops>> for Graphic {
 /// and discarding all other non-matching content. Recursion through `Graphic::Graphic` sub-`List`s composes transforms and opacity.
 fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) -> Option<List<T>>) -> List<T> {
 	fn flatten_recursive<T>(output: &mut List<T>, current_graphic_list: List<Graphic>, extract_variant: fn(Graphic) -> Option<List<T>>) {
-		for current_graphic_row in current_graphic_list.into_iter() {
+		for current_graphic_item in current_graphic_list.into_iter() {
 			// Whether the parent carries each attribute: a structural fact (column presence), never a value comparison.
 			// Flattening composes a parent attribute onto its children only when the parent has it,
 			// so an absent parent attribute never invents a column the children didn't already have.
-			let parent_has_transform = current_graphic_row.attribute::<DAffine2>(ATTR_TRANSFORM).is_some();
-			let parent_has_opacity = current_graphic_row.attribute::<f64>(ATTR_OPACITY).is_some();
-			let parent_has_fill = current_graphic_row.attribute::<f64>(ATTR_OPACITY_FILL).is_some();
-			let parent_has_layer_path = current_graphic_row.attribute::<List<NodeId>>(ATTR_EDITOR_LAYER_PATH).is_some();
+			let parent_has_transform = current_graphic_item.attribute::<DAffine2>(ATTR_TRANSFORM).is_some();
+			let parent_has_opacity = current_graphic_item.attribute::<f64>(ATTR_OPACITY).is_some();
+			let parent_has_fill = current_graphic_item.attribute::<f64>(ATTR_OPACITY_FILL).is_some();
+			let parent_has_layer_path = current_graphic_item.attribute::<List<NodeId>>(ATTR_EDITOR_LAYER_PATH).is_some();
 
-			let layer_path: List<NodeId> = current_graphic_row.attribute_cloned_or_default(ATTR_EDITOR_LAYER_PATH);
-			let current_transform: DAffine2 = current_graphic_row.attribute_cloned_or_default(ATTR_TRANSFORM);
-			let current_opacity: f64 = current_graphic_row.attribute_cloned_or(ATTR_OPACITY, 1.);
-			let current_fill: f64 = current_graphic_row.attribute_cloned_or(ATTR_OPACITY_FILL, 1.);
+			let layer_path: List<NodeId> = current_graphic_item.attribute_cloned_or_default(ATTR_EDITOR_LAYER_PATH);
+			let current_transform: DAffine2 = current_graphic_item.attribute_cloned_or_default(ATTR_TRANSFORM);
+			let current_opacity: f64 = current_graphic_item.attribute_cloned_or(ATTR_OPACITY, 1.);
+			let current_fill: f64 = current_graphic_item.attribute_cloned_or(ATTR_OPACITY_FILL, 1.);
 
-			match current_graphic_row.into_element() {
+			match current_graphic_item.into_element() {
 				// Compose the parent's transform/opacity/fill onto each child, but only for attributes the parent carries.
 				// A child lacking one is padded with the composition identity (`1.` for opacity/fill, identity for transform), so composing through it is a no-op.
 				Graphic::Graphic(mut sub_list) => {
@@ -153,16 +150,16 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 							// Each `|| item.attribute(...)` keeps an attribute the item itself carries
 							// (recomposed with the parent's identity value) even when the parent lacks it
 							if parent_has_transform || item.attribute::<DAffine2>(ATTR_TRANSFORM).is_some() {
-								let row_transform: DAffine2 = item.attribute_cloned_or_default(ATTR_TRANSFORM);
-								item.set_attribute(ATTR_TRANSFORM, current_transform * row_transform);
+								let item_transform: DAffine2 = item.attribute_cloned_or_default(ATTR_TRANSFORM);
+								item.set_attribute(ATTR_TRANSFORM, current_transform * item_transform);
 							}
 							if parent_has_opacity || item.attribute::<f64>(ATTR_OPACITY).is_some() {
-								let row_opacity: f64 = item.attribute_cloned_or(ATTR_OPACITY, 1.);
-								item.set_attribute(ATTR_OPACITY, current_opacity * row_opacity);
+								let item_opacity: f64 = item.attribute_cloned_or(ATTR_OPACITY, 1.);
+								item.set_attribute(ATTR_OPACITY, current_opacity * item_opacity);
 							}
 							if parent_has_fill || item.attribute::<f64>(ATTR_OPACITY_FILL).is_some() {
-								let row_fill: f64 = item.attribute_cloned_or(ATTR_OPACITY_FILL, 1.);
-								item.set_attribute(ATTR_OPACITY_FILL, current_fill * row_fill);
+								let item_fill: f64 = item.attribute_cloned_or(ATTR_OPACITY_FILL, 1.);
+								item.set_attribute(ATTR_OPACITY_FILL, current_fill * item_fill);
 							}
 							if parent_has_layer_path {
 								item.set_attribute(ATTR_EDITOR_LAYER_PATH, layer_path.clone());
@@ -188,11 +185,11 @@ pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 		Fill::None => None,
 		Fill::Solid(color) => Some(List::new_from_element((*color).into())),
 		Fill::Gradient(gradient) => {
-			let gradient_row = Item::new_from_element(gradient.stops.clone())
+			let gradient_item = Item::new_from_element(gradient.stops.clone())
 				.with_attribute(ATTR_TRANSFORM, gradient.to_transform())
 				.with_attribute(ATTR_GRADIENT_TYPE, gradient.gradient_type)
 				.with_attribute(ATTR_SPREAD_METHOD, gradient.spread_method);
-			let gradient_list = List::new_from_item(gradient_row);
+			let gradient_list = List::new_from_item(gradient_item);
 
 			Some(List::new_from_element(Graphic::Gradient(gradient_list)))
 		}
@@ -205,7 +202,7 @@ pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
 	color.as_ref().map(|color| List::new_from_element((*color).into()))
 }
 
-/// Look up the paint graphics stored under attribute for a vector row, normalizing any graphic list type to `List<Graphic>`.
+/// Look up the paint graphics stored under attribute for a vector item, normalizing any graphic list type to `List<Graphic>`.
 pub fn graphic_list_at<'a>(list: &'a List<Vector>, index: usize, attribute: &str) -> Option<Cow<'a, List<Graphic>>> {
 	list.attribute::<List<Graphic>>(attribute, index)
 		.map(Cow::Borrowed)
@@ -218,8 +215,8 @@ pub fn graphic_list_at<'a>(list: &'a List<Vector>, index: usize, attribute: &str
 		.filter(|graphic_list| graphic_list.element(0).is_some_and(|graphic| !graphic.is_empty()))
 }
 
-/// Look up the fill paint graphics for a vector row, falling back to the legacy
-/// `style.fill` when the row attribute is absent or empty.
+/// Look up the fill paint graphics for a vector item, falling back to the legacy
+/// `style.fill` when the attribute is absent or empty.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
 	graphic_list_at(list, index, ATTR_FILL).or_else(|| {
@@ -228,8 +225,8 @@ pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_,
 	})
 }
 
-/// Look up the stroke paint graphics for a vector row, falling back to the legacy
-/// `style.stroke.color` when the row attribute is absent or empty.
+/// Look up the stroke paint graphics for a vector item, falling back to the legacy
+/// `style.stroke.color` when the attribute is absent or empty.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
 	graphic_list_at(list, index, ATTR_STROKE).or_else(|| {
@@ -238,8 +235,8 @@ pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'
 	})
 }
 
-/// Check whether the fill paint for a vector row is fully opaque, falling back to
-/// the legacy `style.fill` when the row attribute is absent.
+/// Check whether the fill paint for a vector item is fully opaque, falling back to
+/// the legacy `style.fill` when the attribute is absent.
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
@@ -254,8 +251,8 @@ pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
 	}
 }
 
-/// Check whether the fill paint for a vector row is fully transparent, falling back to
-/// the legacy `style.fill` when the row attribute is absent.
+/// Check whether the fill paint for a vector item is fully transparent, falling back to
+/// the legacy `style.fill` when the attribute is absent.
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
@@ -270,8 +267,8 @@ pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
 	}
 }
 
-/// Check whether the stroke paint for a vector row is fully opaque, falling back to
-/// the legacy `style.stroke.color` when the row attribute is absent.
+/// Check whether the stroke paint for a vector item is fully opaque, falling back to
+/// the legacy `style.stroke.color` when the attribute is absent.
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
@@ -284,8 +281,8 @@ pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
 	color.is_opaque()
 }
 
-/// Check whether the stroke paint for a vector row is fully transparent, falling back to
-/// the legacy `style.stroke.color` when the row attribute is absent.
+/// Check whether the stroke paint for a vector item is fully transparent, falling back to
+/// the legacy `style.stroke.color` when the attribute is absent.
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
@@ -349,7 +346,7 @@ impl IntoGraphicList for List<Graphic> {
 
 impl IntoGraphicList for List<Vector> {
 	fn into_graphic_list(self) -> List<Graphic> {
-		// Propagate `editor:layer_path` from item 0 onto the wrapper Graphic row so a subsequent
+		// Propagate `editor:layer_path` from item 0 onto the wrapper Graphic item so a subsequent
 		// `flatten_graphic_list` doesn't overwrite the inner Vector's stamp with an empty value
 		let layer_path: List<NodeId> = self.attribute_cloned_or_default(ATTR_EDITOR_LAYER_PATH, 0);
 		let mut graphic_list = List::new_from_element(Graphic::Vector(self));
@@ -564,17 +561,17 @@ impl BoundingBox for Graphic {
 }
 
 impl ListConvert<Graphic> for Vector {
-	fn convert_row(self) -> Graphic {
+	fn convert_item(self) -> Graphic {
 		Graphic::Vector(List::new_from_element(self))
 	}
 }
 impl ListConvert<Graphic> for Raster<CPU> {
-	fn convert_row(self) -> Graphic {
+	fn convert_item(self) -> Graphic {
 		Graphic::RasterCPU(List::new_from_element(self))
 	}
 }
 impl ListConvert<Graphic> for Raster<GPU> {
-	fn convert_row(self) -> Graphic {
+	fn convert_item(self) -> Graphic {
 		Graphic::RasterGPU(List::new_from_element(self))
 	}
 }
@@ -614,9 +611,9 @@ impl<T: Clone> AtIndex for List<T> {
 	type Output = List<T>;
 
 	fn at_index(&self, index: usize) -> Option<Self::Output> {
-		self.clone_item(index).map(|row| {
+		self.clone_item(index).map(|item| {
 			let mut result_list = Self::default();
-			result_list.push(row);
+			result_list.push(item);
 			result_list
 		})
 	}
@@ -647,9 +644,9 @@ impl<T: Clone> OmitIndex for List<T> {
 		let mut result = Self::default();
 		for i in 0..self.len() {
 			if i != index
-				&& let Some(row) = self.clone_item(i)
+				&& let Some(item) = self.clone_item(i)
 			{
-				result.push(row);
+				result.push(item);
 			}
 		}
 		result

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL, ATTR_STROKE, Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -220,7 +220,7 @@ pub fn graphic_list_at<'a>(list: &'a List<Vector>, index: usize, attribute: &str
 /// `style.fill` when the row attribute is absent or empty.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	graphic_list_at(list, index, ATTR_FILL_GRAPHIC).or_else(|| {
+	graphic_list_at(list, index, ATTR_FILL).or_else(|| {
 		let vector = list.element(index)?;
 		fill_to_graphic_list(vector.style.fill()).map(Cow::Owned)
 	})
@@ -230,7 +230,7 @@ pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_,
 /// `style.stroke.color` when the row attribute is absent or empty.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	graphic_list_at(list, index, ATTR_STROKE_GRAPHIC).or_else(|| {
+	graphic_list_at(list, index, ATTR_STROKE).or_else(|| {
 		let vector = list.element(index)?;
 		color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
 	})
@@ -241,7 +241,7 @@ pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL_GRAPHIC) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL) {
 		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
 	}
 	let Some(vector) = list.element(index) else { return false };
@@ -257,7 +257,7 @@ pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL_GRAPHIC) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL) {
 		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
 	}
 	let Some(vector) = list.element(index) else { return false };
@@ -273,7 +273,7 @@ pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE_GRAPHIC) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE) {
 		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -287,7 +287,7 @@ pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE_GRAPHIC) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE) {
 		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -460,13 +460,13 @@ impl Graphic {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
 
-				let fill_opaque_or_absent = match graphic_list_at(vector, index, ATTR_FILL_GRAPHIC) {
+				let fill_opaque_or_absent = match graphic_list_at(vector, index, ATTR_FILL) {
 					Some(graphic_list) => graphic_list.element(0).is_none_or(|graphic| graphic.is_opaque()),
 					None => element.style.fill().is_opaque(),
 				};
 
 				let stroke_invisible_or_transparent = element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
-					|| if let Some(graphic_list) = graphic_list_at(vector, index, ATTR_STROKE_GRAPHIC) {
+					|| if let Some(graphic_list) = graphic_list_at(vector, index, ATTR_STROKE) {
 						graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent())
 					} else {
 						element.style.stroke().and_then(|stroke| stroke.color()).is_none_or(|color| color.a() == 0.)

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -4,7 +4,7 @@ use core_types::list::List;
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
-use core_types::{ATTR_CLIPPING_MASK, ATTR_EDITOR_LAYER_PATH, ATTR_OPACITY, ATTR_OPACITY_FILL, ATTR_TRANSFORM, Color};
+use core_types::{ATTR_CLIPPING_MASK, ATTR_EDITOR_LAYER_PATH, ATTR_GRADIENT_TYPE, ATTR_OPACITY, ATTR_OPACITY_FILL, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use dyn_any::DynAny;
 use glam::DAffine2;
 use raster_types::{CPU, GPU, Raster};
@@ -12,6 +12,7 @@ use vector_types::GradientStops;
 // use vector_types::Vector;
 
 pub use vector_types::Vector;
+use vector_types::vector::style::Fill;
 
 /// The possible forms of graphical content that can be rendered by the Render node into either an image or SVG syntax.
 #[derive(Clone, Debug, CacheHash, PartialEq, DynAny)]
@@ -176,6 +177,24 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 	let mut output = List::new();
 	flatten_recursive(&mut output, content, extract_variant);
 	output
+}
+
+/// Converts a `Fill` enum into the `Table<Graphic>` representation used as paint storage.
+/// TODO: Remove once all paint sources flow through `Table<Graphic>` directly without going through the `Fill` enum.
+pub fn fill_to_paint(fill: &Fill) -> Option<Table<Graphic>> {
+	match fill {
+		Fill::None => None,
+		Fill::Solid(color) => Some(Table::new_from_element((*color).into())),
+		Fill::Gradient(gradient) => {
+			let gradient_row = TableRow::new_from_element(gradient.stops.clone())
+				.with_attribute(ATTR_TRANSFORM, gradient.to_transform())
+				.with_attribute(ATTR_GRADIENT_TYPE, gradient.gradient_type)
+				.with_attribute(ATTR_SPREAD_METHOD, gradient.spread_method);
+			let gradient_table = Table::new_from_row(gradient_row);
+
+			Some(Table::new_from_element(Graphic::Gradient(gradient_table)))
+		}
+	}
 }
 
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -474,9 +474,11 @@ impl Graphic {
 				!list.is_empty()
 					&& (0..list.len()).all(|i| {
 						let Some(vector) = list.element(i) else { return false };
-						let fill_opaque = is_fill_opaque_at(list, i);
+						let opacity: f64 = list.attribute_cloned_or(ATTR_OPACITY, i, 1.);
+						let opacity_fill: f64 = list.attribute_cloned_or(ATTR_OPACITY_FILL, i, 1.);
+						let fill_opaque = opacity_fill >= 1. - f64::EPSILON && is_fill_opaque_at(list, i);
 						let stroke_opaque_or_invisible = vector.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || is_stroke_opaque_at(list, i);
-						fill_opaque && stroke_opaque_or_invisible
+						opacity >= 1. - f64::EPSILON && fill_opaque && stroke_opaque_or_invisible
 					})
 			}
 			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
@@ -490,7 +492,12 @@ impl Graphic {
 			Graphic::Graphic(list) => list.iter_element_values().all(Graphic::is_fully_transparent),
 			Graphic::Vector(list) => (0..list.len()).all(|i| {
 				let Some(vector) = list.element(i) else { return false };
-				let fill_invisible = is_fill_fully_transparent_at(list, i);
+				let opacity: f64 = list.attribute_cloned_or(ATTR_OPACITY, i, 1.);
+				if opacity <= f64::EPSILON {
+					return true;
+				}
+				let opacity_fill: f64 = list.attribute_cloned_or(ATTR_OPACITY_FILL, i, 1.);
+				let fill_invisible = opacity_fill <= f64::EPSILON || is_fill_fully_transparent_at(list, i);
 				let stroke_invisible = vector.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || is_stroke_fully_transparent_at(list, i);
 				fill_invisible && stroke_invisible
 			}),

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -365,6 +365,14 @@ impl Graphic {
 			_ => false,
 		}
 	}
+
+	pub fn is_opaque(&self) -> bool {
+		match self {
+			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
+			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
+			_ => false,
+		}
+	}
 }
 
 impl BoundingBox for Graphic {
@@ -522,5 +530,81 @@ mod tests {
 		group.set_attribute(ATTR_OPACITY, 0, 0.5_f64);
 		let flattened: List<Vector> = group.into_flattened_list();
 		assert_eq!(flattened.attribute_cloned_or_default::<f64>(ATTR_OPACITY, 0), 0.5);
+	}
+}
+
+#[cfg(test)]
+mod graphic_is_opaque_tests {
+	use vector_types::{GradientSpreadMethod, GradientStop};
+
+	use super::*;
+
+	fn color_graphic(alpha: f64) -> Graphic {
+		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
+		Graphic::Color(List::new_from_element(color))
+	}
+
+	fn gradient_graphic(gradient: GradientStops) -> Graphic {
+		let mut gradient_list = List::new_from_element(gradient);
+		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
+		Graphic::Gradient(gradient_list)
+	}
+
+	#[test]
+	fn opaque_color_is_opaque() {
+		let g = color_graphic(1.0);
+		assert!(g.is_opaque());
+	}
+
+	#[test]
+	fn transparent_color_is_not_opaque() {
+		let g = color_graphic(0.5);
+		assert!(!g.is_opaque());
+	}
+
+	#[test]
+	fn vector_is_not_opaque() {
+		let g = Graphic::Vector(List::default());
+		assert!(!g.is_opaque());
+	}
+
+	#[test]
+	fn gradient_with_all_opaque_stops_is_opaque() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(g.is_opaque());
+	}
+
+	#[test]
+	fn gradient_with_transparent_stop_is_not_opaque() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(!g.is_opaque());
 	}
 }

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -394,9 +394,11 @@ impl Graphic {
 
 				let stroke_paint_graphic_list = stroke_paint_graphic_list_at(vector, index);
 				let stroke_paint_graphic = stroke_paint_graphic_list.as_deref().and_then(|l| l.element(0));
+				let fill_graphic_list = fill_graphic_list_at(vector, index);
+				let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
 
 				opacity > 1. - f64::EPSILON
-					&& element.style.fill().is_opaque()
+					&& fill_graphic.is_none_or(|g| g.is_opaque())
 					&& (element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|graphic| graphic.is_fully_transparent()))
 			}),
 			_ => false,

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::{Item, List};
+use core_types::list::{ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -366,7 +368,16 @@ impl Graphic {
 			Graphic::Vector(vector) => (0..vector.len()).all(|index| {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
-				opacity > 1. - f64::EPSILON && element.style.fill().is_opaque() && element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
+				let stroke_paint_graphic_list = vector
+					.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
+					.filter(|list| !list.is_empty())
+					.map(Cow::Borrowed)
+					.or_else(|| color_to_graphic_list(element.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
+				let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
+				opacity > 1. - f64::EPSILON
+					&& element.style.fill().is_opaque()
+					&& (element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|graphic| graphic.is_fully_transparent()))
 			}),
 			_ => false,
 		}
@@ -376,6 +387,15 @@ impl Graphic {
 		match self {
 			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
 			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
+			_ => false,
+		}
+	}
+
+	pub fn is_fully_transparent(&self) -> bool {
+		match self {
+			Self::Color(list) => list.element(0).is_some_and(|c| c.a() == 0.),
+			Self::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() == 0.)),
+			// FIXME: Write recursive check for other types
 			_ => false,
 		}
 	}

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -517,6 +517,18 @@ impl Graphic {
 			Graphic::RasterCPU(_) | Graphic::RasterGPU(_) => false,
 		}
 	}
+
+	/// Returns true if this graphic's inner list is empty.
+	pub fn is_empty(&self) -> bool {
+		match self {
+			Graphic::Graphic(list) => list.is_empty(),
+			Graphic::Vector(list) => list.is_empty(),
+			Graphic::Color(list) => list.is_empty(),
+			Graphic::Gradient(list) => list.is_empty(),
+			Graphic::RasterCPU(list) => list.is_empty(),
+			Graphic::RasterGPU(list) => list.is_empty(),
+		}
+	}
 }
 
 impl BoundingBox for Graphic {

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -205,11 +205,22 @@ pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
 	color.as_ref().map(|color| List::new_from_element((*color).into()))
 }
 
+/// Look up the paint graphics stored under attribute for a vector row, normalizing any graphic list type to `List<Graphic>`.
+pub fn graphic_list_at<'a>(list: &'a List<Vector>, index: usize, attribute: &str) -> Option<Cow<'a, List<Graphic>>> {
+	list.attribute::<List<Graphic>>(attribute, index)
+		.map(Cow::Borrowed)
+		.or_else(|| list.attribute::<List<Color>>(attribute, index).map(|c| Cow::Owned(c.clone().into_graphic_list())))
+		.or_else(|| list.attribute::<List<GradientStops>>(attribute, index).map(|g| Cow::Owned(g.clone().into_graphic_list())))
+		.or_else(|| list.attribute::<List<Vector>>(attribute, index).map(|v| Cow::Owned(v.clone().into_graphic_list())))
+		.or_else(|| list.attribute::<List<Raster<CPU>>>(attribute, index).map(|r| Cow::Owned(r.clone().into_graphic_list())))
+		.or_else(|| list.attribute::<List<Raster<GPU>>>(attribute, index).map(|r| Cow::Owned(r.clone().into_graphic_list())))
+}
+
 /// Look up the fill paint graphics for a vector row, falling back to the legacy
 /// `style.fill` when the row attribute is absent or empty.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
+	graphic_list_at(list, index, ATTR_FILL_GRAPHIC).or_else(|| {
 		let vector = list.element(index)?;
 		fill_to_graphic_list(vector.style.fill()).map(Cow::Owned)
 	})
@@ -219,7 +230,7 @@ pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_,
 /// `style.stroke.color` when the row attribute is absent or empty.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
+	graphic_list_at(list, index, ATTR_STROKE_GRAPHIC).or_else(|| {
 		let vector = list.element(index)?;
 		color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
 	})
@@ -230,7 +241,7 @@ pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL_GRAPHIC) {
 		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
 	}
 	let Some(vector) = list.element(index) else { return false };
@@ -246,7 +257,7 @@ pub fn is_fill_opaque_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Fill` fallback path performs.
 /// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_FILL_GRAPHIC) {
 		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
 	}
 	let Some(vector) = list.element(index) else { return false };
@@ -262,7 +273,7 @@ pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE_GRAPHIC) {
 		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -276,7 +287,7 @@ pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
+	if let Some(graphic_list) = graphic_list_at(list, index, ATTR_STROKE_GRAPHIC) {
 		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -449,13 +460,13 @@ impl Graphic {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
 
-				let fill_opaque_or_absent = match vector.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+				let fill_opaque_or_absent = match graphic_list_at(vector, index, ATTR_FILL_GRAPHIC) {
 					Some(graphic_list) => graphic_list.element(0).is_none_or(|graphic| graphic.is_opaque()),
 					None => element.style.fill().is_opaque(),
 				};
 
 				let stroke_invisible_or_transparent = element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
-					|| if let Some(graphic_list) = vector.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
+					|| if let Some(graphic_list) = graphic_list_at(vector, index, ATTR_STROKE_GRAPHIC) {
 						graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent())
 					} else {
 						element.style.stroke().and_then(|stroke| stroke.color()).is_none_or(|color| color.a() == 0.)

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -1,6 +1,6 @@
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::List;
+use core_types::list::{Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -179,20 +179,20 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 	output
 }
 
-/// Converts a `Fill` enum into the `Table<Graphic>` representation used as paint storage.
-/// TODO: Remove once all paint sources flow through `Table<Graphic>` directly without going through the `Fill` enum.
-pub fn fill_to_paint(fill: &Fill) -> Option<Table<Graphic>> {
+/// Converts a `Fill` enum into the `List<Graphic>` representation used as paint storage.
+/// TODO: Remove once all paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 	match fill {
 		Fill::None => None,
-		Fill::Solid(color) => Some(Table::new_from_element((*color).into())),
+		Fill::Solid(color) => Some(List::new_from_element((*color).into())),
 		Fill::Gradient(gradient) => {
-			let gradient_row = TableRow::new_from_element(gradient.stops.clone())
+			let gradient_row = Item::new_from_element(gradient.stops.clone())
 				.with_attribute(ATTR_TRANSFORM, gradient.to_transform())
 				.with_attribute(ATTR_GRADIENT_TYPE, gradient.gradient_type)
 				.with_attribute(ATTR_SPREAD_METHOD, gradient.spread_method);
-			let gradient_table = Table::new_from_row(gradient_row);
+			let gradient_list = List::new_from_item(gradient_row);
 
-			Some(Table::new_from_element(Graphic::Gradient(gradient_table)))
+			Some(List::new_from_element(Graphic::Gradient(gradient_list)))
 		}
 	}
 }

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -214,6 +214,8 @@ pub fn graphic_list_at<'a>(list: &'a List<Vector>, index: usize, attribute: &str
 		.or_else(|| list.attribute::<List<Vector>>(attribute, index).map(|v| Cow::Owned(v.clone().into_graphic_list())))
 		.or_else(|| list.attribute::<List<Raster<CPU>>>(attribute, index).map(|r| Cow::Owned(r.clone().into_graphic_list())))
 		.or_else(|| list.attribute::<List<Raster<GPU>>>(attribute, index).map(|r| Cow::Owned(r.clone().into_graphic_list())))
+		// Treat a blank attribute as absent so consumers fall back to the legacy `style` instead of masking it.
+		.filter(|graphic_list| graphic_list.element(0).is_some_and(|graphic| !graphic.is_empty()))
 }
 
 /// Look up the fill paint graphics for a vector row, falling back to the legacy

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -218,8 +218,8 @@ pub fn fill_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_,
 /// Look up the stroke paint graphics for a vector row, falling back to the legacy
 /// `style.stroke.color` when the row attribute is absent or empty.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
-pub fn stroke_paint_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
-	list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
+pub fn stroke_graphic_list_at(list: &List<Vector>, index: usize) -> Option<Cow<'_, List<Graphic>>> {
+	list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index).map(Cow::Borrowed).or_else(|| {
 		let vector = list.element(index)?;
 		color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned)
 	})
@@ -262,7 +262,7 @@ pub fn is_fill_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
 		return graphic_list.element(0).is_some_and(|graphic| graphic.is_opaque());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -276,7 +276,7 @@ pub fn is_stroke_opaque_at(list: &List<Vector>, index: usize) -> bool {
 /// This avoids the `List<Graphic>` allocation that the legacy `Stroke.color` fallback path performs.
 /// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
 pub fn is_stroke_fully_transparent_at(list: &List<Vector>, index: usize) -> bool {
-	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+	if let Some(graphic_list) = list.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
 		return graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent());
 	}
 	let Some(color) = list.element(index).and_then(|vector| vector.style.stroke()).and_then(|stroke| stroke.color()) else {
@@ -455,7 +455,7 @@ impl Graphic {
 				};
 
 				let stroke_invisible_or_transparent = element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
-					|| if let Some(graphic_list) = vector.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index) {
+					|| if let Some(graphic_list) = vector.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index) {
 						graphic_list.element(0).is_none_or(|graphic| graphic.is_fully_transparent())
 					} else {
 						element.style.stroke().and_then(|stroke| stroke.color()).is_none_or(|color| color.a() == 0.)

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,11 +1,11 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
-use core_types::table::Table;
+use core_types::list::List;
 use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
 use graphic_types::Graphic;
-use graphic_types::graphic::fill_to_paint;
+use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
@@ -17,7 +17,7 @@ pub trait RenderExt {
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
 }
 
-impl RenderExt for Table<Color> {
+impl RenderExt for List<Color> {
 	type Output = String;
 
 	fn render(
@@ -40,7 +40,7 @@ impl RenderExt for Table<Color> {
 	}
 }
 
-impl RenderExt for Table<GradientStops> {
+impl RenderExt for List<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
@@ -118,13 +118,13 @@ impl RenderExt for Fill {
 
 	/// Renders the fill, adding necessary defs through mutating the first argument.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		let Some(paint_table) = fill_to_paint(self) else { return r#" fill="none""#.to_string() };
-		let Some(paint) = paint_table.element(0) else { return String::new() };
+		let Some(paint_list) = fill_to_graphic_list(self) else { return r#" fill="none""#.to_string() };
+		let Some(paint) = paint_list.element(0) else { return String::new() };
 
 		match paint {
-			Graphic::Color(color_table) => color_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
-			Graphic::Gradient(stops_table) => {
-				let gradient_id = stops_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+			Graphic::Color(color_list) => color_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Graphic::Gradient(stops_list) => {
+				let gradient_id = stops_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
 				format!(r##" fill="url('#{gradient_id}')""##)
 			}
 			_ => {

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -246,7 +246,8 @@ impl RenderExt for List<Graphic> {
 			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
 				let bounds = if target == PaintTarget::Stroke {
 					// To prevent a wraparound artefact occurring when the tile boundary and the stroke region are perfectly aligned, the local coordinate is expanded slightly.
-					let inflate = DVec2::new(1.0 / item_transform.matrix2.x_axis.length(), 1.0 / item_transform.matrix2.y_axis.length());
+					let inverse = |len: f64| if len > 0. { 1.0 / len } else { 0. };
+					let inflate = DVec2::new(inverse(item_transform.matrix2.x_axis.length()), inverse(item_transform.matrix2.y_axis.length()));
 					let min = bounds.transform_point2(DVec2::ZERO) - inflate;
 					let max = bounds.transform_point2(DVec2::ONE) + inflate;
 					DAffine2::from_scale_angle_translation(max - min, 0., min)

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,9 +1,11 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
+use crate::{Render, RenderSvgSegmentList, SvgRender};
 use core_types::color::SRGBA8;
 use core_types::list::List;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
+use graphic_types::Graphic;
 use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{PaintOrder, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
@@ -12,7 +14,17 @@ use vector_types::gradient::GradientSpreadMethod;
 
 pub trait RenderExt {
 	type Output;
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
+	#[allow(clippy::too_many_arguments)]
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		render_params: &RenderParams,
+	) -> Self::Output;
 }
 
 impl RenderExt for List<Color> {
@@ -21,6 +33,7 @@ impl RenderExt for List<Color> {
 	fn render(
 		&self,
 		_svg_defs: &mut String,
+		_item_transform: DAffine2,
 		_element_transform: DAffine2,
 		_stroke_transform: DAffine2,
 		_bounds: DAffine2,
@@ -42,7 +55,16 @@ impl RenderExt for List<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, _render_params: &RenderParams) -> Self::Output {
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		_item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		_render_params: &RenderParams,
+	) -> Self::Output {
 		let mut stop = String::new();
 
 		let Some(stops) = self.element(0) else { return 0 };
@@ -118,6 +140,7 @@ impl RenderExt for Stroke {
 	fn render(
 		&self,
 		_svg_defs: &mut String,
+		_item_transform: DAffine2,
 		_element_transform: DAffine2,
 		_stroke_transform: DAffine2,
 		_bounds: DAffine2,
@@ -173,4 +196,74 @@ impl RenderExt for Stroke {
 		}
 		attributes
 	}
+}
+
+impl RenderExt for List<Graphic> {
+	type Output = String;
+
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		render_params: &RenderParams,
+	) -> Self::Output {
+		let fill_graphic = self.element(0);
+
+		match fill_graphic {
+			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Some(Graphic::Gradient(gradient_list)) => {
+				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+				format!(r##" fill="url(#{gradient_id})""##)
+			}
+			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
+				render_svg_fill_pattern(svg_defs, self, item_transform, bounds, render_params)
+					.map(|id| format!(r##" fill="url(#{id})""##))
+					.unwrap_or_else(|| r#" fill="none""#.to_string())
+			}
+			None => r#" fill="none""#.to_string(),
+		}
+	}
+}
+
+/// Emits an SVG `<pattern>` paint server into `svg_defs` that renders the given graphic list as the fill content, and returns the pattern ID.
+/// Currently, this function is only used for clipping-based filling, not for tiling.
+fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
+	let min = bounds.transform_point2(DVec2::ZERO);
+	let max = bounds.transform_point2(DVec2::ONE);
+	let size = max - min;
+	if size.x <= 0. || size.y <= 0. {
+		return None;
+	}
+
+	// Render the pattern content recursively
+	let mut content = SvgRender::new();
+	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
+
+	// Unwrap the inner def element
+	write!(svg_defs, "{}", content.svg_defs).unwrap();
+
+	let pattern_transform = item_transform * DAffine2::from_translation(min);
+	let transform_str = format_transform_matrix(pattern_transform);
+	let transform_attr = if transform_str.is_empty() {
+		String::new()
+	} else {
+		format!(r#" patternTransform="{transform_str}""#)
+	};
+
+	let pattern_id = format!("pattern-{}", generate_uuid());
+	write!(
+		svg_defs,
+		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
+		size.x, size.y,
+	)
+	.unwrap();
+
+	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
+	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
+
+	Some(pattern_id)
 }

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -253,7 +253,7 @@ impl RenderExt for List<Graphic> {
 				} else {
 					bounds
 				};
-				render_svg_pattern(svg_defs, self, item_transform, bounds, render_params)
+				render_svg_pattern(svg_defs, self, stroke_transform, bounds, render_params)
 					.map(|id| format!(r##" {paint_attr}="url(#{id})""##))
 					.unwrap_or_else(|| format!(r#" {paint_attr}="none""#))
 			}
@@ -264,7 +264,7 @@ impl RenderExt for List<Graphic> {
 
 /// Emits an SVG `<pattern>` paint server into `svg_defs` that renders the given graphic list as the paint content, and returns the pattern ID.
 /// Currently, this function is only used for clipping-based filling and stroking, not considering tiling yet.
-fn render_svg_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
+fn render_svg_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, stroke_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
 	let min = bounds.transform_point2(DVec2::ZERO);
 	let max = bounds.transform_point2(DVec2::ONE);
 	let size = max - min;
@@ -279,7 +279,7 @@ fn render_svg_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, 
 	// Unwrap the inner def element
 	write!(svg_defs, "{}", content.svg_defs).unwrap();
 
-	let pattern_transform = item_transform * DAffine2::from_translation(min);
+	let pattern_transform = stroke_transform * DAffine2::from_translation(min);
 	let transform_str = format_transform_matrix(pattern_transform);
 	let transform_attr = if transform_str.is_empty() {
 		String::new()

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -12,7 +12,7 @@ use std::fmt::Write;
 use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PaintTarget {
 	Fill,
 	Stroke,
@@ -244,7 +244,16 @@ impl RenderExt for List<Graphic> {
 				format!(r##" {paint_attr}="url(#{gradient_id})""##)
 			}
 			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
-				render_svg_fill_pattern(svg_defs, self, item_transform, bounds, render_params)
+				let bounds = if target == PaintTarget::Stroke {
+					// To prevent a wraparound artefact occurring when the tile boundary and the stroke region are perfectly aligned, the local coordinate is expanded slightly.
+					let inflate = DVec2::new(1.0 / item_transform.matrix2.x_axis.length(), 1.0 / item_transform.matrix2.y_axis.length());
+					let min = bounds.transform_point2(DVec2::ZERO) - inflate;
+					let max = bounds.transform_point2(DVec2::ONE) + inflate;
+					DAffine2::from_scale_angle_translation(max - min, 0., min)
+				} else {
+					bounds
+				};
+				render_svg_pattern(svg_defs, self, item_transform, bounds, render_params)
 					.map(|id| format!(r##" {paint_attr}="url(#{id})""##))
 					.unwrap_or_else(|| format!(r#" {paint_attr}="none""#))
 			}
@@ -253,9 +262,9 @@ impl RenderExt for List<Graphic> {
 	}
 }
 
-/// Emits an SVG `<pattern>` paint server into `svg_defs` that renders the given graphic list as the fill content, and returns the pattern ID.
-/// Currently, this function is only used for clipping-based filling, not for tiling.
-fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
+/// Emits an SVG `<pattern>` paint server into `svg_defs` that renders the given graphic list as the paint content, and returns the pattern ID.
+/// Currently, this function is only used for clipping-based filling and stroking, not considering tiling yet.
+fn render_svg_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
 	let min = bounds.transform_point2(DVec2::ZERO);
 	let max = bounds.transform_point2(DVec2::ONE);
 	let size = max - min;

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,6 +1,6 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
-use core_types::list::List;
 use core_types::color::SRGBA8;
+use core_types::list::List;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -36,6 +36,7 @@ impl PaintTarget {
 
 pub trait RenderExt {
 	type Output;
+
 	#[allow(clippy::too_many_arguments)]
 	fn render(
 		&self,
@@ -246,7 +247,7 @@ impl RenderExt for List<Graphic> {
 			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
 				let bounds = if target == PaintTarget::Stroke {
 					// To prevent a wraparound artefact occurring when the tile boundary and the stroke region are perfectly aligned, the local coordinate is expanded slightly.
-					let inverse = |len: f64| if len > 0. { 1.0 / len } else { 0. };
+					let inverse = |len: f64| if len > 0. { 1. / len } else { 0. };
 					let inflate = DVec2::new(inverse(item_transform.matrix2.x_axis.length()), inverse(item_transform.matrix2.y_axis.length()));
 					let min = bounds.transform_point2(DVec2::ZERO) - inflate;
 					let max = bounds.transform_point2(DVec2::ONE) + inflate;

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -40,7 +40,7 @@ impl RenderExt for List<Color> {
 		_transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
 	) -> Self::Output {
-		let Some(color) = self.element(0) else { return String::new() };
+		let Some(color) = self.element(0) else { return r#" fill="none""#.to_string() };
 
 		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
 		if color.a() < 1. {

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,10 +1,15 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
+use core_types::table::Table;
 use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
-use glam::DAffine2;
-use graphic_types::vector_types::gradient::{Gradient, GradientType};
+use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
+use glam::{DAffine2, DVec2};
+use graphic_types::Graphic;
+use graphic_types::graphic::fill_to_paint;
+use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
+use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
 
 pub trait RenderExt {
@@ -12,13 +17,42 @@ pub trait RenderExt {
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
 }
 
-impl RenderExt for Gradient {
+impl RenderExt for Table<Color> {
+	type Output = String;
+
+	fn render(
+		&self,
+		_svg_defs: &mut String,
+		_element_transform: DAffine2,
+		_stroke_transform: DAffine2,
+		_bounds: DAffine2,
+		_transformed_bounds: DAffine2,
+		_render_params: &RenderParams,
+	) -> Self::Output {
+		let Some(color) = self.element(0) else { return String::new() };
+
+		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
+		if color.a() < 1. {
+			let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
+		}
+
+		result
+	}
+}
+
+impl RenderExt for Table<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, _render_params: &RenderParams) -> Self::Output {
 		let mut stop = String::new();
-		for (position, color, original_midpoint) in self.stops.interpolated_samples() {
+
+		let Some(stops) = self.element(0) else { return 0 };
+		let gradient_type: GradientType = self.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+		let gradient_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+		let spread_method: GradientSpreadMethod = self.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
+
+		for (position, color, original_midpoint) in stops.interpolated_samples() {
 			stop.push_str("<stop");
 			if position != 0. {
 				let _ = write!(stop, r#" offset="{}""#, (position * 1_000_000.).round() / 1_000_000.);
@@ -33,9 +67,9 @@ impl RenderExt for Gradient {
 			stop.push_str(" />")
 		}
 
-		let transform_points = element_transform * stroke_transform * bounds;
-		let start = transform_points.transform_point2(self.start);
-		let end = transform_points.transform_point2(self.end);
+		let transform_points = element_transform * stroke_transform * bounds * gradient_transform;
+		let start = transform_points.transform_point2(DVec2::ZERO);
+		let end = transform_points.transform_point2(DVec2::X);
 
 		let gradient_transform = if transformed_bounds.matrix2.determinant() != 0. {
 			transformed_bounds.inverse()
@@ -49,15 +83,15 @@ impl RenderExt for Gradient {
 			format!(r#" gradientTransform="{gradient_transform}""#)
 		};
 
-		let spread_method = if self.spread_method == GradientSpreadMethod::Pad {
+		let spread_method = if spread_method == GradientSpreadMethod::Pad {
 			String::new()
 		} else {
-			format!(r#" spreadMethod="{}""#, self.spread_method.svg_name())
+			format!(r#" spreadMethod="{}""#, spread_method.svg_name())
 		};
 
 		let gradient_id = generate_uuid();
 
-		match self.gradient_type {
+		match gradient_type {
 			GradientType::Linear => {
 				let _ = write!(
 					svg_defs,
@@ -84,18 +118,17 @@ impl RenderExt for Fill {
 
 	/// Renders the fill, adding necessary defs through mutating the first argument.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		match self {
-			Self::None => r#" fill="none""#.to_string(),
-			Self::Solid(color) => {
-				let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
-				if color.a() < 1. {
-					let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
-				}
-				result
-			}
-			Self::Gradient(gradient) => {
-				let gradient_id = gradient.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+		let Some(paint_table) = fill_to_paint(self) else { return r#" fill="none""#.to_string() };
+		let Some(paint) = paint_table.element(0) else { return String::new() };
+
+		match paint {
+			Graphic::Color(color_table) => color_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Graphic::Gradient(stops_table) => {
+				let gradient_id = stops_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
 				format!(r##" fill="url('#{gradient_id}')""##)
+			}
+			_ => {
+				todo!()
 			}
 		}
 	}

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -12,6 +12,28 @@ use std::fmt::Write;
 use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
 
+#[derive(Copy, Clone)]
+pub enum PaintTarget {
+	Fill,
+	Stroke,
+}
+
+impl PaintTarget {
+	fn paint_attr(self) -> &'static str {
+		match self {
+			Self::Fill => "fill",
+			Self::Stroke => "stroke",
+		}
+	}
+
+	fn opacity_attr(self) -> &'static str {
+		match self {
+			Self::Fill => "fill-opacity",
+			Self::Stroke => "stroke-opacity",
+		}
+	}
+}
+
 pub trait RenderExt {
 	type Output;
 	#[allow(clippy::too_many_arguments)]
@@ -24,6 +46,7 @@ pub trait RenderExt {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output;
 }
 
@@ -39,12 +62,13 @@ impl RenderExt for List<Color> {
 		_bounds: DAffine2,
 		_transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output {
 		let Some(color) = self.element(0) else { return r#" fill="none""#.to_string() };
 
-		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
+		let mut result = format!(r##" {}="#{}""##, target.paint_attr(), SRGBA8::from(*color).to_rgb_hex());
 		if color.a() < 1. {
-			let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
+			let _ = write!(result, r#" {}="{}""#, target.opacity_attr(), (color.a() * 1000.).round() / 1000.);
 		}
 
 		result
@@ -64,6 +88,7 @@ impl RenderExt for List<GradientStops> {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
+		_target: PaintTarget,
 	) -> Self::Output {
 		let mut stop = String::new();
 
@@ -136,7 +161,7 @@ impl RenderExt for List<GradientStops> {
 impl RenderExt for Stroke {
 	type Output = String;
 
-	/// Provide the SVG attributes for the stroke.
+	/// Provide the shape-related SVG attributes for the stroke. The paint-related attributes for the stroke are generated from `List<Graphic>.render` with `PaintTarget::Stroke`.
 	fn render(
 		&self,
 		_svg_defs: &mut String,
@@ -146,9 +171,9 @@ impl RenderExt for Stroke {
 		_bounds: DAffine2,
 		_transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		_target: PaintTarget,
 	) -> Self::Output {
 		// Don't render a stroke at all if it would be invisible
-		let Some(color) = self.color else { return String::new() };
 		if !self.has_renderable_stroke() {
 			return String::new();
 		}
@@ -166,10 +191,7 @@ impl RenderExt for Stroke {
 		let paint_order = (self.paint_order != PaintOrder::StrokeAbove || render_params.override_paint_order).then_some(PaintOrder::StrokeBelow);
 
 		// Render the needed stroke attributes
-		let mut attributes = format!(r##" stroke="#{}""##, SRGBA8::from(color).to_rgb_hex());
-		if color.a() < 1. {
-			let _ = write!(&mut attributes, r#" stroke-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
-		}
+		let mut attributes = String::new();
 		if let Some(mut weight) = weight {
 			if stroke_align.is_some() && render_params.aligned_strokes {
 				weight *= 2.;
@@ -210,21 +232,23 @@ impl RenderExt for List<Graphic> {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output {
 		let fill_graphic = self.element(0);
+		let paint_attr = target.paint_attr();
 
 		match fill_graphic {
-			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params, target),
 			Some(Graphic::Gradient(gradient_list)) => {
-				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-				format!(r##" fill="url(#{gradient_id})""##)
+				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params, target);
+				format!(r##" {paint_attr}="url(#{gradient_id})""##)
 			}
 			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
 				render_svg_fill_pattern(svg_defs, self, item_transform, bounds, render_params)
-					.map(|id| format!(r##" fill="url(#{id})""##))
-					.unwrap_or_else(|| r#" fill="none""#.to_string())
+					.map(|id| format!(r##" {paint_attr}="url(#{id})""##))
+					.unwrap_or_else(|| format!(r#" {paint_attr}="none""#))
 			}
-			None => r#" fill="none""#.to_string(),
+			None => format!(r#" {paint_attr}="none""#),
 		}
 	}
 }

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -4,10 +4,8 @@ use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
-use graphic_types::Graphic;
-use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::vector_types::gradient::GradientType;
-use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
+use graphic_types::vector_types::vector::style::{PaintOrder, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
 use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
@@ -113,27 +111,6 @@ impl RenderExt for List<GradientStops> {
 	}
 }
 
-impl RenderExt for Fill {
-	type Output = String;
-
-	/// Renders the fill, adding necessary defs through mutating the first argument.
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		let Some(paint_list) = fill_to_graphic_list(self) else { return r#" fill="none""#.to_string() };
-		let Some(paint) = paint_list.element(0) else { return String::new() };
-
-		match paint {
-			Graphic::Color(color_list) => color_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
-			Graphic::Gradient(stops_list) => {
-				let gradient_id = stops_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-				format!(r##" fill="url('#{gradient_id}')""##)
-			}
-			_ => {
-				todo!()
-			}
-		}
-	}
-}
-
 impl RenderExt for Stroke {
 	type Output = String;
 
@@ -195,21 +172,5 @@ impl RenderExt for Stroke {
 			let _ = write!(&mut attributes, r#" style="paint-order: stroke;" "#);
 		}
 		attributes
-	}
-}
-
-impl RenderExt for PathStyle {
-	type Output = String;
-
-	/// Renders the shape's fill and stroke attributes as a string with them concatenated together.
-	#[allow(clippy::too_many_arguments)]
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> String {
-		let fill_attribute = self.fill.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-		let stroke_attribute = self
-			.stroke
-			.as_ref()
-			.map(|stroke| stroke.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params))
-			.unwrap_or_default();
-		format!("{fill_attribute}{stroke_attribute}")
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::fill_to_paint;
+use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1111,7 +1111,7 @@ impl Render for List<Vector> {
 		}
 	}
 
-	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, _context: &mut RenderContext, render_params: &RenderParams) {
+	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
 		use graphic_types::vector_types::vector::style::{GradientType, StrokeCap, StrokeJoin};
 
 		for index in 0..self.len() {
@@ -1182,26 +1182,32 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
-			// TODO: This conversion is only necessary during the transition period from Fill to Table<Graphic>
-			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
-				let Some(paint_table) = fill_to_paint(element.style.fill()) else {
+			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
+				// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
+				// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
+				let Some(fill_graphic) = self
+					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+					.filter(|t| !t.is_empty())
+					.cloned()
+					.or_else(|| fill_to_graphic_list(element.style.fill()))
+				else {
 					return;
 				};
 
-				for paint_idx in 0..paint_table.len() {
-					let Some(paint) = paint_table.element(paint_idx) else { continue };
+				for paint_idx in 0..fill_graphic.len() {
+					let Some(paint) = fill_graphic.element(paint_idx) else { continue };
 					match paint {
-						Graphic::Color(table) => {
-							let Some(color) = table.element(0) else { continue };
+						Graphic::Color(list) => {
+							let Some(color) = list.element(0) else { continue };
 
 							let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
 							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
 						}
-						Graphic::Gradient(stops_table) => {
-							let Some(stops) = stops_table.element(0) else { continue };
-							let gradient_type: GradientType = stops_table.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
-							let gradient_transform: DAffine2 = stops_table.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
-							let spread_method: GradientSpreadMethod = stops_table.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
+						Graphic::Gradient(stops_list) => {
+							let Some(stops) = stops_list.element(0) else { continue };
+							let gradient_type: GradientType = stops_list.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+							let gradient_transform: DAffine2 = stops_list.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+							let spread_method: GradientSpreadMethod = stops_list.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
 
 							let mut peniko_stops = peniko::ColorStops::new();
 							for (position, color, _) in stops.interpolated_samples() {
@@ -1259,14 +1265,18 @@ impl Render for List<Vector> {
 							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
 							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
 						}
-						_ => todo!(),
+						Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_) => {
+							scene.push_clip_layer(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), path);
+							paint.render_to_vello(scene, multiplied_transform, context, render_params);
+							scene.pop_layer();
+						}
 					};
 				}
 			};
 
 			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.
 			let use_face_fill = element.use_face_fill();
-			let do_fill = |scene: &mut Scene| {
+			let do_fill = |scene: &mut Scene, context: &mut RenderContext| {
 				if use_face_fill {
 					for mut face_path in element.construct_faces().filter(|face| face.area() >= 0.) {
 						face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
@@ -1274,12 +1284,12 @@ impl Render for List<Vector> {
 						for element in face_path {
 							kurbo_path.push(element);
 						}
-						do_fill_path(scene, &kurbo_path, peniko::Fill::NonZero);
+						do_fill_path(scene, context, &kurbo_path, peniko::Fill::NonZero);
 					}
 				} else if element.is_branching() {
-					do_fill_path(scene, &path, peniko::Fill::EvenOdd);
+					do_fill_path(scene, context, &path, peniko::Fill::EvenOdd);
 				} else {
-					do_fill_path(scene, &path, peniko::Fill::NonZero);
+					do_fill_path(scene, context, &path, peniko::Fill::NonZero);
 				}
 			};
 
@@ -1349,7 +1359,7 @@ impl Render for List<Vector> {
 
 						if wants_stroke_below {
 							scene.push_layer(peniko::Fill::NonZero, peniko::Mix::Normal, 1., kurbo::Affine::IDENTITY, &rect);
-							vector_list.render_to_vello(scene, parent_transform, _context, &render_params.for_alignment(applied_stroke_transform));
+							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
 							do_stroke(scene, 2.);
@@ -1357,13 +1367,13 @@ impl Render for List<Vector> {
 							scene.pop_layer();
 							scene.pop_layer();
 
-							do_fill(scene);
+							do_fill(scene, context);
 						} else {
 							// Fill first (unclipped), then stroke (clipped) above
-							do_fill(scene);
+							do_fill(scene, context);
 
 							scene.push_layer(peniko::Fill::NonZero, peniko::Mix::Normal, 1., kurbo::Affine::IDENTITY, &rect);
-							vector_list.render_to_vello(scene, parent_transform, _context, &render_params.for_alignment(applied_stroke_transform));
+							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
 							do_stroke(scene, 2.);
@@ -1385,7 +1395,7 @@ impl Render for List<Vector> {
 
 						for operation in &order {
 							match operation {
-								Op::Fill => do_fill(scene),
+								Op::Fill => do_fill(scene, context),
 								Op::Stroke => do_stroke(scene, 1.),
 							}
 						}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -18,6 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
+use graphic_types::graphic::fill_to_paint;
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1181,70 +1182,86 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
-			// Closures to avoid duplicated fill/stroke drawing logic
-			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| match element.style.fill() {
-				Fill::Solid(color) => {
-					let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
-					scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
-				}
-				Fill::Gradient(gradient) => {
-					let mut stops = peniko::ColorStops::new();
-					for (position, color, _) in gradient.stops.interpolated_samples() {
-						stops.push(peniko::ColorStop {
-							offset: position as f32,
-							color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
-						});
-					}
+			// TODO: This conversion is only necessary during the transition period from Fill to Table<Graphic>
+			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
+				let Some(paint_table) = fill_to_paint(element.style.fill()) else {
+					return;
+				};
 
-					let bounds = element.nonzero_bounding_box();
-					let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+				for paint_idx in 0..paint_table.len() {
+					let Some(paint) = paint_table.element(paint_idx) else { continue };
+					match paint {
+						Graphic::Color(table) => {
+							let Some(color) = table.element(0) else { continue };
 
-					let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
-						parent_transform.inverse()
-					} else {
-						Default::default()
-					};
-					let mod_points = inverse_parent_transform * multiplied_transform * bound_transform;
+							let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
+							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
+						}
+						Graphic::Gradient(stops_table) => {
+							let Some(stops) = stops_table.element(0) else { continue };
+							let gradient_type: GradientType = stops_table.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+							let gradient_transform: DAffine2 = stops_table.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+							let spread_method: GradientSpreadMethod = stops_table.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
 
-					let start = mod_points.transform_point2(gradient.start);
-					let end = mod_points.transform_point2(gradient.end);
-
-					let fill = peniko::Brush::Gradient(peniko::Gradient {
-						kind: match gradient.gradient_type {
-							GradientType::Linear => peniko::LinearGradientPosition {
-								start: to_point(start),
-								end: to_point(end),
+							let mut peniko_stops = peniko::ColorStops::new();
+							for (position, color, _) in stops.interpolated_samples() {
+								peniko_stops.push(peniko::ColorStop {
+									offset: position as f32,
+									color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
+								});
 							}
-							.into(),
-							GradientType::Radial => {
-								let radius = start.distance(end);
-								peniko::RadialGradientPosition {
-									start_center: to_point(start),
-									start_radius: 0.,
-									end_center: to_point(start),
-									end_radius: radius as f32,
-								}
-								.into()
-							}
-						},
-						extend: match gradient.spread_method {
-							GradientSpreadMethod::Pad => peniko::Extend::Pad,
-							GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
-							GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
-						},
-						stops,
-						interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
-						..Default::default()
-					});
-					let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
-						element_transform.inverse()
-					} else {
-						Default::default()
+
+							let bounds = element.nonzero_bounding_box();
+							let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+
+							let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
+								parent_transform.inverse()
+							} else {
+								Default::default()
+							};
+							let mod_points = inverse_parent_transform * multiplied_transform * bound_transform * gradient_transform;
+
+							let start = mod_points.transform_point2(DVec2::ZERO);
+							let end = mod_points.transform_point2(DVec2::X);
+
+							let fill = peniko::Brush::Gradient(peniko::Gradient {
+								kind: match gradient_type {
+									GradientType::Linear => peniko::LinearGradientPosition {
+										start: to_point(start),
+										end: to_point(end),
+									}
+									.into(),
+									GradientType::Radial => {
+										let radius = start.distance(end);
+										peniko::RadialGradientPosition {
+											start_center: to_point(start),
+											start_radius: 0.,
+											end_center: to_point(start),
+											end_radius: radius as f32,
+										}
+										.into()
+									}
+								},
+								extend: match spread_method {
+									GradientSpreadMethod::Pad => peniko::Extend::Pad,
+									GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
+									GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
+								},
+								stops: peniko_stops,
+								interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
+								..Default::default()
+							});
+							let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
+								element_transform.inverse()
+							} else {
+								Default::default()
+							};
+							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
+							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
+						}
+						_ => todo!(),
 					};
-					let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
-					scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
 				}
-				Fill::None => {}
 			};
 
 			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1676,7 +1676,7 @@ impl Render for List<Vector> {
 /// correctly) plus one `FreePoint` per disconnected anchor, apply the transform, and append.
 fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector_list: &List<Vector>, index: usize, geometry: &Vector, transform: DAffine2) {
 	let filled = if let Some(graphic_list) = graphic_list_at(vector_list, index, ATTR_FILL) {
-		graphic_list.element(0).is_some()
+		graphic_list.element(0).is_some_and(|graphic| !graphic.is_empty())
 	} else if let Some(vector) = vector_list.element(index) {
 		!matches!(vector.style.fill(), Fill::None)
 	} else {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -346,87 +346,17 @@ fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
 	}
 }
 
-/// Emits a SVG `<pattern>` paint server element that renders any graphic element into def and returns the id.
-/// Currently this function uses `<pattern>` as a clip-based paint server, which means the content is rendered once without tiling.
-fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, path_bbox: [DVec2; 2], item_transform: DAffine2, render_params: &RenderParams) -> Option<String> {
-	let [min, max] = path_bbox;
-	let size = max - min;
-	if size.x <= 0. || size.y <= 0. {
-		return None;
-	}
-
-	// Render the pattern content recursively
-	let mut content = SvgRender::new();
-	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
-
-	// Unwrap the inner def element
-	write!(svg_defs, "{}", content.svg_defs).unwrap();
-
-	let pattern_transform = item_transform * DAffine2::from_translation(min);
-	let transform_str = format_transform_matrix(pattern_transform);
-	let transform_attr = if transform_str.is_empty() {
-		String::new()
-	} else {
-		format!(r#" patternTransform="{transform_str}""#)
-	};
-
-	let pattern_id = format!("pattern-{}", generate_uuid());
-	write!(
-		svg_defs,
-		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
-		size.x, size.y,
-	)
-	.unwrap();
-
-	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
-	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
-
-	Some(pattern_id)
-}
-
-/// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
-#[allow(clippy::too_many_arguments)]
-fn compute_svg_fill_attribute(
-	fill_graphic_list: Option<&List<Graphic>>,
-	defs: &mut String,
-	element_transform: DAffine2,
-	applied_stroke_transform: DAffine2,
-	bounds_matrix: DAffine2,
-	transformed_bounds_matrix: DAffine2,
-	item_transform: DAffine2,
-	render_params: &RenderParams,
-) -> String {
-	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
-
-	match fill_graphic {
-		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
-		Some(Graphic::Gradient(gradient_list)) => {
-			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
-			format!(r##" fill="url(#{gradient_id})""##)
-		}
-		Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
-			let list = fill_graphic_list.unwrap();
-			let min = bounds_matrix.transform_point2(DVec2::ZERO);
-			let max = bounds_matrix.transform_point2(DVec2::ONE);
-			render_svg_fill_pattern(defs, list, [min, max], item_transform, render_params)
-				.map(|id| format!(r##" fill="url(#{id})""##))
-				.unwrap_or_else(|| r#" fill="none""#.to_string())
-		}
-		None => r#" fill="none""#.to_string(),
-	}
-}
-
 /// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
 #[allow(clippy::too_many_arguments)]
 fn emit_svg_fill_path(
 	render: &mut SvgRender,
 	d: String,
-	element_transform: DAffine2,
 	fill_graphic_list: Option<&List<Graphic>>,
+	item_transform: DAffine2,
+	element_transform: DAffine2,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
-	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) {
 	render.leaf_tag("path", |attributes| {
@@ -436,16 +366,19 @@ fn emit_svg_fill_path(
 			attributes.push(ATTR_TRANSFORM, matrix);
 		}
 		let defs = &mut attributes.0.svg_defs;
-		let fill_attribute = compute_svg_fill_attribute(
-			fill_graphic_list,
-			defs,
-			element_transform,
-			applied_stroke_transform,
-			bounds_matrix,
-			transformed_bounds_matrix,
-			item_transform,
-			render_params,
-		);
+		let fill_attribute = fill_graphic_list
+			.map(|list| {
+				list.render(
+					defs,
+					item_transform,
+					element_transform,
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				)
+			})
+			.unwrap_or_else(|| r#" fill="none""#.to_string());
 		attributes.push_val(fill_attribute);
 	});
 }
@@ -1093,12 +1026,12 @@ impl Render for List<Vector> {
 				emit_svg_fill_path(
 					render,
 					path.clone(),
-					element_transform,
 					fill_graphic_list.as_deref(),
+					item_transform,
+					element_transform,
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
-					item_transform,
 					render_params,
 				);
 			}
@@ -1125,12 +1058,12 @@ impl Render for List<Vector> {
 					emit_svg_fill_path(
 						render,
 						face_d,
-						element_transform,
 						fill_graphic_list.as_deref(),
+						item_transform,
+						element_transform,
 						applied_stroke_transform,
 						bounds_matrix,
 						transformed_bounds_matrix,
-						item_transform,
 						render_params,
 					);
 				}
@@ -1177,22 +1110,36 @@ impl Render for List<Vector> {
 				let stroke_attribute = vector
 					.style
 					.stroke()
-					.map(|stroke| stroke.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params))
+					.map(|stroke| {
+						stroke.render(
+							defs,
+							item_transform,
+							element_transform,
+							applied_stroke_transform,
+							bounds_matrix,
+							transformed_bounds_matrix,
+							&render_params,
+						)
+					})
 					.unwrap_or_default();
 
 				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
 					r#" fill="none""#.to_string()
 				} else {
-					compute_svg_fill_attribute(
-						fill_graphic_list.as_deref(),
-						defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						item_transform,
-						&render_params,
-					)
+					fill_graphic_list
+						.as_deref()
+						.map(|list| {
+							list.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+							)
+						})
+						.unwrap_or_else(|| r#" fill="none""#.to_string())
 				};
 
 				if let Some((id, mask_type, _)) = push_id {
@@ -1221,12 +1168,12 @@ impl Render for List<Vector> {
 				emit_svg_fill_path(
 					render,
 					path.clone(),
-					element_transform,
 					fill_graphic_list.as_deref(),
+					item_transform,
+					element_transform,
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
-					item_transform,
 					render_params,
 				);
 			}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1145,7 +1145,7 @@ impl Render for List<Vector> {
 						}
 
 						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-							if let Some(fill_graphic_list) = fill_graphic_list.as_ref() {
+							if let Some(fill_graphic_list) = fill_graphic_list.as_deref() {
 								let face_clip_id = format!("clip-{}", generate_uuid());
 								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
 								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
@@ -1160,7 +1160,7 @@ impl Render for List<Vector> {
 				&& !use_face_fill
 				&& !wants_stroke_below
 				&& !override_paint_order
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
 			{
 				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
@@ -1248,7 +1248,7 @@ impl Render for List<Vector> {
 			if !needs_separate_alignment_fill
 				&& !use_face_fill
 				&& (wants_stroke_below || override_paint_order)
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
 			{
 				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
@@ -1342,17 +1342,16 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
+			// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
+			// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
+			let fill_graphic_list: Option<Cow<List<Graphic>>> = self
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+				.filter(|t| !t.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned));
+
 			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
-				// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
-				// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
-				let Some(fill_graphic) = self
-					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
-					.filter(|t| !t.is_empty())
-					.map(Cow::Borrowed)
-					.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned))
-				else {
-					return;
-				};
+				let Some(fill_graphic) = fill_graphic_list.as_deref() else { return };
 
 				for paint_idx in 0..fill_graphic.len() {
 					let Some(paint) = fill_graphic.element(paint_idx) else { continue };

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL, ATTR_STROKE, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -450,11 +450,11 @@ pub struct RenderMetadata {
 	pub text_frames: HashMap<NodeId, DAffine2>,
 	pub clip_targets: HashSet<NodeId>,
 	pub vector_data: HashMap<NodeId, Arc<Vector>>,
-	/// Per-layer `ATTR_FILL_GRAPHIC` row attribute, exposed so message handlers can read paint
+	/// Per-layer `ATTR_FILL` row attribute, exposed so message handlers can read paint
 	/// information that lives on the list rather than on `PathStyle.fill`.
 	#[cfg_attr(feature = "serde", serde(skip))]
 	pub fill_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
-	/// Per-layer `ATTR_STROKE_GRAPHIC` row attribute, exposed so message handlers can read
+	/// Per-layer `ATTR_STROKE` row attribute, exposed so message handlers can read
 	/// stroke paint information that lives on the list rather than on `Stroke.color`.
 	#[cfg_attr(feature = "serde", serde(skip))]
 	pub stroke_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
@@ -1609,11 +1609,11 @@ impl Render for List<Vector> {
 				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
 
 				// Surface row attribute paint sources (only for item 0) so message handlers can read
-				// `ATTR_FILL_GRAPHIC` / `ATTR_STROKE_GRAPHIC` without rebuilding the list.
-				if let Some(fill_graphic) = graphic_list_at(self, index, ATTR_FILL_GRAPHIC) {
+				// `ATTR_FILL` / `ATTR_STROKE` without rebuilding the list.
+				if let Some(fill_graphic) = graphic_list_at(self, index, ATTR_FILL) {
 					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_graphic.into_owned()));
 				}
-				if let Some(stroke_graphic) = graphic_list_at(self, index, ATTR_STROKE_GRAPHIC) {
+				if let Some(stroke_graphic) = graphic_list_at(self, index, ATTR_STROKE) {
 					metadata.stroke_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_graphic.into_owned()));
 				}
 
@@ -1675,7 +1675,7 @@ impl Render for List<Vector> {
 /// Build one `CompoundPath` (non-zero fill rule, so holes like the inside of an "O" work
 /// correctly) plus one `FreePoint` per disconnected anchor, apply the transform, and append.
 fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector_list: &List<Vector>, index: usize, geometry: &Vector, transform: DAffine2) {
-	let filled = if let Some(graphic_list) = graphic_list_at(vector_list, index, ATTR_FILL_GRAPHIC) {
+	let filled = if let Some(graphic_list) = graphic_list_at(vector_list, index, ATTR_FILL) {
 		graphic_list.element(0).is_some()
 	} else if let Some(vector) = vector_list.element(index) {
 		!matches!(vector.style.fill(), Fill::None)

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -27,6 +27,7 @@ use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, S
 use graphic_types::{Artboard, Graphic, Vector};
 use kurbo::{Affine, Cap, Join, Shape};
 use num_traits::Zero;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::ops::Deref;
@@ -1071,8 +1072,8 @@ impl Render for List<Vector> {
 			let fill_graphic_list = self
 				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
 				.filter(|list| !list.is_empty())
-				.cloned()
-				.or_else(|| fill_to_graphic_list(vector.style.fill()));
+				.map(Cow::Borrowed)
+				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
 			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
@@ -1101,7 +1102,7 @@ impl Render for List<Vector> {
 					path.clone(),
 					element_transform,
 					item_transform,
-					fill_graphic_list.as_ref(),
+					fill_graphic_list.as_deref(),
 					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
@@ -1259,7 +1260,7 @@ impl Render for List<Vector> {
 					path,
 					element_transform,
 					item_transform,
-					fill_graphic_list.as_ref(),
+					fill_graphic_list.as_deref(),
 					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
@@ -1347,8 +1348,8 @@ impl Render for List<Vector> {
 				let Some(fill_graphic) = self
 					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
 					.filter(|t| !t.is_empty())
-					.cloned()
-					.or_else(|| fill_to_graphic_list(element.style.fill()))
+					.map(Cow::Borrowed)
+					.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned))
 				else {
 					return;
 				};

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1,4 +1,4 @@
-use crate::render_ext::RenderExt;
+use crate::render_ext::{PaintTarget, RenderExt};
 use crate::to_peniko::{BlendModeExt, ToPenikoColor};
 use core_types::CacheHash;
 use core_types::blending::BlendMode;
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::fill_to_graphic_list;
+use graphic_types::graphic::{color_to_graphic_list, fill_to_graphic_list};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -367,6 +367,7 @@ fn emit_svg_fill_path(
 					bounds_matrix,
 					transformed_bounds_matrix,
 					render_params,
+					PaintTarget::Fill,
 				)
 			})
 			.unwrap_or_else(|| r#" fill="none""#.to_string());
@@ -1004,8 +1005,17 @@ impl Render for List<Vector> {
 				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
+			let stroke_paint_graphic_list = self
+				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
+			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
-			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
+			let can_draw_aligned_stroke = path_is_closed
+				&& vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered())
+				&& stroke_paint_graphic.is_some_and(|graphic| !graphic.is_fully_transparent());
 			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
@@ -1098,21 +1108,47 @@ impl Render for List<Vector> {
 				render_params.aligned_strokes = can_draw_aligned_stroke;
 				render_params.override_paint_order = override_paint_order;
 
-				let stroke_attribute = vector
+				let stroke_shape_attribute = vector
 					.style
 					.stroke()
 					.map(|stroke| {
-						stroke.render(
-							defs,
-							item_transform,
-							element_transform,
-							applied_stroke_transform,
-							bounds_matrix,
-							transformed_bounds_matrix,
-							&render_params,
-						)
+						if stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0)).is_some() {
+							stroke.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+								PaintTarget::Stroke,
+							)
+						} else {
+							String::new()
+						}
 					})
 					.unwrap_or_default();
+
+				// Need to avoid generating only paint attribute, otherwise SVG uses 1px width stroke as a fallback
+				let stroke_paint_attribute = if vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) {
+					stroke_paint_graphic_list
+						.as_deref()
+						.map(|list| {
+							list.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+								PaintTarget::Stroke,
+							)
+						})
+						.unwrap_or_else(|| r#" stroke="none""#.to_string())
+				} else {
+					String::new()
+				};
 
 				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
 					r#" fill="none""#.to_string()
@@ -1128,6 +1164,7 @@ impl Render for List<Vector> {
 								bounds_matrix,
 								transformed_bounds_matrix,
 								&render_params,
+								PaintTarget::Fill,
 							)
 						})
 						.unwrap_or_else(|| r#" fill="none""#.to_string())
@@ -1138,7 +1175,8 @@ impl Render for List<Vector> {
 					attributes.push(mask_type.to_attribute(), selector);
 				}
 				attributes.push_val(fill_attribute);
-				attributes.push_val(stroke_attribute);
+				attributes.push_val(stroke_shape_attribute);
+				attributes.push_val(stroke_paint_attribute);
 
 				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
@@ -1218,6 +1256,7 @@ impl Render for List<Vector> {
 			// Used by both the blend-layer clip rect inflation below (as `max_aabb_inflation`'s `path_is_closed` arg, equivalent here since
 			// the function ignores the arg for Center align) and the `SrcIn`/`SrcOut` aligned-stroke branch further down.
 			let stroke = element.style.stroke();
+			// FIXME: Need to add Graphic.is_fully_transparent check
 			let can_draw_aligned_stroke = stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered()) && element.stroke_bezier_paths().all(|p| p.closed());
 
 			let opacity = (opacity_attr * if render_params.for_mask { 1. } else { opacity_fill_attr }) as f32;

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -23,7 +23,7 @@ use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
 use graphic_types::vector_types::vector::click_target::{ClickTarget, FreePoint};
-use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, StrokeAlign};
+use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, StrokeAlign, StrokeCap, StrokeJoin};
 use graphic_types::{Artboard, Graphic, Vector};
 use kurbo::{Affine, Cap, Join, Shape, StrokeOpts};
 use num_traits::Zero;
@@ -1200,7 +1200,7 @@ impl Render for List<Vector> {
 						.as_deref()
 						.map(|list| {
 							// Gradient should align with the fill path bbox so that a shared gradient lines up across fill and stroke.
-							// only clipping-based paints need the stroke-inclusive bbox.
+							// Only clipping-based paints need the stroke-inclusive bbox.
 							let paint_bounds = match list.element(0) {
 								Some(Graphic::Color(_)) | Some(Graphic::Gradient(_)) => bounds_matrix,
 								_ => stroke_bounds_matrix,
@@ -1281,8 +1281,6 @@ impl Render for List<Vector> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
-		use graphic_types::vector_types::vector::style::{StrokeCap, StrokeJoin};
-
 		for index in 0..self.len() {
 			use graphic_types::vector_types::vector;
 
@@ -1359,8 +1357,8 @@ impl Render for List<Vector> {
 			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
 				let Some(fill_graphic) = fill_graphic_list.as_deref() else { return };
 
-				for paint_idx in 0..fill_graphic.len() {
-					let Some(paint) = fill_graphic.element(paint_idx) else { continue };
+				for paint_index in 0..fill_graphic.len() {
+					let Some(paint) = fill_graphic.element(paint_index) else { continue };
 					match paint {
 						Graphic::Color(list) => {
 							let Some(color) = list.element(0) else { continue };
@@ -1413,8 +1411,8 @@ impl Render for List<Vector> {
 				let Some(stroke_graphic_list) = stroke_graphic_list.as_deref() else { return };
 				let Some(stroke) = element.style.stroke() else { return };
 
-				for paint_idx in 0..stroke_graphic_list.len() {
-					let Some(stroke_graphic) = stroke_graphic_list.element(paint_idx) else {
+				for paint_index in 0..stroke_graphic_list.len() {
+					let Some(stroke_graphic) = stroke_graphic_list.element(paint_index) else {
 						continue;
 					};
 

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::{fill_graphic_list_at, is_stroke_fully_transparent_at, stroke_paint_graphic_list_at};
+use graphic_types::graphic::{fill_graphic_list_at, is_stroke_fully_transparent_at, stroke_graphic_list_at};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -454,10 +454,10 @@ pub struct RenderMetadata {
 	/// information that lives on the list rather than on `PathStyle.fill`.
 	#[cfg_attr(feature = "serde", serde(skip))]
 	pub fill_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
-	/// Per-layer `ATTR_STROKE_PAINT_GRAPHIC` row attribute, exposed so message handlers can read
+	/// Per-layer `ATTR_STROKE_GRAPHIC` row attribute, exposed so message handlers can read
 	/// stroke paint information that lives on the list rather than on `Stroke.color`.
 	#[cfg_attr(feature = "serde", serde(skip))]
-	pub stroke_paint_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
+	pub stroke_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
 	pub backgrounds: Vec<Background>,
 }
 
@@ -482,7 +482,7 @@ impl RenderMetadata {
 			clip_targets,
 			vector_data,
 			fill_attributes,
-			stroke_paint_attributes,
+			stroke_attributes,
 			backgrounds,
 		} = self;
 		upstream_footprints.extend(other.upstream_footprints.iter());
@@ -494,7 +494,7 @@ impl RenderMetadata {
 		clip_targets.extend(other.clip_targets.iter());
 		vector_data.extend(other.vector_data.iter().map(|(id, data)| (*id, data.clone())));
 		fill_attributes.extend(other.fill_attributes.iter().map(|(id, data)| (*id, data.clone())));
-		stroke_paint_attributes.extend(other.stroke_paint_attributes.iter().map(|(id, data)| (*id, data.clone())));
+		stroke_attributes.extend(other.stroke_attributes.iter().map(|(id, data)| (*id, data.clone())));
 
 		// TODO: Find a better non O(n^2) way to merge backgrounds
 		for background in &other.backgrounds {
@@ -1073,13 +1073,13 @@ impl Render for List<Vector> {
 			let fill_graphic_list = fill_graphic_list_at(self, index);
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
-			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(self, index);
-			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+			let stroke_graphic_list = stroke_graphic_list_at(self, index);
+			let stroke_graphic = stroke_graphic_list.as_ref().and_then(|l| l.element(0));
 
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed
 				&& vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered())
-				&& stroke_paint_graphic.is_some_and(|graphic| !graphic.is_fully_transparent());
+				&& stroke_graphic.is_some_and(|graphic| !graphic.is_fully_transparent());
 			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
@@ -1176,7 +1176,7 @@ impl Render for List<Vector> {
 					.style
 					.stroke()
 					.map(|stroke| {
-						if stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0)).is_some() {
+						if stroke_graphic_list.as_ref().and_then(|l| l.element(0)).is_some() {
 							stroke.render(
 								defs,
 								item_transform,
@@ -1194,9 +1194,9 @@ impl Render for List<Vector> {
 					.unwrap_or_default();
 
 				// Need to avoid generating only paint attribute, otherwise SVG uses 1px width stroke as a fallback
-				let stroke_paint_visible = vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) && stroke_paint_graphic.is_some_and(|g| !g.is_fully_transparent());
-				let stroke_paint_attribute = if stroke_paint_visible {
-					stroke_paint_graphic_list
+				let stroke_visible = vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) && stroke_graphic.is_some_and(|g| !g.is_fully_transparent());
+				let stroke_attribute = if stroke_visible {
+					stroke_graphic_list
 						.as_deref()
 						.map(|list| {
 							// Gradient should align with the fill path bbox so that a shared gradient lines up across fill and stroke.
@@ -1247,7 +1247,7 @@ impl Render for List<Vector> {
 				}
 				attributes.push_val(fill_attribute);
 				attributes.push_val(stroke_shape_attribute);
-				attributes.push_val(stroke_paint_attribute);
+				attributes.push_val(stroke_attribute);
 
 				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
@@ -1317,7 +1317,7 @@ impl Render for List<Vector> {
 			}
 
 			let fill_graphic_list = fill_graphic_list_at(self, index);
-			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(self, index);
+			let stroke_graphic_list = stroke_graphic_list_at(self, index);
 
 			// If we're using opacity or a blend mode, we need to push a layer
 			let blend_mode = match render_params.render_mode {
@@ -1410,11 +1410,11 @@ impl Render for List<Vector> {
 			};
 
 			let do_stroke = |scene: &mut Scene, width_scale: f64, context: &mut RenderContext| {
-				let Some(stroke_paint_graphic_list) = stroke_paint_graphic_list.as_deref() else { return };
+				let Some(stroke_graphic_list) = stroke_graphic_list.as_deref() else { return };
 				let Some(stroke) = element.style.stroke() else { return };
 
-				for paint_idx in 0..stroke_paint_graphic_list.len() {
-					let Some(stroke_paint_graphic) = stroke_paint_graphic_list.element(paint_idx) else {
+				for paint_idx in 0..stroke_graphic_list.len() {
+					let Some(stroke_graphic) = stroke_graphic_list.element(paint_idx) else {
 						continue;
 					};
 
@@ -1443,7 +1443,7 @@ impl Render for List<Vector> {
 						continue;
 					};
 
-					match stroke_paint_graphic {
+					match stroke_graphic {
 						Graphic::Color(list) => {
 							let Some(color) = list.element(0) else { continue };
 							let brush = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
@@ -1467,7 +1467,7 @@ impl Render for List<Vector> {
 							let stroked = peniko::kurbo::stroke(path.iter(), &stroke, &StrokeOpts::default(), 0.01);
 
 							scene.push_clip_layer(peniko::Fill::NonZero, kurbo::Affine::new(element_transform.to_cols_array()), &stroked);
-							stroke_paint_graphic.render_to_vello(scene, multiplied_transform, context, render_params);
+							stroke_graphic.render_to_vello(scene, multiplied_transform, context, render_params);
 							scene.pop_layer();
 						}
 					};
@@ -1609,12 +1609,12 @@ impl Render for List<Vector> {
 				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
 
 				// Surface row attribute paint sources (only for item 0) so message handlers can read
-				// `ATTR_FILL_GRAPHIC` / `ATTR_STROKE_PAINT_GRAPHIC` without rebuilding the list.
-				if let Some(fill_paint) = self.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).cloned() {
-					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_paint));
+				// `ATTR_FILL_GRAPHIC` / `ATTR_STROKE_GRAPHIC` without rebuilding the list.
+				if let Some(fill_graphic) = self.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).cloned() {
+					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_graphic));
 				}
-				if let Some(stroke_paint) = self.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index).cloned() {
-					metadata.stroke_paint_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_paint));
+				if let Some(stroke_graphic) = self.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index).cloned() {
+					metadata.stroke_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_graphic));
 				}
 
 				// Surface `editor:text_frame` for the Text tool's drag cage

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1199,12 +1199,18 @@ impl Render for List<Vector> {
 					stroke_paint_graphic_list
 						.as_deref()
 						.map(|list| {
+							// Gradient should align with the fill path bbox so that a shared gradient lines up across fill and stroke.
+							// only clipping-based paints need the stroke-inclusive bbox.
+							let paint_bounds = match list.element(0) {
+								Some(Graphic::Color(_)) | Some(Graphic::Gradient(_)) => bounds_matrix,
+								_ => stroke_bounds_matrix,
+							};
 							list.render(
 								defs,
 								item_transform,
 								element_transform,
 								applied_stroke_transform,
-								stroke_bounds_matrix,
+								paint_bounds,
 								transformed_bounds_matrix,
 								&render_params,
 								PaintTarget::Stroke,

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -450,6 +450,14 @@ pub struct RenderMetadata {
 	pub text_frames: HashMap<NodeId, DAffine2>,
 	pub clip_targets: HashSet<NodeId>,
 	pub vector_data: HashMap<NodeId, Arc<Vector>>,
+	/// Per-layer `ATTR_FILL_GRAPHIC` row attribute, exposed so message handlers can read paint
+	/// information that lives on the list rather than on `PathStyle.fill`.
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub fill_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
+	/// Per-layer `ATTR_STROKE_PAINT_GRAPHIC` row attribute, exposed so message handlers can read
+	/// stroke paint information that lives on the list rather than on `Stroke.color`.
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub stroke_paint_attributes: HashMap<NodeId, Arc<List<Graphic>>>,
 	pub backgrounds: Vec<Background>,
 }
 
@@ -473,6 +481,8 @@ impl RenderMetadata {
 			text_frames,
 			clip_targets,
 			vector_data,
+			fill_attributes,
+			stroke_paint_attributes,
 			backgrounds,
 		} = self;
 		upstream_footprints.extend(other.upstream_footprints.iter());
@@ -483,6 +493,8 @@ impl RenderMetadata {
 		text_frames.extend(other.text_frames.iter());
 		clip_targets.extend(other.clip_targets.iter());
 		vector_data.extend(other.vector_data.iter().map(|(id, data)| (*id, data.clone())));
+		fill_attributes.extend(other.fill_attributes.iter().map(|(id, data)| (*id, data.clone())));
+		stroke_paint_attributes.extend(other.stroke_paint_attributes.iter().map(|(id, data)| (*id, data.clone())));
 
 		// TODO: Find a better non O(n^2) way to merge backgrounds
 		for background in &other.backgrounds {
@@ -1589,6 +1601,15 @@ impl Render for List<Vector> {
 				// Source geometry (not the click-target override) so editing tools work on letterforms.
 				// Only item 0 is recorded since editing tools can only target a single item currently.
 				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
+
+				// Surface row attribute paint sources (only for item 0) so message handlers can read
+				// `ATTR_FILL_GRAPHIC` / `ATTR_STROKE_PAINT_GRAPHIC` without rebuilding the list.
+				if let Some(fill_paint) = self.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).cloned() {
+					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_paint));
+				}
+				if let Some(stroke_paint) = self.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index).cloned() {
+					metadata.stroke_paint_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_paint));
+				}
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
 				if let Some(&frame) = self.attribute::<DAffine2>(ATTR_EDITOR_TEXT_FRAME, index) {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1123,7 +1123,8 @@ impl Render for List<Vector> {
 					.unwrap_or_default();
 
 				// Need to avoid generating only paint attribute, otherwise SVG uses 1px width stroke as a fallback
-				let stroke_paint_attribute = if vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) {
+				let stroke_paint_visible = vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) && stroke_paint_graphic.is_some_and(|g| !g.is_fully_transparent());
+				let stroke_paint_attribute = if stroke_paint_visible {
 					stroke_paint_graphic_list
 						.as_deref()
 						.map(|list| {
@@ -1539,12 +1540,12 @@ impl Render for List<Vector> {
 				let item_relative_transform = item_zero_inverse * transform;
 
 				let mut click_targets_unwrapped = Vec::new();
-				extend_targets_from_vector(&mut click_targets_unwrapped, click_target_vector, item_relative_transform);
+				extend_targets_from_vector(&mut click_targets_unwrapped, self, index, click_target_vector, item_relative_transform);
 				accumulated_click_targets.entry(element_id).or_default().extend(click_targets_unwrapped.into_iter().map(Arc::new));
 
 				// Outlines always use source geometry so the visual outline reflects actual letterforms
 				let mut outlines_unwrapped = Vec::new();
-				extend_targets_from_vector(&mut outlines_unwrapped, source, item_relative_transform);
+				extend_targets_from_vector(&mut outlines_unwrapped, self, index, source, item_relative_transform);
 				accumulated_outlines.entry(element_id).or_default().extend(outlines_unwrapped.into_iter().map(Arc::new));
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
@@ -1581,7 +1582,7 @@ impl Render for List<Vector> {
 			// Use click-target override geometry if the item provides one (e.g. 'Text' node's per-glyph bounding boxes)
 			let vector = self.attribute::<Vector>(ATTR_EDITOR_CLICK_TARGET, index).unwrap_or(source);
 
-			extend_targets_from_vector(click_targets, vector, transform);
+			extend_targets_from_vector(click_targets, self, index, vector, transform);
 		}
 	}
 
@@ -1591,7 +1592,7 @@ impl Render for List<Vector> {
 			let Some(source) = self.element(index) else { continue };
 			let transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
 
-			extend_targets_from_vector(outlines, source, transform);
+			extend_targets_from_vector(outlines, self, index, source, transform);
 		}
 	}
 
@@ -1604,15 +1605,17 @@ impl Render for List<Vector> {
 
 /// Build one `CompoundPath` (non-zero fill rule, so holes like the inside of an "O" work
 /// correctly) plus one `FreePoint` per disconnected anchor, apply the transform, and append.
-fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector: &Vector, transform: DAffine2) {
-	let filled = vector.style.fill() != &Fill::None;
+fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector_list: &List<Vector>, index: usize, geometry: &Vector, transform: DAffine2) {
+	let fill_graphic_list = fill_graphic_list_at(vector_list, index);
+	let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
+	let filled = fill_graphic.is_some();
 
-	let mut subpaths: Vec<Subpath<_>> = vector.stroke_bezier_paths().collect();
+	let mut subpaths: Vec<Subpath<_>> = geometry.stroke_bezier_paths().collect();
 	let all_subpaths_closed = subpaths.iter().all(|subpath| subpath.closed());
 
 	// Inside/Outside-aligned strokes reach `weight` from the centerline rather than `weight / 2` per side,
 	// so they need double the click inflation. Alignment is only honored by the renderer for fully-closed paths.
-	let stroke_width = vector.style.stroke().map_or(0., |stroke| {
+	let stroke_width = geometry.style.stroke().map_or(0., |stroke| {
 		if stroke.align.is_not_centered() && all_subpaths_closed {
 			stroke.weight * 2.
 		} else {
@@ -1632,7 +1635,7 @@ fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector: &Vector, t
 		targets.push(click_target);
 	}
 
-	for click_target in extend_free_point_targets(vector, transform) {
+	for click_target in extend_free_point_targets(geometry, transform) {
 		targets.push(click_target);
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -982,9 +982,11 @@ impl Render for List<Vector> {
 			let element_transform = element_transform.unwrap_or(DAffine2::IDENTITY);
 			let layer_bounds = vector.bounding_box().unwrap_or_default();
 			let transformed_bounds = vector.bounding_box_with_transform(applied_stroke_transform).unwrap_or_default();
+			let stroke_layer_bounds = vector.stroke_inclusive_bounding_box_with_transform(DAffine2::IDENTITY).unwrap_or(layer_bounds);
 
 			let bounds_matrix = DAffine2::from_scale_angle_translation(layer_bounds[1] - layer_bounds[0], 0., layer_bounds[0]);
 			let transformed_bounds_matrix = element_transform * DAffine2::from_scale_angle_translation(transformed_bounds[1] - transformed_bounds[0], 0., transformed_bounds[0]);
+			let stroke_bounds_matrix = DAffine2::from_scale_angle_translation(stroke_layer_bounds[1] - stroke_layer_bounds[0], 0., stroke_layer_bounds[0]);
 
 			let mut path = String::new();
 
@@ -1133,7 +1135,7 @@ impl Render for List<Vector> {
 								item_transform,
 								element_transform,
 								applied_stroke_transform,
-								bounds_matrix,
+								stroke_bounds_matrix,
 								transformed_bounds_matrix,
 								&render_params,
 								PaintTarget::Stroke,

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -220,6 +220,8 @@ pub struct RenderParams {
 	pub alignment_parent_transform: Option<DAffine2>,
 	pub aligned_strokes: bool,
 	pub override_paint_order: bool,
+	// Are we rendering for a pattern content
+	pub inside_pattern: bool,
 	pub artboard_background: Option<Color>,
 	/// Viewport zoom level (document-space scale). Used to compute constant viewport-pixel stroke widths in Outline mode.
 	pub viewport_zoom: f64,
@@ -235,8 +237,12 @@ impl RenderParams {
 		Self { alignment_parent_transform, ..*self }
 	}
 
+	pub fn for_pattern(&self) -> Self {
+		Self { inside_pattern: true, ..*self }
+	}
+
 	pub fn to_canvas(&self) -> bool {
-		!self.for_export && !self.thumbnail && !self.for_mask
+		!self.for_export && !self.thumbnail && !self.for_mask && !self.inside_pattern
 	}
 }
 
@@ -340,23 +346,73 @@ fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
 	}
 }
 
+/// Emits a SVG `<pattern>` paint server element that renders any graphic element into def and returns the id.
+/// Currently this function uses `<pattern>` as a clip-based paint server, which means the content is rendered once without tiling.
+fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, path_bbox: [DVec2; 2], item_transform: DAffine2, render_params: &RenderParams) -> Option<String> {
+	let [min, max] = path_bbox;
+	let size = max - min;
+	if size.x <= 0. || size.y <= 0. {
+		return None;
+	}
+
+	// Render the pattern content recursively
+	let mut content = SvgRender::new();
+	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
+
+	// Unwrap the inner def element
+	write!(svg_defs, "{}", content.svg_defs).unwrap();
+
+	let pattern_transform = item_transform * DAffine2::from_translation(min);
+	let transform_str = format_transform_matrix(pattern_transform);
+	let transform_attr = if transform_str.is_empty() {
+		String::new()
+	} else {
+		format!(r#" patternTransform="{transform_str}""#)
+	};
+
+	let pattern_id = format!("pattern-{}", generate_uuid());
+	write!(
+		svg_defs,
+		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
+		size.x, size.y,
+	)
+	.unwrap();
+
+	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
+	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
+
+	Some(pattern_id)
+}
+
 /// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
+#[allow(clippy::too_many_arguments)]
 fn compute_svg_fill_attribute(
-	fill_graphic: Option<&Graphic>,
+	fill_graphic_list: Option<&List<Graphic>>,
 	defs: &mut String,
 	element_transform: DAffine2,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
+	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) -> String {
+	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
+
 	match fill_graphic {
 		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
 		Some(Graphic::Gradient(gradient_list)) => {
 			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
-			format!(r##" fill="url('#{gradient_id}')""##)
+			format!(r##" fill="url(#{gradient_id})""##)
 		}
-		_ => r#" fill="none""#.to_string(),
+		Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
+			let list = fill_graphic_list.unwrap();
+			let min = bounds_matrix.transform_point2(DVec2::ZERO);
+			let max = bounds_matrix.transform_point2(DVec2::ONE);
+			render_svg_fill_pattern(defs, list, [min, max], item_transform, render_params)
+				.map(|id| format!(r##" fill="url(#{id})""##))
+				.unwrap_or_else(|| r#" fill="none""#.to_string())
+		}
+		None => r#" fill="none""#.to_string(),
 	}
 }
 
@@ -366,10 +422,11 @@ fn emit_svg_fill_path(
 	render: &mut SvgRender,
 	d: String,
 	element_transform: DAffine2,
-	fill_graphic: Option<&Graphic>,
+	fill_graphic_list: Option<&List<Graphic>>,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
+	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) {
 	render.leaf_tag("path", |attributes| {
@@ -379,71 +436,18 @@ fn emit_svg_fill_path(
 			attributes.push(ATTR_TRANSFORM, matrix);
 		}
 		let defs = &mut attributes.0.svg_defs;
-		let fill_attribute = compute_svg_fill_attribute(fill_graphic, defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+		let fill_attribute = compute_svg_fill_attribute(
+			fill_graphic_list,
+			defs,
+			element_transform,
+			applied_stroke_transform,
+			bounds_matrix,
+			transformed_bounds_matrix,
+			item_transform,
+			render_params,
+		);
 		attributes.push_val(fill_attribute);
 	});
-}
-
-/// Emits an SVG `<g clip-path>` group that renders the fill graphic clipped to the path referenced by `clip_id`.
-fn emit_svg_fill_clip(render: &mut SvgRender, clip_id: &str, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, render_params: &RenderParams) {
-	render.parent_tag(
-		"g",
-		|attributes| {
-			attributes.push("clip-path", format!("url(#{clip_id})"));
-		},
-		|render| {
-			let matrix = format_transform_matrix(item_transform);
-			if matrix.is_empty() {
-				fill_graphic_list.render_svg(render, render_params);
-				return;
-			}
-			render.parent_tag(
-				"g",
-				|attributes| {
-					attributes.push(ATTR_TRANSFORM, matrix);
-				},
-				|render| {
-					fill_graphic_list.render_svg(render, render_params);
-				},
-			);
-		},
-	);
-}
-
-/// Emits the fill element for aligned-stroke paths, dispatching between `<path>` for Color/Gradient and `<g clip-path>` for Vector/Raster/Graphic.
-#[allow(clippy::too_many_arguments)]
-fn emit_aligned_fill_pass(
-	render: &mut SvgRender,
-	d: String,
-	element_transform: DAffine2,
-	item_transform: DAffine2,
-	fill_graphic_list: Option<&List<Graphic>>,
-	clip_id: Option<&str>,
-	applied_stroke_transform: DAffine2,
-	bounds_matrix: DAffine2,
-	transformed_bounds_matrix: DAffine2,
-	render_params: &RenderParams,
-) {
-	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
-	match fill_graphic {
-		Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
-			emit_svg_fill_path(
-				render,
-				d,
-				element_transform,
-				fill_graphic,
-				applied_stroke_transform,
-				bounds_matrix,
-				transformed_bounds_matrix,
-				render_params,
-			);
-		}
-		Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-			if let (Some(clip_id), Some(fill_graphic_list)) = (clip_id, fill_graphic_list) {
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
-			}
-		}
-	}
 }
 
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
@@ -1076,37 +1080,25 @@ impl Render for List<Vector> {
 				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
-			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
-
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip || need_clipping);
+			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
 			let override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
 			let use_face_fill = vector.use_face_fill();
 
-			// Register the clipPath in <defs> and remember its id for the <g clip-path> below
-			let clip_id = if need_clipping && !use_face_fill {
-				let id = format!("clip-{}", generate_uuid());
-				write!(&mut render.svg_defs, r##"<clipPath id="{id}"><path d="{path}"/></clipPath>"##).unwrap();
-				Some(id)
-			} else {
-				None
-			};
-
 			if needs_separate_alignment_fill && !wants_stroke_below {
-				emit_aligned_fill_pass(
+				emit_svg_fill_path(
 					render,
 					path.clone(),
 					element_transform,
-					item_transform,
 					fill_graphic_list.as_deref(),
-					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
+					item_transform,
 					render_params,
 				);
 			}
@@ -1130,39 +1122,18 @@ impl Render for List<Vector> {
 					face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
 					let face_d = face_path.to_svg();
 
-					match fill_graphic {
-						Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
-							emit_svg_fill_path(
-								render,
-								face_d,
-								element_transform,
-								fill_graphic,
-								applied_stroke_transform,
-								bounds_matrix,
-								transformed_bounds_matrix,
-								render_params,
-							);
-						}
-
-						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-							if let Some(fill_graphic_list) = fill_graphic_list.as_deref() {
-								let face_clip_id = format!("clip-{}", generate_uuid());
-								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
-								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
-							}
-						}
-					}
+					emit_svg_fill_path(
+						render,
+						face_d,
+						element_transform,
+						fill_graphic_list.as_deref(),
+						applied_stroke_transform,
+						bounds_matrix,
+						transformed_bounds_matrix,
+						item_transform,
+						render_params,
+					);
 				}
-			}
-
-			// Clipping-based fill should be drawn before the stroke path (default paint order)
-			if !needs_separate_alignment_fill
-				&& !use_face_fill
-				&& !wants_stroke_below
-				&& !override_paint_order
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
-			{
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
 
 			render.leaf_tag("path", |attributes| {
@@ -1213,12 +1184,13 @@ impl Render for List<Vector> {
 					r#" fill="none""#.to_string()
 				} else {
 					compute_svg_fill_attribute(
-						fill_graphic,
+						fill_graphic_list.as_deref(),
 						defs,
 						element_transform,
 						applied_stroke_transform,
 						bounds_matrix,
 						transformed_bounds_matrix,
+						item_transform,
 						&render_params,
 					)
 				};
@@ -1244,27 +1216,17 @@ impl Render for List<Vector> {
 				}
 			});
 
-			// Clipping-based fill should be drawn after the stroke path
-			if !needs_separate_alignment_fill
-				&& !use_face_fill
-				&& (wants_stroke_below || override_paint_order)
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
-			{
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
-			}
-
 			// When splitting passes and stroke is below, draw the fill after the stroke.
 			if needs_separate_alignment_fill && wants_stroke_below {
-				emit_aligned_fill_pass(
+				emit_svg_fill_path(
 					render,
-					path,
+					path.clone(),
 					element_transform,
-					item_transform,
 					fill_graphic_list.as_deref(),
-					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
+					item_transform,
 					render_params,
 				);
 			}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1605,16 +1605,18 @@ impl Render for List<Vector> {
 				accumulated_outlines.entry(element_id).or_default().extend(outlines_unwrapped.into_iter().map(Arc::new));
 
 				// Source geometry (not the click-target override) so editing tools work on letterforms.
+				// Recorded together with `vector_data` from the same (first) row so `style` stays consistent with the paint.
 				// Only item 0 is recorded since editing tools can only target a single item currently.
-				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
+				// If that row has no paint attribute, none is recorded and consumers fall back to `style`.
+				if let std::collections::hash_map::Entry::Vacant(e) = metadata.vector_data.entry(element_id) {
+					e.insert(Arc::new(source.clone()));
 
-				// Surface row attribute paint sources (only for item 0) so message handlers can read
-				// `ATTR_FILL` / `ATTR_STROKE` without rebuilding the list.
-				if let Some(fill_graphic) = graphic_list_at(self, index, ATTR_FILL) {
-					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_graphic.into_owned()));
-				}
-				if let Some(stroke_graphic) = graphic_list_at(self, index, ATTR_STROKE) {
-					metadata.stroke_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_graphic.into_owned()));
+					if let Some(fill_graphic) = graphic_list_at(self, index, ATTR_FILL) {
+						metadata.fill_attributes.insert(element_id, Arc::new(fill_graphic.into_owned()));
+					}
+					if let Some(stroke_graphic) = graphic_list_at(self, index, ATTR_STROKE) {
+						metadata.stroke_attributes.insert(element_id, Arc::new(stroke_graphic.into_owned()));
+					}
 				}
 
 				// Surface `editor:text_frame` for the Text tool's drag cage

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
+use core_types::list::{Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::{color_to_graphic_list, fill_to_graphic_list};
+use graphic_types::graphic::{fill_graphic_list_at, stroke_paint_graphic_list_at};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -27,7 +27,6 @@ use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, S
 use graphic_types::{Artboard, Graphic, Vector};
 use kurbo::{Affine, Cap, Join, Shape};
 use num_traits::Zero;
-use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::ops::Deref;
@@ -1000,18 +999,10 @@ impl Render for List<Vector> {
 				MaskType::Mask
 			};
 
-			let fill_graphic_list = self
-				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
-				.filter(|list| !list.is_empty())
-				.map(Cow::Borrowed)
-				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
+			let fill_graphic_list = fill_graphic_list_at(self, index);
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
-			let stroke_paint_graphic_list = self
-				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
-				.filter(|list| !list.is_empty())
-				.map(Cow::Borrowed)
-				.or_else(|| color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
+			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(self, index);
 			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
 
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
@@ -1284,12 +1275,7 @@ impl Render for List<Vector> {
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
 			// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
-			// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
-			let fill_graphic_list: Option<Cow<List<Graphic>>> = self
-				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
-				.filter(|t| !t.is_empty())
-				.map(Cow::Borrowed)
-				.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned));
+			let fill_graphic_list = fill_graphic_list_at(self, index);
 
 			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
 				let Some(fill_graphic) = fill_graphic_list.as_deref() else { return };

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::{fill_graphic_list_at, is_stroke_fully_transparent_at, stroke_graphic_list_at};
+use graphic_types::graphic::{fill_graphic_list_at, graphic_list_at, is_stroke_fully_transparent_at, stroke_graphic_list_at};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1610,11 +1610,11 @@ impl Render for List<Vector> {
 
 				// Surface row attribute paint sources (only for item 0) so message handlers can read
 				// `ATTR_FILL_GRAPHIC` / `ATTR_STROKE_GRAPHIC` without rebuilding the list.
-				if let Some(fill_graphic) = self.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index).cloned() {
-					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_graphic));
+				if let Some(fill_graphic) = graphic_list_at(self, index, ATTR_FILL_GRAPHIC) {
+					metadata.fill_attributes.entry(element_id).or_insert_with(|| Arc::new(fill_graphic.into_owned()));
 				}
-				if let Some(stroke_graphic) = self.attribute::<List<Graphic>>(ATTR_STROKE_GRAPHIC, index).cloned() {
-					metadata.stroke_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_graphic));
+				if let Some(stroke_graphic) = graphic_list_at(self, index, ATTR_STROKE_GRAPHIC) {
+					metadata.stroke_attributes.entry(element_id).or_insert_with(|| Arc::new(stroke_graphic.into_owned()));
 				}
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
@@ -1675,7 +1675,7 @@ impl Render for List<Vector> {
 /// Build one `CompoundPath` (non-zero fill rule, so holes like the inside of an "O" work
 /// correctly) plus one `FreePoint` per disconnected anchor, apply the transform, and append.
 fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector_list: &List<Vector>, index: usize, geometry: &Vector, transform: DAffine2) {
-	let filled = if let Some(graphic_list) = vector_list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+	let filled = if let Some(graphic_list) = graphic_list_at(vector_list, index, ATTR_FILL_GRAPHIC) {
 		graphic_list.element(0).is_some()
 	} else if let Some(vector) = vector_list.element(index) {
 		!matches!(vector.style.fill(), Fill::None)

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::{fill_graphic_list_at, stroke_paint_graphic_list_at};
+use graphic_types::graphic::{fill_graphic_list_at, is_stroke_fully_transparent_at, stroke_paint_graphic_list_at};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1314,9 +1314,9 @@ impl Render for List<Vector> {
 			// Used by both the blend-layer clip rect inflation below (as `max_aabb_inflation`'s `path_is_closed` arg, equivalent here since
 			// the function ignores the arg for Center align) and the `SrcIn`/`SrcOut` aligned-stroke branch further down.
 			let stroke = element.style.stroke();
-			let is_all_stroke_fully_transparent = stroke_paint_graphic_list.as_deref().is_none_or(|list| list.iter_element_values().all(Graphic::is_fully_transparent));
-			let can_draw_aligned_stroke =
-				!is_all_stroke_fully_transparent && stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered()) && element.stroke_bezier_paths().all(|p| p.closed());
+			let can_draw_aligned_stroke = !is_stroke_fully_transparent_at(self, index)
+				&& stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered())
+				&& element.stroke_bezier_paths().all(|p| p.closed());
 
 			let opacity = (opacity_attr * if render_params.for_mask { 1. } else { opacity_fill_attr }) as f32;
 			if opacity < 1. || blend_mode_attr != BlendMode::default() {
@@ -1651,9 +1651,13 @@ impl Render for List<Vector> {
 /// Build one `CompoundPath` (non-zero fill rule, so holes like the inside of an "O" work
 /// correctly) plus one `FreePoint` per disconnected anchor, apply the transform, and append.
 fn extend_targets_from_vector(targets: &mut Vec<ClickTarget>, vector_list: &List<Vector>, index: usize, geometry: &Vector, transform: DAffine2) {
-	let fill_graphic_list = fill_graphic_list_at(vector_list, index);
-	let fill_graphic = fill_graphic_list.as_deref().and_then(|l| l.element(0));
-	let filled = fill_graphic.is_some();
+	let filled = if let Some(graphic_list) = vector_list.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index) {
+		graphic_list.element(0).is_some()
+	} else if let Some(vector) = vector_list.element(index) {
+		!matches!(vector.style.fill(), Fill::None)
+	} else {
+		false
+	};
 
 	let mut subpaths: Vec<Subpath<_>> = geometry.stroke_bezier_paths().collect();
 	let all_subpaths_closed = subpaths.iter().all(|subpath| subpath.closed());

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -391,7 +391,9 @@ pub struct RenderMetadata {
 	/// The Text tool composes this with `transform_to_viewport(layer)` to position its drag cage.
 	pub text_frames: HashMap<NodeId, DAffine2>,
 	pub clip_targets: HashSet<NodeId>,
-	pub vector_data: HashMap<NodeId, Arc<Vector>>,
+	// `RenderMetadata` only enters serialization via `TaggedValue::RenderOutput`, which also skips serde.
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub vector_data: HashMap<NodeId, Arc<List<Vector>>>,
 	pub backgrounds: Vec<Background>,
 }
 
@@ -1525,6 +1527,11 @@ impl Render for List<Vector> {
 		let mut accumulated_click_targets: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 		let mut accumulated_outlines: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 
+		// Source geometry (not the click-target override) so editing tools work on letterforms.
+		if let Some(element_id) = caller_element_id {
+			metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(self.clone()));
+		}
+
 		for index in 0..self.len() {
 			let Some(source) = self.element(index) else { continue };
 			let transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
@@ -1553,10 +1560,6 @@ impl Render for List<Vector> {
 				let mut outlines_unwrapped = Vec::new();
 				extend_targets_from_vector(&mut outlines_unwrapped, source, item_relative_transform);
 				accumulated_outlines.entry(element_id).or_default().extend(outlines_unwrapped.into_iter().map(Arc::new));
-
-				// Source geometry (not the click-target override) so editing tools work on letterforms.
-				// Only item 0 is recorded since editing tools can only target a single item currently.
-				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
 				if let Some(&frame) = self.attribute::<DAffine2>(ATTR_EDITOR_TEXT_FRAME, index) {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -25,7 +25,7 @@ use graphic_types::vector_types::subpath::Subpath;
 use graphic_types::vector_types::vector::click_target::{ClickTarget, FreePoint};
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, StrokeAlign};
 use graphic_types::{Artboard, Graphic, Vector};
-use kurbo::{Affine, Cap, Join, Shape};
+use kurbo::{Affine, Cap, Join, Shape, StrokeOpts};
 use num_traits::Zero;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
@@ -372,6 +372,65 @@ fn emit_svg_fill_path(
 			.unwrap_or_else(|| r#" fill="none""#.to_string());
 		attributes.push_val(fill_attribute);
 	});
+}
+
+fn create_peniko_gradient_brush(gradient_list: &List<GradientStops>, parent_vector: &Vector, parent_transform: &DAffine2, multiplied_transform: &DAffine2) -> Option<peniko::Brush> {
+	let stops = gradient_list.element(0)?;
+
+	let gradient_type: GradientType = gradient_list.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+	let gradient_transform: DAffine2 = gradient_list.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+	let spread_method: GradientSpreadMethod = gradient_list.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
+
+	let mut peniko_stops = peniko::ColorStops::new();
+	for (position, color, _) in stops.interpolated_samples() {
+		peniko_stops.push(peniko::ColorStop {
+			offset: position as f32,
+			color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
+		});
+	}
+
+	let bounds = parent_vector.nonzero_bounding_box();
+	let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+
+	let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
+		parent_transform.inverse()
+	} else {
+		Default::default()
+	};
+	let mod_points = inverse_parent_transform * multiplied_transform * bound_transform * gradient_transform;
+
+	let start = mod_points.transform_point2(DVec2::ZERO);
+	let end = mod_points.transform_point2(DVec2::X);
+
+	let brush = peniko::Brush::Gradient(peniko::Gradient {
+		kind: match gradient_type {
+			GradientType::Linear => peniko::LinearGradientPosition {
+				start: to_point(start),
+				end: to_point(end),
+			}
+			.into(),
+			GradientType::Radial => {
+				let radius = start.distance(end);
+				peniko::RadialGradientPosition {
+					start_center: to_point(start),
+					start_radius: 0.,
+					end_center: to_point(start),
+					end_radius: radius as f32,
+				}
+				.into()
+			}
+		},
+		extend: match spread_method {
+			GradientSpreadMethod::Pad => peniko::Extend::Pad,
+			GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
+			GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
+		},
+		stops: peniko_stops,
+		interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
+		..Default::default()
+	});
+
+	Some(brush)
 }
 
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
@@ -1206,7 +1265,7 @@ impl Render for List<Vector> {
 	}
 
 	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
-		use graphic_types::vector_types::vector::style::{GradientType, StrokeCap, StrokeJoin};
+		use graphic_types::vector_types::vector::style::{StrokeCap, StrokeJoin};
 
 		for index in 0..self.len() {
 			use graphic_types::vector_types::vector;
@@ -1241,6 +1300,9 @@ impl Render for List<Vector> {
 				}
 			}
 
+			let fill_graphic_list = fill_graphic_list_at(self, index);
+			let stroke_paint_graphic_list = stroke_paint_graphic_list_at(self, index);
+
 			// If we're using opacity or a blend mode, we need to push a layer
 			let blend_mode = match render_params.render_mode {
 				RenderMode::Outline => peniko::Mix::Normal,
@@ -1252,8 +1314,9 @@ impl Render for List<Vector> {
 			// Used by both the blend-layer clip rect inflation below (as `max_aabb_inflation`'s `path_is_closed` arg, equivalent here since
 			// the function ignores the arg for Center align) and the `SrcIn`/`SrcOut` aligned-stroke branch further down.
 			let stroke = element.style.stroke();
-			// FIXME: Need to add Graphic.is_fully_transparent check
-			let can_draw_aligned_stroke = stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered()) && element.stroke_bezier_paths().all(|p| p.closed());
+			let is_all_stroke_fully_transparent = stroke_paint_graphic_list.as_deref().is_none_or(|list| list.iter_element_values().all(Graphic::is_fully_transparent));
+			let can_draw_aligned_stroke =
+				!is_all_stroke_fully_transparent && stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered()) && element.stroke_bezier_paths().all(|p| p.closed());
 
 			let opacity = (opacity_attr * if render_params.for_mask { 1. } else { opacity_fill_attr }) as f32;
 			if opacity < 1. || blend_mode_attr != BlendMode::default() {
@@ -1277,9 +1340,6 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
-			// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
-			let fill_graphic_list = fill_graphic_list_at(self, index);
-
 			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
 				let Some(fill_graphic) = fill_graphic_list.as_deref() else { return };
 
@@ -1292,67 +1352,18 @@ impl Render for List<Vector> {
 							let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
 							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
 						}
-						Graphic::Gradient(stops_list) => {
-							let Some(stops) = stops_list.element(0) else { continue };
-							let gradient_type: GradientType = stops_list.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
-							let gradient_transform: DAffine2 = stops_list.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
-							let spread_method: GradientSpreadMethod = stops_list.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
-
-							let mut peniko_stops = peniko::ColorStops::new();
-							for (position, color, _) in stops.interpolated_samples() {
-								peniko_stops.push(peniko::ColorStop {
-									offset: position as f32,
-									color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
-								});
-							}
-
-							let bounds = element.nonzero_bounding_box();
-							let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
-
-							let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
-								parent_transform.inverse()
-							} else {
-								Default::default()
+						Graphic::Gradient(list) => {
+							let Some(brush) = create_peniko_gradient_brush(list, element, &parent_transform, &multiplied_transform) else {
+								continue;
 							};
-							let mod_points = inverse_parent_transform * multiplied_transform * bound_transform * gradient_transform;
 
-							let start = mod_points.transform_point2(DVec2::ZERO);
-							let end = mod_points.transform_point2(DVec2::X);
-
-							let fill = peniko::Brush::Gradient(peniko::Gradient {
-								kind: match gradient_type {
-									GradientType::Linear => peniko::LinearGradientPosition {
-										start: to_point(start),
-										end: to_point(end),
-									}
-									.into(),
-									GradientType::Radial => {
-										let radius = start.distance(end);
-										peniko::RadialGradientPosition {
-											start_center: to_point(start),
-											start_radius: 0.,
-											end_center: to_point(start),
-											end_radius: radius as f32,
-										}
-										.into()
-									}
-								},
-								extend: match spread_method {
-									GradientSpreadMethod::Pad => peniko::Extend::Pad,
-									GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
-									GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
-								},
-								stops: peniko_stops,
-								interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
-								..Default::default()
-							});
 							let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
 								element_transform.inverse()
 							} else {
 								Default::default()
 							};
 							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
-							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
+							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &brush, Some(brush_transform), path);
 						}
 						Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_) => {
 							scene.push_clip_layer(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), path);
@@ -1382,12 +1393,15 @@ impl Render for List<Vector> {
 				}
 			};
 
-			let do_stroke = |scene: &mut Scene, width_scale: f64| {
-				if let Some(stroke) = element.style.stroke() {
-					let color = match stroke.color {
-						Some(color) => SRGBA8::from(color).to_peniko_color(),
-						None => peniko::Color::TRANSPARENT,
+			let do_stroke = |scene: &mut Scene, width_scale: f64, context: &mut RenderContext| {
+				let Some(stroke_paint_graphic_list) = stroke_paint_graphic_list.as_deref() else { return };
+				let Some(stroke) = element.style.stroke() else { return };
+
+				for paint_idx in 0..stroke_paint_graphic_list.len() {
+					let Some(stroke_paint_graphic) = stroke_paint_graphic_list.element(paint_idx) else {
+						continue;
 					};
+
 					let cap = match stroke.cap {
 						StrokeCap::Butt => Cap::Butt,
 						StrokeCap::Round => Cap::Round,
@@ -1409,9 +1423,38 @@ impl Render for List<Vector> {
 						dash_offset: stroke.dash_offset,
 					};
 
-					if stroke.width > 0. {
-						scene.stroke(&stroke, kurbo::Affine::new(element_transform.to_cols_array()), color, None, &path);
-					}
+					if stroke.width <= 0. {
+						continue;
+					};
+
+					match stroke_paint_graphic {
+						Graphic::Color(list) => {
+							let Some(color) = list.element(0) else { continue };
+							let brush = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
+
+							scene.stroke(&stroke, kurbo::Affine::new(element_transform.to_cols_array()), &brush, None, &path);
+						}
+						Graphic::Gradient(list) => {
+							let Some(brush) = create_peniko_gradient_brush(list, element, &parent_transform, &multiplied_transform) else {
+								continue;
+							};
+							let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
+								element_transform.inverse()
+							} else {
+								Default::default()
+							};
+							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
+
+							scene.stroke(&stroke, kurbo::Affine::new(element_transform.to_cols_array()), &brush, Some(brush_transform), &path);
+						}
+						Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_) => {
+							let stroked = peniko::kurbo::stroke(path.iter(), &stroke, &StrokeOpts::default(), 0.01);
+
+							scene.push_clip_layer(peniko::Fill::NonZero, kurbo::Affine::new(element_transform.to_cols_array()), &stroked);
+							stroke_paint_graphic.render_to_vello(scene, multiplied_transform, context, render_params);
+							scene.pop_layer();
+						}
+					};
 				}
 			};
 
@@ -1451,7 +1494,7 @@ impl Render for List<Vector> {
 							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
-							do_stroke(scene, 2.);
+							do_stroke(scene, 2., context);
 
 							scene.pop_layer();
 							scene.pop_layer();
@@ -1465,7 +1508,7 @@ impl Render for List<Vector> {
 							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
-							do_stroke(scene, 2.);
+							do_stroke(scene, 2., context);
 
 							scene.pop_layer();
 							scene.pop_layer();
@@ -1485,7 +1528,7 @@ impl Render for List<Vector> {
 						for operation in &order {
 							match operation {
 								Op::Fill => do_fill(scene, context),
-								Op::Stroke => do_stroke(scene, 1.),
+								Op::Stroke => do_stroke(scene, 1., context),
 							}
 						}
 					}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -220,7 +220,7 @@ pub struct RenderParams {
 	pub alignment_parent_transform: Option<DAffine2>,
 	pub aligned_strokes: bool,
 	pub override_paint_order: bool,
-	// Are we rendering for a pattern content
+	/// Are we rendering for a pattern content
 	pub inside_pattern: bool,
 	pub artboard_background: Option<Color>,
 	/// Viewport zoom level (document-space scale). Used to compute constant viewport-pixel stroke widths in Outline mode.

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -330,6 +330,121 @@ fn draw_raster_outline(scene: &mut Scene, outline_transform: &DAffine2, render_p
 	scene.stroke(&outline_stroke, Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 }
 
+/// Returns true if the resolved fill graphic fully and opaquely covers the path interior.
+fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
+	match fill_graphic {
+		Some(Graphic::Color(list)) => list.element(0).is_some_and(|c| c.a() >= 1.0),
+		Some(Graphic::Gradient(list)) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1.0)),
+		_ => false,
+	}
+}
+
+/// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
+fn compute_svg_fill_attribute(
+	fill_graphic: Option<&Graphic>,
+	defs: &mut String,
+	element_transform: DAffine2,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) -> String {
+	match fill_graphic {
+		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
+		Some(Graphic::Gradient(gradient_list)) => {
+			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+			format!(r##" fill="url('#{gradient_id}')""##)
+		}
+		_ => r#" fill="none""#.to_string(),
+	}
+}
+
+/// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
+#[allow(clippy::too_many_arguments)]
+fn emit_svg_fill_path(
+	render: &mut SvgRender,
+	d: String,
+	element_transform: DAffine2,
+	fill_graphic: Option<&Graphic>,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) {
+	render.leaf_tag("path", |attributes| {
+		attributes.push("d", d);
+		let matrix = format_transform_matrix(element_transform);
+		if !matrix.is_empty() {
+			attributes.push(ATTR_TRANSFORM, matrix);
+		}
+		let defs = &mut attributes.0.svg_defs;
+		let fill_attribute = compute_svg_fill_attribute(fill_graphic, defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+		attributes.push_val(fill_attribute);
+	});
+}
+
+/// Emits an SVG `<g clip-path>` group that renders the fill graphic clipped to the path referenced by `clip_id`.
+fn emit_svg_fill_clip(render: &mut SvgRender, clip_id: &str, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, render_params: &RenderParams) {
+	render.parent_tag(
+		"g",
+		|attributes| {
+			attributes.push("clip-path", format!("url(#{clip_id})"));
+		},
+		|render| {
+			let matrix = format_transform_matrix(item_transform);
+			if matrix.is_empty() {
+				fill_graphic_list.render_svg(render, render_params);
+				return;
+			}
+			render.parent_tag(
+				"g",
+				|attributes| {
+					attributes.push(ATTR_TRANSFORM, matrix);
+				},
+				|render| {
+					fill_graphic_list.render_svg(render, render_params);
+				},
+			);
+		},
+	);
+}
+
+/// Emits the fill element for aligned-stroke paths, dispatching between `<path>` for Color/Gradient and `<g clip-path>` for Vector/Raster/Graphic.
+#[allow(clippy::too_many_arguments)]
+fn emit_aligned_fill_pass(
+	render: &mut SvgRender,
+	d: String,
+	element_transform: DAffine2,
+	item_transform: DAffine2,
+	fill_graphic_list: Option<&List<Graphic>>,
+	clip_id: Option<&str>,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) {
+	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
+	match fill_graphic {
+		Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
+			emit_svg_fill_path(
+				render,
+				d,
+				element_transform,
+				fill_graphic,
+				applied_stroke_transform,
+				bounds_matrix,
+				transformed_bounds_matrix,
+				render_params,
+			);
+		}
+		Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
+			if let (Some(clip_id), Some(fill_graphic_list)) = (clip_id, fill_graphic_list) {
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
+			}
+		}
+	}
+}
+
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
 // This will require that the transform for child layers into that layer space be calculated, or it could be returned from the RenderOutput instead of click targets.
 #[derive(Debug, Default, Clone, PartialEq, DynAny)]
@@ -922,7 +1037,7 @@ impl Render for List<Vector> {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams) {
 		for index in 0..self.len() {
 			let Some(vector) = self.element(index) else { continue };
-			let multiplied_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
+			let item_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
 			let blend_mode_attr: BlendMode = self.attribute_cloned_or_default(ATTR_BLEND_MODE, index);
 			let opacity_attr: f64 = self.attribute_cloned_or(ATTR_OPACITY, index, 1.);
 			let opacity_fill_attr: f64 = self.attribute_cloned_or(ATTR_OPACITY_FILL, index, 1.);
@@ -930,9 +1045,9 @@ impl Render for List<Vector> {
 			// Only consider strokes with non-zero weight, since default strokes with zero weight would prevent assigning the correct stroke transform
 			let has_real_stroke = vector.style.stroke().filter(|stroke| stroke.weight() > 0.);
 			let set_stroke_transform = has_real_stroke.map(|stroke| stroke.transform).filter(|transform| transform.matrix2.determinant() != 0.);
-			let applied_stroke_transform = set_stroke_transform.unwrap_or(multiplied_transform);
+			let applied_stroke_transform = set_stroke_transform.unwrap_or(item_transform);
 			let applied_stroke_transform = render_params.alignment_parent_transform.unwrap_or(applied_stroke_transform);
-			let element_transform = set_stroke_transform.map(|stroke_transform| multiplied_transform * stroke_transform.inverse());
+			let element_transform = set_stroke_transform.map(|stroke_transform| item_transform * stroke_transform.inverse());
 			let element_transform = element_transform.unwrap_or(DAffine2::IDENTITY);
 			let layer_bounds = vector.bounding_box().unwrap_or_default();
 			let transformed_bounds = vector.bounding_box_with_transform(applied_stroke_transform).unwrap_or_default();
@@ -953,32 +1068,46 @@ impl Render for List<Vector> {
 				MaskType::Mask
 			};
 
+			let fill_graphic_list = self
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+				.filter(|list| !list.is_empty())
+				.cloned()
+				.or_else(|| fill_to_graphic_list(vector.style.fill()));
+			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
+
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(vector.style.fill().is_none() || !vector.style.fill().is_opaque() || mask_type == MaskType::Clip);
+			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip || need_clipping);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
+			let override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
+			let use_face_fill = vector.use_face_fill();
+
+			// Register the clipPath in <defs> and remember its id for the <g clip-path> below
+			let clip_id = if need_clipping && !use_face_fill {
+				let id = format!("clip-{}", generate_uuid());
+				write!(&mut render.svg_defs, r##"<clipPath id="{id}"><path d="{path}"/></clipPath>"##).unwrap();
+				Some(id)
+			} else {
+				None
+			};
 
 			if needs_separate_alignment_fill && !wants_stroke_below {
-				render.leaf_tag("path", |attributes| {
-					attributes.push("d", path.clone());
-					let matrix = format_transform_matrix(element_transform);
-					if !matrix.is_empty() {
-						attributes.push(ATTR_TRANSFORM, matrix);
-					}
-					let mut style = vector.style.clone();
-					style.clear_stroke();
-					let fill_and_stroke = style.render(
-						&mut attributes.0.svg_defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						render_params,
-					);
-					attributes.push_val(fill_and_stroke);
-				});
+				emit_aligned_fill_pass(
+					render,
+					path.clone(),
+					element_transform,
+					item_transform,
+					fill_graphic_list.as_ref(),
+					clip_id.as_deref(),
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				);
 			}
 
 			let push_id = needs_separate_alignment_fill.then_some({
@@ -990,36 +1119,49 @@ impl Render for List<Vector> {
 
 				// The mask must draw at full alpha so the SVG `<mask>`/`<clipPath>` fully zeroes the path interior.
 				// The wrapping SVG group (above) handles the user-set opacity.
-				let vector_item = List::new_from_item(Item::new_from_element(cloned_vector).with_attribute(ATTR_TRANSFORM, multiplied_transform));
+				let vector_item = List::new_from_item(Item::new_from_element(cloned_vector).with_attribute(ATTR_TRANSFORM, item_transform));
 
 				(id, mask_type, vector_item)
 			});
 
-			let use_face_fill = vector.use_face_fill();
 			if use_face_fill {
 				for mut face_path in vector.construct_faces().filter(|face| face.area() >= 0.) {
 					face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
-
 					let face_d = face_path.to_svg();
-					render.leaf_tag("path", |attributes| {
-						attributes.push("d", face_d.clone());
-						let matrix = format_transform_matrix(element_transform);
-						if !matrix.is_empty() {
-							attributes.push(ATTR_TRANSFORM, matrix);
+
+					match fill_graphic {
+						Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
+							emit_svg_fill_path(
+								render,
+								face_d,
+								element_transform,
+								fill_graphic,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								render_params,
+							);
 						}
-						let mut style = vector.style.clone();
-						style.clear_stroke();
-						let fill_only = style.render(
-							&mut attributes.0.svg_defs,
-							element_transform,
-							applied_stroke_transform,
-							bounds_matrix,
-							transformed_bounds_matrix,
-							render_params,
-						);
-						attributes.push_val(fill_only);
-					});
+
+						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
+							if let Some(fill_graphic_list) = fill_graphic_list.as_ref() {
+								let face_clip_id = format!("clip-{}", generate_uuid());
+								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
+								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
+							}
+						}
+					}
 				}
+			}
+
+			// Clipping-based fill should be drawn before the stroke path (default paint order)
+			if !needs_separate_alignment_fill
+				&& !use_face_fill
+				&& !wants_stroke_below
+				&& !override_paint_order
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+			{
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
 
 			render.leaf_tag("path", |attributes| {
@@ -1058,20 +1200,34 @@ impl Render for List<Vector> {
 
 				let mut render_params = render_params.clone();
 				render_params.aligned_strokes = can_draw_aligned_stroke;
-				render_params.override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
+				render_params.override_paint_order = override_paint_order;
 
-				let mut style = vector.style.clone();
-				if needs_separate_alignment_fill || use_face_fill {
-					style.clear_fill();
-				}
+				let stroke_attribute = vector
+					.style
+					.stroke()
+					.map(|stroke| stroke.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params))
+					.unwrap_or_default();
 
-				let fill_and_stroke = style.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params);
+				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
+					r#" fill="none""#.to_string()
+				} else {
+					compute_svg_fill_attribute(
+						fill_graphic,
+						defs,
+						element_transform,
+						applied_stroke_transform,
+						bounds_matrix,
+						transformed_bounds_matrix,
+						&render_params,
+					)
+				};
 
 				if let Some((id, mask_type, _)) = push_id {
 					let selector = format!("url(#{id})");
 					attributes.push(mask_type.to_attribute(), selector);
 				}
-				attributes.push_val(fill_and_stroke);
+				attributes.push_val(fill_attribute);
+				attributes.push_val(stroke_attribute);
 
 				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
@@ -1087,26 +1243,29 @@ impl Render for List<Vector> {
 				}
 			});
 
+			// Clipping-based fill should be drawn after the stroke path
+			if !needs_separate_alignment_fill
+				&& !use_face_fill
+				&& (wants_stroke_below || override_paint_order)
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+			{
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
+			}
+
 			// When splitting passes and stroke is below, draw the fill after the stroke.
 			if needs_separate_alignment_fill && wants_stroke_below {
-				render.leaf_tag("path", |attributes| {
-					attributes.push("d", path);
-					let matrix = format_transform_matrix(element_transform);
-					if !matrix.is_empty() {
-						attributes.push(ATTR_TRANSFORM, matrix);
-					}
-					let mut style = vector.style.clone();
-					style.clear_stroke();
-					let fill_and_stroke = style.render(
-						&mut attributes.0.svg_defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						render_params,
-					);
-					attributes.push_val(fill_and_stroke);
-				});
+				emit_aligned_fill_pass(
+					render,
+					path,
+					element_transform,
+					item_transform,
+					fill_graphic_list.as_ref(),
+					clip_id.as_deref(),
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				);
 			}
 		}
 	}
@@ -2125,5 +2284,86 @@ impl SvgRenderAttrs<'_> {
 	}
 	pub fn push_val(&mut self, value: impl Into<SvgSegment>) {
 		self.0.svg.push(value.into());
+	}
+}
+
+#[cfg(test)]
+mod svg_fill_helper_tests {
+	use vector_types::GradientStop;
+
+	use super::*;
+
+	fn color_graphic(alpha: f64) -> Graphic {
+		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
+		Graphic::Color(List::new_from_element(color))
+	}
+
+	fn gradient_graphic(gradient: GradientStops) -> Graphic {
+		let mut gradient_list = List::new_from_element(gradient);
+		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
+		Graphic::Gradient(gradient_list)
+	}
+
+	#[test]
+	fn opaquely_none_is_false() {
+		assert!(!fill_covers_opaquely(None));
+	}
+
+	#[test]
+	fn opaquely_opaque_color_is_true() {
+		let g = color_graphic(1.0);
+		assert!(fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_transparent_color_is_false() {
+		let g = color_graphic(0.5);
+		assert!(!fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_vector_is_false() {
+		let g = Graphic::Vector(List::default());
+		assert!(!fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_gradient_all_opaque_is_true() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_transparent_gradient_is_false() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(!fill_covers_opaquely(Some(&g)));
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -337,15 +337,6 @@ fn draw_raster_outline(scene: &mut Scene, outline_transform: &DAffine2, render_p
 	scene.stroke(&outline_stroke, Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 }
 
-/// Returns true if the resolved fill graphic fully and opaquely covers the path interior.
-fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
-	match fill_graphic {
-		Some(Graphic::Color(list)) => list.element(0).is_some_and(|c| c.a() >= 1.0),
-		Some(Graphic::Gradient(list)) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1.0)),
-		_ => false,
-	}
-}
-
 /// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
 #[allow(clippy::too_many_arguments)]
 fn emit_svg_fill_path(
@@ -1015,7 +1006,7 @@ impl Render for List<Vector> {
 
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip);
+			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
@@ -2193,86 +2184,5 @@ impl SvgRenderAttrs<'_> {
 	}
 	pub fn push_val(&mut self, value: impl Into<SvgSegment>) {
 		self.0.svg.push(value.into());
-	}
-}
-
-#[cfg(test)]
-mod svg_fill_helper_tests {
-	use vector_types::GradientStop;
-
-	use super::*;
-
-	fn color_graphic(alpha: f64) -> Graphic {
-		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
-		Graphic::Color(List::new_from_element(color))
-	}
-
-	fn gradient_graphic(gradient: GradientStops) -> Graphic {
-		let mut gradient_list = List::new_from_element(gradient);
-		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
-		Graphic::Gradient(gradient_list)
-	}
-
-	#[test]
-	fn opaquely_none_is_false() {
-		assert!(!fill_covers_opaquely(None));
-	}
-
-	#[test]
-	fn opaquely_opaque_color_is_true() {
-		let g = color_graphic(1.0);
-		assert!(fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_transparent_color_is_false() {
-		let g = color_graphic(0.5);
-		assert!(!fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_vector_is_false() {
-		let g = Graphic::Vector(List::default());
-		assert!(!fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_gradient_all_opaque_is_true() {
-		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let gradient = GradientStops::new(vec![
-			GradientStop {
-				position: 0.,
-				midpoint: 0.5,
-				color: color_1,
-			},
-			GradientStop {
-				position: 1.,
-				midpoint: 0.5,
-				color: color_2,
-			},
-		]);
-		let g = gradient_graphic(gradient);
-		assert!(fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_transparent_gradient_is_false() {
-		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
-		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let gradient = GradientStops::new(vec![
-			GradientStop {
-				position: 0.,
-				midpoint: 0.5,
-				color: color_1,
-			},
-			GradientStop {
-				position: 1.,
-				midpoint: 0.5,
-				color: color_2,
-			},
-		]);
-		let g = gradient_graphic(gradient);
-		assert!(!fill_covers_opaquely(Some(&g)));
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -449,9 +449,7 @@ pub struct RenderMetadata {
 	/// The Text tool composes this with `transform_to_viewport(layer)` to position its drag cage.
 	pub text_frames: HashMap<NodeId, DAffine2>,
 	pub clip_targets: HashSet<NodeId>,
-	// `RenderMetadata` only enters serialization via `TaggedValue::RenderOutput`, which also skips serde.
-	#[cfg_attr(feature = "serde", serde(skip))]
-	pub vector_data: HashMap<NodeId, Arc<List<Vector>>>,
+	pub vector_data: HashMap<NodeId, Arc<Vector>>,
 	pub backgrounds: Vec<Background>,
 }
 
@@ -1559,11 +1557,6 @@ impl Render for List<Vector> {
 		let mut accumulated_click_targets: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 		let mut accumulated_outlines: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 
-		// Source geometry (not the click-target override) so editing tools work on letterforms.
-		if let Some(element_id) = caller_element_id {
-			metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(self.clone()));
-		}
-
 		for index in 0..self.len() {
 			let Some(source) = self.element(index) else { continue };
 			let transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
@@ -1592,6 +1585,10 @@ impl Render for List<Vector> {
 				let mut outlines_unwrapped = Vec::new();
 				extend_targets_from_vector(&mut outlines_unwrapped, self, index, source, item_relative_transform);
 				accumulated_outlines.entry(element_id).or_default().extend(outlines_unwrapped.into_iter().map(Arc::new));
+
+				// Source geometry (not the click-target override) so editing tools work on letterforms.
+				// Only item 0 is recorded since editing tools can only target a single item currently.
+				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
 				if let Some(&frame) = self.attribute::<DAffine2>(ATTR_EDITOR_TEXT_FRAME, index) {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1080,7 +1080,7 @@ impl Render for List<Vector> {
 			let can_draw_aligned_stroke = path_is_closed
 				&& vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered())
 				&& stroke_graphic.is_some_and(|graphic| !graphic.is_fully_transparent());
-			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
+			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.covers_opaquely()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);

--- a/node-graph/libraries/vector-types/src/gradient.rs
+++ b/node-graph/libraries/vector-types/src/gradient.rs
@@ -587,6 +587,12 @@ impl Gradient {
 
 		Some(index)
 	}
+
+	/// Builds the affine that places the gradient endpoints at `start` and `end` when applied to canonical gradient space (0,0) -> (1,0)
+	pub fn to_transform(&self) -> DAffine2 {
+		let direction = self.end - self.start;
+		DAffine2::from_cols(direction, direction.perp(), self.start)
+	}
 }
 
 // TODO: Eventually remove this migration document upgrade code
@@ -623,5 +629,29 @@ impl core_types::bounds::BoundingBox for GradientStops {
 		let start = transform.transform_point2(DVec2::ZERO);
 		let end = transform.transform_point2(DVec2::X);
 		core_types::bounds::RenderBoundingBox::Rectangle([start.min(end), start.max(end)])
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use glam::DVec2;
+
+	fn linear_gradient(start: DVec2, end: DVec2) -> Gradient {
+		Gradient { start, end, ..Default::default() }
+	}
+
+	#[test]
+	fn to_transform_roundtrip() {
+		let cases = [(DVec2::ZERO, DVec2::X), (DVec2::new(10., 20.), DVec2::new(50., 30.)), (DVec2::new(-5., -5.), DVec2::new(5., 3.))];
+
+		for (start, end) in cases {
+			let transform = linear_gradient(start, end).to_transform();
+			let recovered_start = transform.transform_point2(DVec2::ZERO);
+			let recovered_end = transform.transform_point2(DVec2::X);
+
+			assert!((recovered_start - start).length() < 1e-10);
+			assert!((recovered_end - end).length() < 1e-10);
+		}
 	}
 }

--- a/node-graph/libraries/vector-types/src/gradient.rs
+++ b/node-graph/libraries/vector-types/src/gradient.rs
@@ -588,7 +588,7 @@ impl Gradient {
 		Some(index)
 	}
 
-	/// Builds the affine that places the gradient endpoints at `start` and `end` when applied to canonical gradient space (0,0) -> (1,0)
+	/// Builds the affine that places the gradient endpoints at `start` and `end` when applied to canonical gradient space (0, 0) -> (1, 0).
 	pub fn to_transform(&self) -> DAffine2 {
 		let direction = self.end - self.start;
 		DAffine2::from_cols(direction, direction.perp(), self.start)

--- a/node-graph/libraries/vector-types/src/vector/style.rs
+++ b/node-graph/libraries/vector-types/src/vector/style.rs
@@ -580,7 +580,7 @@ impl Stroke {
 	}
 
 	pub fn has_renderable_stroke(&self) -> bool {
-		self.weight > 0. && self.color.is_some_and(|color| color.a() != 0.)
+		self.weight > 0.
 	}
 }
 

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,5 +1,5 @@
 use core_types::Context;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, List};
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
@@ -1008,10 +1008,10 @@ fn fill_graphic<P: IntoGraphicList + 'n + Send>(
 	vectors
 }
 
-/// Sets the `stroke_paint_graphic` attribute on each item of the input vector list.
+/// Sets the `stroke_graphic` attribute on each item of the input vector list.
 /// Used for testing of gradient and clipping-based stroke rendering until the proper Stroke node refactor lands.
 #[node_macro::node(category("Debug"))]
-fn stroke_paint_graphic<P: IntoGraphicList + 'n + Send>(
+fn stroke_graphic<P: IntoGraphicList + 'n + Send>(
 	_: impl Ctx,
 	mut vectors: List<Vector>,
 	#[implementations(
@@ -1022,11 +1022,11 @@ fn stroke_paint_graphic<P: IntoGraphicList + 'n + Send>(
         List<Color>,
         List<GradientStops>,
     )]
-	stroke_paint_graphic: P,
+	stroke_graphic: P,
 ) -> List<Vector> {
-	let paint_list = stroke_paint_graphic.into_graphic_list();
+	let paint_list = stroke_graphic.into_graphic_list();
 	for row_idx in 0..vectors.len() {
-		vectors.set_attribute(ATTR_STROKE_PAINT_GRAPHIC, row_idx, paint_list.clone());
+		vectors.set_attribute(ATTR_STROKE_GRAPHIC, row_idx, paint_list.clone());
 	}
 	vectors
 }

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,11 +1,11 @@
 use core_types::Context;
-use core_types::list::List;
+use core_types::list::{ATTR_FILL_GRAPHIC, List};
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
 use glam::{DAffine2, DVec2};
 use graphic_types::raster_types::{CPU, GPU, Raster};
-use graphic_types::{Artboard, Graphic, Vector};
+use graphic_types::{Artboard, Graphic, IntoGraphicList, Vector};
 use log::warn;
 use math_parser::ast;
 use math_parser::context::{EvalContext, NothingMap, ValueProvider};
@@ -983,6 +983,29 @@ fn length(_: impl Ctx, vector: DVec2) -> f64 {
 #[node_macro::node(category("Math: Vector"))]
 fn normalize(_: impl Ctx, vector: DVec2) -> DVec2 {
 	vector.normalize_or_zero()
+}
+
+/// Sets the `fill_graphic` attribute on each item of the input vector list.
+/// Used for testing of clipping-based fill rendering until the proper Fill node refactor lands.
+#[node_macro::node(category("Debug"))]
+fn fill_graphic<P: IntoGraphicList + 'n + Send>(
+	_: impl Ctx,
+	mut vectors: List<Vector>,
+	#[implementations(
+        List<Graphic>,
+        List<Vector>,
+        List<Raster<CPU>>,
+        List<Raster<GPU>>,
+        List<Color>,
+        List<GradientStops>,
+    )]
+	fill_graphic: P,
+) -> List<Vector> {
+	let paint_list = fill_graphic.into_graphic_list();
+	for row_idx in 0..vectors.len() {
+		vectors.set_attribute(ATTR_FILL_GRAPHIC, row_idx, paint_list.clone());
+	}
+	vectors
 }
 
 #[cfg(test)]

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,11 +1,11 @@
 use core_types::Context;
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, List};
+use core_types::list::List;
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
 use glam::{DAffine2, DVec2};
 use graphic_types::raster_types::{CPU, GPU, Raster};
-use graphic_types::{Artboard, Graphic, IntoGraphicList, Vector};
+use graphic_types::{Artboard, Graphic, Vector};
 use log::warn;
 use math_parser::ast;
 use math_parser::context::{EvalContext, NothingMap, ValueProvider};
@@ -983,52 +983,6 @@ fn length(_: impl Ctx, vector: DVec2) -> f64 {
 #[node_macro::node(category("Math: Vector"))]
 fn normalize(_: impl Ctx, vector: DVec2) -> DVec2 {
 	vector.normalize_or_zero()
-}
-
-/// Sets the `fill_graphic` attribute on each item of the input vector list.
-/// Used for testing of clipping-based fill rendering until the proper Fill node refactor lands.
-#[node_macro::node(category("Debug"))]
-fn fill_graphic<P: IntoGraphicList + 'n + Send>(
-	_: impl Ctx,
-	mut vectors: List<Vector>,
-	#[implementations(
-        List<Graphic>,
-        List<Vector>,
-        List<Raster<CPU>>,
-        List<Raster<GPU>>,
-        List<Color>,
-        List<GradientStops>,
-    )]
-	fill_graphic: P,
-) -> List<Vector> {
-	let paint_list = fill_graphic.into_graphic_list();
-	for row_idx in 0..vectors.len() {
-		vectors.set_attribute(ATTR_FILL_GRAPHIC, row_idx, paint_list.clone());
-	}
-	vectors
-}
-
-/// Sets the `stroke_graphic` attribute on each item of the input vector list.
-/// Used for testing of gradient and clipping-based stroke rendering until the proper Stroke node refactor lands.
-#[node_macro::node(category("Debug"))]
-fn stroke_graphic<P: IntoGraphicList + 'n + Send>(
-	_: impl Ctx,
-	mut vectors: List<Vector>,
-	#[implementations(
-        List<Graphic>,
-        List<Vector>,
-        List<Raster<CPU>>,
-        List<Raster<GPU>>,
-        List<Color>,
-        List<GradientStops>,
-    )]
-	stroke_graphic: P,
-) -> List<Vector> {
-	let paint_list = stroke_graphic.into_graphic_list();
-	for row_idx in 0..vectors.len() {
-		vectors.set_attribute(ATTR_STROKE_GRAPHIC, row_idx, paint_list.clone());
-	}
-	vectors
 }
 
 #[cfg(test)]

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,5 +1,5 @@
 use core_types::Context;
-use core_types::list::{ATTR_FILL_GRAPHIC, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
@@ -1004,6 +1004,29 @@ fn fill_graphic<P: IntoGraphicList + 'n + Send>(
 	let paint_list = fill_graphic.into_graphic_list();
 	for row_idx in 0..vectors.len() {
 		vectors.set_attribute(ATTR_FILL_GRAPHIC, row_idx, paint_list.clone());
+	}
+	vectors
+}
+
+/// Sets the `stroke_paint_graphic` attribute on each item of the input vector list.
+/// Used for testing of gradient and clipping-based stroke rendering until the proper Stroke node refactor lands.
+#[node_macro::node(category("Debug"))]
+fn stroke_paint_graphic<P: IntoGraphicList + 'n + Send>(
+	_: impl Ctx,
+	mut vectors: List<Vector>,
+	#[implementations(
+        List<Graphic>,
+        List<Vector>,
+        List<Raster<CPU>>,
+        List<Raster<GPU>>,
+        List<Color>,
+        List<GradientStops>,
+    )]
+	stroke_paint_graphic: P,
+) -> List<Vector> {
+	let paint_list = stroke_paint_graphic.into_graphic_list();
+	for row_idx in 0..vectors.len() {
+		vectors.set_attribute(ATTR_STROKE_PAINT_GRAPHIC, row_idx, paint_list.clone());
 	}
 	vectors
 }

--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -3,7 +3,7 @@ use core::f64::consts::{PI, TAU};
 use core::hash::{Hash, Hasher};
 use core_types::blending::BlendMode;
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List, ListDyn};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List, ListDyn};
 use core_types::registry::types::{Angle, Length, Multiplier, Percentage, PixelLength, Progression, SeedValue};
 use core_types::transform::{Footprint, Transform};
 use core_types::uuid::NodeId;
@@ -1230,15 +1230,15 @@ async fn solidify_stroke<T: IntoGraphicList + 'n + Send + Clone>(_: impl Ctx, #[
 				vector.style.clear_stroke();
 				let mut fill_attributes = attributes.clone();
 				// No stroke remains on the fill row
-				fill_attributes.remove::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC);
+				fill_attributes.remove::<List<Graphic>>(ATTR_STROKE_GRAPHIC);
 				Item::from_parts(vector, fill_attributes)
 			});
 
 			let mut stroke_attributes = attributes;
 			// Drop the original fill and use the stroke paint to fill the outlined stroke
 			stroke_attributes.remove::<List<Graphic>>(ATTR_FILL_GRAPHIC);
-			if let Some(stroke_paint) = stroke_attributes.remove::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC) {
-				stroke_attributes.insert(ATTR_FILL_GRAPHIC, stroke_paint);
+			if let Some(stroke_graphic) = stroke_attributes.remove::<List<Graphic>>(ATTR_STROKE_GRAPHIC) {
+				stroke_attributes.insert(ATTR_FILL_GRAPHIC, stroke_graphic);
 			}
 			let stroke_row = Item::from_parts(solidified_stroke, stroke_attributes);
 

--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -3,7 +3,7 @@ use core::f64::consts::{PI, TAU};
 use core::hash::{Hash, Hasher};
 use core_types::blending::BlendMode;
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
-use core_types::list::{Item, List, ListDyn};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List, ListDyn};
 use core_types::registry::types::{Angle, Length, Multiplier, Percentage, PixelLength, Progression, SeedValue};
 use core_types::transform::{Footprint, Transform};
 use core_types::uuid::NodeId;
@@ -1224,13 +1224,23 @@ async fn solidify_stroke<T: IntoGraphicList + 'n + Send + Clone>(_: impl Ctx, #[
 			}
 
 			// If the original vector has a fill, preserve it as a separate item with the stroke cleared.
-			let has_fill = !vector.style.fill().is_none();
+			let has_attr_fill = attributes.get::<List<Graphic>>(ATTR_FILL_GRAPHIC).is_some_and(|l| !l.is_empty());
+			let has_fill = has_attr_fill || !vector.style.fill().is_none();
 			let fill_row = has_fill.then(|| {
 				vector.style.clear_stroke();
-				Item::from_parts(vector, attributes.clone())
+				let mut fill_attributes = attributes.clone();
+				// No stroke remains on the fill row
+				fill_attributes.remove::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC);
+				Item::from_parts(vector, fill_attributes)
 			});
 
-			let stroke_row = Item::from_parts(solidified_stroke, attributes);
+			let mut stroke_attributes = attributes;
+			// Drop the original fill and use the stroke paint to fill the outlined stroke
+			stroke_attributes.remove::<List<Graphic>>(ATTR_FILL_GRAPHIC);
+			if let Some(stroke_paint) = stroke_attributes.remove::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC) {
+				stroke_attributes.insert(ATTR_FILL_GRAPHIC, stroke_paint);
+			}
+			let stroke_row = Item::from_parts(solidified_stroke, stroke_attributes);
 
 			// Ordering based on the paint order. The first item in the `List` is rendered below the second.
 			match paint_order {

--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -3,7 +3,7 @@ use core::f64::consts::{PI, TAU};
 use core::hash::{Hash, Hasher};
 use core_types::blending::BlendMode;
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
-use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_GRAPHIC, Item, List, ListDyn};
+use core_types::list::{ATTR_FILL, ATTR_STROKE, Item, List, ListDyn};
 use core_types::registry::types::{Angle, Length, Multiplier, Percentage, PixelLength, Progression, SeedValue};
 use core_types::transform::{Footprint, Transform};
 use core_types::uuid::NodeId;
@@ -1224,20 +1224,20 @@ async fn solidify_stroke<T: IntoGraphicList + 'n + Send + Clone>(_: impl Ctx, #[
 			}
 
 			// If the original vector has a fill, preserve it as a separate item with the stroke cleared.
-			let has_attr_fill = attributes.keys().any(|k| k == ATTR_FILL_GRAPHIC);
+			let has_attr_fill = attributes.keys().any(|k| k == ATTR_FILL);
 			let has_fill = has_attr_fill || !vector.style.fill().is_none();
 			let fill_row = has_fill.then(|| {
 				vector.style.clear_stroke();
 				let mut fill_attributes = attributes.clone();
 				// No stroke remains on the fill row
-				fill_attributes.remove::<List<Graphic>>(ATTR_STROKE_GRAPHIC);
+				fill_attributes.remove::<List<Graphic>>(ATTR_STROKE);
 				Item::from_parts(vector, fill_attributes)
 			});
 
 			let mut stroke_attributes = attributes;
 			// Drop the original fill and use the stroke paint to fill the outlined stroke
-			stroke_attributes.remove::<List<Graphic>>(ATTR_FILL_GRAPHIC);
-			stroke_attributes.rename(ATTR_STROKE_GRAPHIC, ATTR_FILL_GRAPHIC);
+			stroke_attributes.remove::<List<Graphic>>(ATTR_FILL);
+			stroke_attributes.rename(ATTR_STROKE, ATTR_FILL);
 
 			let stroke_row = Item::from_parts(solidified_stroke, stroke_attributes);
 

--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -1224,7 +1224,7 @@ async fn solidify_stroke<T: IntoGraphicList + 'n + Send + Clone>(_: impl Ctx, #[
 			}
 
 			// If the original vector has a fill, preserve it as a separate item with the stroke cleared.
-			let has_attr_fill = attributes.get::<List<Graphic>>(ATTR_FILL_GRAPHIC).is_some_and(|l| !l.is_empty());
+			let has_attr_fill = attributes.keys().any(|k| k == ATTR_FILL_GRAPHIC);
 			let has_fill = has_attr_fill || !vector.style.fill().is_none();
 			let fill_row = has_fill.then(|| {
 				vector.style.clear_stroke();
@@ -1237,9 +1237,8 @@ async fn solidify_stroke<T: IntoGraphicList + 'n + Send + Clone>(_: impl Ctx, #[
 			let mut stroke_attributes = attributes;
 			// Drop the original fill and use the stroke paint to fill the outlined stroke
 			stroke_attributes.remove::<List<Graphic>>(ATTR_FILL_GRAPHIC);
-			if let Some(stroke_graphic) = stroke_attributes.remove::<List<Graphic>>(ATTR_STROKE_GRAPHIC) {
-				stroke_attributes.insert(ATTR_FILL_GRAPHIC, stroke_graphic);
-			}
+			stroke_attributes.rename(ATTR_STROKE_GRAPHIC, ATTR_FILL_GRAPHIC);
+
 			let stroke_row = Item::from_parts(solidified_stroke, stroke_attributes);
 
 			// Ordering based on the paint order. The first item in the `List` is rendered below the second.


### PR DESCRIPTION
Partly closes #2779

This PR adds foundation of the renderer to handle `List<Graphic>` as a paint source of fill and stroke.

## Demo

https://github.com/user-attachments/assets/ff0569c6-6ccf-4bc6-9659-e02c01f707b7

The demo file can be found in below.
[render-fill-and-stroke-via-list-graphic.graphite.zip](https://github.com/user-attachments/files/28690258/render-fill-and-stroke-via-list-graphic.graphite.zip)


## Notes

- Added converter from `Fill` / `Color` to `List<Graphic>` to avoid breaking current node flow related to the `Fill` and `Stroke` node. This should be removed after the future refactoring of the node.
- Added `ATTR_FILL = "fill"` and `ATTR_STROKE = "stroke"` attribute keys for storing the paints `List<T>`, where T is the graphic types, on a `List<Vector>` item.
- Refactor Vello / SVG renderer to use `List<Graphic>` as a fill and stroke paint source.
- `RenderExt` implementations for `PathStyle`, `Fill` are no longer needed, now we have implementation for `List<Graphic>` instead. The same for `Stroke` is now shrunk to only generate the shape related attributes.
- For the sake of simplifying the same implementation for stroke and also tiling, clipping paint for SVG is implemented using the `<pattern>` element instead of the `<clipPath>`.