### PR TITLE
Unify the gradient chain lookup used by the stops and attribute reads

### DIFF
--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -283,9 +283,11 @@ pub fn gradient_chain_target_input(layer: LayerNodeIdentifier, network_interface
 
 /// Try to find a "Gradient Value" node that is connected to a "Fill" node, or to a layer directly.
 pub fn get_upstream_gradient_value_node_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
+	let target_input = gradient_chain_target_input(layer, network_interface);
+	let walk_from = network_interface.upstream_output_connector(&target_input, &[])?.node_id()?;
+
 	network_interface
-		.upstream_flow_back_from_nodes(vec![layer.to_node()], &[], FlowType::UpstreamFlow)
-		.skip(1)
+		.upstream_flow_back_from_nodes(vec![walk_from], &[], FlowType::HorizontalFlow)
 		.take_while(|node_id| !network_interface.is_layer(node_id, &[]))
 		.find(|node_id| network_interface.reference(node_id, &[]).as_ref() == Some(&DefinitionIdentifier::ProtoNode(graphene_std::math_nodes::gradient_value::IDENTIFIER)))
 }


### PR DESCRIPTION
Fixes a bug introduced by #4177.

The node-finding logic for "Gradient Value" and other gradient-related attribute insertion nodes (e.g. "Gradient Type") was different, so the gradient tool could target the wrong Fill input in a case where there were multiple 'Fill' nodes. This PR unifies the logic for finding the Fill node that only affects the actual painting.

## Before

https://github.com/user-attachments/assets/e5c39ebd-b7b7-45ac-a35f-677bbd0c22a2


## After

https://github.com/user-attachments/assets/8360ff63-71a1-48ff-a640-3dc1f60cbc76
