### PR TITLE
Lock segment molding to an axis with Shift

### DIFF
--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -354,7 +354,6 @@ impl ClosestSegment {
 		(c1, c2): (DVec2, DVec2),
 		new_b: DVec2,
 		break_colinear_molding: bool,
-		lock_direction: bool,
 		temporary_adjacent_handles_while_molding: Option<[Option<HandleId>; 2]>,
 	) -> Option<[Option<HandleId>; 2]> {
 		let transform = document.metadata().transform_to_viewport_if_feeds(self.layer, &document.network_interface);
@@ -364,13 +363,6 @@ impl ClosestSegment {
 
 		// Apply the drag delta to the segment's handles
 		let b = self.bezier_point_to_viewport;
-		// When the lock direction modifier is held, constrain the drag to the dominant screen axis (purely horizontal or vertical).
-		let new_b = if lock_direction {
-			let drag = new_b - b;
-			if drag.x.abs() >= drag.y.abs() { DVec2::new(new_b.x, b.y) } else { DVec2::new(b.x, new_b.y) }
-		} else {
-			new_b
-		};
 		let delta = transform.inverse().transform_vector2(new_b - b);
 		let (nc1, nc2) = (c1 + delta, c2 + delta);
 

--- a/editor/src/messages/tool/common_functionality/shape_editor.rs
+++ b/editor/src/messages/tool/common_functionality/shape_editor.rs
@@ -354,6 +354,7 @@ impl ClosestSegment {
 		(c1, c2): (DVec2, DVec2),
 		new_b: DVec2,
 		break_colinear_molding: bool,
+		lock_direction: bool,
 		temporary_adjacent_handles_while_molding: Option<[Option<HandleId>; 2]>,
 	) -> Option<[Option<HandleId>; 2]> {
 		let transform = document.metadata().transform_to_viewport_if_feeds(self.layer, &document.network_interface);
@@ -363,6 +364,13 @@ impl ClosestSegment {
 
 		// Apply the drag delta to the segment's handles
 		let b = self.bezier_point_to_viewport;
+		// When the lock direction modifier is held, constrain the drag to the dominant screen axis (purely horizontal or vertical).
+		let new_b = if lock_direction {
+			let drag = new_b - b;
+			if drag.x.abs() >= drag.y.abs() { DVec2::new(new_b.x, b.y) } else { DVec2::new(b.x, new_b.y) }
+		} else {
+			new_b
+		};
 		let delta = transform.inverse().transform_vector2(new_b - b);
 		let (nc1, nc2) = (c1 + delta, c2 + delta);
 

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2131,13 +2131,32 @@ impl Fsm for PathToolFsmState {
 				if let Some(segment) = &mut tool_data.segment
 					&& let Some(molding_segment_handles) = tool_data.molding_info
 				{
+					// While the lock direction modifier is held, constrain the drag to whichever screen axis it has travelled
+					// further along. The axis is stored in `snapping_axis` so the drag overlay draws the same X/Y guide lines
+					// through the grab point as it does when dragging points.
+					let mouse_position = match lock_direction {
+						true => {
+							let delta = input.mouse.position - tool_data.drag_start_pos;
+							let axis = if delta.x.abs() >= delta.y.abs() { Axis::X } else { Axis::Y };
+							tool_data.snapping_axis = Some(axis);
+
+							match axis {
+								Axis::Y => DVec2::new(tool_data.drag_start_pos.x, input.mouse.position.y),
+								Axis::X | Axis::Both => DVec2::new(input.mouse.position.x, tool_data.drag_start_pos.y),
+							}
+						}
+						false => {
+							tool_data.snapping_axis = None;
+							input.mouse.position
+						}
+					};
+
 					tool_data.temporary_adjacent_handles_while_molding = segment.mold_handle_positions(
 						document,
 						responses,
 						molding_segment_handles,
-						input.mouse.position,
+						mouse_position,
 						break_molding,
-						lock_direction,
 						tool_data.temporary_adjacent_handles_while_molding,
 					);
 
@@ -2391,6 +2410,7 @@ impl Fsm for PathToolFsmState {
 				tool_data.molding_segment = false;
 				tool_data.temporary_adjacent_handles_while_molding = None;
 				tool_data.angle_locked = false;
+				tool_data.snapping_axis = None;
 				responses.add(DocumentMessage::AbortTransaction);
 				tool_data.snap_manager.cleanup(responses);
 				PathToolFsmState::Ready
@@ -2513,6 +2533,7 @@ impl Fsm for PathToolFsmState {
 					tool_data.molding_info = None;
 					tool_data.molding_segment = false;
 					tool_data.temporary_adjacent_handles_while_molding = None;
+					tool_data.snapping_axis = None;
 
 					if segment_dissolved || point_inserted {
 						responses.add(DocumentMessage::EndTransaction);

--- a/editor/src/messages/tool/tool_messages/path_tool.rs
+++ b/editor/src/messages/tool/tool_messages/path_tool.rs
@@ -2125,6 +2125,7 @@ impl Fsm for PathToolFsmState {
 				}
 
 				let break_molding = input.keyboard.get(break_colinear_molding as usize);
+				let lock_direction = input.keyboard.get(snap_angle as usize);
 
 				// Logic for molding segment
 				if let Some(segment) = &mut tool_data.segment
@@ -2136,6 +2137,7 @@ impl Fsm for PathToolFsmState {
 						molding_segment_handles,
 						input.mouse.position,
 						break_molding,
+						lock_direction,
 						tool_data.temporary_adjacent_handles_while_molding,
 					);
 
@@ -3638,6 +3640,8 @@ fn update_dynamic_hints(
 				let molding_disable_possible = has_colinear_anchors || handles_stored;
 
 				let mut molding_hints = vec![HintGroup(vec![HintInfo::mouse(MouseMotion::Rmb, ""), HintInfo::keys([Key::Escape], "Cancel").prepend_slash()])];
+
+				molding_hints.push(HintGroup(vec![HintInfo::keys([Key::Shift], "Lock Direction")]));
 
 				if molding_disable_possible {
 					molding_hints.push(HintGroup(vec![HintInfo::keys([Key::Alt], "Break Colinear Handles")]));


### PR DESCRIPTION
Closes #3760

While molding a path segment with the Path tool, holding <kbd>Shift</kbd> now constrains the drag to a single axis (horizontal or vertical), matching the direction-locking behavior of other drag operations in the tool.

### Behavior
- Hold <kbd>Shift</kbd> during a segment mold to lock the movement to the dominant screen axis (whichever of X/Y the drag has travelled further along).
- Release <kbd>Shift</kbd> to resume free movement.
- A "Lock Direction" hint is shown in the status bar while molding.

### Implementation
- `mold_handle_positions` gains a `lock_direction` flag; when set, the incoming pointer position is snapped to the grab point's x or y before the drag delta is computed, so the segment moves purely along one axis.
- The Path tool forwards the existing `snap_angle` (<kbd>Shift</kbd>) key state into the molding branch, where it was previously unused, and adds the corresponding hint.