### PR TITLE
Fix reversing for Repeat On Points (reverse before enumerate)

### DIFF
--- a/node-graph/nodes/repeat/src/repeat_nodes.rs
+++ b/node-graph/nodes/repeat/src/repeat_nodes.rs
@@ -170,13 +170,13 @@ async fn repeat_on_points<T: Into<Graphic> + Default + Send + Clone + 'static>(
 			}
 		};
 
-		let range = points_element.point_domain.positions().iter().enumerate();
+		let range = points_element.point_domain.positions().iter();
 		if reverse {
-			for (index, &point) in range.rev() {
+			for (index, &point) in range.rev().enumerate() {
 				iteration(index, point).await;
 			}
 		} else {
-			for (index, &point) in range {
+			for (index, &point) in range.enumerate() {
 				iteration(index, point).await;
 			}
 		}


### PR DESCRIPTION
Resolves #4142.

Simple change to correct point reversal within `repeat_on_points` to fix the Reverse parameter.

Technically (at least as far as I can tell), the old code reversed the list of points *after* enumerating them, but since Read Index pulls from the enumeration index rather than the point's position in the algorithm's list, reversing the points didn't do anything.  
This change swaps the order, so if the points are being reversed, that happens *before* the enumeration.

Before/after demo:

[Screencast_20260513_022844.webm](https://github.com/user-attachments/assets/070d019b-a0e7-4b4c-ba6b-179be99405c9)

---

**Update**: It turns out that it's not clear if this is intended functionality. If it is, feel free to merge this (or not, lol). If turns out to not be intended, that's cool too.

No AI whatsoever was used in the making of this PR.