### PR TITLE
Implement pasting nodes at cursor position in graph

### DIFF
--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -12,7 +12,9 @@ use crate::messages::portfolio::document::node_graph::document_node_definitions:
 use crate::messages::portfolio::document::node_graph::utility_types::{ContextMenuData, Direction, FrontendGraphDataType, NodeGraphErrorDiagnostic};
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::misc::GroupFolderType;
-use crate::messages::portfolio::document::utility_types::network_interface::{self, FlowType, InputConnector, NodeNetworkInterface, NodeTypePersistentMetadata, OutputConnector, Previewing};
+use crate::messages::portfolio::document::utility_types::network_interface::{
+	self, FlowType, InputConnector, LayerPosition, NodeNetworkInterface, NodePosition, NodeTemplate, NodeTypePersistentMetadata, OutputConnector, Previewing,
+};
 use crate::messages::portfolio::document::utility_types::nodes::{CollapsedLayers, LayerPanelEntry};
 use crate::messages::portfolio::document::utility_types::wires::{GraphWireStyle, WirePath, WirePathUpdate, build_vector_wire};
 use crate::messages::prelude::*;
@@ -776,6 +778,48 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					return;
 				}
 
+				// Get network path of node overlay
+				let Some(network_metadata) = network_interface.network_metadata(breadcrumb_network_path) else {
+					log::error!("Could not get network metadata in PasteNodes");
+					return;
+				};
+
+				let cursor_viewport_location = ipp.mouse.position;
+				let cursor_to_node_graph = network_metadata
+					.persistent_metadata
+					.navigation_metadata
+					.node_graph_to_viewport
+					.inverse()
+					.transform_point2(cursor_viewport_location);
+
+				// Sort the selected nodes by the new id so that we know which node was selected first
+				data.sort_by(|a, b| a.0.cmp(&b.0));
+
+				// Get position of the first node selected for copying that has an absolute position. Calculate paste offset from the cursor
+				// If no nodes with absolute position, then there is no offset from cursor
+				let copy_position_opt = data.iter().find_map(|(_, template)| match &template.persistent_node_metadata.node_type_metadata {
+					NodeTypePersistentMetadata::Layer(layer_metadata) => {
+						if let LayerPosition::Absolute(position) = &layer_metadata.position {
+							Some(position)
+						} else {
+							None
+						}
+					}
+					NodeTypePersistentMetadata::Node(node_metadata) => {
+						if let NodePosition::Absolute(position) = node_metadata.position() {
+							Some(position)
+						} else {
+							None
+						}
+					}
+				});
+
+				let copy_position = if let Some(position) = copy_position_opt { position } else { &IVec2::default() };
+				let graph_delta = IVec2::new(
+					((cursor_to_node_graph.x / 24.).round()) as i32 - copy_position.x,
+					((cursor_to_node_graph.y / 24.).round()) as i32 - copy_position.y,
+				);
+
 				responses.add(DocumentMessage::AddTransaction);
 
 				let new_ids: HashMap<_, _> = nodes.iter().map(|(id, _)| (*id, NodeId::new())).collect();
@@ -783,7 +827,10 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 				responses.add(NodeGraphMessage::AddNodes { nodes, new_ids: new_ids.clone() });
 
 				let nodes: Vec<_> = new_ids.values().copied().collect();
