### PR TITLE
Render stroke via List<Graphic>

### DIFF
--- a/editor/src/messages/portfolio/document/document_message.rs
+++ b/editor/src/messages/portfolio/document/document_message.rs
@@ -12,6 +12,7 @@ use crate::messages::prelude::*;
 use glam::{DAffine2, IVec2};
 use graph_craft::document::NodeId;
 use graphene_std::Color;
+use graphene_std::list::List;
 use graphene_std::raster::BlendMode;
 use graphene_std::raster::Image;
 use graphene_std::transform::Footprint;
@@ -226,8 +227,11 @@ pub enum DocumentMessage {
 	UpdateClipTargets {
 		clip_targets: HashSet<NodeId>,
 	},
+	// `Message` is only serialized at `editor_wrapper.rs`, and only inputs from JS pass through it.
+	// `UpdateVectorData` is produced inside `editor.handle_message` by `node_graph_executor.rs` and consumed in the same dispatch loop, so it never reaches that serialization point.
+	#[serde(skip)]
 	UpdateVectorData {
-		vector_data: HashMap<NodeId, Arc<Vector>>,
+		vector_data: HashMap<NodeId, Arc<List<Vector>>>,
 	},
 	Undo,
 	UngroupSelectedLayers,

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -2393,6 +2393,7 @@ impl DocumentMessageHandler {
 			let has_fill = !matches!(style.fill, Fill::None);
 			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
 			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
+			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
 			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.

--- a/editor/src/messages/portfolio/document/document_message_handler.rs
+++ b/editor/src/messages/portfolio/document/document_message_handler.rs
@@ -32,6 +32,9 @@ use glam::{DAffine2, DVec2};
 use graph_craft::descriptor;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{NodeId, NodeInput, NodeNetwork, OldNodeNetwork};
+use graphene_std::Graphic;
+use graphene_std::graphic::{color_to_graphic_list, fill_to_graphic_list};
+use graphene_std::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
 use graphene_std::math::quad::Quad;
 use graphene_std::path_bool_nodes::boolean_intersect;
 use graphene_std::raster::BlendMode;
@@ -40,8 +43,9 @@ use graphene_std::subpath::Subpath;
 use graphene_std::vector::PointId;
 use graphene_std::vector::click_target::{ClickTarget, ClickTargetType};
 use graphene_std::vector::misc::dvec2_to_point;
-use graphene_std::vector::style::{Fill, RenderMode};
+use graphene_std::vector::style::{RenderMode, Stroke};
 use kurbo::{Affine, BezPath, Line, PathSeg};
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2384,17 +2388,32 @@ impl DocumentMessageHandler {
 		let mut resulting_layers: Vec<NodeId> = Vec::new();
 
 		for layer in selected_layers {
-			let style = self.network_interface.document_metadata().layer_vector_data.get(&layer).map(|arc| arc.style.clone());
-			let Some(style) = style else {
+			let vector_list = self.network_interface.document_metadata().layer_vector_data.get(&layer).cloned();
+			let Some(vector_list) = vector_list else {
 				resulting_layers.push(layer.to_node());
 				continue;
 			};
+			let style = vector_list.element(0).map(|vector| &vector.style);
 
-			let has_fill = !matches!(style.fill, Fill::None);
-			// `style.stroke` is `Some` whenever a `Stroke` node is in the chain, even with weight 0 or a transparent color.
-			// So `is_some()` would treat invisibly-stroked fill-only layers as having a stroke.
-			// FIXME: Consider if we need to check ATTR_STROKE_PAINT_GRAPHIC
-			let has_stroke = style.stroke.as_ref().is_some_and(|s| s.has_renderable_stroke());
+			let fill_graphic_list = vector_list
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, 0)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| style.and_then(|style| fill_to_graphic_list(style.fill())).map(Cow::Owned));
+			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let stroke_paint_graphic_list = vector_list
+				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, 0)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| color_to_graphic_list(style.and_then(|style| style.stroke().and_then(|s| s.color()))).map(Cow::Owned));
+			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let has_fill = fill_graphic.is_some();
+
+			let stroke_renderable = style.is_some_and(|s| s.stroke.as_ref().is_some_and(Stroke::has_renderable_stroke));
+			let stroke_paint_visible = stroke_paint_graphic.is_some_and(|g| !g.is_fully_transparent());
+			let has_stroke = stroke_renderable && stroke_paint_visible;
 
 			// No stroke means there's nothing to solidify. Fill-only layers are already in the desired form, so skip.
 			if !has_stroke {

--- a/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
+++ b/editor/src/messages/portfolio/document/utility_types/document_metadata.rs
@@ -6,6 +6,7 @@ use crate::messages::portfolio::document::utility_types::network_interface::Flow
 use crate::messages::tool::common_functionality::graph_modification_utils;
 use glam::{DAffine2, DVec2};
 use graph_craft::document::NodeId;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath;
 use graphene_std::transform::Footprint;
@@ -38,7 +39,7 @@ pub struct DocumentMetadata {
 	pub vector_modify: HashMap<NodeId, Vector>,
 	/// Vector data keyed by layer ID, used as fallback when no Path node exists.
 	/// This provides accurate SegmentIds for layers without explicit Path nodes.
-	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>,
+	pub layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>,
 	/// Transform from document space to viewport space.
 	pub document_to_viewport: DAffine2,
 }
@@ -225,7 +226,7 @@ impl DocumentMetadata {
 	/// stroke geometry when the layer is a vector with a stroke style. Falls back to the click-target-based
 	/// bounds for non-vector layers (groups, raster, text, color, gradient).
 	pub fn bounding_box_document_with_stroke(&self, layer: LayerNodeIdentifier) -> Option<[DVec2; 2]> {
-		if let Some(vector) = self.layer_vector_data.get(&layer)
+		if let Some(vector) = self.layer_vector_data.get(&layer).and_then(|vector_list| vector_list.element(0))
 			&& let Some(bounds) = vector.stroke_inclusive_bounding_box_with_transform(self.transform_to_document(layer))
 		{
 			return Some(bounds);

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -23,6 +23,7 @@ use graph_craft::Type;
 use graph_craft::document::value::TaggedValue;
 use graph_craft::document::{DocumentNode, DocumentNodeImplementation, NodeId, NodeInput, NodeNetwork, OldDocumentNodeImplementation, OldNodeNetwork};
 use graphene_std::ContextDependencies;
+use graphene_std::list::List;
 use graphene_std::math::quad::Quad;
 use graphene_std::subpath::Subpath;
 use graphene_std::transform::Footprint;
@@ -3230,8 +3231,9 @@ impl NodeNetworkInterface {
 			}
 			return Some(modified);
 		}
-
-		self.document_metadata.layer_vector_data.get(&layer).map(|arc| arc.as_ref().clone())
+		// Only item 0 is returned since editing tools can only target a single item currently.
+		let vector_list = self.document_metadata.layer_vector_data.get(&layer).cloned();
+		vector_list.and_then(|list| list.element(0).cloned())
 	}
 
 	/// The vector geometry an upstream Path node would surface for editing.
@@ -3393,7 +3395,7 @@ impl NodeNetworkInterface {
 	}
 
 	/// Update the layer vector data (for layers without Path nodes)
-	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<Vector>>) {
+	pub fn update_vector_data(&mut self, new_layer_vector_data: HashMap<LayerNodeIdentifier, Arc<List<Vector>>>) {
 		self.document_metadata.layer_vector_data = new_layer_vector_data;
 	}
 }

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -77,7 +77,7 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 /// Gradient's `GradientType` (`Linear` or `Radial`).
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
-/// Table<Graphic> data for fill.
+/// List<Graphic> data for fill.
 pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
 
 // ========================

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -77,6 +77,9 @@ pub const ATTR_SPREAD_METHOD: &str = "spread_method";
 /// Gradient's `GradientType` (`Linear` or `Radial`).
 pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 
+/// Table<Graphic> data for fill.
+pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
+
 // ========================
 // TRAIT: AnyAttributeValue
 // ========================

--- a/node-graph/libraries/core-types/src/list.rs
+++ b/node-graph/libraries/core-types/src/list.rs
@@ -80,6 +80,9 @@ pub const ATTR_GRADIENT_TYPE: &str = "gradient_type";
 /// List<Graphic> data for fill.
 pub const ATTR_FILL_GRAPHIC: &str = "fill_graphic";
 
+/// List<Graphic> data for stroke.
+pub const ATTR_STROKE_PAINT_GRAPHIC: &str = "stroke_paint_graphic";
+
 // ========================
 // TRAIT: AnyAttributeValue
 // ========================

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -356,6 +356,14 @@ impl Graphic {
 			_ => false,
 		}
 	}
+
+	pub fn is_opaque(&self) -> bool {
+		match self {
+			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
+			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
+			_ => false,
+		}
+	}
 }
 
 impl BoundingBox for Graphic {
@@ -479,5 +487,81 @@ impl<T: Clone> OmitIndex for List<T> {
 			return self.clone();
 		}
 		self.omit_index(self.len() - index)
+	}
+}
+
+#[cfg(test)]
+mod graphic_is_opaque_tests {
+	use vector_types::{GradientSpreadMethod, GradientStop};
+
+	use super::*;
+
+	fn color_graphic(alpha: f64) -> Graphic {
+		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
+		Graphic::Color(List::new_from_element(color))
+	}
+
+	fn gradient_graphic(gradient: GradientStops) -> Graphic {
+		let mut gradient_list = List::new_from_element(gradient);
+		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
+		Graphic::Gradient(gradient_list)
+	}
+
+	#[test]
+	fn opaque_color_is_opaque() {
+		let g = color_graphic(1.0);
+		assert!(g.is_opaque());
+	}
+
+	#[test]
+	fn transparent_color_is_not_opaque() {
+		let g = color_graphic(0.5);
+		assert!(!g.is_opaque());
+	}
+
+	#[test]
+	fn vector_is_not_opaque() {
+		let g = Graphic::Vector(List::default());
+		assert!(!g.is_opaque());
+	}
+
+	#[test]
+	fn gradient_with_all_opaque_stops_is_opaque() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(g.is_opaque());
+	}
+
+	#[test]
+	fn gradient_with_transparent_stop_is_not_opaque() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(!g.is_opaque());
 	}
 }

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -1,6 +1,6 @@
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::List;
+use core_types::list::{Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -170,20 +170,20 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 	output
 }
 
-/// Converts a `Fill` enum into the `Table<Graphic>` representation used as paint storage.
-/// TODO: Remove once all paint sources flow through `Table<Graphic>` directly without going through the `Fill` enum.
-pub fn fill_to_paint(fill: &Fill) -> Option<Table<Graphic>> {
+/// Converts a `Fill` enum into the `List<Graphic>` representation used as paint storage.
+/// TODO: Remove once all paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 	match fill {
 		Fill::None => None,
-		Fill::Solid(color) => Some(Table::new_from_element((*color).into())),
+		Fill::Solid(color) => Some(List::new_from_element((*color).into())),
 		Fill::Gradient(gradient) => {
-			let gradient_row = TableRow::new_from_element(gradient.stops.clone())
+			let gradient_row = Item::new_from_element(gradient.stops.clone())
 				.with_attribute(ATTR_TRANSFORM, gradient.to_transform())
 				.with_attribute(ATTR_GRADIENT_TYPE, gradient.gradient_type)
 				.with_attribute(ATTR_SPREAD_METHOD, gradient.spread_method);
-			let gradient_table = Table::new_from_row(gradient_row);
+			let gradient_list = List::new_from_item(gradient_row);
 
-			Some(Table::new_from_element(Graphic::Gradient(gradient_table)))
+			Some(List::new_from_element(Graphic::Gradient(gradient_list)))
 		}
 	}
 }

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -171,7 +171,7 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 }
 
 /// Converts a `Fill` enum into the `List<Graphic>` representation used as paint storage.
-/// TODO: Remove once all paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
+/// TODO: Remove once all fill paint sources flow through `List<Graphic>` directly without going through the `Fill` enum.
 pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 	match fill {
 		Fill::None => None,
@@ -186,6 +186,12 @@ pub fn fill_to_graphic_list(fill: &Fill) -> Option<List<Graphic>> {
 			Some(List::new_from_element(Graphic::Gradient(gradient_list)))
 		}
 	}
