### PR TITLE
Parametric curve plot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6476,6 +6476,7 @@ dependencies = [
  "graphic-types",
  "kurbo",
  "log",
+ "math-parser",
  "node-macro",
  "qrcodegen",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6632,6 +6632,7 @@ dependencies = [
  "graphic-types",
  "kurbo",
  "log",
+ "math-parser",
  "node-macro",
  "qrcodegen",
  "rand",

--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -457,6 +457,10 @@ pub fn get_spiral_id(layer: LayerNodeIdentifier, network_interface: &NodeNetwork
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::spiral::IDENTIFIER))
 }
 
+pub fn get_function_plot_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
+	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::function_plot::IDENTIFIER))
+}
+
 pub fn get_text_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::text::text::IDENTIFIER))
 }

--- a/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
+++ b/editor/src/messages/tool/common_functionality/graph_modification_utils.rs
@@ -583,6 +583,10 @@ pub fn get_spiral_id(layer: LayerNodeIdentifier, network_interface: &NodeNetwork
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::spiral::IDENTIFIER))
 }
 
+pub fn get_function_plot_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
+	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::vector_nodes::function_plot::IDENTIFIER))
+}
+
 pub fn get_text_id(layer: LayerNodeIdentifier, network_interface: &NodeNetworkInterface) -> Option<NodeId> {
 	NodeGraphLayer::new(layer, network_interface).upstream_node_id_from_name(&DefinitionIdentifier::ProtoNode(graphene_std::text::text::IDENTIFIER))
 }

--- a/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
@@ -1,0 +1,55 @@
+use super::shape_utility::ShapeToolModifierKey;
+use super::*;
+use crate::messages::portfolio::document::graph_operation::utility_types::TransformIn;
+use crate::messages::portfolio::document::node_graph::document_node_definitions::resolve_proto_node_type;
+use crate::messages::portfolio::document::utility_types::document_metadata::LayerNodeIdentifier;
+use crate::messages::portfolio::document::utility_types::network_interface::{InputConnector, NodeTemplate};
+use crate::messages::tool::common_functionality::graph_modification_utils;
+use crate::messages::tool::tool_messages::tool_prelude::*;
+use glam::DAffine2;
+use graph_craft::document::NodeInput;
+use graph_craft::document::value::TaggedValue;
+use std::collections::VecDeque;
+
+#[derive(Default)]
+pub struct FunctionPlot;
+
+impl FunctionPlot {
+	pub fn create_node() -> NodeTemplate {
+		let node_type = resolve_proto_node_type(graphene_std::vector::plot_nodes::function_plot::IDENTIFIER).expect("Function Plot node can't be found");
+		node_type.node_template_input_override([None, Some(NodeInput::value(TaggedValue::F64(0.5), false)), Some(NodeInput::value(TaggedValue::F64(0.5), false))])
+	}
+
+	pub fn update_shape(
+		document: &DocumentMessageHandler,
+		ipp: &InputPreprocessorMessageHandler,
+		viewport: &ViewportMessageHandler,
+		layer: LayerNodeIdentifier,
+		shape_tool_data: &mut ShapeToolData,
+		modifier: ShapeToolModifierKey,
+		responses: &mut VecDeque<Message>,
+	) {
+		let [center, lock_ratio, _] = modifier;
+
+		if let Some([start, end]) = shape_tool_data.data.calculate_points(document, ipp, viewport, center, lock_ratio) {
+			let Some(node_id) = graph_modification_utils::get_function_plot_id(layer, &document.network_interface) else {
+				return;
+			};
+
+			responses.add(NodeGraphMessage::SetInput {
+				input_connector: InputConnector::node(node_id, 1),
+				input: NodeInput::value(TaggedValue::F64((start.x - end.x).abs()), false),
+			});
+			responses.add(NodeGraphMessage::SetInput {
+				input_connector: InputConnector::node(node_id, 2),
+				input: NodeInput::value(TaggedValue::F64((start.y - end.y).abs()), false),
+			});
+			responses.add(GraphOperationMessage::TransformSet {
+				layer,
+				transform: DAffine2::from_translation(start.midpoint(end)),
+				transform_in: TransformIn::Viewport,
+				skip_rerender: false,
+			});
+		}
+	}
+}

--- a/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
@@ -36,6 +36,14 @@ impl FunctionPlot {
 				return;
 			};
 
