### PR TITLE
Fix duplicated dropdown selection styling when multiple entries have identical labels

### DIFF
--- a/frontend/src/components/floating-menus/MenuList.svelte
+++ b/frontend/src/components/floating-menus/MenuList.svelte
@@ -482,7 +482,7 @@
 			{#each currentEntries(section, virtualScrollingEntryHeight, virtualScrollingStartIndex, virtualScrollingEndIndex, search) as entry, entryIndex (entryIndex + startIndex)}
 				<LayoutRow
 					class="row"
-					classes={{ open: openChildValue === entry.value, active: entry.label === highlighted?.label, disabled: Boolean(entry.disabled) }}
+					classes={{ open: openChildValue === entry.value, active: entry.value === highlighted?.value, disabled: Boolean(entry.disabled) }}
 					styles={{ height: virtualScrollingEntryHeight || "20px" }}
 					tooltipLabel={entry.tooltipLabel}
 					tooltipDescription={entry.tooltipDescription}

--- a/frontend/src/components/floating-menus/MenuList.svelte
+++ b/frontend/src/components/floating-menus/MenuList.svelte
@@ -97,7 +97,7 @@
 			await tick();
 
 			const flattened = filteredEntries.flat();
-			const highlightedFound = highlighted?.label && flattened.map((entry) => entry.label).includes(highlighted.label);
+			const highlightedFound = highlighted?.value && flattened.map((entry) => entry.value).includes(highlighted.value);
 			const newHighlighted = highlightedFound ? highlighted : flattened[0];
 			setHighlighted(newHighlighted);
 		}
@@ -335,7 +335,7 @@
 		if ((menuOpen || interactive) && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
 			let newIndex = e.key === "ArrowUp" ? flatEntries.length - 1 : 0;
 			if (highlighted) {
-				const index = highlighted ? flatEntries.map((entry) => entry.label).indexOf(highlighted.label) : 0;
+				const index = highlighted ? flatEntries.map((entry) => entry.value).indexOf(highlighted.value) : 0;
 				newIndex = index + (e.key === "ArrowUp" ? -1 : 1);
 
 				// Interactive dropdowns should lock at the end whereas other dropdowns should loop

--- a/frontend/src/components/floating-menus/MenuList.svelte
+++ b/frontend/src/components/floating-menus/MenuList.svelte
@@ -97,7 +97,7 @@
 			await tick();
 
 			const flattened = filteredEntries.flat();
-			const highlightedFound = highlighted?.value && flattened.map((entry) => entry.value).includes(highlighted.value);
+			const highlightedFound = flattened.map((entry) => entry.value).includes(highlighted.value);
 			const newHighlighted = highlightedFound ? highlighted : flattened[0];
 			setHighlighted(newHighlighted);
 		}
@@ -335,7 +335,7 @@
 		if ((menuOpen || interactive) && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
 			let newIndex = e.key === "ArrowUp" ? flatEntries.length - 1 : 0;
 			if (highlighted) {
-				const index = highlighted ? flatEntries.map((entry) => entry.value).indexOf(highlighted.value) : 0;
+				const index = flatEntries.map((entry) => entry.value).indexOf(highlighted.value);
 				newIndex = index + (e.key === "ArrowUp" ? -1 : 1);
 
 				// Interactive dropdowns should lock at the end whereas other dropdowns should loop


### PR DESCRIPTION
If a MenuList contains multiple entries with identical labels, currently both entries will appear selected.
<img width="293" height="215" alt="image" src="https://github.com/user-attachments/assets/2cb2b3c8-e290-40e7-bbad-a3d069409f28" />

This PR ensures only one entry appears selected.
<img width="290" height="211" alt="image" src="https://github.com/user-attachments/assets/73c5e05b-c717-4017-8e5a-a11b18c17c8e" />

This is relevant in the Export Dialog, which renders a dropdown with user specified Artboard names which can be identical.

Fixes: #3878
