### PR TITLE
Tidy up comments by removing several cases of duplicated words

### DIFF
--- a/desktop/src/window/win/native_handle.rs
+++ b/desktop/src/window/win/native_handle.rs
@@ -225,7 +225,7 @@ unsafe extern "system" fn main_window_handle_message(hwnd: HWND, msg: u32, wpara
 			params.rgrc[0].bottom -= inset;
 		}
 
-		// Return 0 to to tell Windows to skip the default non-client area calculation and drawing.
+		// Return 0 to tell Windows to skip the default non-client area calculation and drawing.
 		return LRESULT(0);
 	}
 

--- a/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
@@ -491,7 +491,7 @@ pub fn arc_outline(layer: Option<LayerNodeIdentifier>, document: &DocumentMessag
 	overlay_context.outline(subpath.iter(), viewport, None);
 }
 
-/// Check if the the cursor is inside the geometric star shape made by the Star node without any upstream node modifications
+/// Check if the cursor is inside the geometric star shape made by the Star node without any upstream node modifications
 pub fn inside_star(viewport: DAffine2, n: u32, radius1: f64, radius2: f64, mouse_position: DVec2) -> bool {
 	let mut paths = Vec::new();
 
@@ -520,7 +520,7 @@ pub fn inside_star(viewport: DAffine2, n: u32, radius1: f64, radius2: f64, mouse
 	winding != 0
 }
 
-/// Check if the the cursor is inside the geometric polygon shape made by the Polygon node without any upstream node modifications
+/// Check if the cursor is inside the geometric polygon shape made by the Polygon node without any upstream node modifications
 pub fn inside_polygon(viewport: DAffine2, n: u32, radius: f64, mouse_position: DVec2) -> bool {
 	let mut paths = Vec::new();
 

--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -1797,7 +1797,7 @@ impl Render for List<Raster<GPU>> {
 // Since colors and gradients are technically infinitely big, we have to implement
 // workarounds for rendering them correctly in a way which still allows us
 // to cache the intermediate render data (SVG string/Vello scene).
-// For SVG, this is is achived by creating a truly giant rectangle.
+// For SVG, this is achieved by creating a truly giant rectangle.
 // For Vello, we create a layer with a placeholder transform which we
 // later replace with the current viewport transform before each render.
 impl Render for List<Color> {

--- a/node-graph/libraries/vector-types/src/vector/algorithms/poisson_disk.rs
+++ b/node-graph/libraries/vector-types/src/vector/algorithms/poisson_disk.rs
@@ -150,7 +150,7 @@ fn target_active_square(active_list_levels: &[ActiveListLevel], rng: &mut impl F
 		return (level, active_square_index_in_level);
 	}
 
-	panic!("index_into_area couldn't be be mapped to a square in any level of the active lists");
+	panic!("index_into_area couldn't be mapped to a square in any level of the active lists");
 }
 
 fn point_not_covered_by_poisson_points(point: DVec2, diameter_squared: f64, points_grid: &AccelerationGrid) -> bool {

--- a/node-graph/libraries/vector-types/src/vector/algorithms/spline.rs
+++ b/node-graph/libraries/vector-types/src/vector/algorithms/spline.rs
@@ -21,7 +21,7 @@ pub fn solve_spline_first_handle_open(points: &[DVec2]) -> Vec<DVec2> {
 
 	let mut c = vec![DVec2::new(1., 1.); len_points];
 
-	// 'd' is the the second point in a cubic bezier, which is what we solve for
+	// 'd' is the second point in a cubic bezier, which is what we solve for
 	let mut d = vec![DVec2::ZERO; len_points];
 
 	d[0] = DVec2::new(2. * points[1].x + points[0].x, 2. * points[1].y + points[0].y);


### PR DESCRIPTION
## Summary

All comment-only fixes.

| File | Line | Fix |
|---|---|---|
| `desktop/src/window/win/native_handle.rs` | 228 | "Return 0 to to tell Windows" → "Return 0 to tell Windows" |
| `node-graph/libraries/vector-types/src/vector/algorithms/spline.rs` | 24 | "is the the second point" → "is the second point" |
| `node-graph/libraries/vector-types/src/vector/algorithms/poisson_disk.rs` | 153 | panic message "couldn't be be mapped" → "couldn't be mapped" |
| `node-graph/libraries/rendering/src/renderer.rs` | 1800 | "this is is achived" → "this is achieved" (also fixes "achived") |
| `editor/src/messages/tool/common_functionality/shapes/shape_utility.rs` | 494, 523 | "Check if the the cursor" → "Check if the cursor" |