+}
+
+/// Converts a `Color` into the `List<Graphic>` representation used as paint storage.
+/// TODO: Remove once all stroke paint sources flow through `List<Graphic>` directly without going through `Stroke.color`.
+pub fn color_to_graphic_list(color: Option<Color>) -> Option<List<Graphic>> {
+	color.as_ref().map(|color| List::new_from_element((*color).into()))
 }
 
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -4,7 +4,7 @@ use core_types::list::List;
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
-use core_types::{ATTR_CLIPPING_MASK, ATTR_EDITOR_LAYER_PATH, ATTR_OPACITY, ATTR_OPACITY_FILL, ATTR_TRANSFORM, Color};
+use core_types::{ATTR_CLIPPING_MASK, ATTR_EDITOR_LAYER_PATH, ATTR_GRADIENT_TYPE, ATTR_OPACITY, ATTR_OPACITY_FILL, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use dyn_any::DynAny;
 use glam::DAffine2;
 use raster_types::{CPU, GPU, Raster};
@@ -12,6 +12,7 @@ use vector_types::GradientStops;
 // use vector_types::Vector;
 
 pub use vector_types::Vector;
+use vector_types::vector::style::Fill;
 
 /// The possible forms of graphical content that can be rendered by the Render node into either an image or SVG syntax.
 #[derive(Clone, Debug, CacheHash, PartialEq, DynAny)]
@@ -167,6 +168,24 @@ fn flatten_graphic_list<T>(content: List<Graphic>, extract_variant: fn(Graphic) 
 	let mut output = List::new();
 	flatten_recursive(&mut output, content, extract_variant);
 	output
+}
+
+/// Converts a `Fill` enum into the `Table<Graphic>` representation used as paint storage.
+/// TODO: Remove once all paint sources flow through `Table<Graphic>` directly without going through the `Fill` enum.
+pub fn fill_to_paint(fill: &Fill) -> Option<Table<Graphic>> {
+	match fill {
+		Fill::None => None,
+		Fill::Solid(color) => Some(Table::new_from_element((*color).into())),
+		Fill::Gradient(gradient) => {
+			let gradient_row = TableRow::new_from_element(gradient.stops.clone())
+				.with_attribute(ATTR_TRANSFORM, gradient.to_transform())
+				.with_attribute(ATTR_GRADIENT_TYPE, gradient.gradient_type)
+				.with_attribute(ATTR_SPREAD_METHOD, gradient.spread_method);
+			let gradient_table = Table::new_from_row(gradient_row);
+
+			Some(Table::new_from_element(Graphic::Gradient(gradient_table)))
+		}
+	}
 }
 
 /// Maps from a concrete element type to its corresponding `Graphic` enum variant,

--- a/node-graph/libraries/graphic-types/src/graphic.rs
+++ b/node-graph/libraries/graphic-types/src/graphic.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use core_types::bounds::{BoundingBox, RenderBoundingBox};
 use core_types::graphene_hash::CacheHash;
-use core_types::list::{Item, List};
+use core_types::list::{ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::ops::ListConvert;
 use core_types::render_complexity::RenderComplexity;
 use core_types::uuid::NodeId;
@@ -357,7 +359,16 @@ impl Graphic {
 			Graphic::Vector(vector) => (0..vector.len()).all(|index| {
 				let Some(element) = vector.element(index) else { return false };
 				let opacity: f64 = vector.attribute_cloned_or(ATTR_OPACITY, index, 1.);
-				opacity > 1. - f64::EPSILON && element.style.fill().is_opaque() && element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke())
+				let stroke_paint_graphic_list = vector
+					.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
+					.filter(|list| !list.is_empty())
+					.map(Cow::Borrowed)
+					.or_else(|| color_to_graphic_list(element.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
+				let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
+				opacity > 1. - f64::EPSILON
+					&& element.style.fill().is_opaque()
+					&& (element.style.stroke().is_none_or(|stroke| !stroke.has_renderable_stroke()) || stroke_paint_graphic.is_none_or(|graphic| graphic.is_fully_transparent()))
 			}),
 			_ => false,
 		}
@@ -367,6 +378,15 @@ impl Graphic {
 		match self {
 			Graphic::Color(list) => list.element(0).is_some_and(|color| color.is_opaque()),
 			Graphic::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1. - f32::EPSILON)),
+			_ => false,
+		}
+	}
+
+	pub fn is_fully_transparent(&self) -> bool {
+		match self {
+			Self::Color(list) => list.element(0).is_some_and(|c| c.a() == 0.),
+			Self::Gradient(list) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() == 0.)),
+			// FIXME: Write recursive check for other types
 			_ => false,
 		}
 	}

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,11 +1,11 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
-use core_types::table::Table;
+use core_types::list::List;
 use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
 use graphic_types::Graphic;
-use graphic_types::graphic::fill_to_paint;
+use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
@@ -17,7 +17,7 @@ pub trait RenderExt {
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
 }
 
