### PR TITLE
Test all workspace crates in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
     if: needs.skip-check.outputs.skip != 'true'
     runs-on: [self-hosted, target/native]
     env:
-      RUSTC_WRAPPER: /usr/bin/sccache
+      RUSTC_WRAPPER: ""
       CARGO_INCREMENTAL: 0
       SCCACHE_DIR: /var/lib/github-actions/.cache
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,7 +58,7 @@ jobs:
       - name: 🧪 Run Rust tests
         env:
           # `--cfg=web_sys_unstable_apis` mirrors the `[build]` section of `.cargo/config.toml`
-          RUSTFLAGS: "-Dwarnings --cfg=web_sys_unstable_apis"
+          RUSTFLAGS: "-Dwarnings --cfg=web_sys_unstable_apis --cfg=skip_desktop_license_embed"
         run: mold -run cargo test --workspace --all-features
 
   # Rust format check on GitHub runner

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
     if: needs.skip-check.outputs.skip != 'true'
     runs-on: [self-hosted, target/native]
     env:
-      RUSTC_WRAPPER: ""
+      RUSTC_WRAPPER: /usr/bin/sccache
       CARGO_INCREMENTAL: 0
       SCCACHE_DIR: /var/lib/github-actions/.cache
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           # `--cfg=web_sys_unstable_apis` mirrors the `[build]` section of `.cargo/config.toml`
           RUSTFLAGS: "-Dwarnings --cfg=web_sys_unstable_apis --cfg=skip_desktop_license_embed"
+          RUSTDOCFLAGS: "--cfg=skip_desktop_license_embed"
         run: mold -run cargo test --workspace --all-features
 
   # Rust format check on GitHub runner

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           # `--cfg=web_sys_unstable_apis` mirrors the `[build]` section of `.cargo/config.toml`
           RUSTFLAGS: "-Dwarnings --cfg=web_sys_unstable_apis"
-        run: mold -run cargo test --all-features
+        run: mold -run cargo test --workspace --all-features
 
   # Rust format check on GitHub runner
   rust-fmt:

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -74,3 +74,8 @@ objc2 = { version = "0.6.1", default-features = false }
 objc2-foundation = { version = "0.3.2", default-features = false }
 objc2-app-kit = { version = "0.3.2", default-features = false }
 muda = { git = "https://github.com/timon-schelling/muda.git", rev = "e5bc28bbd6781b18afbfc237981f9ef47eddf863", default-features = false }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(skip_desktop_license_embed)',
+] }

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,7 +1,6 @@
 use rand::Rng;
 use rfd::AsyncFileDialog;
 use std::fs;
-use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -399,16 +398,27 @@ impl App {
 				self.exit(Some(ExitReason::Restart));
 			}
 			DesktopFrontendMessage::LoadThirdPartyLicenses => {
-				let compressed = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/third-party-licenses.txt.xz"));
-				let mut reader = lzma_rust2::XzReader::new(compressed.as_slice(), false);
-				let mut text = String::new();
-				if let Err(e) = reader.read_to_string(&mut text) {
-					tracing::error!("Failed to decompress third-party licenses: {e}");
+				#[cfg(skip_desktop_license_embed)]
+				{
+					tracing::info!("Third-party licenses are not embedded in test builds");
 					return;
 				}
 
-				let message = DesktopWrapperMessage::LoadThirdPartyLicenses { text };
-				responses.push(message);
+				#[cfg(not(skip_desktop_license_embed))]
+				{
+					use std::io::Read;
+
+					let compressed = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/third-party-licenses.txt.xz"));
+					let mut reader = lzma_rust2::XzReader::new(compressed.as_slice(), false);
+					let mut text = String::new();
+					if let Err(e) = reader.read_to_string(&mut text) {
+						tracing::error!("Failed to decompress third-party licenses: {e}");
+						return;
+					}
+
+					let message = DesktopWrapperMessage::LoadThirdPartyLicenses { text };
+					responses.push(message);
+				}
 			}
 		}
 	}

--- a/node-graph/graphene-cli/src/main.rs
+++ b/node-graph/graphene-cli/src/main.rs
@@ -7,7 +7,6 @@ use document_format::{GddV1, GddV1Layout};
 use fern::colors::{Color, ColoredLevelConfig};
 use futures::executor::block_on;
 use graph_craft::application_io::EditorPreferences;
-use graph_craft::application_io::resource::ResourceRegistry;
 use graph_craft::application_io::{PlatformApplicationIo, PlatformEditorApi};
 use graph_craft::document::*;
 use graph_craft::graphene_compiler::Compiler;


### PR DESCRIPTION
Introduce a custom cfg `skip_desktop_license_embed` because `cfg(test)` is false when this crate is compiled as a dependency of another crate.