-				responses.add(NodeGraphMessage::SelectedNodesSet { nodes })
+				responses.add(NodeGraphMessage::SelectedNodesSet { nodes });
+
+				// Shift nodes based on offset
+				responses.add(NodeGraphMessage::ShiftSelectedNodesByAmount { graph_delta, rubber_band: true })
 			}
 			NodeGraphMessage::PointerDown {
 				shift_click,

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -793,7 +793,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					.transform_point2(cursor_viewport_location);
 
 				// Sort the selected nodes by the new id so that we know which node was selected first
-				data.sort_by(|a, b| a.0.cmp(&b.0));
+				data.sort_by_key(|a| a.0);
 
 				// Get position of the first node selected for copying that has an absolute position. Calculate paste offset from the cursor
 				// If no nodes with absolute position, then there is no offset from cursor

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -13,7 +13,7 @@ use crate::messages::portfolio::document::node_graph::utility_types::{ContextMen
 use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
 use crate::messages::portfolio::document::utility_types::misc::GroupFolderType;
 use crate::messages::portfolio::document::utility_types::network_interface::{
-	self, FlowType, InputConnector, LayerPosition, NodeNetworkInterface, NodePosition, NodeTemplate, NodeTypePersistentMetadata, OutputConnector, Previewing,
+	self, FlowType, InputConnector, LayerPosition, NodeNetworkInterface, NodePosition, NodeTypePersistentMetadata, OutputConnector, Previewing,
 };
 use crate::messages::portfolio::document::utility_types::nodes::{CollapsedLayers, LayerPanelEntry};
 use crate::messages::portfolio::document::utility_types::wires::{GraphWireStyle, WirePath, WirePathUpdate, build_vector_wire};
@@ -780,7 +780,7 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 
 				// Get network path of node overlay
 				let Some(network_metadata) = network_interface.network_metadata(breadcrumb_network_path) else {
-					log::error!("Could not get network metadata in PasteNodes");
+					log::error!("Could not get network metadata in InsertNodes");
 					return;
 				};
 
@@ -792,12 +792,9 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					.inverse()
 					.transform_point2(cursor_viewport_location);
 
-				// Sort the selected nodes by the new id so that we know which node was selected first
-				data.sort_by_key(|a| a.0);
-
 				// Get position of the first node selected for copying that has an absolute position. Calculate paste offset from the cursor
 				// If no nodes with absolute position, then there is no offset from cursor
-				let copy_position_opt = data.iter().find_map(|(_, template)| match &template.persistent_node_metadata.node_type_metadata {
+				let copy_position_opt = nodes.iter().find_map(|(_, template)| match &template.persistent_node_metadata.node_type_metadata {
 					NodeTypePersistentMetadata::Layer(layer_metadata) => {
 						if let LayerPosition::Absolute(position) = &layer_metadata.position {
 							Some(position)

--- a/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
+++ b/editor/src/messages/portfolio/document/node_graph/node_graph_message_handler.rs
@@ -814,10 +814,10 @@ impl<'a> MessageHandler<NodeGraphMessage, NodeGraphMessageContext<'a>> for NodeG
 					}
 				});
 
-				let copy_position = if let Some(position) = copy_position_opt { position } else { &IVec2::default() };
+				let copy_position = copy_position_opt.copied().unwrap_or_default();
 				let graph_delta = IVec2::new(
-					((cursor_to_node_graph.x / 24.).round()) as i32 - copy_position.x,
-					((cursor_to_node_graph.y / 24.).round()) as i32 - copy_position.y,
+					((cursor_to_node_graph.x / GRID_SIZE as f64).round()) as i32 - copy_position.x,
+					((cursor_to_node_graph.y / GRID_SIZE as f64).round()) as i32 - copy_position.y,
 				);
 
 				responses.add(DocumentMessage::AddTransaction);

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -7075,7 +7075,10 @@ pub fn collect_node_resources(node: &DocumentNode, out: &mut HashSet<ResourceId>
 
 #[cfg(test)]
 mod network_interface_tests {
-	use crate::test_utils::test_prelude::*;
+	use crate::{
+		messages::portfolio::document::utility_types::network_interface::{LayerPosition, NodePosition, NodeTypePersistentMetadata},
+		test_utils::test_prelude::*,
+	};
 	#[tokio::test]
 	async fn copy_isolated_node() {
 		let mut editor = EditorTestUtils::create();
@@ -7104,5 +7107,83 @@ mod network_interface_tests {
 			nodes.values().any(|other| *other == orignal),
 			"duplicated node should exist\nother nodes: {nodes:#?}\norignal {orignal:#?}"
 		);
+	}
+
+	#[tokio::test]
+	async fn copy_and_paste_nodes() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+		let rectangle = editor
+			.create_node_by_name_and_coordinates(DefinitionIdentifier::ProtoNode(graphene_std::vector::generator_nodes::rectangle::IDENTIFIER), (0, 0))
+			.await;
+		let circle = editor
+			.create_node_by_name_and_coordinates(DefinitionIdentifier::ProtoNode(graphene_std::vector::generator_nodes::circle::IDENTIFIER), (5, 5))
+			.await;
+		editor.handle_message(NodeGraphMessage::SelectedNodesSet { nodes: vec![circle, rectangle] }).await;
+		let frontend_messages = editor.handle_message(NodeGraphMessage::Copy).await;
+		let clipboard = frontend_messages
+			.into_iter()
+			.find_map(|msg| match msg {
+				FrontendMessage::TriggerClipboardWrite { content } => Some(content),
+				_ => None,
+			})
+			.expect("copy message should be dispatched");
+		println!("Clipboard: {clipboard}");
+		// Move mouse then paste at new location
+		let mouse_pos = (24.0, 24.0);
+
+		editor.move_mouse(mouse_pos.0, mouse_pos.1, ModifierKeys::empty(), MouseKeys::empty()).await;
+		editor.left_mousedown(mouse_pos.0, mouse_pos.1, ModifierKeys::empty()).await;
+		editor.left_mouseup(mouse_pos.0, mouse_pos.1, ModifierKeys::empty()).await;
+		editor
+			.handle_message(ClipboardMessage::ReadClipboard {
+				content: ClipboardContentRaw::Text(clipboard),
+			})
+			.await;
+
+		// For each pasted node, check that the change in position is based on the delta of the mouse position and original circle. The mouse position in grid coordinates is (1,1). Since the original
+		// circle is at (5,5), the new circle should be pasted at (1,1), and the new square should be pasted at (-4, -4). Because we preserve selection order, the first selected pasted node should be
+		// a circle, the second a rectangle.
+		let new_positions: Vec<&IVec2> = editor
+			.active_document()
+			.network_interface
+			.selected_nodes()
+			.selected_nodes()
+			.map(|node_id| {
+				let node_metadata = &editor
+					.active_document()
+					.network_interface
+					.document_network_metadata()
+					.persistent_metadata
+					.node_metadata
+					.get(node_id)
+					.expect("Node should exist")
+					.persistent_metadata
+					.node_type_metadata;
+				let new_position = match node_metadata {
+					NodeTypePersistentMetadata::Layer(layer_metadata) => {
+						if let LayerPosition::Absolute(position) = &layer_metadata.position {
+							Some(position)
+						} else {
+							None
+						}
+					}
+					NodeTypePersistentMetadata::Node(node_metadata) => {
+						if let NodePosition::Absolute(position) = node_metadata.position() {
+							Some(position)
+						} else {
+							None
+						}
+					}
+				}
+				.expect("Pasted node should have a position");
+				new_position
+			})
+			.collect();
+		println!("positions of pasted nodes: {:?}", new_positions);
+		// Check position of pasted circle
+		assert_eq!(new_positions[0], &IVec2::new(1, 1));
+		// Check position of pasted rectangle
+		assert_eq!(new_positions[1], &IVec2::new(-4, -4));
 	}
 }

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -6931,6 +6931,7 @@ impl NodePersistentMetadata {
 	pub fn new(position: NodePosition) -> Self {
 		Self { position }
 	}
+
 	pub fn position(&self) -> &NodePosition {
 		&self.position
 	}

--- a/editor/src/messages/portfolio/document/utility_types/network_interface.rs
+++ b/editor/src/messages/portfolio/document/utility_types/network_interface.rs
@@ -372,7 +372,7 @@ impl NodeNetworkInterface {
 	}
 
 	/// Creates a copy for each node by disconnecting nodes which are not connected to other copied nodes.
-	/// Returns an iterator of all persistent metadata for a node and their ids
+	/// Returns an iterator, sorted by original node id, of all persistent metadata for a node and their ids
 	pub fn copy_nodes<'a>(&'a mut self, new_ids: &'a HashMap<NodeId, NodeId>, network_path: &'a [NodeId]) -> impl Iterator<Item = (NodeId, NodeTemplate)> + 'a {
 		let mut new_nodes = new_ids
 			.iter()
@@ -442,6 +442,7 @@ impl NodeNetworkInterface {
 				}
 			}
 		}
+		new_nodes.sort_by_key(|a| a.0);
 		new_nodes.into_iter().map(move |(new, node_id, node)| (new, self.map_ids(node, &node_id, new_ids, network_path)))
 	}
 

--- a/editor/src/test_utils.rs
+++ b/editor/src/test_utils.rs
@@ -330,6 +330,18 @@ impl EditorTestUtils {
 		.await;
 		node_id
 	}
+
+	pub async fn create_node_by_name_and_coordinates(&mut self, node_type: DefinitionIdentifier, xy: (i32, i32)) -> NodeId {
+		let node_id = NodeId::new();
+		self.handle_message(NodeGraphMessage::CreateNodeFromContextMenu {
+			node_id: Some(node_id),
+			node_type,
+			xy: Some(xy),
+			add_transaction: true,
+		})
+		.await;
+		node_id
+	}
 }
 
 pub trait FrontendMessageTestUtils {


### PR DESCRIPTION
<!--
Graphite has ZERO-TOLERANCE for contributing undisclosed AI-generated content.
If your PR involves AI, you must read our AI contribution policy (it's short):
https://graphite.art/volunteer/guide/starting-a-task/ai-contribution-policy

REMEMBER:
- You are responsible for thoroughly testing the successful implementation of your changes and ensuring no obvious regressions occur.
- Egregiously dysfunctional PRs may be assumed to be undisclosed AI slop. If in doubt, ask on Discord before attempting a PR.
- You are highly recommended to include a video showing the before-and-after behavior of your changes and screenshots of any new or modified UI.
- Remember that Graphite maintains high standards for quality and the project is not a classroom for inexperienced developers to gain industry experience.
- In this PR description, reference any relevant tasks by writing "Closes", "Resolves", or "Fixes" with the issue # or the URL of a Discord message documenting the task.
- To acknowledge that you've read this, you must delete these rules and fill in the (strictly human-written) PR description in its place.
-->

Closes #3798 

This PR implements cursor-based paste by calculating the offset of the first selected node to be copied from the location of the most recent click. The following changes were added:

1. The copied nodes are sorted by new id, so that we know the selection order of the nodes.
2. Calculate the difference between the mouse position (`ipp.mouse.position`) and the location of the first selected node.
3. Add the nodes to the graph (`NodeGraphMessage::AddNodes`), and then shift by the offset  (`NodeGraphMessage::ShiftSelectedNodesByAmount`)

One thing I'm not sure about is that one needs to actually click the desired paste location in order for `ipp.mouse.position` to update. Is there another something else tracking the cursor location?

Here's two examples of copy and paste

First we select the Transform node at (-15,3) as well as the Path node.

<img width="1838" height="1098" alt="initial copy" src="https://github.com/user-attachments/assets/2e9a8f1c-09d0-4b4a-a016-d113444f96c8" />

Next, I click (-16,4) based on eyeballing the grid, then paste the nodes with Ctrl+v. The Transform node is pasted to (-16,4), while the pasted Path node maintains the relative distance to the Transform node, without any wires to the Transform node.

<img width="1106" height="956" alt="paste1" src="https://github.com/user-attachments/assets/9c711cbb-b7c6-4750-9e3b-fc49a2e4dcfc" />

Next, I select Stroke -> Transform -> Path and then copy the nodes. Stroke is at (-22, 3).

<img width="1114" height="1074" alt="second copy" src="https://github.com/user-attachments/assets/a9ead154-33ed-4fc4-b0dd-658de890f2be" />

Finally, I click at (-16, 8) then paste with Ctrl+v. We paste Stroke node at (-16, 8), and the other selected nodes are copied as well with wires maintained.

<img width="1094" height="1054" alt="paste2" src="https://github.com/user-attachments/assets/7f2bb158-eff8-443e-b988-54f6326cbf57" />