### PR TITLE
Hide node parameters connected to a NodeInput::Scope in the Properties panel

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_properties.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_properties.rs
@@ -2281,6 +2281,14 @@ pub(crate) fn generate_node_properties(node_id: NodeId, context: &mut NodeProper
 	} else {
 		let number_of_inputs = context.network_interface.number_of_inputs(&node_id, context.selection_network_path);
 		for input_index in 1..number_of_inputs {
+			// Hide inputs that are connected to a scope
+			if let Some(NodeInput::Scope(_)) = context
+				.network_interface
+				.input_from_connector(&InputConnector::node(node_id, input_index), context.selection_network_path)
+			{
+				continue;
+			}
+
 			let row = context.call_widget_override(&node_id, input_index).unwrap_or_else(|| {
 				let Some(implementation) = context.network_interface.implementation(&node_id, context.selection_network_path) else {
 					log::error!("Could not get implementation for node {node_id}");


### PR DESCRIPTION
<img width="373" height="138" alt="image" src="https://github.com/user-attachments/assets/2c4aff6d-035e-4789-95c4-f28d4778a897" />

<img width="461" height="159" alt="image" src="https://github.com/user-attachments/assets/8641fe22-5b9c-4557-8038-dbdf2a8550db" />
