### PR TITLE
Fix number slider value getting stuck tied to mouse position (#4231)

### DIFF
--- a/frontend/src/components/widgets/inputs/NumberInput.svelte
+++ b/frontend/src/components/widgets/inputs/NumberInput.svelte
@@ -418,8 +418,33 @@
 		// while dragging it outside the browser window, because Safari has another bug where the cursor icon is unaffected by that API.
 		if (isSafari) document.body.classList.add("cursor-hidden");
 
-		// Enter dragging state
-		if (usePointerLock) target.requestPointerLock();
+		// Tracks whether the drag has already ended (the mouse was released). Used to resolve the race where
+		// pointer lock finishes engaging only after the user has already released the mouse button.
+		let dragReleased = false;
+
+		// Enter dragging state.
+		// `requestPointerLock()` is asynchronous: the pointer isn't actually locked until the "pointerlockchange"
+		// event fires. If the user releases the mouse before that happens (e.g. a rapid click or a quick
+		// drag-and-release), `endDrag()` cleans up the drag listeners directly, but the still-pending lock may engage
+		// afterward — by which point our "pointerlockchange" listener has already been removed. We use the returned
+		// promise (in browsers that support it) to exit such a late-engaging lock so the cursor doesn't get stuck
+		// locked, and to confirm the drag was already cleaned up if the request is rejected. Without this, the value
+		// could stay tied to mouse movement. See: <https://github.com/GraphiteEditor/Graphite/issues/4231>
+		if (usePointerLock) {
+			const lockRequest = target.requestPointerLock();
+			if (lockRequest instanceof Promise) {
+				lockRequest.then(
+					() => {
+						// If the user already released before the lock engaged, exit it immediately so we aren't stuck locked.
+						if (dragReleased && document.pointerLockElement) document.exitPointerLock();
+					},
+					() => {
+						// The lock request was rejected (e.g. the browser's brief cooldown after rapidly re-locking).
+						// Nothing to do here: `pointerUp` cleans up on release since we never entered pointer lock.
+					},
+				);
+			}
+		}
 		if (import.meta.env.MODE === "native") {
 			editor.appWindowPointerLock();
 		}
@@ -443,24 +468,21 @@
 			initialValueBeforeDragging = value;
 			cumulativeDragDelta = 0;
 
-			if (usePointerLock) document.exitPointerLock();
-			else pointerLockChange();
+			endDrag();
 		};
 		const pointerMove = (e: PointerEvent) => {
 			// TODO: Display a fake cursor over the top of the page which wraps around the edges of the editor.
 
 			// Abort the drag if right click is down. This works here because a "pointermove" event is fired when right clicking even if the cursor didn't move.
 			if (e.buttons & BUTTONS_RIGHT) {
-				if (usePointerLock) document.exitPointerLock();
-				else pointerLockChange();
+				endDrag();
 				return;
 			}
 
 			// If no buttons are down, that means we are stuck in the drag state after having released the mouse, so we should exit.
 			// For some reason on Firefox in Wayland, `e.buttons` can be 0 while `e.button` is -1, but we don't want to exit in that state.
 			if (e.buttons === 0 && e.button !== -1) {
-				if (usePointerLock) document.exitPointerLock();
-				else pointerLockChange();
+				endDrag();
 				return;
 			}
 
@@ -496,6 +518,17 @@
 
 			// Close out the transaction `startDragging` opened so the many emits collapse into one history step (covers both confirmed and aborted drags).
 			commitTransactionIfInProgress();
+		};
+		// Ends the drag and runs the cleanup. If the pointer is actually locked, exiting it fires "pointerlockchange",
+		// which performs the cleanup. Otherwise (we're not using pointer lock, or the lock hasn't engaged yet because
+		// the interaction ended too quickly) no such event will arrive, so we clean up directly. This prevents a stuck
+		// drag where the value stays tied to mouse movement (#4231). Setting `dragReleased` also lets a pointer lock
+		// that engages after this point exit itself immediately (see the `requestPointerLock()` handling above).
+		const endDrag = () => {
+			dragReleased = true;
+
+			if (usePointerLock && document.pointerLockElement) document.exitPointerLock();
+			else pointerLockChange();
 		};
 
 		addEventListener("pointerup", pointerUp);


### PR DESCRIPTION
Generated by Claude. Review this carefully!

Fixes #4231

## Problem

In **Increment** mode, dragging a number field uses the asynchronous Pointer Lock API.
`requestPointerLock()` only takes effect once the `"pointerlockchange"` event fires, and the
drag's cleanup (removing the window `pointermove`/`pointerup` listeners) was driven *exclusively*
by that event via `exitPointerLock()`.

When the interaction ends **before** the lock engages — e.g. a rapid click or a quick
drag-and-release, which is what the reporter triggered by double-clicking — `pointerUp`'s
`document.exitPointerLock()` is a no-op, so `"pointerlockchange"` never fires and the listeners
are never removed. The leaked `pointermove` listener then keeps updating the value on every mouse
move. Because an unpressed move reports `e.buttons === 0` with `e.button === -1`, it also slips
past the existing exit guard (kept for a Firefox/Wayland quirk), so the value stays permanently
tied to the cursor.

## Fix

- Route every drag-exit path (`pointerUp`, right-click abort, buttons-released recovery) through a
  single `endDrag()` helper that cleans up **directly** when the pointer isn't actually locked
  (covers "lock hasn't engaged yet" and "pointer lock not in use"), instead of relying on
  `"pointerlockchange"`.
- Handle the `requestPointerLock()` **promise** so a lock that engages *after* the drag already
  ended exits itself immediately (no stuck-locked cursor), and a rejected request (browser re-lock
  cooldown) doesn't surface as an unhandled rejection.

Single file changed: `frontend/src/components/widgets/inputs/NumberInput.svelte`.

## How I tested

There's no frontend test harness in the repo (CI is `svelte-check` + `eslint`), and the bug is a
timing-dependent race that's hard to hit by hand, so I verified it by **deterministically forcing
the race** in the running editor.

**Static checks**
- `svelte-check` passes (type-correct).
- `eslint` on the changed file: 0 errors.

**Deterministic before/after in the running dev build (Chrome/Chromium, `usePointerLock === true`)**

I temporarily stubbed `requestPointerLock` to return a promise that resolves *after* release
(exactly the slow-lock condition behind the bug), dispatched `pointerdown → pointermove →
pointerup` on a real Increment number field, then moved the mouse **with no button pressed**:

| Code           | Value before release | Value after no-button mouse move | Result        |
|----------------|----------------------|----------------------------------|---------------|
| **Before fix** | `4`                  | `0`                              | ❌ value tied to cursor |
| **After fix**  | `100%`               | `100%`                           | ✅ value unchanged |

A value change on a no-button move is only possible while the leaked `pointermove` listener is
still attached, so the "after" result (no change) confirms the listener is properly removed. The
editor also builds and runs normally with the change.