### PR TITLE
Fix node catalog preserving type search on autofocus

### DIFF
--- a/frontend/src/components/floating-menus/NodeCatalog.svelte
+++ b/frontend/src/components/floating-menus/NodeCatalog.svelte
@@ -113,7 +113,7 @@
 </script>
 
 <LayoutCol class="node-catalog">
-	<TextInput placeholder="Search Nodes…" value={searchTerm} on:value={({ detail }) => (searchTerm = detail)} bind:this={nodeSearchInput} />
+	<TextInput placeholder="Search Nodes…" value={searchTerm} on:value={({ detail }) => (searchTerm = detail)} selectAllOnFocus={false} bind:this={nodeSearchInput} />
 	<div class="list-results" on:wheel|passive|stopPropagation>
 		{#each nodeCategories as nodeCategory}
 			<details open={nodeCategory[1].open}>

--- a/frontend/src/components/widgets/inputs/TextInput.svelte
+++ b/frontend/src/components/widgets/inputs/TextInput.svelte
@@ -16,10 +16,12 @@
 	// Sizing
 	export let minWidth = 0;
 	export let maxWidth = 0;
-	// Tooltips
+		// Tooltips
 	export let tooltipLabel: string | undefined = undefined;
 	export let tooltipDescription: string | undefined = undefined;
 	export let tooltipShortcut: ActionShortcut | undefined = undefined;
+	// Behavior
+	export let selectAllOnFocus = true;
 
 	let className = "";
 	export { className as class };
@@ -28,10 +30,10 @@
 	let self: FieldInput | undefined;
 	let editing = false;
 
-	function onTextFocused() {
+		function onTextFocused() {
 		editing = true;
 
-		self?.selectAllText(value);
+		if (selectAllOnFocus) self?.selectAllText(value);
 	}
 
 	// Called only when `value` is changed from the <input> element via user input and committed, either with the


### PR DESCRIPTION
Fixes #4311 
Prevent Node Catalog autofocus from selecting all text so prefilled type search context is preserved while refining results.
