### PR TITLE
fix: avoid invalid transforms in repeat_array when count is 1

### DIFF
--- a/node-graph/nodes/repeat/src/repeat_nodes.rs
+++ b/node-graph/nodes/repeat/src/repeat_nodes.rs
@@ -65,7 +65,7 @@ pub async fn repeat_array<T: Into<Graphic> + Default + Send + Clone + 'static>(
 ) -> List<T> {
 	let angle = angle.to_radians();
 	let count = count.max(1);
-	let total = (count - 1) as f64;
+	let total = (count - 1).max(1) as f64;
 
 	let mut result_list = List::new();
 


### PR DESCRIPTION
## Summary

While looking through the repeat nodes, I noticed that `repeat_array` allows `count = 1`, but the calculation uses `(count - 1)` as a denominator.

When `count` is 1, this results in a zero denominator and can produce invalid transform values during the angle and translation calculations.

This change guards against that edge case by ensuring the denominator is at least 1.

## Changes

* Prevent division by zero when `count = 1`
* Keep existing behavior unchanged for `count >= 2`

## Testing

Reasoned through the `count = 1` execution path and verified that the denominator can no longer become zero.
