### PR TITLE
usvg::Group::mask() now imported as hidden Graphite-base layers

### DIFF
--- a/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/graph_operation_message_handler.rs
@@ -573,6 +573,20 @@ fn parse_hex_stop_color(hex: &str, opacity: f32) -> Option<Color> {
 	Some(Color::from_rgbaf32_unchecked(r, g, b, opacity))
 }
 
+#[derive(Clone, Copy, Debug)]
+struct ImportedNode {
+	layer: LayerNodeIdentifier,
+	extent: u32,
+}
+
+fn imported_group_extent(child_extents: &[u32]) -> u32 {
+	if child_extents.is_empty() {
+		0
+	} else {
+		(2 * STACK_VERTICAL_GAP as u32) * child_extents.len() as u32 - STACK_VERTICAL_GAP as u32 + child_extents.iter().sum::<u32>()
+	}
+}
+
 /// Import a usvg node as the root of an SVG import operation.
 ///
 /// The root layer uses the full `move_layer_to_stack` (with push/collision logic) to correctly
@@ -597,18 +611,13 @@ fn import_usvg_node(
 
 	match node {
 		usvg::Node::Group(group) => {
-			// Collect child extents for O(n) position calculation
-			let mut child_extents_svg_order: Vec<u32> = Vec::new();
 			let mut group_extents_map: HashMap<LayerNodeIdentifier, Vec<u32>> = HashMap::new();
 
 			// Enable import mode: skips expensive is_acyclic checks and per-node cache invalidation
 			// during wiring since we're building a known tree structure where cycles are impossible
 			modify_inputs.import = true;
 
-			for child in group.children() {
-				let extent = import_usvg_node_inner(modify_inputs, child, NodeId::new(), layer, 0, graphite_gradient_stops, &mut group_extents_map);
-				child_extents_svg_order.push(extent);
-			}
+			let child_extents_svg_order = import_usvg_group_children(modify_inputs, group, layer, graphite_gradient_stops, &mut group_extents_map);
 
 			modify_inputs.import = false;
 			modify_inputs.layer_node = Some(layer);
@@ -638,8 +647,110 @@ fn import_usvg_node(
 	}
 }
 
+/// Imports a group's children in SVG paint order, adding a hidden mask base for a resolved alpha mask.
+fn import_usvg_group_children(
+	modify_inputs: &mut ModifyInputsContext,
+	group: &usvg::Group,
+	parent: LayerNodeIdentifier,
+	graphite_gradient_stops: &HashMap<String, GradientStops>,
+	group_extents_map: &mut HashMap<LayerNodeIdentifier, Vec<u32>>,
+) -> Vec<u32> {
+	let mask = group.mask().filter(|mask| {
+		let supported = usvg_mask_chain_is_alpha(mask);
+		if !supported {
+			warn!(
+				"Skip unsupported luminance SVG mask '{}'; luminance masks cannot be represented as Graphite alpha clipping masks",
+				mask.id()
+			);
+		}
+		supported
+	});
+
+	import_usvg_children_with_mask(
+		modify_inputs,
+		group.children(),
+		mask,
+		parent,
+		usvg_transform(group.abs_transform()),
+		graphite_gradient_stops,
+		group_extents_map,
+	)
+}
+
+fn usvg_mask_chain_is_alpha(mask: &usvg::Mask) -> bool {
+	mask.kind() == usvg::MaskType::Alpha && mask.mask().is_none_or(usvg_mask_chain_is_alpha)
+}
+
+/// Imports one sibling list and represents its optional alpha mask with Graphite's existing clipping-mask nodes.
+fn import_usvg_children_with_mask(
+	modify_inputs: &mut ModifyInputsContext,
+	children: &[usvg::Node],
+	mask: Option<&usvg::Mask>,
+	parent: LayerNodeIdentifier,
+	referencing_transform: DAffine2,
+	graphite_gradient_stops: &HashMap<String, GradientStops>,
+	group_extents_map: &mut HashMap<LayerNodeIdentifier, Vec<u32>>,
+) -> Vec<u32> {
+	let mut child_extents = Vec::new();
+	let mask = mask.filter(|_| !children.is_empty());
+
+	if let Some(mask) = mask {
+		let imported_mask = import_usvg_mask(modify_inputs, mask, parent, 0, referencing_transform, graphite_gradient_stops, group_extents_map);
+		child_extents.push(imported_mask.extent);
+	}
+
+	for child in children {
+		let imported_child = import_usvg_node_inner(modify_inputs, child, NodeId::new(), parent, 0, graphite_gradient_stops, group_extents_map);
+		if mask.is_some() {
+			modify_inputs.layer_node = Some(imported_child.layer);
+			modify_inputs.clip_mode_set(true);
+		}
+		child_extents.push(imported_child.extent);
+	}
+
+	child_extents
+}
+
+/// Imports a resolved SVG alpha mask as one hidden Graphite mask-base layer.
+fn import_usvg_mask(
+	modify_inputs: &mut ModifyInputsContext,
+	mask: &usvg::Mask,
+	parent: LayerNodeIdentifier,
+	insert_index: usize,
+	referencing_transform: DAffine2,
+	graphite_gradient_stops: &HashMap<String, GradientStops>,
+	group_extents_map: &mut HashMap<LayerNodeIdentifier, Vec<u32>>,
+) -> ImportedNode {
+	debug_assert!(usvg_mask_chain_is_alpha(mask));
+
+	let layer = modify_inputs.create_layer(NodeId::new());
+	modify_inputs.network_interface.move_layer_to_stack_for_import(layer, parent, insert_index, &[]);
+	modify_inputs.layer_node = Some(layer);
+
+	let child_extents = import_usvg_children_with_mask(
+		modify_inputs,
+		mask.root().children(),
+		mask.mask(),
+		layer,
+		DAffine2::IDENTITY,
+		graphite_gradient_stops,
+		group_extents_map,
+	);
+
+	let extent = imported_group_extent(&child_extents);
+	group_extents_map.insert(layer, child_extents);
+
+	modify_inputs.layer_node = Some(layer);
+	modify_inputs.transform_set(referencing_transform, TransformIn::Local, false);
+	// Independent fill opacity hides the mask artwork during normal rendering but is
+	// intentionally ignored by the renderer's mask pass, preserving its source alpha.
+	modify_inputs.opacity_fill_set(0.);
+
+	ImportedNode { layer, extent }
+}
+
 /// Recursively import a usvg node as a descendant of the root import layer.
-/// Uses lightweight wiring (no push/collision) and returns the subtree extent for position calculation.
+/// Uses lightweight wiring (no push/collision) and returns the layer plus its subtree extent for position calculation.
 ///
 /// The subtree extent represents the additional vertical grid units that this node's descendants
 /// occupy below the node's position. This is used to calculate correct y_offsets between siblings.
@@ -651,26 +762,17 @@ fn import_usvg_node_inner(
 	insert_index: usize,
 	graphite_gradient_stops: &HashMap<String, GradientStops>,
 	group_extents_map: &mut HashMap<LayerNodeIdentifier, Vec<u32>>,
-) -> u32 {
+) -> ImportedNode {
 	let layer = modify_inputs.create_layer(id);
 	modify_inputs.network_interface.move_layer_to_stack_for_import(layer, parent, insert_index, &[]);
 	modify_inputs.layer_node = Some(layer);
 
-	match node {
+	let extent = match node {
 		usvg::Node::Group(group) => {
-			let mut child_extents: Vec<u32> = Vec::new();
-			for child in group.children() {
-				let extent = import_usvg_node_inner(modify_inputs, child, NodeId::new(), layer, 0, graphite_gradient_stops, group_extents_map);
-				child_extents.push(extent);
-			}
+			let child_extents = import_usvg_group_children(modify_inputs, group, layer, graphite_gradient_stops, group_extents_map);
 			modify_inputs.layer_node = Some(layer);
 
-			let n = child_extents.len();
-			let total_extent = if n == 0 {
-				0
-			} else {
-				(2 * STACK_VERTICAL_GAP as u32) * n as u32 - STACK_VERTICAL_GAP as u32 + child_extents.iter().sum::<u32>()
-			};
+			let total_extent = imported_group_extent(&child_extents);
 			group_extents_map.insert(layer, child_extents);
 			total_extent
 		}
@@ -688,7 +790,9 @@ fn import_usvg_node_inner(
 			modify_inputs.fill_color_set(Some(Color::BLACK));
 			0
 		}
-	}
+	};
+
+	ImportedNode { layer, extent }
 }
 
 /// Helper to apply path data (vector geometry, fill, stroke, transform) to a layer.
@@ -860,4 +964,110 @@ fn apply_usvg_fill(fill: &usvg::Fill, modify_inputs: &mut ModifyInputsContext, g
 		}
 		usvg::Paint::Pattern(_) => warn!("SVG patterns are not currently supported"),
 	};
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::test_utils::test_prelude::*;
+	use graphene_std::renderer::{Render, RenderParams, RenderSvgSegmentList, SvgRender};
+
+	#[tokio::test]
+	async fn svg_group_alpha_mask_imports_as_hidden_clipping_mask() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+
+		let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+			<defs>
+				<mask id="circle-mask" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="128" height="128">
+					<circle cx="64" cy="64" r="48" fill="white" />
+				</mask>
+			</defs>
+			<g transform="translate(10 20)" mask="url(#circle-mask)">
+				<rect width="128" height="128" fill="#2563eb" />
+			</g>
+		</svg>"##;
+
+		editor
+			.handle_message(GraphOperationMessage::NewSvg {
+				id: NodeId::new(),
+				svg: svg.to_string(),
+				transform: DAffine2::IDENTITY,
+				parent: LayerNodeIdentifier::ROOT_PARENT,
+				insert_index: 0,
+				center: false,
+			})
+			.await;
+
+		let instrumented = editor.eval_graph().await.expect("alpha-masked SVG import should evaluate");
+
+		let clip_values: Vec<_> = instrumented.grab_all_input::<graphene_std::blending_nodes::clipping_mask::ClipInput>(&editor.runtime).collect();
+		assert_eq!(clip_values, vec![true], "the visible group child should inherit the SVG mask alpha");
+
+		let has_fill_values: Vec<_> = instrumented.grab_all_input::<graphene_std::blending_nodes::opacity::HasFillInput>(&editor.runtime).collect();
+		assert_eq!(has_fill_values, vec![true], "the imported mask base should enable independent fill opacity");
+
+		let fill_values: Vec<_> = instrumented.grab_all_input::<graphene_std::blending_nodes::opacity::FillInput>(&editor.runtime).collect();
+		assert_eq!(fill_values, vec![0.], "the imported mask artwork should be hidden during ordinary rendering");
+
+		let paint_fills: Vec<_> = instrumented.grab_all_input::<graphene_std::vector::fill::FillInput<List<Color>>>(&editor.runtime).collect();
+		assert!(
+			paint_fills.iter().filter_map(|fill| fill.element(0)).any(|color| *color == Color::WHITE),
+			"alpha mask paint should pass through the ordinary SVG fill importer; got {paint_fills:?}"
+		);
+
+		let translations: Vec<_> = instrumented.grab_all_input::<graphene_std::transform_nodes::transform::TranslationInput>(&editor.runtime).collect();
+		let referencing_translation_count = translations.iter().filter(|translation| translation.abs_diff_eq(DVec2::new(10., 20.), 1e-10)).count();
+		assert!(
+			referencing_translation_count >= 2,
+			"the visible artwork and independent mask subroot should both inherit the referencing transform; got {translations:?}"
+		);
+
+		let rendered_group_svgs: Vec<_> = instrumented
+			.grab_all_input::<graphene_std::graphic::extend::NewInput<graphene_std::Graphic>>(&editor.runtime)
+			.map(|graphics| {
+				let mut render = SvgRender::new();
+				graphics.render_svg(&mut render, &RenderParams::default());
+				format!("{}{}", render.svg_defs, render.svg.to_svg_string())
+			})
+			.collect();
+		let rendered_group_svg = rendered_group_svgs
+			.iter()
+			.find(|svg| svg.contains("<mask") && svg.contains("mask=\"url(#mask-"))
+			.unwrap_or_else(|| panic!("the imported mask attributes should reach the existing SVG mask renderer; intermediate SVGs: {rendered_group_svgs:#?}"));
+		assert!(rendered_group_svg.contains("opacity=\"0\""), "the mask base should remain hidden in the normal render pass");
+	}
+
+	#[tokio::test]
+	async fn svg_luminance_mask_is_not_misinterpreted_as_alpha() {
+		let mut editor = EditorTestUtils::create();
+		editor.new_document().await;
+
+		let svg = r##"<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+			<defs>
+				<mask id="luminance-mask" maskUnits="userSpaceOnUse" x="0" y="0" width="128" height="128">
+					<circle cx="64" cy="64" r="48" fill="white" />
+				</mask>
+			</defs>
+			<rect width="128" height="128" fill="#2563eb" mask="url(#luminance-mask)" />
+		</svg>"##;
+
+		editor
+			.handle_message(GraphOperationMessage::NewSvg {
+				id: NodeId::new(),
+				svg: svg.to_string(),
+				transform: DAffine2::IDENTITY,
+				parent: LayerNodeIdentifier::ROOT_PARENT,
+				insert_index: 0,
+				center: false,
+			})
+			.await;
+
+		let instrumented = editor.eval_graph().await.expect("unsupported luminance-mask SVG import should still evaluate");
+		let clip_values: Vec<_> = instrumented.grab_all_input::<graphene_std::blending_nodes::clipping_mask::ClipInput>(&editor.runtime).collect();
+		assert!(clip_values.is_empty(), "a luminance mask must not be silently imported with alpha-mask semantics");
+
+		let fill_values: Vec<_> = instrumented.grab_all_input::<graphene_std::blending_nodes::opacity::FillInput>(&editor.runtime).collect();
+		assert!(fill_values.is_empty(), "rejecting a luminance mask must not leave an orphaned hidden mask base");
+	}
 }

--- a/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
+++ b/editor/src/messages/portfolio/document/graph_operation/utility_types.rs
@@ -702,7 +702,10 @@ impl<'a> ModifyInputsContext<'a> {
 	}
 
 	pub fn clip_mode_toggle(&mut self, clip_mode: Option<bool>) {
-		let clip = !clip_mode.unwrap_or(false);
+		self.clip_mode_set(!clip_mode.unwrap_or(false));
+	}
+
+	pub fn clip_mode_set(&mut self, clip: bool) {
 		let Some(clip_node_id) = self.existing_proto_node_id(graphene_std::blending_nodes::clipping_mask::IDENTIFIER, true) else {
 			return;
 		};


### PR DESCRIPTION
Hello there was an issue with Group masked not being recognized and now they are.

A clipping setter was added.

Note that luminescence masks are deliberately rejected and generate a warning instead. this because we wanted to split them as separate issues just keep this in mind when merging all the separate issues if this is something you would like to do.

This fixes  #4340