### PR TITLE
widgets:new_document: add swap button to dims

### DIFF
--- a/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message.rs
+++ b/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message.rs
@@ -7,6 +7,7 @@ pub enum NewDocumentDialogMessage {
 	Infinite { infinite: bool },
 	DimensionsX { width: f64 },
 	DimensionsY { height: f64 },
+	SwapDimensions,
 
 	Submit,
 }

--- a/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
+++ b/editor/src/messages/dialog/new_document_dialog/new_document_dialog_message_handler.rs
@@ -21,6 +21,9 @@ impl MessageHandler<NewDocumentDialogMessage, ()> for NewDocumentDialogMessageHa
 			NewDocumentDialogMessage::Infinite { infinite } => self.infinite = infinite,
 			NewDocumentDialogMessage::DimensionsX { width } => self.dimensions.x = width as u32,
 			NewDocumentDialogMessage::DimensionsY { height } => self.dimensions.y = height as u32,
+			NewDocumentDialogMessage::SwapDimensions => {
+				std::mem::swap(&mut self.dimensions.x, &mut self.dimensions.y);
+			}
 			NewDocumentDialogMessage::Submit => {
 				responses.add(PortfolioMessage::NewDocumentWithName { name: self.name.clone() });
 
@@ -130,6 +133,12 @@ impl LayoutHolder for NewDocumentDialogMessageHandler {
 				.disabled(self.infinite)
 				.min_width(100)
 				.on_update(|number_input: &NumberInput| NewDocumentDialogMessage::DimensionsX { width: number_input.value.unwrap() }.into())
+				.widget_instance(),
+			Separator::new(SeparatorStyle::Related).widget_instance(),
+			IconButton::new("SwapHorizontal", 16)
+			    .tooltip_label("Swap Width/Height")
+                .disabled(self.infinite)
+				.on_update(|_| NewDocumentDialogMessage::SwapDimensions.into())
 				.widget_instance(),
 			Separator::new(SeparatorStyle::Related).widget_instance(),
 			NumberInput::new(Some(self.dimensions.y as f64))


### PR DESCRIPTION
add a button to swap dimensions, essentially changing between portrait and landscape mode much more easily

Code written in cursor, less than 40 lines and carefully reviewed.
description written by human.
tested and working.


<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
