### PR TITLE
Fix error from running `cargo check` with a system global Cargo config.toml `rustflags` override

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
-[build]
-# Keep `--cfg=web_sys_unstable_apis` here so the wasm wrapper crates build with the same web-sys API signatures (e.g. `put_image_data`/`get_image_data` taking `i32` rather than `f64`) on both native test builds and the wasm target. Cargo applies `[build]` rustflags only when no target-specific rustflags table matches, so the wasm-specific list below must continue to include this cfg.
+# Keep `--cfg=web_sys_unstable_apis` here so the wasm wrapper crates build with the same web-sys API signatures (e.g. `put_image_data`/`get_image_data` taking `i32` rather than `f64`) on both native and the wasm target.
+[target.'cfg(not(target_family = "wasm"))']
 rustflags = ["--cfg=web_sys_unstable_apis"]
 
-[target.wasm32-unknown-unknown]
+[target.'cfg(target_family = "wasm")']
 rustflags = [
 	# Currently disabled because of https://github.com/GraphiteEditor/Graphite/issues/1262
 	# The current simd implementation leads to undefined behavior


### PR DESCRIPTION
When a global `.cargo/config.toml` is used to overwrite the `rustflags` based on the target ­— as it is the case when using a non default linker — the configured value for `rustflags` in the `[build]` section is ignored instead of being merged with the global configuration. By moving the flags to a `cfg` guard, the precedence issue is avoided.

<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->