-impl RenderExt for Table<Color> {
+impl RenderExt for List<Color> {
 	type Output = String;
 
 	fn render(
@@ -40,7 +40,7 @@ impl RenderExt for Table<Color> {
 	}
 }
 
-impl RenderExt for Table<GradientStops> {
+impl RenderExt for List<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
@@ -118,13 +118,13 @@ impl RenderExt for Fill {
 
 	/// Renders the fill, adding necessary defs through mutating the first argument.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		let Some(paint_table) = fill_to_paint(self) else { return r#" fill="none""#.to_string() };
-		let Some(paint) = paint_table.element(0) else { return String::new() };
+		let Some(paint_list) = fill_to_graphic_list(self) else { return r#" fill="none""#.to_string() };
+		let Some(paint) = paint_list.element(0) else { return String::new() };
 
 		match paint {
-			Graphic::Color(color_table) => color_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
-			Graphic::Gradient(stops_table) => {
-				let gradient_id = stops_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+			Graphic::Color(color_list) => color_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Graphic::Gradient(stops_list) => {
+				let gradient_id = stops_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
 				format!(r##" fill="url('#{gradient_id}')""##)
 			}
 			_ => {

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,9 +1,11 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
+use crate::{Render, RenderSvgSegmentList, SvgRender};
 use core_types::color::SRGBA8;
 use core_types::list::List;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
+use graphic_types::Graphic;
 use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{PaintOrder, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
@@ -12,7 +14,17 @@ use vector_types::gradient::GradientSpreadMethod;
 
 pub trait RenderExt {
 	type Output;
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
+	#[allow(clippy::too_many_arguments)]
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		render_params: &RenderParams,
+	) -> Self::Output;
 }
 
 impl RenderExt for List<Color> {
@@ -21,6 +33,7 @@ impl RenderExt for List<Color> {
 	fn render(
 		&self,
 		_svg_defs: &mut String,
+		_item_transform: DAffine2,
 		_element_transform: DAffine2,
 		_stroke_transform: DAffine2,
 		_bounds: DAffine2,
@@ -42,7 +55,16 @@ impl RenderExt for List<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, _render_params: &RenderParams) -> Self::Output {
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		_item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		_render_params: &RenderParams,
+	) -> Self::Output {
 		let mut stop = String::new();
 
 		let Some(stops) = self.element(0) else { return 0 };
@@ -118,6 +140,7 @@ impl RenderExt for Stroke {
 	fn render(
 		&self,
 		_svg_defs: &mut String,
+		_item_transform: DAffine2,
 		_element_transform: DAffine2,
 		_stroke_transform: DAffine2,
 		_bounds: DAffine2,
@@ -173,4 +196,74 @@ impl RenderExt for Stroke {
 		}
 		attributes
 	}
+}
+
+impl RenderExt for List<Graphic> {
+	type Output = String;
+
+	fn render(
+		&self,
+		svg_defs: &mut String,
+		item_transform: DAffine2,
+		element_transform: DAffine2,
+		stroke_transform: DAffine2,
+		bounds: DAffine2,
+		transformed_bounds: DAffine2,
+		render_params: &RenderParams,
+	) -> Self::Output {
+		let fill_graphic = self.element(0);
+
+		match fill_graphic {
+			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Some(Graphic::Gradient(gradient_list)) => {
+				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+				format!(r##" fill="url(#{gradient_id})""##)
+			}
+			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
+				render_svg_fill_pattern(svg_defs, self, item_transform, bounds, render_params)
+					.map(|id| format!(r##" fill="url(#{id})""##))
+					.unwrap_or_else(|| r#" fill="none""#.to_string())
+			}
+			None => r#" fill="none""#.to_string(),
+		}
+	}
+}
+
+/// Emits an SVG `<pattern>` paint server into `svg_defs` that renders the given graphic list as the fill content, and returns the pattern ID.
+/// Currently, this function is only used for clipping-based filling, not for tiling.
+fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, bounds: DAffine2, render_params: &RenderParams) -> Option<String> {
+	let min = bounds.transform_point2(DVec2::ZERO);
+	let max = bounds.transform_point2(DVec2::ONE);
+	let size = max - min;
+	if size.x <= 0. || size.y <= 0. {
+		return None;
+	}
+
+	// Render the pattern content recursively
+	let mut content = SvgRender::new();
+	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
+
+	// Unwrap the inner def element
+	write!(svg_defs, "{}", content.svg_defs).unwrap();
+
+	let pattern_transform = item_transform * DAffine2::from_translation(min);
+	let transform_str = format_transform_matrix(pattern_transform);
+	let transform_attr = if transform_str.is_empty() {
+		String::new()
+	} else {
+		format!(r#" patternTransform="{transform_str}""#)
+	};
+
+	let pattern_id = format!("pattern-{}", generate_uuid());
+	write!(
+		svg_defs,
+		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
+		size.x, size.y,
+	)
+	.unwrap();
+
+	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
+	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
+
+	Some(pattern_id)
 }

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,6 +1,6 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
-use core_types::list::List;
 use core_types::color::SRGBA8;
+use core_types::list::List;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -40,7 +40,7 @@ impl RenderExt for List<Color> {
 		_transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
 	) -> Self::Output {
-		let Some(color) = self.element(0) else { return String::new() };
+		let Some(color) = self.element(0) else { return r#" fill="none""#.to_string() };
 
 		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
 		if color.a() < 1. {

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -1,10 +1,15 @@
 use crate::renderer::{RenderParams, format_transform_matrix};
+use core_types::table::Table;
 use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
-use glam::DAffine2;
-use graphic_types::vector_types::gradient::{Gradient, GradientType};
+use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
+use glam::{DAffine2, DVec2};
+use graphic_types::Graphic;
+use graphic_types::graphic::fill_to_paint;
+use graphic_types::vector_types::gradient::GradientType;
 use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
+use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
 
 pub trait RenderExt {
@@ -12,13 +17,42 @@ pub trait RenderExt {
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output;
 }
 
-impl RenderExt for Gradient {
+impl RenderExt for Table<Color> {
+	type Output = String;
+
+	fn render(
+		&self,
+		_svg_defs: &mut String,
+		_element_transform: DAffine2,
+		_stroke_transform: DAffine2,
+		_bounds: DAffine2,
+		_transformed_bounds: DAffine2,
+		_render_params: &RenderParams,
+	) -> Self::Output {
+		let Some(color) = self.element(0) else { return String::new() };
+
+		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
+		if color.a() < 1. {
+			let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
+		}
+
+		result
+	}
+}
+
+impl RenderExt for Table<GradientStops> {
 	type Output = u64;
 
 	/// Adds the gradient def through mutating the first argument, returning the gradient ID.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, _render_params: &RenderParams) -> Self::Output {
 		let mut stop = String::new();
-		for (position, color, original_midpoint) in self.stops.interpolated_samples() {
+
+		let Some(stops) = self.element(0) else { return 0 };
+		let gradient_type: GradientType = self.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+		let gradient_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+		let spread_method: GradientSpreadMethod = self.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
+
+		for (position, color, original_midpoint) in stops.interpolated_samples() {
 			stop.push_str("<stop");
 			if position != 0. {
 				let _ = write!(stop, r#" offset="{}""#, (position * 1_000_000.).round() / 1_000_000.);
@@ -33,9 +67,9 @@ impl RenderExt for Gradient {
 			stop.push_str(" />")
 		}
 
-		let transform_points = element_transform * stroke_transform * bounds;
-		let start = transform_points.transform_point2(self.start);
-		let end = transform_points.transform_point2(self.end);
+		let transform_points = element_transform * stroke_transform * bounds * gradient_transform;
+		let start = transform_points.transform_point2(DVec2::ZERO);
+		let end = transform_points.transform_point2(DVec2::X);
 
 		let gradient_transform = if transformed_bounds.matrix2.determinant() != 0. {
 			transformed_bounds.inverse()
@@ -49,15 +83,15 @@ impl RenderExt for Gradient {
 			format!(r#" gradientTransform="{gradient_transform}""#)
 		};
 
-		let spread_method = if self.spread_method == GradientSpreadMethod::Pad {
+		let spread_method = if spread_method == GradientSpreadMethod::Pad {
 			String::new()
 		} else {
-			format!(r#" spreadMethod="{}""#, self.spread_method.svg_name())
+			format!(r#" spreadMethod="{}""#, spread_method.svg_name())
 		};
 
 		let gradient_id = generate_uuid();
 
-		match self.gradient_type {
+		match gradient_type {
 			GradientType::Linear => {
 				let _ = write!(
 					svg_defs,
@@ -84,18 +118,17 @@ impl RenderExt for Fill {
 
 	/// Renders the fill, adding necessary defs through mutating the first argument.
 	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		match self {
-			Self::None => r#" fill="none""#.to_string(),
-			Self::Solid(color) => {
-				let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
-				if color.a() < 1. {
-					let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
-				}
-				result
-			}
-			Self::Gradient(gradient) => {
-				let gradient_id = gradient.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
+		let Some(paint_table) = fill_to_paint(self) else { return r#" fill="none""#.to_string() };
+		let Some(paint) = paint_table.element(0) else { return String::new() };
+
+		match paint {
+			Graphic::Color(color_table) => color_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Graphic::Gradient(stops_table) => {
+				let gradient_id = stops_table.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
 				format!(r##" fill="url('#{gradient_id}')""##)
+			}
+			_ => {
+				todo!()
 			}
 		}
 	}

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -12,6 +12,28 @@ use std::fmt::Write;
 use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
 
+#[derive(Copy, Clone)]
+pub enum PaintTarget {
+	Fill,
+	Stroke,
+}
+
+impl PaintTarget {
+	fn paint_attr(self) -> &'static str {
+		match self {
+			Self::Fill => "fill",
+			Self::Stroke => "stroke",
+		}
+	}
+
+	fn opacity_attr(self) -> &'static str {
+		match self {
+			Self::Fill => "fill-opacity",
+			Self::Stroke => "stroke-opacity",
+		}
+	}
+}
+
 pub trait RenderExt {
 	type Output;
 	#[allow(clippy::too_many_arguments)]
@@ -24,6 +46,7 @@ pub trait RenderExt {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output;
 }
 
@@ -39,12 +62,13 @@ impl RenderExt for List<Color> {
 		_bounds: DAffine2,
 		_transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output {
 		let Some(color) = self.element(0) else { return r#" fill="none""#.to_string() };
 
-		let mut result = format!(r##" fill="#{}""##, SRGBA8::from(*color).to_rgb_hex());
+		let mut result = format!(r##" {}="#{}""##, target.paint_attr(), SRGBA8::from(*color).to_rgb_hex());
 		if color.a() < 1. {
-			let _ = write!(result, r#" fill-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
+			let _ = write!(result, r#" {}="{}""#, target.opacity_attr(), (color.a() * 1000.).round() / 1000.);
 		}
 
 		result
@@ -64,6 +88,7 @@ impl RenderExt for List<GradientStops> {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		_render_params: &RenderParams,
+		_target: PaintTarget,
 	) -> Self::Output {
 		let mut stop = String::new();
 
@@ -136,7 +161,7 @@ impl RenderExt for List<GradientStops> {
 impl RenderExt for Stroke {
 	type Output = String;
 
-	/// Provide the SVG attributes for the stroke.
+	/// Provide the shape-related SVG attributes for the stroke. The paint-related attributes for the stroke are generated from `List<Graphic>.render` with `PaintTarget::Stroke`.
 	fn render(
 		&self,
 		_svg_defs: &mut String,
@@ -146,9 +171,9 @@ impl RenderExt for Stroke {
 		_bounds: DAffine2,
 		_transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		_target: PaintTarget,
 	) -> Self::Output {
 		// Don't render a stroke at all if it would be invisible
-		let Some(color) = self.color else { return String::new() };
 		if !self.has_renderable_stroke() {
 			return String::new();
 		}
@@ -166,10 +191,7 @@ impl RenderExt for Stroke {
 		let paint_order = (self.paint_order != PaintOrder::StrokeAbove || render_params.override_paint_order).then_some(PaintOrder::StrokeBelow);
 
 		// Render the needed stroke attributes
-		let mut attributes = format!(r##" stroke="#{}""##, SRGBA8::from(color).to_rgb_hex());
-		if color.a() < 1. {
-			let _ = write!(&mut attributes, r#" stroke-opacity="{}""#, (color.a() * 1000.).round() / 1000.);
-		}
+		let mut attributes = String::new();
 		if let Some(mut weight) = weight {
 			if stroke_align.is_some() && render_params.aligned_strokes {
 				weight *= 2.;
@@ -210,21 +232,23 @@ impl RenderExt for List<Graphic> {
 		bounds: DAffine2,
 		transformed_bounds: DAffine2,
 		render_params: &RenderParams,
+		target: PaintTarget,
 	) -> Self::Output {
 		let fill_graphic = self.element(0);
+		let paint_attr = target.paint_attr();
 
 		match fill_graphic {
-			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
+			Some(Graphic::Color(color_list)) => color_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params, target),
 			Some(Graphic::Gradient(gradient_list)) => {
-				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-				format!(r##" fill="url(#{gradient_id})""##)
+				let gradient_id = gradient_list.render(svg_defs, item_transform, element_transform, stroke_transform, bounds, transformed_bounds, render_params, target);
+				format!(r##" {paint_attr}="url(#{gradient_id})""##)
 			}
 			Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
 				render_svg_fill_pattern(svg_defs, self, item_transform, bounds, render_params)
-					.map(|id| format!(r##" fill="url(#{id})""##))
-					.unwrap_or_else(|| r#" fill="none""#.to_string())
+					.map(|id| format!(r##" {paint_attr}="url(#{id})""##))
+					.unwrap_or_else(|| format!(r#" {paint_attr}="none""#))
 			}
-			None => r#" fill="none""#.to_string(),
+			None => format!(r#" {paint_attr}="none""#),
 		}
 	}
 }

--- a/node-graph/libraries/rendering/src/render_ext.rs
+++ b/node-graph/libraries/rendering/src/render_ext.rs
@@ -4,10 +4,8 @@ use core_types::color::SRGBA8;
 use core_types::uuid::generate_uuid;
 use core_types::{ATTR_GRADIENT_TYPE, ATTR_SPREAD_METHOD, ATTR_TRANSFORM, Color};
 use glam::{DAffine2, DVec2};
-use graphic_types::Graphic;
-use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::vector_types::gradient::GradientType;
-use graphic_types::vector_types::vector::style::{Fill, PaintOrder, PathStyle, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
+use graphic_types::vector_types::vector::style::{PaintOrder, Stroke, StrokeAlign, StrokeCap, StrokeJoin};
 use std::fmt::Write;
 use vector_types::GradientStops;
 use vector_types::gradient::GradientSpreadMethod;
@@ -113,27 +111,6 @@ impl RenderExt for List<GradientStops> {
 	}
 }
 
-impl RenderExt for Fill {
-	type Output = String;
-
-	/// Renders the fill, adding necessary defs through mutating the first argument.
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> Self::Output {
-		let Some(paint_list) = fill_to_graphic_list(self) else { return r#" fill="none""#.to_string() };
-		let Some(paint) = paint_list.element(0) else { return String::new() };
-
-		match paint {
-			Graphic::Color(color_list) => color_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params),
-			Graphic::Gradient(stops_list) => {
-				let gradient_id = stops_list.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-				format!(r##" fill="url('#{gradient_id}')""##)
-			}
-			_ => {
-				todo!()
-			}
-		}
-	}
-}
-
 impl RenderExt for Stroke {
 	type Output = String;
 
@@ -195,21 +172,5 @@ impl RenderExt for Stroke {
 			let _ = write!(&mut attributes, r#" style="paint-order: stroke;" "#);
 		}
 		attributes
-	}
-}
-
-impl RenderExt for PathStyle {
-	type Output = String;
-
-	/// Renders the shape's fill and stroke attributes as a string with them concatenated together.
-	#[allow(clippy::too_many_arguments)]
-	fn render(&self, svg_defs: &mut String, element_transform: DAffine2, stroke_transform: DAffine2, bounds: DAffine2, transformed_bounds: DAffine2, render_params: &RenderParams) -> String {
-		let fill_attribute = self.fill.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params);
-		let stroke_attribute = self
-			.stroke
-			.as_ref()
-			.map(|stroke| stroke.render(svg_defs, element_transform, stroke_transform, bounds, transformed_bounds, render_params))
-			.unwrap_or_default();
-		format!("{fill_attribute}{stroke_attribute}")
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::fill_to_paint;
+use graphic_types::graphic::fill_to_graphic_list;
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1111,7 +1111,7 @@ impl Render for List<Vector> {
 		}
 	}
 
-	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, _context: &mut RenderContext, render_params: &RenderParams) {
+	fn render_to_vello(&self, scene: &mut Scene, parent_transform: DAffine2, context: &mut RenderContext, render_params: &RenderParams) {
 		use graphic_types::vector_types::vector::style::{GradientType, StrokeCap, StrokeJoin};
 
 		for index in 0..self.len() {
@@ -1182,26 +1182,32 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
-			// TODO: This conversion is only necessary during the transition period from Fill to Table<Graphic>
-			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
-				let Some(paint_table) = fill_to_paint(element.style.fill()) else {
+			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
+				// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
+				// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
+				let Some(fill_graphic) = self
+					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+					.filter(|t| !t.is_empty())
+					.cloned()
+					.or_else(|| fill_to_graphic_list(element.style.fill()))
+				else {
 					return;
 				};
 
-				for paint_idx in 0..paint_table.len() {
-					let Some(paint) = paint_table.element(paint_idx) else { continue };
+				for paint_idx in 0..fill_graphic.len() {
+					let Some(paint) = fill_graphic.element(paint_idx) else { continue };
 					match paint {
-						Graphic::Color(table) => {
-							let Some(color) = table.element(0) else { continue };
+						Graphic::Color(list) => {
+							let Some(color) = list.element(0) else { continue };
 
 							let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
 							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
 						}
-						Graphic::Gradient(stops_table) => {
-							let Some(stops) = stops_table.element(0) else { continue };
-							let gradient_type: GradientType = stops_table.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
-							let gradient_transform: DAffine2 = stops_table.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
-							let spread_method: GradientSpreadMethod = stops_table.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
+						Graphic::Gradient(stops_list) => {
+							let Some(stops) = stops_list.element(0) else { continue };
+							let gradient_type: GradientType = stops_list.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+							let gradient_transform: DAffine2 = stops_list.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+							let spread_method: GradientSpreadMethod = stops_list.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
 
 							let mut peniko_stops = peniko::ColorStops::new();
 							for (position, color, _) in stops.interpolated_samples() {
@@ -1259,14 +1265,18 @@ impl Render for List<Vector> {
 							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
 							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
 						}
-						_ => todo!(),
+						Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_) => {
+							scene.push_clip_layer(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), path);
+							paint.render_to_vello(scene, multiplied_transform, context, render_params);
+							scene.pop_layer();
+						}
 					};
 				}
 			};
 
 			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.
 			let use_face_fill = element.use_face_fill();
-			let do_fill = |scene: &mut Scene| {
+			let do_fill = |scene: &mut Scene, context: &mut RenderContext| {
 				if use_face_fill {
 					for mut face_path in element.construct_faces().filter(|face| face.area() >= 0.) {
 						face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
@@ -1274,12 +1284,12 @@ impl Render for List<Vector> {
 						for element in face_path {
 							kurbo_path.push(element);
 						}
-						do_fill_path(scene, &kurbo_path, peniko::Fill::NonZero);
+						do_fill_path(scene, context, &kurbo_path, peniko::Fill::NonZero);
 					}
 				} else if element.is_branching() {
-					do_fill_path(scene, &path, peniko::Fill::EvenOdd);
+					do_fill_path(scene, context, &path, peniko::Fill::EvenOdd);
 				} else {
-					do_fill_path(scene, &path, peniko::Fill::NonZero);
+					do_fill_path(scene, context, &path, peniko::Fill::NonZero);
 				}
 			};
 
@@ -1349,7 +1359,7 @@ impl Render for List<Vector> {
 
 						if wants_stroke_below {
 							scene.push_layer(peniko::Fill::NonZero, peniko::Mix::Normal, 1., kurbo::Affine::IDENTITY, &rect);
-							vector_list.render_to_vello(scene, parent_transform, _context, &render_params.for_alignment(applied_stroke_transform));
+							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
 							do_stroke(scene, 2.);
@@ -1357,13 +1367,13 @@ impl Render for List<Vector> {
 							scene.pop_layer();
 							scene.pop_layer();
 
-							do_fill(scene);
+							do_fill(scene, context);
 						} else {
 							// Fill first (unclipped), then stroke (clipped) above
-							do_fill(scene);
+							do_fill(scene, context);
 
 							scene.push_layer(peniko::Fill::NonZero, peniko::Mix::Normal, 1., kurbo::Affine::IDENTITY, &rect);
-							vector_list.render_to_vello(scene, parent_transform, _context, &render_params.for_alignment(applied_stroke_transform));
+							vector_list.render_to_vello(scene, parent_transform, context, &render_params.for_alignment(applied_stroke_transform));
 							scene.push_layer(peniko::Fill::NonZero, peniko::BlendMode::new(peniko::Mix::Normal, compose), 1., kurbo::Affine::IDENTITY, &rect);
 
 							do_stroke(scene, 2.);
@@ -1385,7 +1395,7 @@ impl Render for List<Vector> {
 
 						for operation in &order {
 							match operation {
-								Op::Fill => do_fill(scene),
+								Op::Fill => do_fill(scene, context),
 								Op::Stroke => do_stroke(scene, 1.),
 							}
 						}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -18,6 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
+use graphic_types::graphic::fill_to_paint;
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -1181,70 +1182,86 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
-			// Closures to avoid duplicated fill/stroke drawing logic
-			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| match element.style.fill() {
-				Fill::Solid(color) => {
-					let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
-					scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
-				}
-				Fill::Gradient(gradient) => {
-					let mut stops = peniko::ColorStops::new();
-					for (position, color, _) in gradient.stops.interpolated_samples() {
-						stops.push(peniko::ColorStop {
-							offset: position as f32,
-							color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
-						});
-					}
+			// TODO: This conversion is only necessary during the transition period from Fill to Table<Graphic>
+			let do_fill_path = |scene: &mut Scene, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
+				let Some(paint_table) = fill_to_paint(element.style.fill()) else {
+					return;
+				};
 
-					let bounds = element.nonzero_bounding_box();
-					let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+				for paint_idx in 0..paint_table.len() {
+					let Some(paint) = paint_table.element(paint_idx) else { continue };
+					match paint {
+						Graphic::Color(table) => {
+							let Some(color) = table.element(0) else { continue };
 
-					let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
-						parent_transform.inverse()
-					} else {
-						Default::default()
-					};
-					let mod_points = inverse_parent_transform * multiplied_transform * bound_transform;
+							let fill = peniko::Brush::Solid(SRGBA8::from(*color).to_peniko_color());
+							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, None, path);
+						}
+						Graphic::Gradient(stops_table) => {
+							let Some(stops) = stops_table.element(0) else { continue };
+							let gradient_type: GradientType = stops_table.attribute_cloned_or_default(ATTR_GRADIENT_TYPE, 0);
+							let gradient_transform: DAffine2 = stops_table.attribute_cloned_or_default(ATTR_TRANSFORM, 0);
+							let spread_method: GradientSpreadMethod = stops_table.attribute_cloned_or_default(ATTR_SPREAD_METHOD, 0);
 
-					let start = mod_points.transform_point2(gradient.start);
-					let end = mod_points.transform_point2(gradient.end);
-
-					let fill = peniko::Brush::Gradient(peniko::Gradient {
-						kind: match gradient.gradient_type {
-							GradientType::Linear => peniko::LinearGradientPosition {
-								start: to_point(start),
-								end: to_point(end),
+							let mut peniko_stops = peniko::ColorStops::new();
+							for (position, color, _) in stops.interpolated_samples() {
+								peniko_stops.push(peniko::ColorStop {
+									offset: position as f32,
+									color: peniko::color::DynamicColor::from_alpha_color(SRGBA8::from(color).to_peniko_color()),
+								});
 							}
-							.into(),
-							GradientType::Radial => {
-								let radius = start.distance(end);
-								peniko::RadialGradientPosition {
-									start_center: to_point(start),
-									start_radius: 0.,
-									end_center: to_point(start),
-									end_radius: radius as f32,
-								}
-								.into()
-							}
-						},
-						extend: match gradient.spread_method {
-							GradientSpreadMethod::Pad => peniko::Extend::Pad,
-							GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
-							GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
-						},
-						stops,
-						interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
-						..Default::default()
-					});
-					let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
-						element_transform.inverse()
-					} else {
-						Default::default()
+
+							let bounds = element.nonzero_bounding_box();
+							let bound_transform = DAffine2::from_scale_angle_translation(bounds[1] - bounds[0], 0., bounds[0]);
+
+							let inverse_parent_transform = if parent_transform.matrix2.determinant() != 0. {
+								parent_transform.inverse()
+							} else {
+								Default::default()
+							};
+							let mod_points = inverse_parent_transform * multiplied_transform * bound_transform * gradient_transform;
+
+							let start = mod_points.transform_point2(DVec2::ZERO);
+							let end = mod_points.transform_point2(DVec2::X);
+
+							let fill = peniko::Brush::Gradient(peniko::Gradient {
+								kind: match gradient_type {
+									GradientType::Linear => peniko::LinearGradientPosition {
+										start: to_point(start),
+										end: to_point(end),
+									}
+									.into(),
+									GradientType::Radial => {
+										let radius = start.distance(end);
+										peniko::RadialGradientPosition {
+											start_center: to_point(start),
+											start_radius: 0.,
+											end_center: to_point(start),
+											end_radius: radius as f32,
+										}
+										.into()
+									}
+								},
+								extend: match spread_method {
+									GradientSpreadMethod::Pad => peniko::Extend::Pad,
+									GradientSpreadMethod::Reflect => peniko::Extend::Reflect,
+									GradientSpreadMethod::Repeat => peniko::Extend::Repeat,
+								},
+								stops: peniko_stops,
+								interpolation_alpha_space: peniko::InterpolationAlphaSpace::Premultiplied,
+								..Default::default()
+							});
+							let inverse_element_transform = if element_transform.matrix2.determinant() != 0. {
+								element_transform.inverse()
+							} else {
+								Default::default()
+							};
+							let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
+							scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
+						}
+						_ => todo!(),
 					};
-					let brush_transform = kurbo::Affine::new((inverse_element_transform * parent_transform).to_cols_array());
-					scene.fill(fill_rule, kurbo::Affine::new(element_transform.to_cols_array()), &fill, Some(brush_transform), path);
 				}
-				Fill::None => {}
 			};
 
 			// Branching vectors without regions (e.g. mesh grids) need face-by-face fill rendering.

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -346,87 +346,17 @@ fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
 	}
 }
 
-/// Emits a SVG `<pattern>` paint server element that renders any graphic element into def and returns the id.
-/// Currently this function uses `<pattern>` as a clip-based paint server, which means the content is rendered once without tiling.
-fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, path_bbox: [DVec2; 2], item_transform: DAffine2, render_params: &RenderParams) -> Option<String> {
-	let [min, max] = path_bbox;
-	let size = max - min;
-	if size.x <= 0. || size.y <= 0. {
-		return None;
-	}
-
-	// Render the pattern content recursively
-	let mut content = SvgRender::new();
-	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
-
-	// Unwrap the inner def element
-	write!(svg_defs, "{}", content.svg_defs).unwrap();
-
-	let pattern_transform = item_transform * DAffine2::from_translation(min);
-	let transform_str = format_transform_matrix(pattern_transform);
-	let transform_attr = if transform_str.is_empty() {
-		String::new()
-	} else {
-		format!(r#" patternTransform="{transform_str}""#)
-	};
-
-	let pattern_id = format!("pattern-{}", generate_uuid());
-	write!(
-		svg_defs,
-		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
-		size.x, size.y,
-	)
-	.unwrap();
-
-	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
-	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
-
-	Some(pattern_id)
-}
-
-/// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
-#[allow(clippy::too_many_arguments)]
-fn compute_svg_fill_attribute(
-	fill_graphic_list: Option<&List<Graphic>>,
-	defs: &mut String,
-	element_transform: DAffine2,
-	applied_stroke_transform: DAffine2,
-	bounds_matrix: DAffine2,
-	transformed_bounds_matrix: DAffine2,
-	item_transform: DAffine2,
-	render_params: &RenderParams,
-) -> String {
-	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
-
-	match fill_graphic {
-		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
-		Some(Graphic::Gradient(gradient_list)) => {
-			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
-			format!(r##" fill="url(#{gradient_id})""##)
-		}
-		Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
-			let list = fill_graphic_list.unwrap();
-			let min = bounds_matrix.transform_point2(DVec2::ZERO);
-			let max = bounds_matrix.transform_point2(DVec2::ONE);
-			render_svg_fill_pattern(defs, list, [min, max], item_transform, render_params)
-				.map(|id| format!(r##" fill="url(#{id})""##))
-				.unwrap_or_else(|| r#" fill="none""#.to_string())
-		}
-		None => r#" fill="none""#.to_string(),
-	}
-}
-
 /// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
 #[allow(clippy::too_many_arguments)]
 fn emit_svg_fill_path(
 	render: &mut SvgRender,
 	d: String,
-	element_transform: DAffine2,
 	fill_graphic_list: Option<&List<Graphic>>,
+	item_transform: DAffine2,
+	element_transform: DAffine2,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
-	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) {
 	render.leaf_tag("path", |attributes| {
@@ -436,16 +366,19 @@ fn emit_svg_fill_path(
 			attributes.push(ATTR_TRANSFORM, matrix);
 		}
 		let defs = &mut attributes.0.svg_defs;
-		let fill_attribute = compute_svg_fill_attribute(
-			fill_graphic_list,
-			defs,
-			element_transform,
-			applied_stroke_transform,
-			bounds_matrix,
-			transformed_bounds_matrix,
-			item_transform,
-			render_params,
-		);
+		let fill_attribute = fill_graphic_list
+			.map(|list| {
+				list.render(
+					defs,
+					item_transform,
+					element_transform,
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				)
+			})
+			.unwrap_or_else(|| r#" fill="none""#.to_string());
 		attributes.push_val(fill_attribute);
 	});
 }
@@ -1093,12 +1026,12 @@ impl Render for List<Vector> {
 				emit_svg_fill_path(
 					render,
 					path.clone(),
-					element_transform,
 					fill_graphic_list.as_deref(),
+					item_transform,
+					element_transform,
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
-					item_transform,
 					render_params,
 				);
 			}
@@ -1125,12 +1058,12 @@ impl Render for List<Vector> {
 					emit_svg_fill_path(
 						render,
 						face_d,
-						element_transform,
 						fill_graphic_list.as_deref(),
+						item_transform,
+						element_transform,
 						applied_stroke_transform,
 						bounds_matrix,
 						transformed_bounds_matrix,
-						item_transform,
 						render_params,
 					);
 				}
@@ -1177,22 +1110,36 @@ impl Render for List<Vector> {
 				let stroke_attribute = vector
 					.style
 					.stroke()
-					.map(|stroke| stroke.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params))
+					.map(|stroke| {
+						stroke.render(
+							defs,
+							item_transform,
+							element_transform,
+							applied_stroke_transform,
+							bounds_matrix,
+							transformed_bounds_matrix,
+							&render_params,
+						)
+					})
 					.unwrap_or_default();
 
 				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
 					r#" fill="none""#.to_string()
 				} else {
-					compute_svg_fill_attribute(
-						fill_graphic_list.as_deref(),
-						defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						item_transform,
-						&render_params,
-					)
+					fill_graphic_list
+						.as_deref()
+						.map(|list| {
+							list.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+							)
+						})
+						.unwrap_or_else(|| r#" fill="none""#.to_string())
 				};
 
 				if let Some((id, mask_type, _)) = push_id {
@@ -1221,12 +1168,12 @@ impl Render for List<Vector> {
 				emit_svg_fill_path(
 					render,
 					path.clone(),
-					element_transform,
 					fill_graphic_list.as_deref(),
+					item_transform,
+					element_transform,
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
-					item_transform,
 					render_params,
 				);
 			}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1145,7 +1145,7 @@ impl Render for List<Vector> {
 						}
 
 						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-							if let Some(fill_graphic_list) = fill_graphic_list.as_ref() {
+							if let Some(fill_graphic_list) = fill_graphic_list.as_deref() {
 								let face_clip_id = format!("clip-{}", generate_uuid());
 								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
 								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
@@ -1160,7 +1160,7 @@ impl Render for List<Vector> {
 				&& !use_face_fill
 				&& !wants_stroke_below
 				&& !override_paint_order
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
 			{
 				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
@@ -1248,7 +1248,7 @@ impl Render for List<Vector> {
 			if !needs_separate_alignment_fill
 				&& !use_face_fill
 				&& (wants_stroke_below || override_paint_order)
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
 			{
 				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
@@ -1342,17 +1342,16 @@ impl Render for List<Vector> {
 			let use_layer = can_draw_aligned_stroke;
 			let wants_stroke_below = stroke.as_ref().is_some_and(|s| s.paint_order == vector::style::PaintOrder::StrokeBelow);
 
+			// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
+			// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
+			let fill_graphic_list: Option<Cow<List<Graphic>>> = self
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+				.filter(|t| !t.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned));
+
 			let do_fill_path = |scene: &mut Scene, context: &mut RenderContext, path: &kurbo::BezPath, fill_rule: peniko::Fill| {
-				// Try to use ATTR_FILL_GRAPHIC attribute, which is set by `fill_graphic` debug node, then fall back to Fill enum.
-				// TODO: Drop the Fill fall back once the Fill node becomes ready to store corresponding Graphic list directly.
-				let Some(fill_graphic) = self
-					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
-					.filter(|t| !t.is_empty())
-					.map(Cow::Borrowed)
-					.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned))
-				else {
-					return;
-				};
+				let Some(fill_graphic) = fill_graphic_list.as_deref() else { return };
 
 				for paint_idx in 0..fill_graphic.len() {
 					let Some(paint) = fill_graphic.element(paint_idx) else { continue };

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -27,6 +27,7 @@ use graphic_types::vector_types::vector::style::{Fill, PaintOrder, RenderMode, S
 use graphic_types::{Artboard, Graphic, Vector};
 use kurbo::{Affine, Cap, Join, Shape};
 use num_traits::Zero;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::ops::Deref;
@@ -1071,8 +1072,8 @@ impl Render for List<Vector> {
 			let fill_graphic_list = self
 				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
 				.filter(|list| !list.is_empty())
-				.cloned()
-				.or_else(|| fill_to_graphic_list(vector.style.fill()));
+				.map(Cow::Borrowed)
+				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
 			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
@@ -1101,7 +1102,7 @@ impl Render for List<Vector> {
 					path.clone(),
 					element_transform,
 					item_transform,
-					fill_graphic_list.as_ref(),
+					fill_graphic_list.as_deref(),
 					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
@@ -1259,7 +1260,7 @@ impl Render for List<Vector> {
 					path,
 					element_transform,
 					item_transform,
-					fill_graphic_list.as_ref(),
+					fill_graphic_list.as_deref(),
 					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
@@ -1347,8 +1348,8 @@ impl Render for List<Vector> {
 				let Some(fill_graphic) = self
 					.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
 					.filter(|t| !t.is_empty())
-					.cloned()
-					.or_else(|| fill_to_graphic_list(element.style.fill()))
+					.map(Cow::Borrowed)
+					.or_else(|| fill_to_graphic_list(element.style.fill()).map(Cow::Owned))
 				else {
 					return;
 				};

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1,4 +1,4 @@
-use crate::render_ext::RenderExt;
+use crate::render_ext::{PaintTarget, RenderExt};
 use crate::to_peniko::{BlendModeExt, ToPenikoColor};
 use core_types::CacheHash;
 use core_types::blending::BlendMode;
@@ -6,7 +6,7 @@ use core_types::bounds::BoundingBox;
 use core_types::bounds::RenderBoundingBox;
 use core_types::color::Color;
 use core_types::color::SRGBA8;
-use core_types::list::{ATTR_FILL_GRAPHIC, Item, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, Item, List};
 use core_types::math::quad::Quad;
 use core_types::render_complexity::RenderComplexity;
 use core_types::transform::Footprint;
@@ -18,7 +18,7 @@ use core_types::{
 use dyn_any::DynAny;
 use glam::{DAffine2, DVec2};
 use graphene_hash::CacheHashWrapper;
-use graphic_types::graphic::fill_to_graphic_list;
+use graphic_types::graphic::{color_to_graphic_list, fill_to_graphic_list};
 use graphic_types::raster_types::{BitmapMut, CPU, GPU, Image, Raster};
 use graphic_types::vector_types::gradient::{GradientStops, GradientType};
 use graphic_types::vector_types::subpath::Subpath;
@@ -367,6 +367,7 @@ fn emit_svg_fill_path(
 					bounds_matrix,
 					transformed_bounds_matrix,
 					render_params,
+					PaintTarget::Fill,
 				)
 			})
 			.unwrap_or_else(|| r#" fill="none""#.to_string());
@@ -1004,8 +1005,17 @@ impl Render for List<Vector> {
 				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
+			let stroke_paint_graphic_list = self
+				.attribute::<List<Graphic>>(ATTR_STROKE_PAINT_GRAPHIC, index)
+				.filter(|list| !list.is_empty())
+				.map(Cow::Borrowed)
+				.or_else(|| color_to_graphic_list(vector.style.stroke().and_then(|s| s.color())).map(Cow::Owned));
+			let stroke_paint_graphic = stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0));
+
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
-			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
+			let can_draw_aligned_stroke = path_is_closed
+				&& vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered())
+				&& stroke_paint_graphic.is_some_and(|graphic| !graphic.is_fully_transparent());
 			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
@@ -1098,21 +1108,47 @@ impl Render for List<Vector> {
 				render_params.aligned_strokes = can_draw_aligned_stroke;
 				render_params.override_paint_order = override_paint_order;
 
-				let stroke_attribute = vector
+				let stroke_shape_attribute = vector
 					.style
 					.stroke()
 					.map(|stroke| {
-						stroke.render(
-							defs,
-							item_transform,
-							element_transform,
-							applied_stroke_transform,
-							bounds_matrix,
-							transformed_bounds_matrix,
-							&render_params,
-						)
+						if stroke_paint_graphic_list.as_ref().and_then(|l| l.element(0)).is_some() {
+							stroke.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+								PaintTarget::Stroke,
+							)
+						} else {
+							String::new()
+						}
 					})
 					.unwrap_or_default();
+
+				// Need to avoid generating only paint attribute, otherwise SVG uses 1px width stroke as a fallback
+				let stroke_paint_attribute = if vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke()) {
+					stroke_paint_graphic_list
+						.as_deref()
+						.map(|list| {
+							list.render(
+								defs,
+								item_transform,
+								element_transform,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								&render_params,
+								PaintTarget::Stroke,
+							)
+						})
+						.unwrap_or_else(|| r#" stroke="none""#.to_string())
+				} else {
+					String::new()
+				};
 
 				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
 					r#" fill="none""#.to_string()
@@ -1128,6 +1164,7 @@ impl Render for List<Vector> {
 								bounds_matrix,
 								transformed_bounds_matrix,
 								&render_params,
+								PaintTarget::Fill,
 							)
 						})
 						.unwrap_or_else(|| r#" fill="none""#.to_string())
@@ -1138,7 +1175,8 @@ impl Render for List<Vector> {
 					attributes.push(mask_type.to_attribute(), selector);
 				}
 				attributes.push_val(fill_attribute);
-				attributes.push_val(stroke_attribute);
+				attributes.push_val(stroke_shape_attribute);
+				attributes.push_val(stroke_paint_attribute);
 
 				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
@@ -1218,6 +1256,7 @@ impl Render for List<Vector> {
 			// Used by both the blend-layer clip rect inflation below (as `max_aabb_inflation`'s `path_is_closed` arg, equivalent here since
 			// the function ignores the arg for Center align) and the `SrcIn`/`SrcOut` aligned-stroke branch further down.
 			let stroke = element.style.stroke();
+			// FIXME: Need to add Graphic.is_fully_transparent check
 			let can_draw_aligned_stroke = stroke.as_ref().is_some_and(|s| s.has_renderable_stroke() && s.align.is_not_centered()) && element.stroke_bezier_paths().all(|p| p.closed());
 
 			let opacity = (opacity_attr * if render_params.for_mask { 1. } else { opacity_fill_attr }) as f32;

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -337,15 +337,6 @@ fn draw_raster_outline(scene: &mut Scene, outline_transform: &DAffine2, render_p
 	scene.stroke(&outline_stroke, Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 }
 
-/// Returns true if the resolved fill graphic fully and opaquely covers the path interior.
-fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
-	match fill_graphic {
-		Some(Graphic::Color(list)) => list.element(0).is_some_and(|c| c.a() >= 1.0),
-		Some(Graphic::Gradient(list)) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1.0)),
-		_ => false,
-	}
-}
-
 /// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
 #[allow(clippy::too_many_arguments)]
 fn emit_svg_fill_path(
@@ -1015,7 +1006,7 @@ impl Render for List<Vector> {
 
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip);
+			let can_use_paint_order = !(fill_graphic.is_none_or(|graphic| !graphic.is_opaque()) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
@@ -2185,86 +2176,5 @@ impl SvgRenderAttrs<'_> {
 	}
 	pub fn push_val(&mut self, value: impl Into<SvgSegment>) {
 		self.0.svg.push(value.into());
-	}
-}
-
-#[cfg(test)]
-mod svg_fill_helper_tests {
-	use vector_types::GradientStop;
-
-	use super::*;
-
-	fn color_graphic(alpha: f64) -> Graphic {
-		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
-		Graphic::Color(List::new_from_element(color))
-	}
-
-	fn gradient_graphic(gradient: GradientStops) -> Graphic {
-		let mut gradient_list = List::new_from_element(gradient);
-		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
-		Graphic::Gradient(gradient_list)
-	}
-
-	#[test]
-	fn opaquely_none_is_false() {
-		assert!(!fill_covers_opaquely(None));
-	}
-
-	#[test]
-	fn opaquely_opaque_color_is_true() {
-		let g = color_graphic(1.0);
-		assert!(fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_transparent_color_is_false() {
-		let g = color_graphic(0.5);
-		assert!(!fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_vector_is_false() {
-		let g = Graphic::Vector(List::default());
-		assert!(!fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_gradient_all_opaque_is_true() {
-		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let gradient = GradientStops::new(vec![
-			GradientStop {
-				position: 0.,
-				midpoint: 0.5,
-				color: color_1,
-			},
-			GradientStop {
-				position: 1.,
-				midpoint: 0.5,
-				color: color_2,
-			},
-		]);
-		let g = gradient_graphic(gradient);
-		assert!(fill_covers_opaquely(Some(&g)));
-	}
-
-	#[test]
-	fn opaquely_transparent_gradient_is_false() {
-		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
-		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
-		let gradient = GradientStops::new(vec![
-			GradientStop {
-				position: 0.,
-				midpoint: 0.5,
-				color: color_1,
-			},
-			GradientStop {
-				position: 1.,
-				midpoint: 0.5,
-				color: color_2,
-			},
-		]);
-		let g = gradient_graphic(gradient);
-		assert!(!fill_covers_opaquely(Some(&g)));
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -220,6 +220,8 @@ pub struct RenderParams {
 	pub alignment_parent_transform: Option<DAffine2>,
 	pub aligned_strokes: bool,
 	pub override_paint_order: bool,
+	// Are we rendering for a pattern content
+	pub inside_pattern: bool,
 	pub artboard_background: Option<Color>,
 	/// Viewport zoom level (document-space scale). Used to compute constant viewport-pixel stroke widths in Outline mode.
 	pub viewport_zoom: f64,
@@ -235,8 +237,12 @@ impl RenderParams {
 		Self { alignment_parent_transform, ..*self }
 	}
 
+	pub fn for_pattern(&self) -> Self {
+		Self { inside_pattern: true, ..*self }
+	}
+
 	pub fn to_canvas(&self) -> bool {
-		!self.for_export && !self.thumbnail && !self.for_mask
+		!self.for_export && !self.thumbnail && !self.for_mask && !self.inside_pattern
 	}
 }
 
@@ -340,23 +346,73 @@ fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
 	}
 }
 
+/// Emits a SVG `<pattern>` paint server element that renders any graphic element into def and returns the id.
+/// Currently this function uses `<pattern>` as a clip-based paint server, which means the content is rendered once without tiling.
+fn render_svg_fill_pattern(svg_defs: &mut String, fill_graphic_list: &List<Graphic>, path_bbox: [DVec2; 2], item_transform: DAffine2, render_params: &RenderParams) -> Option<String> {
+	let [min, max] = path_bbox;
+	let size = max - min;
+	if size.x <= 0. || size.y <= 0. {
+		return None;
+	}
+
+	// Render the pattern content recursively
+	let mut content = SvgRender::new();
+	fill_graphic_list.render_svg(&mut content, &render_params.for_pattern());
+
+	// Unwrap the inner def element
+	write!(svg_defs, "{}", content.svg_defs).unwrap();
+
+	let pattern_transform = item_transform * DAffine2::from_translation(min);
+	let transform_str = format_transform_matrix(pattern_transform);
+	let transform_attr = if transform_str.is_empty() {
+		String::new()
+	} else {
+		format!(r#" patternTransform="{transform_str}""#)
+	};
+
+	let pattern_id = format!("pattern-{}", generate_uuid());
+	write!(
+		svg_defs,
+		r##"<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" x="0" y="0" width="{}" height="{}"{transform_attr}>"##,
+		size.x, size.y,
+	)
+	.unwrap();
+
+	let content_shift = format_transform_matrix(DAffine2::from_translation(-min));
+	write!(svg_defs, r##"<g transform="{content_shift}">{}</g></pattern>"##, content.svg.to_svg_string()).unwrap();
+
+	Some(pattern_id)
+}
+
 /// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
+#[allow(clippy::too_many_arguments)]
 fn compute_svg_fill_attribute(
-	fill_graphic: Option<&Graphic>,
+	fill_graphic_list: Option<&List<Graphic>>,
 	defs: &mut String,
 	element_transform: DAffine2,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
+	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) -> String {
+	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
+
 	match fill_graphic {
 		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
 		Some(Graphic::Gradient(gradient_list)) => {
 			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
-			format!(r##" fill="url('#{gradient_id}')""##)
+			format!(r##" fill="url(#{gradient_id})""##)
 		}
-		_ => r#" fill="none""#.to_string(),
+		Some(Graphic::Vector(_)) | Some(Graphic::RasterCPU(_)) | Some(Graphic::RasterGPU(_)) | Some(Graphic::Graphic(_)) => {
+			let list = fill_graphic_list.unwrap();
+			let min = bounds_matrix.transform_point2(DVec2::ZERO);
+			let max = bounds_matrix.transform_point2(DVec2::ONE);
+			render_svg_fill_pattern(defs, list, [min, max], item_transform, render_params)
+				.map(|id| format!(r##" fill="url(#{id})""##))
+				.unwrap_or_else(|| r#" fill="none""#.to_string())
+		}
+		None => r#" fill="none""#.to_string(),
 	}
 }
 
@@ -366,10 +422,11 @@ fn emit_svg_fill_path(
 	render: &mut SvgRender,
 	d: String,
 	element_transform: DAffine2,
-	fill_graphic: Option<&Graphic>,
+	fill_graphic_list: Option<&List<Graphic>>,
 	applied_stroke_transform: DAffine2,
 	bounds_matrix: DAffine2,
 	transformed_bounds_matrix: DAffine2,
+	item_transform: DAffine2,
 	render_params: &RenderParams,
 ) {
 	render.leaf_tag("path", |attributes| {
@@ -379,71 +436,18 @@ fn emit_svg_fill_path(
 			attributes.push(ATTR_TRANSFORM, matrix);
 		}
 		let defs = &mut attributes.0.svg_defs;
-		let fill_attribute = compute_svg_fill_attribute(fill_graphic, defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+		let fill_attribute = compute_svg_fill_attribute(
+			fill_graphic_list,
+			defs,
+			element_transform,
+			applied_stroke_transform,
+			bounds_matrix,
+			transformed_bounds_matrix,
+			item_transform,
+			render_params,
+		);
 		attributes.push_val(fill_attribute);
 	});
-}
-
-/// Emits an SVG `<g clip-path>` group that renders the fill graphic clipped to the path referenced by `clip_id`.
-fn emit_svg_fill_clip(render: &mut SvgRender, clip_id: &str, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, render_params: &RenderParams) {
-	render.parent_tag(
-		"g",
-		|attributes| {
-			attributes.push("clip-path", format!("url(#{clip_id})"));
-		},
-		|render| {
-			let matrix = format_transform_matrix(item_transform);
-			if matrix.is_empty() {
-				fill_graphic_list.render_svg(render, render_params);
-				return;
-			}
-			render.parent_tag(
-				"g",
-				|attributes| {
-					attributes.push(ATTR_TRANSFORM, matrix);
-				},
-				|render| {
-					fill_graphic_list.render_svg(render, render_params);
-				},
-			);
-		},
-	);
-}
-
-/// Emits the fill element for aligned-stroke paths, dispatching between `<path>` for Color/Gradient and `<g clip-path>` for Vector/Raster/Graphic.
-#[allow(clippy::too_many_arguments)]
-fn emit_aligned_fill_pass(
-	render: &mut SvgRender,
-	d: String,
-	element_transform: DAffine2,
-	item_transform: DAffine2,
-	fill_graphic_list: Option<&List<Graphic>>,
-	clip_id: Option<&str>,
-	applied_stroke_transform: DAffine2,
-	bounds_matrix: DAffine2,
-	transformed_bounds_matrix: DAffine2,
-	render_params: &RenderParams,
-) {
-	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
-	match fill_graphic {
-		Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
-			emit_svg_fill_path(
-				render,
-				d,
-				element_transform,
-				fill_graphic,
-				applied_stroke_transform,
-				bounds_matrix,
-				transformed_bounds_matrix,
-				render_params,
-			);
-		}
-		Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-			if let (Some(clip_id), Some(fill_graphic_list)) = (clip_id, fill_graphic_list) {
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
-			}
-		}
-	}
 }
 
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
@@ -1076,37 +1080,25 @@ impl Render for List<Vector> {
 				.or_else(|| fill_to_graphic_list(vector.style.fill()).map(Cow::Owned));
 			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
 
-			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
-
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip || need_clipping);
+			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
 			let override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
 			let use_face_fill = vector.use_face_fill();
 
-			// Register the clipPath in <defs> and remember its id for the <g clip-path> below
-			let clip_id = if need_clipping && !use_face_fill {
-				let id = format!("clip-{}", generate_uuid());
-				write!(&mut render.svg_defs, r##"<clipPath id="{id}"><path d="{path}"/></clipPath>"##).unwrap();
-				Some(id)
-			} else {
-				None
-			};
-
 			if needs_separate_alignment_fill && !wants_stroke_below {
-				emit_aligned_fill_pass(
+				emit_svg_fill_path(
 					render,
 					path.clone(),
 					element_transform,
-					item_transform,
 					fill_graphic_list.as_deref(),
-					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
+					item_transform,
 					render_params,
 				);
 			}
@@ -1130,39 +1122,18 @@ impl Render for List<Vector> {
 					face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
 					let face_d = face_path.to_svg();
 
-					match fill_graphic {
-						Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
-							emit_svg_fill_path(
-								render,
-								face_d,
-								element_transform,
-								fill_graphic,
-								applied_stroke_transform,
-								bounds_matrix,
-								transformed_bounds_matrix,
-								render_params,
-							);
-						}
-
-						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
-							if let Some(fill_graphic_list) = fill_graphic_list.as_deref() {
-								let face_clip_id = format!("clip-{}", generate_uuid());
-								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
-								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
-							}
-						}
-					}
+					emit_svg_fill_path(
+						render,
+						face_d,
+						element_transform,
+						fill_graphic_list.as_deref(),
+						applied_stroke_transform,
+						bounds_matrix,
+						transformed_bounds_matrix,
+						item_transform,
+						render_params,
+					);
 				}
-			}
-
-			// Clipping-based fill should be drawn before the stroke path (default paint order)
-			if !needs_separate_alignment_fill
-				&& !use_face_fill
-				&& !wants_stroke_below
-				&& !override_paint_order
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
-			{
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
 
 			render.leaf_tag("path", |attributes| {
@@ -1213,12 +1184,13 @@ impl Render for List<Vector> {
 					r#" fill="none""#.to_string()
 				} else {
 					compute_svg_fill_attribute(
-						fill_graphic,
+						fill_graphic_list.as_deref(),
 						defs,
 						element_transform,
 						applied_stroke_transform,
 						bounds_matrix,
 						transformed_bounds_matrix,
+						item_transform,
 						&render_params,
 					)
 				};
@@ -1244,27 +1216,17 @@ impl Render for List<Vector> {
 				}
 			});
 
-			// Clipping-based fill should be drawn after the stroke path
-			if !needs_separate_alignment_fill
-				&& !use_face_fill
-				&& (wants_stroke_below || override_paint_order)
-				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_deref())
-			{
-				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
-			}
-
 			// When splitting passes and stroke is below, draw the fill after the stroke.
 			if needs_separate_alignment_fill && wants_stroke_below {
-				emit_aligned_fill_pass(
+				emit_svg_fill_path(
 					render,
-					path,
+					path.clone(),
 					element_transform,
-					item_transform,
 					fill_graphic_list.as_deref(),
-					clip_id.as_deref(),
 					applied_stroke_transform,
 					bounds_matrix,
 					transformed_bounds_matrix,
+					item_transform,
 					render_params,
 				);
 			}

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -330,6 +330,121 @@ fn draw_raster_outline(scene: &mut Scene, outline_transform: &DAffine2, render_p
 	scene.stroke(&outline_stroke, Affine::IDENTITY, outline_color_peniko, None, &outline_path);
 }
 
+/// Returns true if the resolved fill graphic fully and opaquely covers the path interior.
+fn fill_covers_opaquely(fill_graphic: Option<&Graphic>) -> bool {
+	match fill_graphic {
+		Some(Graphic::Color(list)) => list.element(0).is_some_and(|c| c.a() >= 1.0),
+		Some(Graphic::Gradient(list)) => list.element(0).is_some_and(|stops| stops.iter().all(|stop| stop.color.a() >= 1.0)),
+		_ => false,
+	}
+}
+
+/// Returns the fill attribute for SVG tags corresponding to the given fill_graphic.
+fn compute_svg_fill_attribute(
+	fill_graphic: Option<&Graphic>,
+	defs: &mut String,
+	element_transform: DAffine2,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) -> String {
+	match fill_graphic {
+		Some(Graphic::Color(color_list)) => color_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params),
+		Some(Graphic::Gradient(gradient_list)) => {
+			let gradient_id = gradient_list.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+			format!(r##" fill="url('#{gradient_id}')""##)
+		}
+		_ => r#" fill="none""#.to_string(),
+	}
+}
+
+/// Emits an SVG `<path>` element with the resolved fill attribute corresponding to the given fill_graphic.
+#[allow(clippy::too_many_arguments)]
+fn emit_svg_fill_path(
+	render: &mut SvgRender,
+	d: String,
+	element_transform: DAffine2,
+	fill_graphic: Option<&Graphic>,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) {
+	render.leaf_tag("path", |attributes| {
+		attributes.push("d", d);
+		let matrix = format_transform_matrix(element_transform);
+		if !matrix.is_empty() {
+			attributes.push(ATTR_TRANSFORM, matrix);
+		}
+		let defs = &mut attributes.0.svg_defs;
+		let fill_attribute = compute_svg_fill_attribute(fill_graphic, defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, render_params);
+		attributes.push_val(fill_attribute);
+	});
+}
+
+/// Emits an SVG `<g clip-path>` group that renders the fill graphic clipped to the path referenced by `clip_id`.
+fn emit_svg_fill_clip(render: &mut SvgRender, clip_id: &str, fill_graphic_list: &List<Graphic>, item_transform: DAffine2, render_params: &RenderParams) {
+	render.parent_tag(
+		"g",
+		|attributes| {
+			attributes.push("clip-path", format!("url(#{clip_id})"));
+		},
+		|render| {
+			let matrix = format_transform_matrix(item_transform);
+			if matrix.is_empty() {
+				fill_graphic_list.render_svg(render, render_params);
+				return;
+			}
+			render.parent_tag(
+				"g",
+				|attributes| {
+					attributes.push(ATTR_TRANSFORM, matrix);
+				},
+				|render| {
+					fill_graphic_list.render_svg(render, render_params);
+				},
+			);
+		},
+	);
+}
+
+/// Emits the fill element for aligned-stroke paths, dispatching between `<path>` for Color/Gradient and `<g clip-path>` for Vector/Raster/Graphic.
+#[allow(clippy::too_many_arguments)]
+fn emit_aligned_fill_pass(
+	render: &mut SvgRender,
+	d: String,
+	element_transform: DAffine2,
+	item_transform: DAffine2,
+	fill_graphic_list: Option<&List<Graphic>>,
+	clip_id: Option<&str>,
+	applied_stroke_transform: DAffine2,
+	bounds_matrix: DAffine2,
+	transformed_bounds_matrix: DAffine2,
+	render_params: &RenderParams,
+) {
+	let fill_graphic = fill_graphic_list.and_then(|l| l.element(0));
+	match fill_graphic {
+		Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
+			emit_svg_fill_path(
+				render,
+				d,
+				element_transform,
+				fill_graphic,
+				applied_stroke_transform,
+				bounds_matrix,
+				transformed_bounds_matrix,
+				render_params,
+			);
+		}
+		Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
+			if let (Some(clip_id), Some(fill_graphic_list)) = (clip_id, fill_graphic_list) {
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
+			}
+		}
+	}
+}
+
 // TODO: Click targets can be removed from the render output, since the vector data is available in the vector modify data from Monitor nodes.
 // This will require that the transform for child layers into that layer space be calculated, or it could be returned from the RenderOutput instead of click targets.
 #[derive(Debug, Default, Clone, PartialEq, DynAny)]
@@ -922,7 +1037,7 @@ impl Render for List<Vector> {
 	fn render_svg(&self, render: &mut SvgRender, render_params: &RenderParams) {
 		for index in 0..self.len() {
 			let Some(vector) = self.element(index) else { continue };
-			let multiplied_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
+			let item_transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
 			let blend_mode_attr: BlendMode = self.attribute_cloned_or_default(ATTR_BLEND_MODE, index);
 			let opacity_attr: f64 = self.attribute_cloned_or(ATTR_OPACITY, index, 1.);
 			let opacity_fill_attr: f64 = self.attribute_cloned_or(ATTR_OPACITY_FILL, index, 1.);
@@ -930,9 +1045,9 @@ impl Render for List<Vector> {
 			// Only consider strokes with non-zero weight, since default strokes with zero weight would prevent assigning the correct stroke transform
 			let has_real_stroke = vector.style.stroke().filter(|stroke| stroke.weight() > 0.);
 			let set_stroke_transform = has_real_stroke.map(|stroke| stroke.transform).filter(|transform| transform.matrix2.determinant() != 0.);
-			let applied_stroke_transform = set_stroke_transform.unwrap_or(multiplied_transform);
+			let applied_stroke_transform = set_stroke_transform.unwrap_or(item_transform);
 			let applied_stroke_transform = render_params.alignment_parent_transform.unwrap_or(applied_stroke_transform);
-			let element_transform = set_stroke_transform.map(|stroke_transform| multiplied_transform * stroke_transform.inverse());
+			let element_transform = set_stroke_transform.map(|stroke_transform| item_transform * stroke_transform.inverse());
 			let element_transform = element_transform.unwrap_or(DAffine2::IDENTITY);
 			let layer_bounds = vector.bounding_box().unwrap_or_default();
 			let transformed_bounds = vector.bounding_box_with_transform(applied_stroke_transform).unwrap_or_default();
@@ -953,32 +1068,46 @@ impl Render for List<Vector> {
 				MaskType::Mask
 			};
 
+			let fill_graphic_list = self
+				.attribute::<List<Graphic>>(ATTR_FILL_GRAPHIC, index)
+				.filter(|list| !list.is_empty())
+				.cloned()
+				.or_else(|| fill_to_graphic_list(vector.style.fill()));
+			let fill_graphic = fill_graphic_list.as_ref().and_then(|l| l.element(0));
+
+			let need_clipping = matches!(fill_graphic, Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)));
+
 			let path_is_closed = vector.stroke_bezier_paths().all(|path| path.closed());
 			let can_draw_aligned_stroke = path_is_closed && vector.style.stroke().is_some_and(|stroke| stroke.has_renderable_stroke() && stroke.align.is_not_centered());
-			let can_use_paint_order = !(vector.style.fill().is_none() || !vector.style.fill().is_opaque() || mask_type == MaskType::Clip);
+			let can_use_paint_order = !(fill_graphic.is_none() || !fill_covers_opaquely(fill_graphic) || mask_type == MaskType::Clip || need_clipping);
 
 			let needs_separate_alignment_fill = can_draw_aligned_stroke && !can_use_paint_order;
 			let wants_stroke_below = vector.style.stroke().map(|s| s.paint_order) == Some(PaintOrder::StrokeBelow);
+			let override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
+			let use_face_fill = vector.use_face_fill();
+
+			// Register the clipPath in <defs> and remember its id for the <g clip-path> below
+			let clip_id = if need_clipping && !use_face_fill {
+				let id = format!("clip-{}", generate_uuid());
+				write!(&mut render.svg_defs, r##"<clipPath id="{id}"><path d="{path}"/></clipPath>"##).unwrap();
+				Some(id)
+			} else {
+				None
+			};
 
 			if needs_separate_alignment_fill && !wants_stroke_below {
-				render.leaf_tag("path", |attributes| {
-					attributes.push("d", path.clone());
-					let matrix = format_transform_matrix(element_transform);
-					if !matrix.is_empty() {
-						attributes.push(ATTR_TRANSFORM, matrix);
-					}
-					let mut style = vector.style.clone();
-					style.clear_stroke();
-					let fill_and_stroke = style.render(
-						&mut attributes.0.svg_defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						render_params,
-					);
-					attributes.push_val(fill_and_stroke);
-				});
+				emit_aligned_fill_pass(
+					render,
+					path.clone(),
+					element_transform,
+					item_transform,
+					fill_graphic_list.as_ref(),
+					clip_id.as_deref(),
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				);
 			}
 
 			let push_id = needs_separate_alignment_fill.then_some({
@@ -990,36 +1119,49 @@ impl Render for List<Vector> {
 
 				// The mask must draw at full alpha so the SVG `<mask>`/`<clipPath>` fully zeroes the path interior.
 				// The wrapping SVG group (above) handles the user-set opacity.
-				let vector_item = List::new_from_item(Item::new_from_element(cloned_vector).with_attribute(ATTR_TRANSFORM, multiplied_transform));
+				let vector_item = List::new_from_item(Item::new_from_element(cloned_vector).with_attribute(ATTR_TRANSFORM, item_transform));
 
 				(id, mask_type, vector_item)
 			});
 
-			let use_face_fill = vector.use_face_fill();
 			if use_face_fill {
 				for mut face_path in vector.construct_faces().filter(|face| face.area() >= 0.) {
 					face_path.apply_affine(Affine::new(applied_stroke_transform.to_cols_array()));
-
 					let face_d = face_path.to_svg();
-					render.leaf_tag("path", |attributes| {
-						attributes.push("d", face_d.clone());
-						let matrix = format_transform_matrix(element_transform);
-						if !matrix.is_empty() {
-							attributes.push(ATTR_TRANSFORM, matrix);
+
+					match fill_graphic {
+						Some(Graphic::Color(_) | Graphic::Gradient(_)) | None => {
+							emit_svg_fill_path(
+								render,
+								face_d,
+								element_transform,
+								fill_graphic,
+								applied_stroke_transform,
+								bounds_matrix,
+								transformed_bounds_matrix,
+								render_params,
+							);
 						}
-						let mut style = vector.style.clone();
-						style.clear_stroke();
-						let fill_only = style.render(
-							&mut attributes.0.svg_defs,
-							element_transform,
-							applied_stroke_transform,
-							bounds_matrix,
-							transformed_bounds_matrix,
-							render_params,
-						);
-						attributes.push_val(fill_only);
-					});
+
+						Some(Graphic::Vector(_) | Graphic::RasterCPU(_) | Graphic::RasterGPU(_) | Graphic::Graphic(_)) => {
+							if let Some(fill_graphic_list) = fill_graphic_list.as_ref() {
+								let face_clip_id = format!("clip-{}", generate_uuid());
+								write!(&mut render.svg_defs, r##"<clipPath id="{face_clip_id}"><path d="{face_d}"/></clipPath>"##).unwrap();
+								emit_svg_fill_clip(render, &face_clip_id, fill_graphic_list, item_transform, render_params);
+							}
+						}
+					}
 				}
+			}
+
+			// Clipping-based fill should be drawn before the stroke path (default paint order)
+			if !needs_separate_alignment_fill
+				&& !use_face_fill
+				&& !wants_stroke_below
+				&& !override_paint_order
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+			{
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
 			}
 
 			render.leaf_tag("path", |attributes| {
@@ -1058,20 +1200,34 @@ impl Render for List<Vector> {
 
 				let mut render_params = render_params.clone();
 				render_params.aligned_strokes = can_draw_aligned_stroke;
-				render_params.override_paint_order = can_draw_aligned_stroke && can_use_paint_order;
+				render_params.override_paint_order = override_paint_order;
 
-				let mut style = vector.style.clone();
-				if needs_separate_alignment_fill || use_face_fill {
-					style.clear_fill();
-				}
+				let stroke_attribute = vector
+					.style
+					.stroke()
+					.map(|stroke| stroke.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params))
+					.unwrap_or_default();
 
-				let fill_and_stroke = style.render(defs, element_transform, applied_stroke_transform, bounds_matrix, transformed_bounds_matrix, &render_params);
+				let fill_attribute = if needs_separate_alignment_fill || use_face_fill {
+					r#" fill="none""#.to_string()
+				} else {
+					compute_svg_fill_attribute(
+						fill_graphic,
+						defs,
+						element_transform,
+						applied_stroke_transform,
+						bounds_matrix,
+						transformed_bounds_matrix,
+						&render_params,
+					)
+				};
 
 				if let Some((id, mask_type, _)) = push_id {
 					let selector = format!("url(#{id})");
 					attributes.push(mask_type.to_attribute(), selector);
 				}
-				attributes.push_val(fill_and_stroke);
+				attributes.push_val(fill_attribute);
+				attributes.push_val(stroke_attribute);
 
 				if vector.is_branching() && !use_face_fill {
 					attributes.push("fill-rule", "evenodd");
@@ -1087,26 +1243,29 @@ impl Render for List<Vector> {
 				}
 			});
 
+			// Clipping-based fill should be drawn after the stroke path
+			if !needs_separate_alignment_fill
+				&& !use_face_fill
+				&& (wants_stroke_below || override_paint_order)
+				&& let (Some(clip_id), Some(fill_graphic_list)) = (clip_id.as_ref(), fill_graphic_list.as_ref())
+			{
+				emit_svg_fill_clip(render, clip_id, fill_graphic_list, item_transform, render_params);
+			}
+
 			// When splitting passes and stroke is below, draw the fill after the stroke.
 			if needs_separate_alignment_fill && wants_stroke_below {
-				render.leaf_tag("path", |attributes| {
-					attributes.push("d", path);
-					let matrix = format_transform_matrix(element_transform);
-					if !matrix.is_empty() {
-						attributes.push(ATTR_TRANSFORM, matrix);
-					}
-					let mut style = vector.style.clone();
-					style.clear_stroke();
-					let fill_and_stroke = style.render(
-						&mut attributes.0.svg_defs,
-						element_transform,
-						applied_stroke_transform,
-						bounds_matrix,
-						transformed_bounds_matrix,
-						render_params,
-					);
-					attributes.push_val(fill_and_stroke);
-				});
+				emit_aligned_fill_pass(
+					render,
+					path,
+					element_transform,
+					item_transform,
+					fill_graphic_list.as_ref(),
+					clip_id.as_deref(),
+					applied_stroke_transform,
+					bounds_matrix,
+					transformed_bounds_matrix,
+					render_params,
+				);
 			}
 		}
 	}
@@ -2117,5 +2276,86 @@ impl SvgRenderAttrs<'_> {
 	}
 	pub fn push_val(&mut self, value: impl Into<SvgSegment>) {
 		self.0.svg.push(value.into());
+	}
+}
+
+#[cfg(test)]
+mod svg_fill_helper_tests {
+	use vector_types::GradientStop;
+
+	use super::*;
+
+	fn color_graphic(alpha: f64) -> Graphic {
+		let color = Color::from_rgbaf32(1.0, 0.0, 0.0, alpha as f32).unwrap();
+		Graphic::Color(List::new_from_element(color))
+	}
+
+	fn gradient_graphic(gradient: GradientStops) -> Graphic {
+		let mut gradient_list = List::new_from_element(gradient);
+		gradient_list.set_attribute(ATTR_SPREAD_METHOD, 0, GradientSpreadMethod::Pad);
+		Graphic::Gradient(gradient_list)
+	}
+
+	#[test]
+	fn opaquely_none_is_false() {
+		assert!(!fill_covers_opaquely(None));
+	}
+
+	#[test]
+	fn opaquely_opaque_color_is_true() {
+		let g = color_graphic(1.0);
+		assert!(fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_transparent_color_is_false() {
+		let g = color_graphic(0.5);
+		assert!(!fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_vector_is_false() {
+		let g = Graphic::Vector(List::default());
+		assert!(!fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_gradient_all_opaque_is_true() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(fill_covers_opaquely(Some(&g)));
+	}
+
+	#[test]
+	fn opaquely_transparent_gradient_is_false() {
+		let color_1 = Color::from_rgbaf32(1.0, 0.0, 0.0, 0.5).unwrap();
+		let color_2 = Color::from_rgbaf32(1.0, 0.0, 0.0, 1.).unwrap();
+		let gradient = GradientStops::new(vec![
+			GradientStop {
+				position: 0.,
+				midpoint: 0.5,
+				color: color_1,
+			},
+			GradientStop {
+				position: 1.,
+				midpoint: 0.5,
+				color: color_2,
+			},
+		]);
+		let g = gradient_graphic(gradient);
+		assert!(!fill_covers_opaquely(Some(&g)));
 	}
 }

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -391,7 +391,9 @@ pub struct RenderMetadata {
 	/// The Text tool composes this with `transform_to_viewport(layer)` to position its drag cage.
 	pub text_frames: HashMap<NodeId, DAffine2>,
 	pub clip_targets: HashSet<NodeId>,
-	pub vector_data: HashMap<NodeId, Arc<Vector>>,
+	// `RenderMetadata` only enters serialization via `TaggedValue::RenderOutput`, which also skips serde.
+	#[cfg_attr(feature = "serde", serde(skip))]
+	pub vector_data: HashMap<NodeId, Arc<List<Vector>>>,
 	pub backgrounds: Vec<Background>,
 }
 
@@ -1525,6 +1527,11 @@ impl Render for List<Vector> {
 		let mut accumulated_click_targets: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 		let mut accumulated_outlines: HashMap<NodeId, Vec<Arc<ClickTarget>>> = HashMap::new();
 
+		// Source geometry (not the click-target override) so editing tools work on letterforms.
+		if let Some(element_id) = caller_element_id {
+			metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(self.clone()));
+		}
+
 		for index in 0..self.len() {
 			let Some(source) = self.element(index) else { continue };
 			let transform: DAffine2 = self.attribute_cloned_or_default(ATTR_TRANSFORM, index);
@@ -1553,10 +1560,6 @@ impl Render for List<Vector> {
 				let mut outlines_unwrapped = Vec::new();
 				extend_targets_from_vector(&mut outlines_unwrapped, source, item_relative_transform);
 				accumulated_outlines.entry(element_id).or_default().extend(outlines_unwrapped.into_iter().map(Arc::new));
-
-				// Source geometry (not the click-target override) so editing tools work on letterforms.
-				// Only item 0 is recorded since editing tools can only target a single item currently.
-				metadata.vector_data.entry(element_id).or_insert_with(|| Arc::new(source.clone()));
 
 				// Surface `editor:text_frame` for the Text tool's drag cage
 				if let Some(&frame) = self.attribute::<DAffine2>(ATTR_EDITOR_TEXT_FRAME, index) {

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -220,7 +220,7 @@ pub struct RenderParams {
 	pub alignment_parent_transform: Option<DAffine2>,
 	pub aligned_strokes: bool,
 	pub override_paint_order: bool,
-	// Are we rendering for a pattern content
+	/// Are we rendering for a pattern content
 	pub inside_pattern: bool,
 	pub artboard_background: Option<Color>,
 	/// Viewport zoom level (document-space scale). Used to compute constant viewport-pixel stroke widths in Outline mode.

--- a/node-graph/libraries/vector-types/src/gradient.rs
+++ b/node-graph/libraries/vector-types/src/gradient.rs
@@ -587,6 +587,12 @@ impl Gradient {
 
 		Some(index)
 	}
+
+	/// Builds the affine that places the gradient endpoints at `start` and `end` when applied to canonical gradient space (0,0) -> (1,0)
+	pub fn to_transform(&self) -> DAffine2 {
+		let direction = self.end - self.start;
+		DAffine2::from_cols(direction, direction.perp(), self.start)
+	}
 }
 
 // TODO: Eventually remove this migration document upgrade code
@@ -623,5 +629,29 @@ impl core_types::bounds::BoundingBox for GradientStops {
 		let start = transform.transform_point2(DVec2::ZERO);
 		let end = transform.transform_point2(DVec2::X);
 		core_types::bounds::RenderBoundingBox::Rectangle([start.min(end), start.max(end)])
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use glam::DVec2;
+
+	fn linear_gradient(start: DVec2, end: DVec2) -> Gradient {
+		Gradient { start, end, ..Default::default() }
+	}
+
+	#[test]
+	fn to_transform_roundtrip() {
+		let cases = [(DVec2::ZERO, DVec2::X), (DVec2::new(10., 20.), DVec2::new(50., 30.)), (DVec2::new(-5., -5.), DVec2::new(5., 3.))];
+
+		for (start, end) in cases {
+			let transform = linear_gradient(start, end).to_transform();
+			let recovered_start = transform.transform_point2(DVec2::ZERO);
+			let recovered_end = transform.transform_point2(DVec2::X);
+
+			assert!((recovered_start - start).length() < 1e-10);
+			assert!((recovered_end - end).length() < 1e-10);
+		}
 	}
 }

--- a/node-graph/libraries/vector-types/src/vector/style.rs
+++ b/node-graph/libraries/vector-types/src/vector/style.rs
@@ -573,7 +573,7 @@ impl Stroke {
 	}
 
 	pub fn has_renderable_stroke(&self) -> bool {
-		self.weight > 0. && self.color.is_some_and(|color| color.a() != 0.)
+		self.weight > 0.
 	}
 }
 

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,11 +1,11 @@
 use core_types::Context;
-use core_types::list::List;
+use core_types::list::{ATTR_FILL_GRAPHIC, List};
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
 use glam::{DAffine2, DVec2};
 use graphic_types::raster_types::{CPU, GPU, Raster};
-use graphic_types::{Artboard, Graphic, Vector};
+use graphic_types::{Artboard, Graphic, IntoGraphicList, Vector};
 use log::warn;
 use math_parser::ast;
 use math_parser::context::{EvalContext, NothingMap, ValueProvider};
@@ -983,6 +983,29 @@ fn length(_: impl Ctx, vector: DVec2) -> f64 {
 #[node_macro::node(category("Math: Vector"))]
 fn normalize(_: impl Ctx, vector: DVec2) -> DVec2 {
 	vector.normalize_or_zero()
+}
+
+/// Sets the `fill_graphic` attribute on each item of the input vector list.
+/// Used for testing of clipping-based fill rendering until the proper Fill node refactor lands.
+#[node_macro::node(category("Debug"))]
+fn fill_graphic<P: IntoGraphicList + 'n + Send>(
+	_: impl Ctx,
+	mut vectors: List<Vector>,
+	#[implementations(
+        List<Graphic>,
+        List<Vector>,
+        List<Raster<CPU>>,
+        List<Raster<GPU>>,
+        List<Color>,
+        List<GradientStops>,
+    )]
+	fill_graphic: P,
+) -> List<Vector> {
+	let paint_list = fill_graphic.into_graphic_list();
+	for row_idx in 0..vectors.len() {
+		vectors.set_attribute(ATTR_FILL_GRAPHIC, row_idx, paint_list.clone());
+	}
+	vectors
 }
 
 #[cfg(test)]

--- a/node-graph/nodes/math/src/lib.rs
+++ b/node-graph/nodes/math/src/lib.rs
@@ -1,5 +1,5 @@
 use core_types::Context;
-use core_types::list::{ATTR_FILL_GRAPHIC, List};
+use core_types::list::{ATTR_FILL_GRAPHIC, ATTR_STROKE_PAINT_GRAPHIC, List};
 use core_types::registry::types::{Fraction, Percentage, PixelSize};
 use core_types::transform::Footprint;
 use core_types::{Color, Ctx, num_traits};
@@ -1004,6 +1004,29 @@ fn fill_graphic<P: IntoGraphicList + 'n + Send>(
 	let paint_list = fill_graphic.into_graphic_list();
 	for row_idx in 0..vectors.len() {
 		vectors.set_attribute(ATTR_FILL_GRAPHIC, row_idx, paint_list.clone());
+	}
+	vectors
+}
+
+/// Sets the `stroke_paint_graphic` attribute on each item of the input vector list.
+/// Used for testing of gradient and clipping-based stroke rendering until the proper Stroke node refactor lands.
+#[node_macro::node(category("Debug"))]
+fn stroke_paint_graphic<P: IntoGraphicList + 'n + Send>(
+	_: impl Ctx,
+	mut vectors: List<Vector>,
+	#[implementations(
+        List<Graphic>,
+        List<Vector>,
+        List<Raster<CPU>>,
+        List<Raster<GPU>>,
+        List<Color>,
+        List<GradientStops>,
+    )]
+	stroke_paint_graphic: P,
+) -> List<Vector> {
+	let paint_list = stroke_paint_graphic.into_graphic_list();
+	for row_idx in 0..vectors.len() {
+		vectors.set_attribute(ATTR_STROKE_PAINT_GRAPHIC, row_idx, paint_list.clone());
 	}
 	vectors
 }


### PR DESCRIPTION
WIP

Use `List<Graphic>` in `ATTR_STROKE_PAINT_GRAPHIC` for the paint of a stroke instead of `Stroke.color`.

This PR depends on #4111, thus it needs to be merged first.