### PR TITLE
Fix the Fill node not restoring its solid color after switching to gradient and back

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -2451,35 +2451,38 @@ pub(crate) fn fill_properties(node_id: NodeId, context: &mut NodePropertiesConte
 	widgets_first_row.push(
 		ColorInput::default()
 			.value(FillChoiceUI::from(&FillChoice::from(fill.clone())))
-			.on_update(move |x: &ColorInput| Message::Batched {
-				messages: Box::new([
-					match &fill2 {
-						Fill::None => NodeGraphMessage::SetInputValue {
+			.on_update(move |x: &ColorInput| {
+				let new_fill = FillChoice::from(&x.value).to_fill(fill2.as_gradient());
+				Message::Batched {
+					messages: Box::new([
+						match &new_fill {
+							Fill::None => NodeGraphMessage::SetInputValue {
+								node_id,
+								input_index: BackupColorInput::INDEX,
+								value: TaggedValue::Color(None),
+							}
+							.into(),
+							Fill::Solid(color) => NodeGraphMessage::SetInputValue {
+								node_id,
+								input_index: BackupColorInput::INDEX,
+								value: TaggedValue::Color(Some(*color)),
+							}
+							.into(),
+							Fill::Gradient(gradient) => NodeGraphMessage::SetInputValue {
+								node_id,
+								input_index: BackupGradientInput::INDEX,
+								value: TaggedValue::FillGradient(gradient.clone()),
+							}
+							.into(),
+						},
+						NodeGraphMessage::SetInputValue {
 							node_id,
-							input_index: BackupColorInput::INDEX,
-							value: TaggedValue::Color(None),
+							input_index: FillInput::<Color>::INDEX,
+							value: TaggedValue::Fill(new_fill),
 						}
 						.into(),
-						Fill::Solid(color) => NodeGraphMessage::SetInputValue {
-							node_id,
-							input_index: BackupColorInput::INDEX,
-							value: TaggedValue::Color(Some(*color)),
-						}
-						.into(),
-						Fill::Gradient(gradient) => NodeGraphMessage::SetInputValue {
-							node_id,
-							input_index: BackupGradientInput::INDEX,
-							value: TaggedValue::FillGradient(gradient.clone()),
-						}
-						.into(),
-					},
-					NodeGraphMessage::SetInputValue {
-						node_id,
-						input_index: FillInput::<Color>::INDEX,
-						value: TaggedValue::Fill(FillChoice::from(&x.value).to_fill(fill2.as_gradient())),
-					}
-					.into(),
-				]),
+					]),
+				}
 			})
 			.on_commit(commit_value)
 			.widget_instance(),

--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -2453,28 +2453,19 @@ pub(crate) fn fill_properties(node_id: NodeId, context: &mut NodePropertiesConte
 			.value(FillChoiceUI::from(&FillChoice::from(fill.clone())))
 			.on_update(move |x: &ColorInput| {
 				let new_fill = FillChoice::from(&x.value).to_fill(fill2.as_gradient());
+				let (backup_index, backup_value) = match &new_fill {
+					Fill::None => (BackupColorInput::INDEX, TaggedValue::Color(None)),
+					Fill::Solid(color) => (BackupColorInput::INDEX, TaggedValue::Color(Some(*color))),
+					Fill::Gradient(gradient) => (BackupGradientInput::INDEX, TaggedValue::FillGradient(gradient.clone())),
+				};
 				Message::Batched {
 					messages: Box::new([
-						match &new_fill {
-							Fill::None => NodeGraphMessage::SetInputValue {
-								node_id,
-								input_index: BackupColorInput::INDEX,
-								value: TaggedValue::Color(None),
-							}
-							.into(),
-							Fill::Solid(color) => NodeGraphMessage::SetInputValue {
-								node_id,
-								input_index: BackupColorInput::INDEX,
-								value: TaggedValue::Color(Some(*color)),
-							}
-							.into(),
-							Fill::Gradient(gradient) => NodeGraphMessage::SetInputValue {
-								node_id,
-								input_index: BackupGradientInput::INDEX,
-								value: TaggedValue::FillGradient(gradient.clone()),
-							}
-							.into(),
-						},
+						NodeGraphMessage::SetInputValue {
+							node_id,
+							input_index: backup_index,
+							value: backup_value,
+						}
+						.into(),
 						NodeGraphMessage::SetInputValue {
 							node_id,
 							input_index: FillInput::<Color>::INDEX,


### PR DESCRIPTION
closes #3824 

When the colour changes, we now compute the new fill value once and save that same new value both as the active Fill and into the correct backup slot.


https://github.com/user-attachments/assets/c69f08c4-5e78-4503-8ec6-ae694eae857c