+			// We want viewport zoom independent size and 1 scalefactor
+			let document_to_viewport = document
+				.navigation_handler
+				.calculate_offset_transform(viewport.center_in_viewport_space().into(), &document.document_ptz);
+
+			let start = document_to_viewport.inverse().transform_point2(start);
+			let end = document_to_viewport.inverse().transform_point2(end);
+
 			responses.add(NodeGraphMessage::SetInput {
 				input_connector: InputConnector::node(node_id, 1),
 				input: NodeInput::value(TaggedValue::F64((start.x - end.x).abs()), false),
@@ -47,7 +55,7 @@ impl FunctionPlot {
 			responses.add(GraphOperationMessage::TransformSet {
 				layer,
 				transform: DAffine2::from_translation(start.midpoint(end)),
-				transform_in: TransformIn::Viewport,
+				transform_in: TransformIn::Local,
 				skip_rerender: false,
 			});
 		}

--- a/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/function_plot.rs
@@ -45,11 +45,11 @@ impl FunctionPlot {
 			let end = document_to_viewport.inverse().transform_point2(end);
 
 			responses.add(NodeGraphMessage::SetInput {
-				input_connector: InputConnector::node(node_id, 1),
+				input_connector: InputConnector::node(node_id, graphene_std::vector::plot_nodes::function_plot::WidthInput),
 				input: NodeInput::value(TaggedValue::F64((start.x - end.x).abs()), false),
 			});
 			responses.add(NodeGraphMessage::SetInput {
-				input_connector: InputConnector::node(node_id, 2),
+				input_connector: InputConnector::node(node_id, graphene_std::vector::plot_nodes::function_plot::HeightInput),
 				input: NodeInput::value(TaggedValue::F64((start.y - end.y).abs()), false),
 			});
 			responses.add(GraphOperationMessage::TransformSet {

--- a/editor/src/messages/tool/common_functionality/shapes/mod.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/mod.rs
@@ -2,6 +2,7 @@ pub mod arc_shape;
 pub mod arrow_shape;
 pub mod circle_shape;
 pub mod ellipse_shape;
+pub mod function_plot;
 pub mod grid_shape;
 pub mod line_shape;
 pub mod polygon_shape;

--- a/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
+++ b/editor/src/messages/tool/common_functionality/shapes/shape_utility.rs
@@ -35,6 +35,7 @@ pub enum ShapeType {
 	Spiral,
 	Grid,
 	Arrow,
+	FunctionPlot,
 	Line,      // KEEP THIS AT THE END
 	Rectangle, // KEEP THIS AT THE END
 	Ellipse,   // KEEP THIS AT THE END
@@ -50,6 +51,7 @@ impl ShapeType {
 		ShapeType::Spiral,
 		ShapeType::Grid,
 		ShapeType::Arrow,
+		ShapeType::FunctionPlot,
 		ShapeType::Line,      // KEEP THIS AT THE END
 		ShapeType::Rectangle, // KEEP THIS AT THE END
 		ShapeType::Ellipse,   // KEEP THIS AT THE END
@@ -70,6 +72,7 @@ impl ShapeType {
 			Self::Spiral => "Spiral",
 			Self::Grid => "Grid",
 			Self::Arrow => "Arrow",
+			Self::FunctionPlot => "Function Plot",
 			Self::Line => "Line",           // KEEP THIS AT THE END
 			Self::Rectangle => "Rectangle", // KEEP THIS AT THE END
 			Self::Ellipse => "Ellipse",     // KEEP THIS AT THE END

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -15,6 +15,7 @@ use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::shapes::arc_shape::Arc;
 use crate::messages::tool::common_functionality::shapes::arrow_shape::Arrow;
 use crate::messages::tool::common_functionality::shapes::circle_shape::Circle;
+use crate::messages::tool::common_functionality::shapes::function_plot::FunctionPlot;
 use crate::messages::tool::common_functionality::shapes::grid_shape::Grid;
 use crate::messages::tool::common_functionality::shapes::line_shape::LineToolData;
 use crate::messages::tool::common_functionality::shapes::polygon_shape::Polygon;
@@ -30,6 +31,7 @@ use crate::messages::tool::utility_types::DocumentToolData;
 use graph_craft::document::NodeId;
 use graph_craft::document::value::TaggedValue;
 use graphene_std::renderer::Quad;
+use graphene_std::vector::function_plot;
 use graphene_std::vector::misc::{ArcType, GridType, SpiralType};
 use graphene_std::vector::style::FillChoice;
 use graphene_std::{Color, NodeInputDecleration};
@@ -212,6 +214,12 @@ fn create_shape_option_widget(shape_type: ShapeType) -> WidgetInstance {
 			}
 			.into()
 		}),
+		MenuListEntry::new("FunctionPlot").label("Function Plot").on_commit(move |_| {
+			ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::ShapeType(ShapeType::FunctionPlot),
+			}
+			.into()
+		}),
 	]];
 	DropdownInput::new(entries).selected_index(Some(shape_type as u32)).widget_instance()
 }
@@ -347,6 +355,7 @@ fn sync_shape_options_from_selection(options: &mut ShapeToolOptions, tool_data: 
 		(spiral::IDENTIFIER, ShapeType::Spiral),
 		(grid::IDENTIFIER, ShapeType::Grid),
 		(arrow::IDENTIFIER, ShapeType::Arrow),
+		(function_plot::IDENTIFIER, ShapeType::FunctionPlot),
 	]
 	.into_iter()
 	.find_map(|(id, shape)| layer_view.upstream_node_id_from_name(&proto(id)).map(|_| shape)) else {
@@ -430,7 +439,7 @@ fn sync_shape_options_from_selection(options: &mut ShapeToolOptions, tool_data: 
 				changed = true;
 			}
 		}
-		ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle => {}
+		ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle | ShapeType::FunctionPlot => {}
 	}
 
 	changed
@@ -1116,7 +1125,15 @@ impl Fsm for ShapeToolFsmState {
 				};
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::FunctionPlot => {
 						tool_data.data.start(document, input, viewport);
 					}
 					ShapeType::Arrow | ShapeType::Line => {
@@ -1139,6 +1156,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::create_node(tool_options.spiral_type, tool_options.turns),
 					ShapeType::Grid => Grid::create_node(tool_options.grid_type),
 					ShapeType::Arrow => Arrow::create_node(tool_options.arrow_shaft_width, tool_options.arrow_head_width, tool_options.arrow_head_length),
+					ShapeType::FunctionPlot => FunctionPlot::create_node(),
 					ShapeType::Line => Line::create_node(),
 					ShapeType::Rectangle => Rectangle::create_node(),
 					ShapeType::Ellipse => Ellipse::create_node(),
@@ -1150,7 +1168,15 @@ impl Fsm for ShapeToolFsmState {
 				let defered_responses = &mut VecDeque::new();
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::FunctionPlot => {
 						defered_responses.add(GraphOperationMessage::TransformSet {
 							layer,
 							transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
@@ -1212,6 +1238,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::update_shape(document, input, viewport, layer, tool_data, responses),
 					ShapeType::Grid => Grid::update_shape(document, input, layer, tool_options.grid_type, tool_data, modifier, responses),
 					ShapeType::Arrow => Arrow::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
+					ShapeType::FunctionPlot => FunctionPlot::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Line => Line::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Rectangle => Rectangle::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Ellipse => Ellipse::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
@@ -1464,6 +1491,11 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
 					HintInfo::keys([Key::Control], "Lock Angle").prepend_plus(),
 				])],
+				ShapeType::FunctionPlot => vec![HintGroup(vec![
+					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Boundary"),
+					HintInfo::keys([Key::Shift], "Constrain Square").prepend_plus(),
+					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
+				])],
 				ShapeType::Line => vec![HintGroup(vec![
 					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Line"),
 					HintInfo::keys([Key::Shift], "15° Increments").prepend_plus(),
@@ -1488,7 +1520,7 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 			let tool_hint_group = match shape {
 				ShapeType::Polygon | ShapeType::Star | ShapeType::Arc => HintGroup(vec![HintInfo::keys([Key::Shift], "Constrain Regular"), HintInfo::keys([Key::Alt], "From Center")]),
 				ShapeType::Circle => HintGroup(vec![HintInfo::keys([Key::Alt], "From Center")]),
-				ShapeType::Spiral => HintGroup(vec![]),
+				ShapeType::Spiral | ShapeType::FunctionPlot => HintGroup(vec![]),
 				ShapeType::Grid => HintGroup(vec![HintInfo::keys([Key::Shift], "Constrain Regular"), HintInfo::keys([Key::Alt], "From Center")]),
 				ShapeType::Arrow => HintGroup(vec![
 					HintInfo::keys([Key::Shift], "15° Increments"),

--- a/editor/src/messages/tool/tool_messages/shape_tool.rs
+++ b/editor/src/messages/tool/tool_messages/shape_tool.rs
@@ -15,6 +15,7 @@ use crate::messages::tool::common_functionality::resize::Resize;
 use crate::messages::tool::common_functionality::shapes::arc_shape::Arc;
 use crate::messages::tool::common_functionality::shapes::arrow_shape::Arrow;
 use crate::messages::tool::common_functionality::shapes::circle_shape::Circle;
+use crate::messages::tool::common_functionality::shapes::function_plot::FunctionPlot;
 use crate::messages::tool::common_functionality::shapes::grid_shape::Grid;
 use crate::messages::tool::common_functionality::shapes::line_shape::LineToolData;
 use crate::messages::tool::common_functionality::shapes::polygon_shape::Polygon;
@@ -30,6 +31,7 @@ use crate::messages::tool::utility_types::DocumentToolData;
 use graph_craft::document::NodeId;
 use graph_craft::document::value::TaggedValue;
 use graphene_std::renderer::Quad;
+use graphene_std::vector::function_plot;
 use graphene_std::vector::misc::{ArcType, GridType, SpiralType};
 use graphene_std::vector::style::FillChoice;
 use graphene_std::{Color, ParameterRef};
@@ -212,6 +214,12 @@ fn create_shape_option_widget(shape_type: ShapeType) -> WidgetInstance {
 			}
 			.into()
 		}),
+		MenuListEntry::new("FunctionPlot").label("Function Plot").on_commit(move |_| {
+			ShapeToolMessage::UpdateOptions {
+				options: ShapeOptionsUpdate::ShapeType(ShapeType::FunctionPlot),
+			}
+			.into()
+		}),
 	]];
 	DropdownInput::new(entries).selected_index(Some(shape_type as u32)).widget_instance()
 }
@@ -325,6 +333,7 @@ fn sync_shape_options_from_selection(options: &mut ShapeToolOptions, tool_data: 
 		(spiral::IDENTIFIER, ShapeType::Spiral),
 		(grid::IDENTIFIER, ShapeType::Grid),
 		(arrow::IDENTIFIER, ShapeType::Arrow),
+		(function_plot::IDENTIFIER, ShapeType::FunctionPlot),
 	]
 	.into_iter()
 	.find_map(|(id, shape)| layer_view.upstream_node_id_from_name(&proto(id)).map(|_| shape)) else {
@@ -407,7 +416,7 @@ fn sync_shape_options_from_selection(options: &mut ShapeToolOptions, tool_data: 
 				changed = true;
 			}
 		}
-		ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle => {}
+		ShapeType::Ellipse | ShapeType::Rectangle | ShapeType::Line | ShapeType::Circle | ShapeType::FunctionPlot => {}
 	}
 
 	changed
@@ -1088,7 +1097,15 @@ impl Fsm for ShapeToolFsmState {
 				};
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::FunctionPlot => {
 						tool_data.data.start(document, input, viewport);
 					}
 					ShapeType::Arrow | ShapeType::Line => {
@@ -1111,6 +1128,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::create_node(tool_options.spiral_type, tool_options.turns),
 					ShapeType::Grid => Grid::create_node(tool_options.grid_type),
 					ShapeType::Arrow => Arrow::create_node(tool_options.arrow_shaft_width, tool_options.arrow_head_width, tool_options.arrow_head_length),
+					ShapeType::FunctionPlot => FunctionPlot::create_node(),
 					ShapeType::Line => Line::create_node(),
 					ShapeType::Rectangle => Rectangle::create_node(),
 					ShapeType::Ellipse => Ellipse::create_node(),
@@ -1122,7 +1140,15 @@ impl Fsm for ShapeToolFsmState {
 				let defered_responses = &mut VecDeque::new();
 
 				match tool_data.current_shape {
-					ShapeType::Polygon | ShapeType::Star | ShapeType::Circle | ShapeType::Arc | ShapeType::Spiral | ShapeType::Grid | ShapeType::Rectangle | ShapeType::Ellipse => {
+					ShapeType::Polygon
+					| ShapeType::Star
+					| ShapeType::Circle
+					| ShapeType::Arc
+					| ShapeType::Spiral
+					| ShapeType::Grid
+					| ShapeType::Rectangle
+					| ShapeType::Ellipse
+					| ShapeType::FunctionPlot => {
 						defered_responses.add(GraphOperationMessage::TransformSet {
 							layer,
 							transform: DAffine2::from_scale_angle_translation(DVec2::ONE, 0., input.mouse.position),
@@ -1186,6 +1212,7 @@ impl Fsm for ShapeToolFsmState {
 					ShapeType::Spiral => Spiral::update_shape(document, input, viewport, layer, tool_data, responses),
 					ShapeType::Grid => Grid::update_shape(document, input, layer, tool_options.grid_type, tool_data, modifier, responses),
 					ShapeType::Arrow => Arrow::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
+					ShapeType::FunctionPlot => FunctionPlot::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Line => Line::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Rectangle => Rectangle::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
 					ShapeType::Ellipse => Ellipse::update_shape(document, input, viewport, layer, tool_data, modifier, responses),
@@ -1438,6 +1465,11 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
 					HintInfo::keys([Key::Control], "Lock Angle").prepend_plus(),
 				])],
+				ShapeType::FunctionPlot => vec![HintGroup(vec![
+					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Boundary"),
+					HintInfo::keys([Key::Shift], "Constrain Square").prepend_plus(),
+					HintInfo::keys([Key::Alt], "From Center").prepend_plus(),
+				])],
 				ShapeType::Line => vec![HintGroup(vec![
 					HintInfo::mouse(MouseMotion::LmbDrag, "Draw Line"),
 					HintInfo::keys([Key::Shift], "15° Increments").prepend_plus(),
@@ -1462,7 +1494,7 @@ fn update_dynamic_hints(state: &ShapeToolFsmState, responses: &mut VecDeque<Mess
 			let tool_hint_group = match shape {
 				ShapeType::Polygon | ShapeType::Star | ShapeType::Arc => HintGroup(vec![HintInfo::keys([Key::Shift], "Constrain Regular"), HintInfo::keys([Key::Alt], "From Center")]),
 				ShapeType::Circle => HintGroup(vec![HintInfo::keys([Key::Alt], "From Center")]),
-				ShapeType::Spiral => HintGroup(vec![]),
+				ShapeType::Spiral | ShapeType::FunctionPlot => HintGroup(vec![]),
 				ShapeType::Grid => HintGroup(vec![HintInfo::keys([Key::Shift], "Constrain Regular"), HintInfo::keys([Key::Alt], "From Center")]),
 				ShapeType::Arrow => HintGroup(vec![
 					HintInfo::keys([Key::Shift], "15° Increments"),

--- a/libraries/math-parser/src/constants.rs
+++ b/libraries/math-parser/src/constants.rs
@@ -64,7 +64,7 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invsin",
+			"asin",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.asin()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.asin()))),
@@ -73,7 +73,7 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invcos",
+			"acos",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.acos()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.acos()))),
@@ -82,7 +82,7 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invtan",
+			"atan",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.atan()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.atan()))),
@@ -91,7 +91,7 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invcsc",
+			"acsc",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.recip().asin()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.recip().asin()))),
@@ -100,7 +100,7 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invsec",
+			"asec",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.recip().acos()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.recip().acos()))),
@@ -109,10 +109,129 @@ lazy_static! {
 		);
 
 		map.insert(
-			"invcot",
+			"acot",
 			Box::new(|values| match values {
 				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real((PI / 2. - real).atan()))),
 				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex((Complex::new(PI / 2., 0.) - complex).atan()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"ln",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.ln()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.ln()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"log",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.log10()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.log10()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"exp",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.exp()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.exp()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"abs",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.abs()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Real(complex.norm()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"floor",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.floor()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"ceil",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.ceil()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"round",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.round()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"min",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(a)), Value::Number(Number::Real(b))] => Some(Value::Number(Number::Real(a.min(*b)))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"max",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(a)), Value::Number(Number::Real(b))] => Some(Value::Number(Number::Real(a.max(*b)))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"atan2",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(y)), Value::Number(Number::Real(x))] => Some(Value::Number(Number::Real(y.atan2(*x)))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"sign",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.signum()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"sinh",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.sinh()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.sinh()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"cosh",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.cosh()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.cosh()))),
