### PR TITLE
Desktop: Disable UI acceleration by default on Linux

### DIFF
--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -65,10 +65,7 @@ impl Default for PreferencesMessageHandler {
 			viewport_zoom_wheel_rate: VIEWPORT_ZOOM_WHEEL_RATE,
 			ui_scale: UI_SCALE_DEFAULT,
 			max_render_region_size: EditorPreferences::default().max_render_region_size,
-			#[cfg(target_os = "linux")] // TODO: Remove this once we have ui acceleration working more reliably on linux
-			disable_ui_acceleration: true,
-			#[cfg(not(target_os = "linux"))] // TODO: Remove this once we have ui acceleration working more reliably on linux
-			disable_ui_acceleration: false,
+			disable_ui_acceleration: cfg!(target_os = "linux"), // TODO: Set this back to false once we have ui acceleration working more reliably on linux
 			#[cfg(target_os = "macos")]
 			vsync: false,
 		}

--- a/editor/src/messages/preferences/preferences_message_handler.rs
+++ b/editor/src/messages/preferences/preferences_message_handler.rs
@@ -65,6 +65,9 @@ impl Default for PreferencesMessageHandler {
 			viewport_zoom_wheel_rate: VIEWPORT_ZOOM_WHEEL_RATE,
 			ui_scale: UI_SCALE_DEFAULT,
 			max_render_region_size: EditorPreferences::default().max_render_region_size,
+			#[cfg(target_os = "linux")] // TODO: Remove this once we have ui acceleration working more reliably on linux
+			disable_ui_acceleration: true,
+			#[cfg(not(target_os = "linux"))] // TODO: Remove this once we have ui acceleration working more reliably on linux
 			disable_ui_acceleration: false,
 			#[cfg(target_os = "macos")]
 			vsync: false,


### PR DESCRIPTION
we should change this back once we have ui acceleration working more reliably on linux

but for now this seem like a ok solution

<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
