### PR TITLE
Change footprint to always be in physical instead of logical space

### DIFF
--- a/node-graph/libraries/rendering/src/renderer.rs
+++ b/node-graph/libraries/rendering/src/renderer.rs
@@ -213,8 +213,6 @@ pub enum RenderOutputType {
 pub struct RenderParams {
 	pub render_mode: RenderMode,
 	pub footprint: Footprint,
-	/// Ratio of physical pixels to logical pixels. `scale := physical_pixels / logical_pixels`
-	/// Ignored when rendering to SVG.
 	#[cache_hash(skip)]
 	pub scale: f64,
 	pub render_output_type: RenderOutputType,

--- a/node-graph/nodes/gstd/src/render_background.rs
+++ b/node-graph/nodes/gstd/src/render_background.rs
@@ -44,7 +44,7 @@ async fn render_background<'a: 'n>(
 				})
 				.await;
 
-			RenderOutputType::Texture(blended.into())
+			RenderOutputType::Texture(blended)
 		}
 		RenderOutputType::Svg {
 			svg: foreground_svg,

--- a/node-graph/nodes/gstd/src/render_background.rs
+++ b/node-graph/nodes/gstd/src/render_background.rs
@@ -34,7 +34,7 @@ async fn render_background<'a: 'n>(
 
 	let data = match foreground_data {
 		RenderOutputType::Texture(foreground_texture) => {
-			let doc_to_screen = (glam::DAffine2::from_scale(glam::DVec2::splat(render_params.scale)) * render_params.footprint.transform).as_affine2();
+			let doc_to_screen = render_params.footprint.transform.as_affine2();
 			let blended = pipeline
 				.run::<CompositeBackground>(&CompositeBackgroundArgs {
 					foreground: foreground_texture.as_ref(),
@@ -51,6 +51,8 @@ async fn render_background<'a: 'n>(
 			image_data: foreground_images,
 		} => {
 			let mut render = SvgRender::new();
+
+			let logical_transform = glam::DAffine2::from_scale(glam::DVec2::splat(1.0 / render_params.scale)) * render_params.footprint.transform;
 
 			if render_params.viewport_zoom > 0. {
 				let draw_checkerboard = |render: &mut SvgRender, rect: vello::kurbo::Rect, pattern_origin: glam::DVec2, checker_id_prefix: &str| {
@@ -79,6 +81,7 @@ async fn render_background<'a: 'n>(
 					if render_params.scale > 0. {
 						let logical_resolution = render_params.footprint.resolution.as_dvec2() / render_params.scale;
 						let logical_footprint = Footprint {
+							transform: logical_transform,
 							resolution: logical_resolution.round().as_uvec2().max(glam::UVec2::ONE),
 							..render_params.footprint
 						};
@@ -101,7 +104,7 @@ async fn render_background<'a: 'n>(
 			}
 
 			let logical_resolution = render_params.footprint.resolution.as_dvec2() / render_params.scale;
-			render.wrap_with_transform(render_params.footprint.transform, Some(logical_resolution));
+			render.wrap_with_transform(logical_transform, Some(logical_resolution));
 
 			let background = SvgRenderOutput::from(render);
 			assert!(background.svg_defs.is_empty());

--- a/node-graph/nodes/gstd/src/render_cache.rs
+++ b/node-graph/nodes/gstd/src/render_cache.rs
@@ -379,16 +379,7 @@ pub async fn render_output_cache<'a: 'n>(
 		if missing_region.tiles.is_empty() {
 			continue;
 		}
-		let region = render_missing_region(
-			missing_region,
-			|ctx| data.eval(ctx),
-			ctx.clone(),
-			render_params,
-			&footprint.transform,
-			&device_origin_offset,
-			render_params.scale,
-		)
-		.await;
+		let region = render_missing_region(missing_region, |ctx| data.eval(ctx), ctx.clone(), render_params, &footprint.transform, &device_origin_offset).await;
 		new_regions.push(region);
 	}
 
@@ -405,8 +396,7 @@ pub async fn render_output_cache<'a: 'n>(
 	let executor = executor.expect("GPU executor not available");
 	let output_texture = executor.request_texture(physical_resolution).await;
 
-	let logical_viewport_transform = DAffine2::from_scale(DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
-	let combined_metadata = composite_cached_regions(&all_regions, &output_texture, &device_origin_offset, &logical_viewport_transform, executor);
+	let combined_metadata = composite_cached_regions(&all_regions, &output_texture, &device_origin_offset, &footprint.transform, executor);
 
 	RenderOutput {
 		data: RenderOutputType::Texture(output_texture.into()),
@@ -421,7 +411,6 @@ async fn render_missing_region<F, Fut>(
 	render_params: &RenderParams,
 	viewport_transform: &DAffine2,
 	viewport_origin_offset: &DVec2,
-	device_scale: f64,
 ) -> CachedRegion
 where
 	F: Fn(Context<'static>) -> Fut,
@@ -449,8 +438,7 @@ where
 		unreachable!("render_missing_region: expected texture output from Vello render");
 	};
 
-	let logical_region_transform = DAffine2::from_scale(DVec2::splat(1.0 / device_scale)) * region_transform;
-	let pixel_to_document = logical_region_transform.inverse();
+	let pixel_to_document = region_transform.inverse();
 	result.metadata.apply_transform(pixel_to_document);
 
 	let memory_size = (region_pixel_size.x * region_pixel_size.y) as usize * BYTES_PER_PIXEL;

--- a/node-graph/nodes/gstd/src/render_cache.rs
+++ b/node-graph/nodes/gstd/src/render_cache.rs
@@ -37,7 +37,6 @@ pub struct CachedRegion {
 pub struct CacheKey {
 	pub max_region_area: u32,
 	pub render_mode_hash: u64,
-	pub device_scale: u64,
 	pub zoom: u64,
 	pub rotation: u64,
 	pub for_export: bool,
@@ -55,7 +54,6 @@ impl CacheKey {
 	fn new(
 		max_region_area: u32,
 		render_mode_hash: u64,
-		device_scale: f64,
 		zoom: f64,
 		rotation: f64,
 		for_export: bool,
@@ -81,7 +79,6 @@ impl CacheKey {
 		Self {
 			max_region_area,
 			render_mode_hash,
-			device_scale: device_scale.to_bits(),
 			zoom: zoom.to_bits(),
 			rotation: quantized_rotation.to_bits(),
 			for_export,
@@ -345,7 +342,7 @@ pub async fn render_output_cache<'a: 'n>(
 		return data.eval(context.into_context()).await;
 	}
 
-	let zoom = footprint.scale_magnitudes().x / render_params.scale;
+	let zoom = footprint.scale_magnitudes().x;
 	let rotation = footprint.decompose_rotation();
 
 	let device_origin_offset = footprint.transform.translation;
@@ -359,7 +356,6 @@ pub async fn render_output_cache<'a: 'n>(
 	let cache_key = CacheKey::new(
 		max_region_area,
 		render_params.render_mode as u64,
-		render_params.scale,
 		zoom,
 		rotation,
 		render_params.for_export,

--- a/node-graph/nodes/gstd/src/render_cache.rs
+++ b/node-graph/nodes/gstd/src/render_cache.rs
@@ -395,7 +395,7 @@ pub async fn render_output_cache<'a: 'n>(
 	let combined_metadata = composite_cached_regions(&all_regions, &output_texture, &device_origin_offset, &footprint.transform, executor);
 
 	RenderOutput {
-		data: RenderOutputType::Texture(output_texture.into()),
+		data: RenderOutputType::Texture(output_texture),
 		metadata: combined_metadata,
 	}
 }

--- a/node-graph/nodes/gstd/src/render_cache.rs
+++ b/node-graph/nodes/gstd/src/render_cache.rs
@@ -345,12 +345,10 @@ pub async fn render_output_cache<'a: 'n>(
 		return data.eval(context.into_context()).await;
 	}
 
-	let device_scale = render_params.scale;
-	let zoom = footprint.scale_magnitudes().x;
+	let zoom = footprint.scale_magnitudes().x / render_params.scale;
 	let rotation = footprint.decompose_rotation();
 
-	let viewport_origin_offset = footprint.transform.translation;
-	let device_origin_offset = viewport_origin_offset * device_scale;
+	let device_origin_offset = footprint.transform.translation;
 	let viewport_bounds_device = AxisAlignedBbox {
 		start: -device_origin_offset,
 		end: footprint.resolution.as_dvec2() - device_origin_offset,
@@ -361,7 +359,7 @@ pub async fn render_output_cache<'a: 'n>(
 	let cache_key = CacheKey::new(
 		max_region_area,
 		render_params.render_mode as u64,
-		device_scale,
+		render_params.scale,
 		zoom,
 		rotation,
 		render_params.for_export,
@@ -387,8 +385,8 @@ pub async fn render_output_cache<'a: 'n>(
 			ctx.clone(),
 			render_params,
 			&footprint.transform,
-			&viewport_origin_offset,
-			device_scale,
+			&device_origin_offset,
+			render_params.scale,
 		)
 		.await;
 		new_regions.push(region);
@@ -406,7 +404,9 @@ pub async fn render_output_cache<'a: 'n>(
 
 	let executor = executor.expect("GPU executor not available");
 	let output_texture = executor.request_texture(physical_resolution).await;
-	let combined_metadata = composite_cached_regions(&all_regions, &output_texture, &device_origin_offset, &footprint.transform, &executor);
+
+	let logical_viewport_transform = DAffine2::from_scale(DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
+	let combined_metadata = composite_cached_regions(&all_regions, &output_texture, &device_origin_offset, &logical_viewport_transform, executor);
 
 	RenderOutput {
 		data: RenderOutputType::Texture(output_texture.into()),
@@ -433,7 +433,7 @@ where
 	let tile_count = (max_tile - min_tile) + IVec2::ONE;
 	let region_pixel_size = (tile_count * TILE_SIZE as i32).as_uvec2();
 
-	let tile_global_offset = min_tile.as_dvec2() * (TILE_SIZE as f64 / device_scale) + *viewport_origin_offset;
+	let tile_global_offset = min_tile.as_dvec2() * TILE_SIZE as f64 + *viewport_origin_offset;
 	let region_transform = DAffine2::from_translation(-tile_global_offset) * *viewport_transform;
 	let region_footprint = Footprint {
 		transform: region_transform,
@@ -449,7 +449,8 @@ where
 		unreachable!("render_missing_region: expected texture output from Vello render");
 	};
 
-	let pixel_to_document = region_transform.inverse();
+	let logical_region_transform = DAffine2::from_scale(DVec2::splat(1.0 / device_scale)) * region_transform;
+	let pixel_to_document = logical_region_transform.inverse();
 	result.metadata.apply_transform(pixel_to_document);
 
 	let memory_size = (region_pixel_size.x * region_pixel_size.y) as usize * BYTES_PER_PIXEL;

--- a/node-graph/nodes/gstd/src/render_node.rs
+++ b/node-graph/nodes/gstd/src/render_node.rs
@@ -88,13 +88,12 @@ async fn render<'a: 'n>(
 	let mut render_params = render_params.clone();
 	render_params.footprint = *footprint;
 
-	let logical_transform = glam::DAffine2::from_scale(glam::DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
-
 	let RenderIntermediate { ty, mut metadata } = data;
-	metadata.apply_transform(logical_transform);
+	metadata.apply_transform(footprint.transform);
 
 	let data = match (render_params.render_output_type, ty) {
 		(RenderOutputTypeRequest::Svg, RenderIntermediateType::Svg(data)) => {
+			let logical_transform = glam::DAffine2::from_scale(glam::DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
 			let logical_resolution = render_params.footprint.resolution.as_dvec2() / render_params.scale;
 
 			let mut render = SvgRender::from(data.as_ref());
@@ -180,5 +179,8 @@ async fn create_context<'a: 'n>(
 		.with_vararg(Box::new(render_params))
 		.into_context();
 
-	data.eval(ctx).await
+	let mut result = data.eval(ctx).await;
+
+	result.metadata.apply_transform(glam::DAffine2::from_scale(glam::DVec2::splat(1. / render_config.scale)));
+	result
 }

--- a/node-graph/nodes/gstd/src/render_node.rs
+++ b/node-graph/nodes/gstd/src/render_node.rs
@@ -1,6 +1,6 @@
 use core_types::list::List;
 use core_types::transform::{Footprint, Transform};
-use core_types::{CloneVarArgs, ExtractAll, ExtractVarArgs, InjectFootprint};
+use core_types::{CloneVarArgs, ExtractAll, ExtractVarArgs};
 use core_types::{Color, Context, Ctx, ExtractFootprint, OwnedContextImpl, WasmNotSend};
 use graph_craft::document::value::{RenderOutput, RenderOutputType};
 use graphene_application_io::{ExportFormat, RenderConfig};
@@ -24,7 +24,7 @@ pub struct RenderIntermediate {
 
 #[node_macro::node(category(""))]
 async fn render_intermediate<'a: 'n, T: 'static + Render + WasmNotSend + Send + Sync>(
-	ctx: impl Ctx + ExtractVarArgs + ExtractAll + CloneVarArgs + InjectFootprint,
+	ctx: impl Ctx + ExtractVarArgs + ExtractAll + CloneVarArgs,
 	#[implementations(
 		Context -> List<Artboard>,
 		Context -> List<Graphic>,
@@ -42,12 +42,7 @@ async fn render_intermediate<'a: 'n, T: 'static + Render + WasmNotSend + Send + 
 		.downcast_ref::<RenderParams>()
 		.expect("Downcasting render params yielded invalid type");
 
-	let logical_footprint = *ctx.footprint();
-	let physical_footprint = Footprint {
-		transform: glam::DAffine2::from_scale(glam::DVec2::splat(render_params.scale)) * logical_footprint.transform,
-		..logical_footprint
-	};
-	let ctx = OwnedContextImpl::from(ctx.clone()).with_footprint(physical_footprint).into_context();
+	let ctx = OwnedContextImpl::from(ctx.clone()).into_context();
 	let data = data.eval(ctx).await;
 
 	let footprint = Footprint::default();
@@ -93,15 +88,17 @@ async fn render<'a: 'n>(
 	let mut render_params = render_params.clone();
 	render_params.footprint = *footprint;
 
+	let logical_transform = glam::DAffine2::from_scale(glam::DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
+
 	let RenderIntermediate { ty, mut metadata } = data;
-	metadata.apply_transform(footprint.transform);
+	metadata.apply_transform(logical_transform);
 
 	let data = match (render_params.render_output_type, ty) {
 		(RenderOutputTypeRequest::Svg, RenderIntermediateType::Svg(data)) => {
 			let logical_resolution = render_params.footprint.resolution.as_dvec2() / render_params.scale;
 
 			let mut render = SvgRender::from(data.as_ref());
-			render.wrap_with_transform(render_params.footprint.transform, Some(logical_resolution));
+			render.wrap_with_transform(logical_transform, Some(logical_resolution));
 
 			let output = SvgRenderOutput::from(render);
 			assert!(output.svg_defs.is_empty());
@@ -113,11 +110,9 @@ async fn render<'a: 'n>(
 		}
 		(RenderOutputTypeRequest::Vello, RenderIntermediateType::Vello(data)) => {
 			let (scene, context) = data.as_ref();
-			let scale = render_params.scale;
 			let physical_resolution = render_params.footprint.resolution;
 
-			let scale_transform = glam::DAffine2::from_scale(glam::DVec2::splat(scale));
-			let footprint_transform = scale_transform * render_params.footprint.transform;
+			let footprint_transform = render_params.footprint.transform;
 			let footprint_transform_vello = vello::kurbo::Affine::new(footprint_transform.to_cols_array());
 
 			let mut transformed_scene = vello::Scene::new();
@@ -157,11 +152,15 @@ async fn create_context<'a: 'n>(
 	render_config: RenderConfig,
 	data: impl Node<Context<'static>, Output = RenderOutput>,
 ) -> RenderOutput {
-	let footprint = render_config.viewport;
-
 	let render_output_type = match render_config.export_format {
 		ExportFormat::Svg => RenderOutputTypeRequest::Svg,
 		ExportFormat::Raster => RenderOutputTypeRequest::Vello,
+	};
+
+	let logical_viewport = render_config.viewport;
+	let footprint = Footprint {
+		transform: glam::DAffine2::from_scale(glam::DVec2::splat(render_config.scale)) * logical_viewport.transform,
+		..logical_viewport
 	};
 
 	let render_params = RenderParams {
@@ -169,7 +168,7 @@ async fn create_context<'a: 'n>(
 		for_export: render_config.for_export,
 		render_output_type,
 		scale: render_config.scale,
-		viewport_zoom: footprint.scale_magnitudes().x,
+		viewport_zoom: logical_viewport.scale_magnitudes().x,
 		..Default::default()
 	};
 

--- a/node-graph/nodes/gstd/src/render_node.rs
+++ b/node-graph/nodes/gstd/src/render_node.rs
@@ -1,6 +1,6 @@
 use core_types::list::List;
 use core_types::transform::{Footprint, Transform};
-use core_types::{CloneVarArgs, ExtractAll, ExtractVarArgs};
+use core_types::{CloneVarArgs, ExtractAll, ExtractVarArgs, InjectFootprint};
 use core_types::{Color, Context, Ctx, ExtractFootprint, OwnedContextImpl, WasmNotSend};
 use graph_craft::document::value::{RenderOutput, RenderOutputType};
 use graphene_application_io::{ExportFormat, RenderConfig};
@@ -24,7 +24,7 @@ pub struct RenderIntermediate {
 
 #[node_macro::node(category(""))]
 async fn render_intermediate<'a: 'n, T: 'static + Render + WasmNotSend + Send + Sync>(
-	ctx: impl Ctx + ExtractVarArgs + ExtractAll + CloneVarArgs,
+	ctx: impl Ctx + ExtractVarArgs + ExtractAll + CloneVarArgs + InjectFootprint,
 	#[implementations(
 		Context -> List<Artboard>,
 		Context -> List<Graphic>,
@@ -42,7 +42,12 @@ async fn render_intermediate<'a: 'n, T: 'static + Render + WasmNotSend + Send + 
 		.downcast_ref::<RenderParams>()
 		.expect("Downcasting render params yielded invalid type");
 
-	let ctx = OwnedContextImpl::from(ctx.clone()).into_context();
+	let logical_footprint = *ctx.footprint();
+	let physical_footprint = Footprint {
+		transform: glam::DAffine2::from_scale(glam::DVec2::splat(render_params.scale)) * logical_footprint.transform,
+		..logical_footprint
+	};
+	let ctx = OwnedContextImpl::from(ctx.clone()).with_footprint(physical_footprint).into_context();
 	let data = data.eval(ctx).await;
 
 	let footprint = Footprint::default();

--- a/node-graph/nodes/gstd/src/render_node.rs
+++ b/node-graph/nodes/gstd/src/render_node.rs
@@ -94,7 +94,7 @@ async fn render<'a: 'n>(
 	let data = match (render_params.render_output_type, ty) {
 		(RenderOutputTypeRequest::Svg, RenderIntermediateType::Svg(data)) => {
 			let logical_transform = glam::DAffine2::from_scale(glam::DVec2::splat(1.0 / render_params.scale)) * footprint.transform;
-			let logical_resolution = render_params.footprint.resolution.as_dvec2() / render_params.scale;
+			let logical_resolution = footprint.resolution.as_dvec2() / render_params.scale;
 
 			let mut render = SvgRender::from(data.as_ref());
 			render.wrap_with_transform(logical_transform, Some(logical_resolution));
@@ -109,10 +109,8 @@ async fn render<'a: 'n>(
 		}
 		(RenderOutputTypeRequest::Vello, RenderIntermediateType::Vello(data)) => {
 			let (scene, context) = data.as_ref();
-			let physical_resolution = render_params.footprint.resolution;
 
-			let footprint_transform = render_params.footprint.transform;
-			let footprint_transform_vello = vello::kurbo::Affine::new(footprint_transform.to_cols_array());
+			let footprint_transform_vello = vello::kurbo::Affine::new(footprint.transform.to_cols_array());
 
 			let mut transformed_scene = vello::Scene::new();
 			transformed_scene.append(scene, Some(footprint_transform_vello));
@@ -125,7 +123,7 @@ async fn render<'a: 'n>(
 			// the result is `-INFINITY`, which the old equality check missed; Vello then rasterized a unit rect with non-finite
 			// vertices, dropping the gradient and tanking performance. `!is_finite()` also covers NaN as a guard against future
 			// code paths where `matrix[0]` could land on `0 * INFINITY`.
-			let scaled_infinite_transform = vello::kurbo::Affine::scale_non_uniform(physical_resolution.x as f64, physical_resolution.y as f64);
+			let scaled_infinite_transform = vello::kurbo::Affine::scale_non_uniform(footprint.resolution.x as f64, footprint.resolution.y as f64);
 			for transform in transformed_scene.encoding_mut().transforms.iter_mut() {
 				if !transform.matrix[0].is_finite() {
 					*transform = vello_encoding::Transform::from_kurbo(&scaled_infinite_transform);
@@ -134,10 +132,10 @@ async fn render<'a: 'n>(
 
 			let texture = executor
 				.expect("GPU executor not available")
-				.render_vello_scene(&transformed_scene, physical_resolution, context, None)
+				.render_vello_scene(&transformed_scene, footprint.resolution, context, None)
 				.await
 				.expect("Failed to render Vello scene");
-			RenderOutputType::Texture(texture.into())
+			RenderOutputType::Texture(texture)
 		}
 		_ => unreachable!("Render node did not receive its requested data type"),
 	};

--- a/node-graph/nodes/gstd/src/render_pixel_preview.rs
+++ b/node-graph/nodes/gstd/src/render_pixel_preview.rs
@@ -21,7 +21,7 @@ pub async fn render_pixel_preview<'a: 'n>(
 	let physical_scale = render_params.scale;
 
 	let footprint = *ctx.footprint();
-	let viewport_zoom = footprint.scale_magnitudes().x * physical_scale;
+	let viewport_zoom = footprint.scale_magnitudes().x;
 
 	if render_params.render_mode != RenderMode::PixelPreview || !matches!(render_params.render_output_type, RenderOutputTypeRequest::Vello) || viewport_zoom <= 1. {
 		let context = OwnedContextImpl::from(ctx).into_context();
@@ -32,6 +32,7 @@ pub async fn render_pixel_preview<'a: 'n>(
 	let logical_resolution = physical_resolution.as_dvec2() / physical_scale;
 
 	let logical_footprint = Footprint {
+		transform: DAffine2::from_scale(DVec2::splat(1. / physical_scale)) * footprint.transform,
 		resolution: logical_resolution.as_uvec2().max(UVec2::ONE),
 		..footprint
 	};
@@ -45,7 +46,7 @@ pub async fn render_pixel_preview<'a: 'n>(
 	let upstream_resolution = upstream_size.as_uvec2().max(UVec2::ONE);
 
 	let upstream_footprint = Footprint {
-		transform: DAffine2::from_scale(DVec2::splat(1. / physical_scale)) * DAffine2::from_translation(-upstream_min),
+		transform: DAffine2::from_translation(-upstream_min),
 		resolution: upstream_resolution,
 		quality: footprint.quality,
 	};
@@ -55,7 +56,8 @@ pub async fn render_pixel_preview<'a: 'n>(
 
 	let RenderOutputType::Texture(ref source_texture) = result.data else { return result };
 
-	let transform = DAffine2::from_translation(-upstream_min) * footprint.transform.inverse() * DAffine2::from_scale(logical_resolution);
+	let logical_transform = DAffine2::from_scale(DVec2::splat(1. / physical_scale)) * footprint.transform;
+	let transform = DAffine2::from_translation(-upstream_min) * logical_transform.inverse() * DAffine2::from_scale(logical_resolution);
 
 	let resampled = pipeline
 		.run::<PixelPreview>(&PixelPreviewArgs {
@@ -69,7 +71,7 @@ pub async fn render_pixel_preview<'a: 'n>(
 
 	result
 		.metadata
-		.apply_transform(footprint.transform * DAffine2::from_translation(upstream_min) * DAffine2::from_scale(DVec2::splat(physical_scale)));
+		.apply_transform(logical_transform * DAffine2::from_translation(upstream_min) * DAffine2::from_scale(DVec2::splat(physical_scale)));
 
 	result
 }

--- a/node-graph/nodes/gstd/src/render_pixel_preview.rs
+++ b/node-graph/nodes/gstd/src/render_pixel_preview.rs
@@ -69,9 +69,7 @@ pub async fn render_pixel_preview<'a: 'n>(
 
 	result.data = RenderOutputType::Texture(resampled);
 
-	result
-		.metadata
-		.apply_transform(logical_transform * DAffine2::from_translation(upstream_min) * DAffine2::from_scale(DVec2::splat(physical_scale)));
+	result.metadata.apply_transform(footprint.transform * DAffine2::from_translation(upstream_min));
 
 	result
 }


### PR DESCRIPTION
The render node(s) pass along the logical instead of the physical scale as part of the footprint, leading to upstream nodes rendering at the wrong scale and producing textures of the wrong size.

wrong at 2.8x scale
<img width="326" height="381" alt="image" src="https://github.com/user-attachments/assets/c9a0c8c3-7378-4bf3-9482-0ff7c8086afd" />

correct at 2.8x scale
<img width="260" height="287" alt="image" src="https://github.com/user-attachments/assets/4a874461-211c-469f-8f45-2fb4abfc072e" />


The first Commit is a minimal fix.
The second makes the create context node responsible for converting the render configs footprint to physical scale and then passing that along. Things that explicitly require logical scale like metadata and svg rendering convert back to logical.

Both approaches work, @TrueDoctor any opinions?
I'm slightly in favor of the second.