### PR TITLE
Fix a previewed node's dashed output wire appearing at the wrong position

### DIFF
--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -4239,6 +4239,10 @@ impl NodeNetworkInterface {
 					}
 					NodeTypePersistentMetadata::Node(_) => {}
 				}
+				// Altering an export may move the connectors meaning the ports must be refreshed.
+				if matches!(input_connector, InputConnector::Export(_)) {
+					self.unload_import_export_ports(network_path)
+				}
 				self.unload_upstream_node_click_targets(vec![*upstream_node_id], network_path);
 				self.unload_stack_dependents(network_path);
 				self.try_set_upstream_to_chain(input_connector, network_path);

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -4241,7 +4241,7 @@ impl NodeNetworkInterface {
 				}
 				// Altering an export may move the connectors meaning the ports must be refreshed.
 				if matches!(input_connector, InputConnector::Export(_)) {
-					self.unload_import_export_ports(network_path)
+					self.unload_import_export_ports(network_path);
 				}
 				self.unload_upstream_node_click_targets(vec![*upstream_node_id], network_path);
 				self.unload_stack_dependents(network_path);


### PR DESCRIPTION
Closes #4279

Patch written by @0HyperCube in https://github.com/GraphiteEditor/Graphite/issues/4279#issue-4725500995