### PR TITLE
Bump linesweeper to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,9 +3169,9 @@ checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linesweeper"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8421b276e96af0ace5f3d8d2d165d0dea07fe764d2fe94ec06bb1acaf8a1e759"
+checksum = "9c19728333c060c6569a53c9a0e56c4be0df52cb4e6e07a8fbe16084cecce769"
 dependencies = [
  "arrayvec",
  "kurbo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ cargo-gpu-install = { version = "0.10.0-alpha.1", default-features = false }
 qrcodegen = "1.8"
 lzma-rust2 = { version = "0.16", default-features = false, features = ["std", "encoder", "optimization", "xz"] }
 scraper = "0.25"
-linesweeper = "0.3"
+linesweeper = "0.4"
 smallvec = "1.13.2"
 zip = { version = "8", default-features = false }
 

--- a/node-graph/nodes/path-bool/src/lib.rs
+++ b/node-graph/nodes/path-bool/src/lib.rs
@@ -77,6 +77,13 @@ impl linesweeper::topology::WindingNumber for WindingNumber {
 		elems[tag] = if positive { 1 } else { -1 };
 		Self { elems }
 	}
+
+	fn of_tag(&self, (tag, out_of): Self::Tag) -> Self {
+		let mut elems = SmallVec::with_capacity(out_of);
+		elems.resize(out_of, 0);
+		elems[tag] = self.elems[tag];
+		Self { elems }
+	}
 }
 
 impl std::ops::AddAssign for WindingNumber {
@@ -162,11 +169,8 @@ fn boolean_operation_on_vector_list(vector: &List<Vector>, boolean_operation: Bo
 		}
 	};
 	let contours = top.contours(|winding| winding.is_inside(boolean_operation));
-
-	// TODO: Linesweeper emits contours in the opposite winding direction from the rest of Kurbo's and Graphite's vector graphics system (clockwise in screen coordinates).
-	// TODO: Report this upstream to Linesweeper and remove this `.reverse()` workaround once fixed.
 	for subpath in from_bez_paths(contours.contours().map(|c| &c.path)) {
-		row.element_mut().append_subpath(subpath.reverse(), false);
+		row.element_mut().append_subpath(subpath, false);
 	}
 
 	list.push(row);

--- a/node-graph/nodes/path-bool/src/lib.rs
+++ b/node-graph/nodes/path-bool/src/lib.rs
@@ -81,7 +81,11 @@ impl linesweeper::topology::WindingNumber for WindingNumber {
 	fn of_tag(&self, (tag, out_of): Self::Tag) -> Self {
 		let mut elems = SmallVec::with_capacity(out_of);
 		elems.resize(out_of, 0);
-		elems[tag] = self.elems[tag];
+		if let (Some(slot), Some(&value)) = (elems.get_mut(tag), self.elems.get(tag)) {
+			*slot = value;
+		} else {
+			log::warn!("WindingNumber::of_tag: tag {tag} out of bounds (out_of {out_of}, len {})", self.elems.len());
+		}
 		Self { elems }
 	}
 }


### PR DESCRIPTION
As linesweeper 0.4 reversed the path direction, this removes the temporary reversal.