### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: 🐞 Bug Report
+description: Create a new bug report.
+title: 'Bug: <title>'
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: ':stop_sign: _Make sure you are reporting an issue. For general questions, please use [https://discord.graphite.art/](https://discord.graphite.art/)._'
+
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: 'Please [search :mag: the issues](https://github.com/GraphiteEditor/Graphite/issues) to check if this bug has already been reported.'
+      options:
+      - label: I have searched the existing issues
+        required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: 'A clear and concise description of what the bug is.'
+      placeholder: 'Steps to reproduce the behavior:'
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: 'A clear and concise description of what you expected to happen.'
+      placeholder: 'What did you expect to happen?'
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: 'If applicable, add screenshots to help explain your problem.'
+      placeholder: 'Paste screenshots here'
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: 'Add any other context about the problem here.'
+      placeholder: 'Additional context'
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Question 
+    url: https://discord.graphite.art/
+    about: Please ask your question in our Discord server for faster support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: 💡 Feature Request
+description: Suggest an idea for Graphite.
+title: 'Feature Request: <title>'
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: ':bulb: _Have an idea for a new feature? Please provide as much detail as possible to help us understand your request._'
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: 'Please [search :mag: the issues](https://github.com/GraphiteEditor/Graphite/issues) to check if this feature has already been requested.'
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: 'A clear and concise description of what the feature is.'
+      placeholder: 'What is the feature you would like to see?'
+    validations:
+      required: true


### PR DESCRIPTION
I'd like to know what's good information for you guys when making an issue, so I made basic issue templates. Inspired by [Appium's issue templates](https://github.com/appium/appium/tree/master/.github/ISSUE_TEMPLATE)

Feel free to add options that are pertinent to Graphite