+				_ => None,
+			}),
+		);
+
+		map.insert(
+			"tanh",
+			Box::new(|values| match values {
+				[Value::Number(Number::Real(real))] => Some(Value::Number(Number::Real(real.tanh()))),
+				[Value::Number(Number::Complex(complex))] => Some(Value::Number(Number::Complex(complex.tanh()))),
 				_ => None,
 			}),
 		);

--- a/node-graph/nodes/vector/Cargo.toml
+++ b/node-graph/nodes/vector/Cargo.toml
@@ -24,6 +24,7 @@ repeat-nodes = { workspace = true }
 dyn-any = { workspace = true }
 glam = { workspace = true }
 kurbo = { workspace = true }
+math-parser = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 log = { workspace = true }

--- a/node-graph/nodes/vector/Cargo.toml
+++ b/node-graph/nodes/vector/Cargo.toml
@@ -25,6 +25,7 @@ dyn-any = { workspace = true }
 glam = { workspace = true }
 kurbo = { workspace = true }
 delaunator = { workspace = true }
+math-parser = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 log = { workspace = true }

--- a/node-graph/nodes/vector/src/lib.rs
+++ b/node-graph/nodes/vector/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod generator_nodes;
 pub mod merge_qr_squares;
+pub mod plot_nodes;
 pub mod vector_modification_nodes;
 mod vector_nodes;
 
@@ -10,6 +11,7 @@ extern crate log;
 pub use core_types as gcore;
 pub use generator_nodes::*;
 pub use graphic_types;
+pub use plot_nodes::*;
 pub use vector_modification_nodes::*;
 pub use vector_nodes::*;
 pub use vector_types;

--- a/node-graph/nodes/vector/src/lib.rs
+++ b/node-graph/nodes/vector/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod generator_nodes;
 pub mod merge_qr_squares;
+pub mod plot_nodes;
 pub mod vector_modification_nodes;
 mod vector_nodes;
 mod voronoi;
@@ -11,6 +12,7 @@ extern crate log;
 pub use core_types as gcore;
 pub use generator_nodes::*;
 pub use graphic_types;
+pub use plot_nodes::*;
 pub use vector_modification_nodes::*;
 pub use vector_nodes::*;
 pub use vector_types;

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -1,0 +1,214 @@
+use core_types::Ctx;
+use core_types::list::List;
+use glam::DVec2;
+use graphic_types::Vector;
+use log::warn;
+use math_parser::ast;
+use math_parser::context::{EvalContext, NothingMap, ValueProvider};
+use math_parser::value::Value;
+use std::collections::{HashMap, HashSet};
+use vector_types::subpath;
+
+struct PlotContext<'a> {
+	values: &'a HashMap<String, f64>,
+}
+
+impl ValueProvider for PlotContext<'_> {
+	fn get_value(&self, name: &str) -> Option<Value> {
+		self.values.get(name).map(|v| Value::from_f64(*v))
+	}
+}
+
+/// Plots a parametric curve.
+#[node_macro::node(category("Vector: Shape"))]
+fn function_plot(
+	_: impl Ctx,
+	_primary: (),
+	/// Width of the plot's bounding box
+	#[unit(" px")]
+	#[default(100)]
+	width: f64,
+	/// Height of the plot's bounding box
+	#[unit(" px")]
+	#[default(100)]
+	height: f64,
+	/// A math expression for x(t). For y = f(x) functions simply enter x.
+	#[default(sin(t + pi / 2))]
+	x_expression: String,
+	/// A math expression for y(t). For y = f(x) functions simply enter f(x).
+	#[default(sin(2 * t))]
+	y_expression: String,
+	/// Minimum value for the parameter to evaluate.
+	#[default(-1.)]
+	parameter_min_value: f64,
+	/// Maximum value for the parameter to evaluate.
+	#[default(1.)]
+	parameter_max_value: f64,
+	/// How many samples should we take
+	#[default(100)]
+	sample_count: u32,
+	/// Auto close
+	#[default(true)]
+	auto_close: bool,
+) -> List<Vector> {
+	let mut list = List::new();
+
+	let (x_node, _unit) = match ast::Node::try_parse_from_str(&x_expression) {
+		Ok(expr) => expr,
+		Err(e) => {
+			warn!("Invalid expression: `{x_expression}`\n{e:?}");
+			return list;
+		}
+	};
+
+	let (y_node, _unit) = match ast::Node::try_parse_from_str(&y_expression) {
+		Ok(expr) => expr,
+		Err(e) => {
+			warn!("Invalid expression: `{y_expression}`\n{e:?}");
+			return list;
+		}
+	};
+
+	let mut x_vars = HashSet::new();
+	collect_variables(&x_node, &mut x_vars);
+
+	if x_vars.len() > 1 {
+		warn!("Currently at most one variable is supported");
+		return list;
+	}
+
+	let mut y_vars = HashSet::new();
+	collect_variables(&y_node, &mut y_vars);
+
+	if x_vars != y_vars {
+		warn!("X and Y expressions must use the same variables");
+		return list;
+	}
+
+	let mut values: HashMap<String, f64> = HashMap::new();
+	let variable_name = x_vars.iter().next().unwrap().clone();
+	values.insert(variable_name.clone(), 0.);
+
+	let interval = (parameter_max_value - parameter_min_value) / sample_count as f64;
+
+	let mut anchor_positions = Vec::<DVec2>::new();
+	let mut x_min = 0.;
+	let mut x_max = 0.;
+	let mut y_min = 0.;
+	let mut y_max = 0.;
+
+	for i in 0..=sample_count {
+		let t = parameter_min_value + i as f64 * interval;
+
+		if let Some(value) = values.get_mut(&variable_name) {
+			*value = t;
+		}
+
+		let context = EvalContext::new(PlotContext { values: &values }, NothingMap);
+
+		let x_value = match x_node.eval(&context) {
+			Ok(value) => value,
+			Err(e) => {
+				warn!("Expression evaluation error: {e:?}");
+				return list;
+			}
+		};
+
+		let y_value = match y_node.eval(&context) {
+			Ok(value) => value,
+			Err(e) => {
+				warn!("Expression evaluation error: {e:?}");
+				return list;
+			}
+		};
+
+		let x_value = match x_value.as_real() {
+			Some(v) => v,
+			None => {
+				warn!("Complex values are currently unsupported");
+				return list;
+			}
+		};
+		let y_value = match y_value.as_real() {
+			Some(v) => v,
+			None => {
+				warn!("Complex values are currently unsupported");
+				return list;
+			}
+		};
+
+		if i == 0 || x_value < x_min {
+			x_min = x_value;
+		}
+
+		if i == 0 || x_value > x_max {
+			x_max = x_value;
+		}
+
+		if i == 0 || y_value < y_min {
+			y_min = y_value;
+		}
+
+		if i == 0 || y_value > y_max {
+			y_max = y_value;
+		}
+
+		anchor_positions.push(DVec2::new(x_value, y_value));
+	}
+
+	let x_scale = width / (x_max - x_min);
+	let y_scale = height / (y_max - y_min);
+
+	let scale = x_scale.min(y_scale);
+
+	let curve_width = (x_max - x_min) * scale;
+	let curve_height = (y_max - y_min) * scale;
+
+	let x_offset = (width - curve_width) / 2.; // For centering the curve
+	let y_offset = (height - curve_height) / 2.;
+
+	for anchor_position in &mut anchor_positions {
+		anchor_position.x = (anchor_position.x - x_min) * scale + x_offset;
+		anchor_position.y = (y_max - anchor_position.y) * scale + y_offset;
+	}
+
+	let mut closed = false;
+
+	if auto_close && let (Some(first), Some(last)) = (anchor_positions.first(), anchor_positions.last()) {
+		let distance = first.distance(*last);
+
+		closed = distance < 1.;
+		if closed {
+			anchor_positions.pop();
+		}
+	}
+
+	let shape = Vector::from_subpath(subpath::Subpath::from_anchors(anchor_positions, closed));
+
+	List::new_from_element(shape)
+}
+
+fn collect_variables(node: &ast::Node, vars: &mut HashSet<String>) {
+	match node {
+		ast::Node::Var(name) => {
+			vars.insert(name.clone());
+		}
+
+		ast::Node::Lit(_) => {}
+
+		ast::Node::UnaryOp { expr, .. } => {
+			collect_variables(expr, vars);
+		}
+
+		ast::Node::BinOp { lhs, rhs, .. } => {
+			collect_variables(lhs, vars);
+			collect_variables(rhs, vars);
+		}
+
+		ast::Node::FnCall { expr, .. } => {
+			for arg in expr {
+				collect_variables(arg, vars);
+			}
+		}
+	}
+}

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -28,29 +28,59 @@ impl ValueProvider for PlotContext<'_> {
 	}
 }
 
