### PR TITLE
Fix pen tool preview line disappearing during undo

### DIFF
--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -2234,8 +2234,6 @@ impl Fsm for PenToolFsmState {
 				if tool_data.point_index > 0 {
 					tool_data.point_index -= 1;
 
-					tool_data.next_point = input.mouse.position;
-					tool_data.next_handle_start = input.mouse.position;
 					tool_data.handle_end = Some(input.mouse.position);
 
 					tool_data

--- a/editor/src/messages/tool/tool_messages/pen_tool.rs
+++ b/editor/src/messages/tool/tool_messages/pen_tool.rs
@@ -2233,6 +2233,11 @@ impl Fsm for PenToolFsmState {
 			(PenToolFsmState::DraggingHandle(..) | PenToolFsmState::PlacingAnchor, PenToolMessage::Undo) => {
 				if tool_data.point_index > 0 {
 					tool_data.point_index -= 1;
+
+					tool_data.next_point = input.mouse.position;
+					tool_data.next_handle_start = input.mouse.position;
+					tool_data.handle_end = Some(input.mouse.position);
+
 					tool_data
 						.place_anchor(SnapData::new(document, input, viewport), transform, input.mouse.position, responses)
 						.unwrap_or(PenToolFsmState::PlacingAnchor)


### PR DESCRIPTION
## Summary

Fixes an issue where the Pen tool preview line could disappear after repeatedly undoing while drawing a path.

The undo flow restored anchor history state but did not fully restore the temporary preview/handle continuation state used by the active Pen tool session. This caused the preview segment from the last anchor point to the cursor to stop rendering consistently after multiple undo operations.

## Changes

Updated the Pen tool undo handling to restore transient preview-related state during undo operations by refreshing:
* `next_point`
* `next_handle_start`
* `handle_end`

This keeps the preview segment active and consistent while continuing to draw after repeated undo actions.

## Testing
Tested by:
* creating polyline paths
* repeatedly undoing points
* continuing path drawing after undo
* verifying the preview line remains visible and interactive

Closes #3790
