### PR TITLE
Fix Pen tool regression that broke dragging a sharp tangent out of the last-placed anchor

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -624,6 +624,8 @@ impl PenToolData {
 			if let Some(point) = self.latest_point_mut() {
 				point.in_segment = None;
 			}
+
+			return;
 		}
 
 		// Closing path


### PR DESCRIPTION
Regression introduced in 123108c813c722e7c8c53d9a58f94f0328a195ac.