-/// Plots a parametric curve. Please note that at most 1 variable is supported in the expressions.
+/// Plots a parametric curve. Please note that at most one variable is currently supported in the expressions.
+///
+/// You can use the following mathematical operators:
+/// • **Addition**: x + y
+/// • **Subtraction**: x - y
+/// • **Multiplication**: x * y or 2x
+/// • **Division**: x / y
+/// • **Modulo**: x % y
+/// • **Power**: x ^ y
+///
+/// You can use the following trigonometric functions:
+/// • **sin(x)**: sine
+/// • **cos(x)**: cosine
+/// • **tan(x)**: tangent
+/// • **csc(x)**: cosecant, 1 / sin(x)
+/// • **sec(x)**: secant, 1 / cos(x)
+/// • **cot(x)**: cotangent, 1 / tan(x)
+///
+/// You can use the following inverse trigonometric functions:
+/// • **asin(x)**: arcsine
+/// • **acos(x)**: arccosine
+/// • **atan(x)**: arctangent
+/// • **acsc(x)**: inverse cosecant, asin(1 / x)
+/// • **asec(x)**: inverse secant, acos(1 / x)
+/// • **acot(x)**: inverse cotangent, atan(π/2 - x)
+///
 /// You can use the following mathematical functions:
-/// • ** Arithmetic operators **: +, -, *, /, %, ^, !
-/// • **sin**:
-/// • **cos**:
-/// • **tan**:
-/// • **csc**: cosecant, 1/sin(x)
-/// • **sec**: secant, 1/cos(x)
-/// • **cot**: cotangent, 1 / tan(x)
-/// • **invsin**: arcsin
-/// • **invcos**: arccos
-/// • **invtan**: arctan
-/// • **invcsc**: asin(1/x)
-/// • **invsec**: acos(1/x)
-/// • **invcot**: atan(PI/2-x)
-/// • **sqrt**: square root
-
-/// You can use the following mathematical contants:
-/// • **pi**: 3.1415926535
-/// • **tau**: 2*PI
-/// • **e**: Euler's number, 2.7182818284
-/// • **phi**: golden ratio, 1.6180339887
-/// • **G**: gravity acceleration
+/// • **sqrt(x)**: square root
+/// • **abs(x)**: absolute value
+/// • **exp(x)**: exponential function, e^x
+/// • **ln(x)**: natural logarithm
+/// • **log(x)**: base-10 logarithm
+/// • **floor(x)**: round down to the nearest integer
+/// • **ceil(x)**: round up to the nearest integer
+/// • **round(x)**: round to the nearest integer
+/// • **sign(x)**: sign function (-1, 0, or 1)
+///
+/// You can use the following multi-argument functions:
+/// • **min(a, b)**: minimum of two values
+/// • **max(a, b)**: maximum of two values
+/// • **atan2(y, x)**: four-quadrant arctangent
+///
+/// You can use the following hyperbolic functions:
+/// • **sinh(x)**: hyperbolic sine
+/// • **cosh(x)**: hyperbolic cosine
+/// • **tanh(x)**: hyperbolic tangent
+///
+/// You can use the following mathematical constants:
+/// • **pi**: π ≈ 3.141592653589793
+/// • **tau**: τ = 2π
+/// • **e**: Euler's number, ≈ 2.718281828459045
+/// • **phi**: Golden ratio, ≈ 1.618033988749895
+/// • **G**: Standard gravitational acceleration
 ///
 #[node_macro::node(category("Vector: Shape"))]
 fn function_plot(

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -46,10 +46,10 @@ fn function_plot(
 	#[default(sin(2 * t))]
 	y_expression: String,
 	/// Minimum value for the parameter to evaluate.
-	#[default(-1.)]
+	#[default(0.)]
 	parameter_min_value: f64,
 	/// Maximum value for the parameter to evaluate.
-	#[default(1.)]
+	#[default(6.28318530718)]
 	parameter_max_value: f64,
 	/// How many samples should we take
 	#[default(100)]
@@ -68,7 +68,7 @@ fn function_plot(
 		None => return List::new(),
 	};
 
-	transform_plot_positions(&mut anchor_positions, &bounds, width, height);
+	fit_plot_to_bounds(&mut anchor_positions, &bounds, width, height);
 
 	let mut closed = false;
 
@@ -90,7 +90,7 @@ fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str
 	let mut values = HashMap::<String, f64>::new();
 	values.insert(variable_name.to_string(), 0.);
 
-	let interval = (parameter_max_value - parameter_min_value) / sample_count as f64;
+	let interval = (parameter_max_value - parameter_min_value) / (sample_count - 1) as f64;
 
 	let mut anchor_positions = Vec::<DVec2>::new();
 
@@ -99,7 +99,7 @@ fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str
 	let mut y_min = 0.;
 	let mut y_max = 0.;
 
-	for i in 0..=sample_count {
+	for i in 0..sample_count {
 		let t = parameter_min_value + i as f64 * interval;
 
 		if let Some(value) = values.get_mut(variable_name) {
@@ -162,7 +162,7 @@ fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str
 	Some((anchor_positions, PlotBounds { x_min, x_max, y_min, y_max }))
 }
 
-fn transform_plot_positions(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width: f64, height: f64) {
+fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width: f64, height: f64) {
 	let x_scale = width / (bounds.x_max - bounds.x_min).max(f64::EPSILON);
 	let y_scale = height / (bounds.y_max - bounds.y_min).max(f64::EPSILON);
 

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -48,6 +48,13 @@ struct CurveBounds {
 	y_max: f64,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PlotTransform {
+	scale: f64,
+	x_center: f64,
+	y_center: f64,
+}
+
 struct PlotContext<'a> {
 	values: &'a HashMap<String, f64>,
 }
@@ -145,6 +152,9 @@ fn function_plot(
 	/// Auto close
 	#[default(true)]
 	auto_close: bool,
+	/// Plot Axes
+	#[default(true)]
+	plot_axes: bool,
 ) -> List<Vector> {
 	let mut plots = List::new();
 	let (x_node, y_node, variable_name) = match parse_plot_expressions(&x_expression, &y_expression) {
@@ -157,10 +167,12 @@ fn function_plot(
 		None => return plots,
 	};
 
+	let plot_transform = calculate_plot_transform(&bounds, width, height);
+
 	let segments = detect_curve_segments(sample_points, discontinuity_sensitivity);
 
 	for mut segment_anchors in segments {
-		fit_plot_to_bounds(&mut segment_anchors, &bounds, width, height);
+		fit_plot_to_bounds(&mut segment_anchors, &plot_transform);
 
 		let mut closed = false;
 
@@ -179,6 +191,19 @@ fn function_plot(
 			plots = List::new_from_element(shape);
 		} else {
 			plots.push(Item::new_from_element(shape));
+		}
+	}
+
+	if plot_axes {
+		let axes = build_plot_axes(&bounds, &plot_transform);
+		for axis in axes {
+			let shape = Vector::from_subpath(subpath::Subpath::from_anchors(axis, false));
+
+			if plots.is_empty() {
+				plots = List::new_from_element(shape);
+			} else {
+				plots.push(Item::new_from_element(shape));
+			}
 		}
 	}
 
@@ -228,6 +253,7 @@ fn sample_interval(
 	max_depth: u32,
 ) {
 	if current_depth >= max_depth {
+		update_bounds(&begin_point, bounds);
 		sample_points.push(begin_point);
 		return;
 	}
@@ -238,9 +264,6 @@ fn sample_interval(
 	let Some(point_mid) = evaluate_expressions(t_mid, x_node, y_node, variable_name) else {
 		return;
 	};
-	if let SamplePoint::Valid { .. } = point_mid {
-		update_bounds(&point_mid, bounds);
-	}
 
 	if current_depth > min_depth && begin_point.is_valid() && end_point.is_valid() {
 		let t_quarter = t_begin + (t_end - t_begin) * 0.25;
@@ -253,14 +276,6 @@ fn sample_interval(
 		let Some(point_q3) = evaluate_expressions(t_q3, x_node, y_node, variable_name) else {
 			return;
 		};
-
-		if let SamplePoint::Valid { .. } = point_q1 {
-			update_bounds(&point_q1, bounds);
-		}
-
-		if let SamplePoint::Valid { .. } = point_q3 {
-			update_bounds(&point_q3, bounds);
-		}
 
 		let Some(begin_coord) = begin_point.coord() else { return };
 		let Some(end_coord) = end_point.coord() else { return };
@@ -285,6 +300,7 @@ fn sample_interval(
 		}
 
 		if max_error < tolerance {
+			update_bounds(&begin_point, bounds);
 			sample_points.push(begin_point);
 			return;
 		}
@@ -463,7 +479,7 @@ fn extrapolate_limit(p_coord: DVec2, p1_coord: DVec2, p2_coord: DVec2) -> f64 {
 	}
 }
 
-fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &CurveBounds, width: f64, height: f64) {
+fn calculate_plot_transform(bounds: &CurveBounds, width: f64, height: f64) -> PlotTransform {
 	let x_scale = width / (bounds.x_max - bounds.x_min).max(f64::EPSILON);
 	let y_scale = height / (bounds.y_max - bounds.y_min).max(f64::EPSILON);
 
@@ -472,10 +488,35 @@ fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &CurveBounds, widt
 	let x_center = (bounds.x_min + bounds.x_max) / 2.;
 	let y_center = (bounds.y_min + bounds.y_max) / 2.;
 
+	PlotTransform { scale, x_center, y_center }
+}
+
+fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], plot_transform: &PlotTransform) {
 	for anchor_position in anchor_positions {
-		anchor_position.x = (anchor_position.x - x_center) * scale;
-		anchor_position.y = (y_center - anchor_position.y) * scale;
+		*anchor_position = fit_point_to_bounds(*anchor_position, plot_transform);
 	}
+}
+
+fn fit_point_to_bounds(point: DVec2, plot_transform: &PlotTransform) -> DVec2 {
+	DVec2::new((point.x - plot_transform.x_center) * plot_transform.scale, (plot_transform.y_center - point.y) * plot_transform.scale)
+}
+
+fn build_plot_axes(bounds: &CurveBounds, plot_transform: &PlotTransform) -> Vec<CurveSegment> {
+	let axis_x = if bounds.x_min <= 0. && bounds.x_max >= 0. { 0. } else { (bounds.x_min + bounds.x_max) / 2. };
+
+	let axis_y = if bounds.y_min <= 0. && bounds.y_max >= 0. { 0. } else { (bounds.y_min + bounds.y_max) / 2. };
+
+	let horizontal = vec![
+		fit_point_to_bounds(DVec2::new(bounds.x_min, axis_y), plot_transform),
+		fit_point_to_bounds(DVec2::new(bounds.x_max, axis_y), plot_transform),
+	];
+
+	let vertical = vec![
+		fit_point_to_bounds(DVec2::new(axis_x, bounds.y_min), plot_transform),
+		fit_point_to_bounds(DVec2::new(axis_x, bounds.y_max), plot_transform),
+	];
+
+	vec![horizontal, vertical]
 }
 
 fn parse_plot_expressions(x_expression: &str, y_expression: &str) -> Option<(ast::Node, ast::Node, String)> {

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -9,9 +9,39 @@ use math_parser::value::Value;
 use std::collections::{HashMap, HashSet};
 use vector_types::subpath;
 
+const TOLERANCE_FACTOR: f64 = 0.005;
+
+#[derive(Debug, Clone, Copy)]
+enum SamplePoint {
+	Valid { parameter: f64, coord: DVec2 },
+
+	Invalid { parameter: f64 },
+}
+
+impl SamplePoint {
+	pub fn parameter(&self) -> f64 {
+		match self {
+			SamplePoint::Valid { parameter, .. } => *parameter,
+			SamplePoint::Invalid { parameter } => *parameter,
+		}
+	}
+
+	pub fn coord(&self) -> Option<DVec2> {
+		match self {
+			SamplePoint::Valid { coord, .. } => Some(*coord),
+			SamplePoint::Invalid { .. } => None,
+		}
+	}
+
+	pub fn is_valid(&self) -> bool {
+		matches!(self, SamplePoint::Valid { .. })
+	}
+}
+
 type CurveSegment = Vec<DVec2>;
 
-struct PlotBounds {
+#[derive(Debug)]
+struct CurveBounds {
 	x_min: f64,
 	x_max: f64,
 	y_min: f64,
@@ -106,9 +136,12 @@ fn function_plot(
 	/// Maximum value for the parameter to evaluate.
 	#[default(6.28318530718)]
 	parameter_max_value: f64,
-	/// How many samples should we take
-	#[default(100)]
-	sample_count: u32,
+	/// Level of sampling detail
+	#[default(7)]
+	level_of_detail: u32,
+	/// Discontinuity detection sensitivity
+	#[default(0.3)]
+	discontinuity_sensitivity: f64,
 	/// Auto close
 	#[default(true)]
 	auto_close: bool,
@@ -119,10 +152,12 @@ fn function_plot(
 		None => return plots,
 	};
 
-	let (mut segments, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, sample_count) {
+	let (sample_points, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, level_of_detail) {
 		Some(result) => result,
 		None => return plots,
 	};
+
+	let segments = detect_curve_segments(sample_points, discontinuity_sensitivity);
 
 	for mut segment_anchors in segments {
 		fit_plot_to_bounds(&mut segment_anchors, &bounds, width, height);
@@ -150,86 +185,285 @@ fn function_plot(
 	plots
 }
 
-fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str, parameter_min_value: f64, parameter_max_value: f64, sample_count: u32) -> Option<(Vec<CurveSegment>, PlotBounds)> {
-	let mut values = HashMap::<String, f64>::new();
-	values.insert(variable_name.to_string(), 0.);
+fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str, parameter_min_value: f64, parameter_max_value: f64, sample_count: u32) -> Option<(Vec<SamplePoint>, CurveBounds)> {
+	let point_start = evaluate_expressions(parameter_min_value, x_node, y_node, variable_name)?;
 
-	let interval = (parameter_max_value - parameter_min_value) / (sample_count - 1) as f64;
+	let point_end = evaluate_expressions(parameter_max_value, x_node, y_node, variable_name)?;
 
-	let mut segments = Vec::new();
-	let mut segment_anchors = Vec::<DVec2>::new();
+	let mut bounds = CurveBounds {
+		x_min: f64::INFINITY,
+		x_max: f64::NEG_INFINITY,
+		y_min: f64::INFINITY,
+		y_max: f64::NEG_INFINITY,
+	};
 
-	let mut x_min = 0.;
-	let mut x_max = 0.;
-	let mut y_min = 0.;
-	let mut y_max = 0.;
-	debug!("sample_plot_curve------");
-
-	for i in 0..sample_count {
-		let t = parameter_min_value + i as f64 * interval;
-
-		if let Some(value) = values.get_mut(variable_name) {
-			*value = t;
-		}
-
-		let context = EvalContext::new(PlotContext { values: &values }, NothingMap);
-
-		let x_value = match x_node.eval(&context) {
-			Ok(value) => value,
-			Err(e) => {
-				warn!("Expression evaluation error: {e:?}");
-				return None;
-			}
-		};
-
-		let y_value = match y_node.eval(&context) {
-			Ok(value) => value,
-			Err(e) => {
-				warn!("Expression evaluation error: {e:?}");
-				return None;
-			}
-		};
-
-		let point = match (x_value.as_real().filter(|v| v.is_finite()), y_value.as_real().filter(|v| v.is_finite())) {
-			(Some(x), Some(y)) => DVec2::new(x, y),
-			_ => {
-				if segment_anchors.len() >= 2 {
-					debug!("new segment");
-					segments.push(segment_anchors);
-					segment_anchors = Vec::new();
-				}
-				continue;
-			}
-		};
-
-		if i == 0 || point.x < x_min {
-			x_min = point.x;
-		}
-
-		if i == 0 || point.x > x_max {
-			x_max = point.x;
-		}
-
-		if i == 0 || point.y < y_min {
-			y_min = point.y;
-		}
-
-		if i == 0 || point.y > y_max {
-			y_max = point.y;
-		}
-
-		segment_anchors.push(point);
+	if point_start.is_valid() {
+		update_bounds(&point_start, &mut bounds);
 	}
 
-	if segment_anchors.len() >= 2 {
-		segments.push(segment_anchors);
+	if point_end.is_valid() {
+		update_bounds(&point_end, &mut bounds);
 	}
 
-	debug!("sample_plot_curve------");
-	Some((segments, PlotBounds { x_min, x_max, y_min, y_max }))
+	let mut sample_points = Vec::<SamplePoint>::new();
+
+	sample_interval(point_start, point_end, &mut sample_points, &mut bounds, x_node, y_node, variable_name, 0, 4, sample_count);
+
+	sample_points.push(point_end);
+
+	Some((sample_points, bounds))
 }
 
-fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width: f64, height: f64) {
+#[allow(clippy::too_many_arguments)]
+fn sample_interval(
+	begin_point: SamplePoint,
+	end_point: SamplePoint,
+	sample_points: &mut Vec<SamplePoint>,
+	bounds: &mut CurveBounds,
+	x_node: &ast::Node,
+	y_node: &ast::Node,
+	variable_name: &str,
+	current_depth: u32,
+	min_depth: u32,
+	max_depth: u32,
+) {
+	if current_depth >= max_depth {
+		sample_points.push(begin_point);
+		return;
+	}
+
+	let t_begin = begin_point.parameter();
+	let t_end = end_point.parameter();
+	let t_mid = t_begin + (t_end - t_begin) * 0.50;
+	let Some(point_mid) = evaluate_expressions(t_mid, x_node, y_node, variable_name) else {
+		return;
+	};
+	if let SamplePoint::Valid { .. } = point_mid {
+		update_bounds(&point_mid, bounds);
+	}
+
+	if current_depth > min_depth && begin_point.is_valid() && end_point.is_valid() {
+		let t_quarter = t_begin + (t_end - t_begin) * 0.25;
+		let t_q3 = t_begin + (t_end - t_begin) * 0.75;
+
+		let Some(point_q1) = evaluate_expressions(t_quarter, x_node, y_node, variable_name) else {
+			return;
+		};
+
+		let Some(point_q3) = evaluate_expressions(t_q3, x_node, y_node, variable_name) else {
+			return;
+		};
+
+		if let SamplePoint::Valid { .. } = point_q1 {
+			update_bounds(&point_q1, bounds);
+		}
+
+		if let SamplePoint::Valid { .. } = point_q3 {
+			update_bounds(&point_q3, bounds);
+		}
+
+		let Some(begin_coord) = begin_point.coord() else { return };
+		let Some(end_coord) = end_point.coord() else { return };
+
+		let segment_length = begin_coord.distance(end_coord);
+		let tolerance = segment_length * TOLERANCE_FACTOR;
+
+		let segment_q1 = begin_coord + (end_coord - begin_coord) * 0.25;
+		let segment_mid = (begin_coord + end_coord) * 0.5;
+		let segment_q3 = begin_coord + (end_coord - begin_coord) * 0.75;
+
+		let mut max_error: f64 = 0.;
+
+		if let Some(q1) = point_q1.coord() {
+			max_error = max_error.max(q1.distance(segment_q1));
+		}
+		if let Some(mid) = point_mid.coord() {
+			max_error = max_error.max(mid.distance(segment_mid));
+		}
+		if let Some(q3) = point_q3.coord() {
+			max_error = max_error.max(q3.distance(segment_q3));
+		}
+
+		if max_error < tolerance {
+			sample_points.push(begin_point);
+			return;
+		}
+	}
+
+	sample_interval(begin_point, point_mid, sample_points, bounds, x_node, y_node, variable_name, current_depth + 1, min_depth, max_depth);
+
+	sample_interval(point_mid, end_point, sample_points, bounds, x_node, y_node, variable_name, current_depth + 1, min_depth, max_depth);
+}
+
+fn evaluate_expressions(t: f64, x_node: &ast::Node, y_node: &ast::Node, variable_name: &str) -> Option<SamplePoint> {
+	let mut values = HashMap::<String, f64>::new();
+	values.insert(variable_name.to_string(), t);
+
+	let context = EvalContext::new(PlotContext { values: &values }, NothingMap);
+
+	let x_value = match x_node.eval(&context) {
+		Ok(value) => value,
+		Err(e) => {
+			warn!("Expression evaluation error: {e:?}");
+			return None;
+		}
+	};
+
+	let y_value = match y_node.eval(&context) {
+		Ok(value) => value,
+		Err(e) => {
+			warn!("Expression evaluation error: {e:?}");
+			return None;
+		}
+	};
+
+	let point = match (x_value.as_real().filter(|v| v.is_finite()), y_value.as_real().filter(|v| v.is_finite())) {
+		(Some(x), Some(y)) => SamplePoint::Valid {
+			parameter: t,
+			coord: DVec2::new(x, y),
+		},
+
+		_ => SamplePoint::Invalid { parameter: t },
+	};
+
+	Some(point)
+}
+
+fn update_bounds(point: &SamplePoint, bounds: &mut CurveBounds) {
+	let Some(coord) = point.coord() else {
+		return;
+	};
+
+	bounds.x_min = bounds.x_min.min(coord.x);
+	bounds.x_max = bounds.x_max.max(coord.x);
+
+	bounds.y_min = bounds.y_min.min(coord.y);
+	bounds.y_max = bounds.y_max.max(coord.y);
+}
+
+fn detect_curve_segments(curve_points: Vec<SamplePoint>, discontinuity_sensitivity: f64) -> Vec<CurveSegment> {
+	let mut segments: Vec<Vec<DVec2>> = Vec::new();
+	let mut segment = Vec::<DVec2>::new();
+
+	let mut previous_right_continuity = Some(true);
+
+	for i in 0..curve_points.len() {
+		let current_point = &curve_points[i];
+		if !current_point.is_valid() {
+			continue;
+		}
+
+		let mut push_to_last_segment = false;
+		let mut continue_segment = true;
+		if i < curve_points.len() - 1 {
+			continue_segment = curve_points[i + 1].is_valid();
+		}
+
+		if continue_segment {
+			let mut left_continuity = Some(true);
+			let mut right_continuity = Some(true);
+
+			if i > 1 {
+				let prev_prev_point = &curve_points[i - 2];
+				let prev_point = &curve_points[i - 1];
+				left_continuity = extrapolate_continuity(current_point, prev_prev_point, prev_point, discontinuity_sensitivity);
+			}
+
+			if i < curve_points.len() - 2 {
+				let next_point = &curve_points[i + 1];
+				let next_next_point = &curve_points[i + 2];
+
+				right_continuity = extrapolate_continuity(current_point, next_point, next_next_point, discontinuity_sensitivity);
+			}
+
+			if right_continuity == Some(false) {
+				continue_segment = false;
+			}
+
+			if previous_right_continuity == Some(false) && left_continuity == Some(true) {
+				push_to_last_segment = true;
+			}
+
+			previous_right_continuity = right_continuity;
+		}
+
+		if push_to_last_segment && !segments.is_empty() {
+			segments.last_mut().unwrap().push(current_point.coord().unwrap());
+		} else {
+			segment.push(current_point.coord().unwrap());
+		}
+
+		if !continue_segment {
+			if segment.len() > 1 {
+				segments.push(segment);
+			}
+
+			segment = Vec::new();
+		}
+	}
+
+	if segment.len() > 1 {
+		segments.push(segment);
+	}
+
+	segments
+}
+
+fn extrapolate_continuity(point: &SamplePoint, neighbor1: &SamplePoint, neighbor2: &SamplePoint, discontinuity_sensitivity: f64) -> Option<bool> {
+	if !point.is_valid() || !neighbor1.is_valid() || !neighbor2.is_valid() {
+		return None;
+	}
+	let current_coord = point.coord().unwrap();
+
+	let left_limit_x = extrapolate_limit(
+		DVec2 {
+			x: point.parameter(),
+			y: current_coord.x,
+		},
+		DVec2 {
+			x: neighbor1.parameter(),
+			y: neighbor1.coord().unwrap().x,
+		},
+		DVec2 {
+			x: neighbor2.parameter(),
+			y: neighbor2.coord().unwrap().x,
+		},
+	);
+
+	let left_limit_y = extrapolate_limit(
+		DVec2 {
+			x: point.parameter(),
+			y: current_coord.y,
+		},
+		DVec2 {
+			x: neighbor1.parameter(),
+			y: neighbor1.coord().unwrap().y,
+		},
+		DVec2 {
+			x: neighbor2.parameter(),
+			y: neighbor2.coord().unwrap().y,
+		},
+	);
+
+	let segment_length = current_coord.distance(neighbor2.coord().unwrap());
+	let tolerance = segment_length * discontinuity_sensitivity;
+
+	if (left_limit_x - current_coord.x).abs() > tolerance || (left_limit_y - current_coord.y).abs() > tolerance {
+		return Some(false);
+	}
+
+	Some(true)
+}
+
+fn extrapolate_limit(p_coord: DVec2, p1_coord: DVec2, p2_coord: DVec2) -> f64 {
+	if (p2_coord.x - p1_coord.x).abs() > f64::EPSILON {
+		(p_coord.x - p1_coord.x) * (p2_coord.y - p1_coord.y) / (p2_coord.x - p1_coord.x) + p1_coord.y
+	} else {
+		p2_coord.y + (p2_coord.y - p1_coord.y)
+	}
+}
+
+fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &CurveBounds, width: f64, height: f64) {
 	let x_scale = width / (bounds.x_max - bounds.x_min).max(f64::EPSILON);
 	let y_scale = height / (bounds.y_max - bounds.y_min).max(f64::EPSILON);
 

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -1,5 +1,5 @@
 use core_types::Ctx;
-use core_types::list::List;
+use core_types::list::{Item, List};
 use glam::DVec2;
 use graphic_types::Vector;
 use log::warn;
@@ -8,6 +8,8 @@ use math_parser::context::{EvalContext, NothingMap, ValueProvider};
 use math_parser::value::Value;
 use std::collections::{HashMap, HashSet};
 use vector_types::subpath;
+
+type CurveSegment = Vec<DVec2>;
 
 struct PlotBounds {
 	x_min: f64,
@@ -26,7 +28,30 @@ impl ValueProvider for PlotContext<'_> {
 	}
 }
 
-/// Plots a parametric curve.
+/// Plots a parametric curve. Please note that at most 1 variable is supported in the expressions.
+/// You can use the following mathematical functions:
+/// • ** Arithmetic operators **: +, -, *, /, %, ^, !
+/// • **sin**:
+/// • **cos**:
+/// • **tan**:
+/// • **csc**: cosecant, 1/sin(x)
+/// • **sec**: secant, 1/cos(x)
+/// • **cot**: cotangent, 1 / tan(x)
+/// • **invsin**: arcsin
+/// • **invcos**: arccos
+/// • **invtan**: arctan
+/// • **invcsc**: asin(1/x)
+/// • **invsec**: acos(1/x)
+/// • **invcot**: atan(PI/2-x)
+/// • **sqrt**: square root
+
+/// You can use the following mathematical contants:
+/// • **pi**: 3.1415926535
+/// • **tau**: 2*PI
+/// • **e**: Euler's number, 2.7182818284
+/// • **phi**: golden ratio, 1.6180339887
+/// • **G**: gravity acceleration
+///
 #[node_macro::node(category("Vector: Shape"))]
 fn function_plot(
 	_: impl Ctx,
@@ -58,46 +83,57 @@ fn function_plot(
 	#[default(true)]
 	auto_close: bool,
 ) -> List<Vector> {
+	let mut plots = List::new();
 	let (x_node, y_node, variable_name) = match parse_plot_expressions(&x_expression, &y_expression) {
 		Some(result) => result,
-		None => return List::new(),
+		None => return plots,
 	};
 
-	let (mut anchor_positions, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, sample_count) {
+	let (mut segments, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, sample_count) {
 		Some(result) => result,
-		None => return List::new(),
+		None => return plots,
 	};
 
-	fit_plot_to_bounds(&mut anchor_positions, &bounds, width, height);
+	for mut segment_anchors in segments {
+		fit_plot_to_bounds(&mut segment_anchors, &bounds, width, height);
 
-	let mut closed = false;
+		let mut closed = false;
 
-	if auto_close && let (Some(first), Some(last)) = (anchor_positions.first(), anchor_positions.last()) {
-		let distance = first.distance(*last);
+		if auto_close && let (Some(first), Some(last)) = (segment_anchors.first(), segment_anchors.last()) {
+			let distance = first.distance(*last);
 
-		closed = distance < 1.;
-		if closed {
-			anchor_positions.pop();
+			closed = distance < 1.;
+			if closed {
+				segment_anchors.pop();
+			}
+		}
+
+		let shape = Vector::from_subpath(subpath::Subpath::from_anchors(segment_anchors, closed));
+
+		if plots.is_empty() {
+			plots = List::new_from_element(shape);
+		} else {
+			plots.push(Item::new_from_element(shape));
 		}
 	}
 
-	let shape = Vector::from_subpath(subpath::Subpath::from_anchors(anchor_positions, closed));
-
-	List::new_from_element(shape)
+	plots
 }
 
-fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str, parameter_min_value: f64, parameter_max_value: f64, sample_count: u32) -> Option<(Vec<DVec2>, PlotBounds)> {
+fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str, parameter_min_value: f64, parameter_max_value: f64, sample_count: u32) -> Option<(Vec<CurveSegment>, PlotBounds)> {
 	let mut values = HashMap::<String, f64>::new();
 	values.insert(variable_name.to_string(), 0.);
 
 	let interval = (parameter_max_value - parameter_min_value) / (sample_count - 1) as f64;
 
-	let mut anchor_positions = Vec::<DVec2>::new();
+	let mut segments = Vec::new();
+	let mut segment_anchors = Vec::<DVec2>::new();
 
 	let mut x_min = 0.;
 	let mut x_max = 0.;
 	let mut y_min = 0.;
 	let mut y_max = 0.;
+	debug!("sample_plot_curve------");
 
 	for i in 0..sample_count {
 		let t = parameter_min_value + i as f64 * interval;
@@ -124,42 +160,43 @@ fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str
 			}
 		};
 
-		let x_value = match x_value.as_real() {
-			Some(v) => v,
-			None => {
-				warn!("Complex values are currently unsupported");
-				return None;
+		let point = match (x_value.as_real().filter(|v| v.is_finite()), y_value.as_real().filter(|v| v.is_finite())) {
+			(Some(x), Some(y)) => DVec2::new(x, y),
+			_ => {
+				if segment_anchors.len() >= 2 {
+					debug!("new segment");
+					segments.push(segment_anchors);
+					segment_anchors = Vec::new();
+				}
+				continue;
 			}
 		};
 
-		let y_value = match y_value.as_real() {
-			Some(v) => v,
-			None => {
-				warn!("Complex values are currently unsupported");
-				return None;
-			}
-		};
-
-		if i == 0 || x_value < x_min {
-			x_min = x_value;
+		if i == 0 || point.x < x_min {
+			x_min = point.x;
 		}
 
-		if i == 0 || x_value > x_max {
-			x_max = x_value;
+		if i == 0 || point.x > x_max {
+			x_max = point.x;
 		}
 
-		if i == 0 || y_value < y_min {
-			y_min = y_value;
+		if i == 0 || point.y < y_min {
+			y_min = point.y;
 		}
 
-		if i == 0 || y_value > y_max {
-			y_max = y_value;
+		if i == 0 || point.y > y_max {
+			y_max = point.y;
 		}
 
-		anchor_positions.push(DVec2::new(x_value, y_value));
+		segment_anchors.push(point);
 	}
 
-	Some((anchor_positions, PlotBounds { x_min, x_max, y_min, y_max }))
+	if segment_anchors.len() >= 2 {
+		segments.push(segment_anchors);
+	}
+
+	debug!("sample_plot_curve------");
+	Some((segments, PlotBounds { x_min, x_max, y_min, y_max }))
 }
 
 fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width: f64, height: f64) {
@@ -168,15 +205,12 @@ fn fit_plot_to_bounds(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width
 
 	let scale = x_scale.min(y_scale);
 
-	let curve_width = (bounds.x_max - bounds.x_min) * scale;
-	let curve_height = (bounds.y_max - bounds.y_min) * scale;
-
-	let x_offset = (width - curve_width) / 2.;
-	let y_offset = (height - curve_height) / 2.;
+	let x_center = (bounds.x_min + bounds.x_max) / 2.;
+	let y_center = (bounds.y_min + bounds.y_max) / 2.;
 
 	for anchor_position in anchor_positions {
-		anchor_position.x = (anchor_position.x - bounds.x_min) * scale + x_offset;
-		anchor_position.y = (bounds.y_max - anchor_position.y) * scale + y_offset;
+		anchor_position.x = (anchor_position.x - x_center) * scale;
+		anchor_position.y = (y_center - anchor_position.y) * scale;
 	}
 }
 
@@ -184,14 +218,17 @@ fn parse_plot_expressions(x_expression: &str, y_expression: &str) -> Option<(ast
 	let (x_node, x_vars) = parse_expression(x_expression)?;
 	let (y_node, y_vars) = parse_expression(y_expression)?;
 
-	if x_vars != y_vars {
-		warn!("X and Y expressions must use the same variables");
-		return None;
-	}
-
-	let variable_name = match x_vars.iter().next() {
-		Some(name) => name.clone(),
-		None => {
+	let variable_name = match (x_vars.iter().next(), y_vars.iter().next()) {
+		(Some(x), Some(y)) => {
+			if x != y {
+				warn!("X and Y expressions must use the same variable");
+				return None;
+			}
+			x.clone()
+		}
+		(Some(x), None) => x.clone(),
+		(None, Some(y)) => y.clone(),
+		(None, None) => {
 			warn!("At least one variable is required");
 			return None;
 		}

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -9,6 +9,13 @@ use math_parser::value::Value;
 use std::collections::{HashMap, HashSet};
 use vector_types::subpath;
 
+struct PlotBounds {
+	x_min: f64,
+	x_max: f64,
+	y_min: f64,
+	y_max: f64,
+}
+
 struct PlotContext<'a> {
 	values: &'a HashMap<String, f64>,
 }
@@ -51,47 +58,42 @@ fn function_plot(
 	#[default(true)]
 	auto_close: bool,
 ) -> List<Vector> {
-	let mut list = List::new();
-
-	let (x_node, _unit) = match ast::Node::try_parse_from_str(&x_expression) {
-		Ok(expr) => expr,
-		Err(e) => {
-			warn!("Invalid expression: `{x_expression}`\n{e:?}");
-			return list;
-		}
+	let (x_node, y_node, variable_name) = match parse_plot_expressions(&x_expression, &y_expression) {
+		Some(result) => result,
+		None => return List::new(),
 	};
 
-	let (y_node, _unit) = match ast::Node::try_parse_from_str(&y_expression) {
-		Ok(expr) => expr,
-		Err(e) => {
-			warn!("Invalid expression: `{y_expression}`\n{e:?}");
-			return list;
-		}
+	let (mut anchor_positions, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, sample_count) {
+		Some(result) => result,
+		None => return List::new(),
 	};
 
-	let mut x_vars = HashSet::new();
-	collect_variables(&x_node, &mut x_vars);
+	transform_plot_positions(&mut anchor_positions, &bounds, width, height);
 
-	if x_vars.len() > 1 {
-		warn!("Currently at most one variable is supported");
-		return list;
+	let mut closed = false;
+
+	if auto_close && let (Some(first), Some(last)) = (anchor_positions.first(), anchor_positions.last()) {
+		let distance = first.distance(*last);
+
+		closed = distance < 1.;
+		if closed {
+			anchor_positions.pop();
+		}
 	}
 
-	let mut y_vars = HashSet::new();
-	collect_variables(&y_node, &mut y_vars);
+	let shape = Vector::from_subpath(subpath::Subpath::from_anchors(anchor_positions, closed));
 
-	if x_vars != y_vars {
-		warn!("X and Y expressions must use the same variables");
-		return list;
-	}
+	List::new_from_element(shape)
+}
 
-	let mut values: HashMap<String, f64> = HashMap::new();
-	let variable_name = x_vars.iter().next().unwrap().clone();
-	values.insert(variable_name.clone(), 0.);
+fn sample_plot_curve(x_node: &ast::Node, y_node: &ast::Node, variable_name: &str, parameter_min_value: f64, parameter_max_value: f64, sample_count: u32) -> Option<(Vec<DVec2>, PlotBounds)> {
+	let mut values = HashMap::<String, f64>::new();
+	values.insert(variable_name.to_string(), 0.);
 
 	let interval = (parameter_max_value - parameter_min_value) / sample_count as f64;
 
 	let mut anchor_positions = Vec::<DVec2>::new();
+
 	let mut x_min = 0.;
 	let mut x_max = 0.;
 	let mut y_min = 0.;
@@ -100,7 +102,7 @@ fn function_plot(
 	for i in 0..=sample_count {
 		let t = parameter_min_value + i as f64 * interval;
 
-		if let Some(value) = values.get_mut(&variable_name) {
+		if let Some(value) = values.get_mut(variable_name) {
 			*value = t;
 		}
 
@@ -110,7 +112,7 @@ fn function_plot(
 			Ok(value) => value,
 			Err(e) => {
 				warn!("Expression evaluation error: {e:?}");
-				return list;
+				return None;
 			}
 		};
 
@@ -118,7 +120,7 @@ fn function_plot(
 			Ok(value) => value,
 			Err(e) => {
 				warn!("Expression evaluation error: {e:?}");
-				return list;
+				return None;
 			}
 		};
 
@@ -126,14 +128,15 @@ fn function_plot(
 			Some(v) => v,
 			None => {
 				warn!("Complex values are currently unsupported");
-				return list;
+				return None;
 			}
 		};
+
 		let y_value = match y_value.as_real() {
 			Some(v) => v,
 			None => {
 				warn!("Complex values are currently unsupported");
-				return list;
+				return None;
 			}
 		};
 
@@ -156,36 +159,65 @@ fn function_plot(
 		anchor_positions.push(DVec2::new(x_value, y_value));
 	}
 
-	let x_scale = width / (x_max - x_min);
-	let y_scale = height / (y_max - y_min);
+	Some((anchor_positions, PlotBounds { x_min, x_max, y_min, y_max }))
+}
+
+fn transform_plot_positions(anchor_positions: &mut [DVec2], bounds: &PlotBounds, width: f64, height: f64) {
+	let x_scale = width / (bounds.x_max - bounds.x_min).max(f64::EPSILON);
+	let y_scale = height / (bounds.y_max - bounds.y_min).max(f64::EPSILON);
 
 	let scale = x_scale.min(y_scale);
 
-	let curve_width = (x_max - x_min) * scale;
-	let curve_height = (y_max - y_min) * scale;
+	let curve_width = (bounds.x_max - bounds.x_min) * scale;
+	let curve_height = (bounds.y_max - bounds.y_min) * scale;
 
-	let x_offset = (width - curve_width) / 2.; // For centering the curve
+	let x_offset = (width - curve_width) / 2.;
 	let y_offset = (height - curve_height) / 2.;
 
-	for anchor_position in &mut anchor_positions {
-		anchor_position.x = (anchor_position.x - x_min) * scale + x_offset;
-		anchor_position.y = (y_max - anchor_position.y) * scale + y_offset;
+	for anchor_position in anchor_positions {
+		anchor_position.x = (anchor_position.x - bounds.x_min) * scale + x_offset;
+		anchor_position.y = (bounds.y_max - anchor_position.y) * scale + y_offset;
+	}
+}
+
+fn parse_plot_expressions(x_expression: &str, y_expression: &str) -> Option<(ast::Node, ast::Node, String)> {
+	let (x_node, x_vars) = parse_expression(x_expression)?;
+	let (y_node, y_vars) = parse_expression(y_expression)?;
+
+	if x_vars != y_vars {
+		warn!("X and Y expressions must use the same variables");
+		return None;
 	}
 
-	let mut closed = false;
-
-	if auto_close && let (Some(first), Some(last)) = (anchor_positions.first(), anchor_positions.last()) {
-		let distance = first.distance(*last);
-
-		closed = distance < 1.;
-		if closed {
-			anchor_positions.pop();
+	let variable_name = match x_vars.iter().next() {
+		Some(name) => name.clone(),
+		None => {
+			warn!("At least one variable is required");
+			return None;
 		}
+	};
+
+	Some((x_node, y_node, variable_name))
+}
+
+fn parse_expression(expression: &str) -> Option<(ast::Node, HashSet<String>)> {
+	let (node, _unit) = match ast::Node::try_parse_from_str(expression) {
+		Ok(expr) => expr,
+		Err(e) => {
+			warn!("Invalid expression: `{expression}`\n{e:?}");
+			return None;
+		}
+	};
+
+	let mut variables = HashSet::new();
+	collect_variables(&node, &mut variables);
+
+	if variables.len() > 1 {
+		warn!("Currently at most one variable is supported");
+		return None;
 	}
 
-	let shape = Vector::from_subpath(subpath::Subpath::from_anchors(anchor_positions, closed));
-
-	List::new_from_element(shape)
+	Some((node, variables))
 }
 
 fn collect_variables(node: &ast::Node, vars: &mut HashSet<String>) {

--- a/node-graph/nodes/vector/src/plot_nodes.rs
+++ b/node-graph/nodes/vector/src/plot_nodes.rs
@@ -7,7 +7,7 @@ use math_parser::ast;
 use math_parser::context::{EvalContext, NothingMap, ValueProvider};
 use math_parser::value::Value;
 use std::collections::{HashMap, HashSet};
-use vector_types::subpath;
+use vector_types::vector::misc::bezpath_from_anchors_and_handles;
 
 const TOLERANCE_FACTOR: f64 = 0.005;
 
@@ -126,57 +126,66 @@ fn function_plot(
 	/// Width of the plot's bounding box
 	#[unit(" px")]
 	#[default(100)]
-	width: f64,
+	width: Item<f64>,
 	/// Height of the plot's bounding box
 	#[unit(" px")]
 	#[default(100)]
-	height: f64,
+	height: Item<f64>,
 	/// A math expression for x(t). For y = f(x) functions simply enter x.
 	#[default(sin(t + pi / 2))]
-	x_expression: String,
+	x_expression: Item<String>,
 	/// A math expression for y(t). For y = f(x) functions simply enter f(x).
 	#[default(sin(2 * t))]
-	y_expression: String,
+	y_expression: Item<String>,
 	/// Minimum value for the parameter to evaluate.
 	#[default(0.)]
-	parameter_min_value: f64,
+	parameter_min_value: Item<f64>,
 	/// Maximum value for the parameter to evaluate.
 	#[default(6.28318530718)]
-	parameter_max_value: f64,
+	parameter_max_value: Item<f64>,
 	/// Level of sampling detail
 	#[default(7)]
-	level_of_detail: u32,
+	level_of_detail: Item<u32>,
 	/// Discontinuity detection sensitivity
 	#[default(0.3)]
-	discontinuity_sensitivity: f64,
+	discontinuity_sensitivity: Item<f64>,
 	/// Auto close
 	#[default(true)]
-	auto_close: bool,
+	auto_close: Item<bool>,
 	/// Plot Axes
 	#[default(true)]
-	plot_axes: bool,
+	plot_axes: Item<bool>,
 ) -> List<Vector> {
 	let mut plots = List::new();
-	let (x_node, y_node, variable_name) = match parse_plot_expressions(&x_expression, &y_expression) {
+	let (x_node, y_node, variable_name) = match parse_plot_expressions(x_expression.element(), y_expression.element()) {
 		Some(result) => result,
 		None => return plots,
 	};
 
-	let (sample_points, bounds) = match sample_plot_curve(&x_node, &y_node, &variable_name, parameter_min_value, parameter_max_value, level_of_detail) {
+	let (sample_points, bounds) = match sample_plot_curve(
+		&x_node,
+		&y_node,
+		&variable_name,
+		*parameter_min_value.element(),
+		*parameter_max_value.element(),
+		*level_of_detail.element(),
+	) {
 		Some(result) => result,
 		None => return plots,
 	};
 
-	let plot_transform = calculate_plot_transform(&bounds, width, height);
+	let plot_transform = calculate_plot_transform(&bounds, *width.element(), *height.element());
 
-	let segments = detect_curve_segments(sample_points, discontinuity_sensitivity);
+	let segments = detect_curve_segments(sample_points, *discontinuity_sensitivity.element());
 
 	for mut segment_anchors in segments {
 		fit_plot_to_bounds(&mut segment_anchors, &plot_transform);
 
 		let mut closed = false;
 
-		if auto_close && let (Some(first), Some(last)) = (segment_anchors.first(), segment_anchors.last()) {
+		if *auto_close.element()
+			&& let (Some(first), Some(last)) = (segment_anchors.first(), segment_anchors.last())
+		{
 			let distance = first.distance(*last);
 
 			closed = distance < 1.;
@@ -185,7 +194,9 @@ fn function_plot(
 			}
 		}
 
-		let shape = Vector::from_subpath(subpath::Subpath::from_anchors(segment_anchors, closed));
+		let bezpath = bezpath_from_anchors_and_handles(segment_anchors.into_iter().map(|anchor| (anchor, None, None)), closed);
+
+		let shape = Vector::from_bezpath(bezpath);
 
 		if plots.is_empty() {
 			plots = List::new_from_element(shape);
@@ -194,10 +205,12 @@ fn function_plot(
 		}
 	}
 
-	if plot_axes {
+	if *plot_axes.element() {
 		let axes = build_plot_axes(&bounds, &plot_transform);
 		for axis in axes {
-			let shape = Vector::from_subpath(subpath::Subpath::from_anchors(axis, false));
+			let bezpath = bezpath_from_anchors_and_handles(axis.into_iter().map(|anchor| (anchor, None, None)), false);
+
+			let shape = Vector::from_bezpath(bezpath);
 
 			if plots.is_empty() {
 				plots = List::new_from_element(shape);
@@ -543,10 +556,10 @@ fn parse_plot_expressions(x_expression: &str, y_expression: &str) -> Option<(ast
 }
 
 fn parse_expression(expression: &str) -> Option<(ast::Node, HashSet<String>)> {
-	let (node, _unit) = match ast::Node::try_parse_from_str(expression) {
-		Ok(expr) => expr,
+	let node = match ast::Node::try_parse_from_str(expression) {
+		Ok(node) => node,
 		Err(e) => {
-			warn!("Invalid expression: `{expression}`\n{e:?}");
+			warn!("Invalid expression: ``{expression}`\n{e:?}");
 			return None;
 		}
 	};
@@ -583,6 +596,12 @@ fn collect_variables(node: &ast::Node, vars: &mut HashSet<String>) {
 			for arg in expr {
 				collect_variables(arg, vars);
 			}
+		}
+
+		ast::Node::Conditional { condition, if_block, else_block } => {
+			collect_variables(condition, vars);
+			collect_variables(if_block, vars);
+			collect_variables(else_block, vars);
 		}
 	}
 }


### PR DESCRIPTION
This adds a simple parametric curve plot to Graphite.
This algorithm is designed to be simple it allows the user to add simple function plots to the document. It has no intention to compete with other more professional plotting software, like Desmos.
It uses an adaptive sampling (instead of fixed one), because in this way the plot looks better with less points and also the discontinuity detection works better too.

Known limitations:
- at most one variable is currently supported in the expressions
- there are no symbolic analysis for precise function domain detection, we are figuring out the domain by evaluating the given expressions
- the discontinuity detection is also happening by analysing the sampled data; it may detect false positives/false negatives
- there are no periodicity detection, since we are doing a simple adaptive sampling

Part of: [#2458](https://github.com/GraphiteEditor/Graphite/issues/2458)