### PR TITLE
Fix dev environment configurations with devcontainer, vscode, and cargo-about

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,13 @@
 	"image": "mcr.microsoft.com/devcontainers/base:debian",
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
-			"profile": "default"
+			"profile": "default",
+			"targets": "wasm32-unknown-unknown"
 		},
 		"ghcr.io/devcontainers/features/node:1": {}
 	},
-	"onCreateCommand": "cargo install cargo-about && cargo install -f wasm-bindgen-cli@0.2.121",
+	// NOTE: Keep this in sync with WASM_BINDGEN_CLI_VERSION and CARGO_ABOUT_VERSION in `.github/workflows/build.yml`
+	"onCreateCommand": "curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && cargo binstall --no-confirm --force cargo-about@0.9.0 wasm-bindgen-cli@0.2.121",
 	"customizations": {
 		"vscode": {
 			// NOTE: Keep this in sync with `.vscode/extensions.json`
@@ -16,14 +18,16 @@
 				"tamasfe.even-better-toml",
 				// Web
 				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
 				"svelte.svelte-vscode",
 				"vitaliymaz.vscode-svg-previewer",
 				// Code quality
 				"wayou.vscode-todo-highlight",
 				"streetsidesoftware.code-spell-checker",
-				// Helpful
+				// Git
 				"mhutchie.git-graph",
 				"qezhu.gitlink",
+				// Helpful
 				"wmaurer.change-case"
 			]
 		}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ flamegraph.svg
 .direnv
 .DS_Store
 .nvim.lua
+devcontainer-lock.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
 		"tamasfe.even-better-toml",
 		// Web
 		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
 		"svelte.svelte-vscode",
 		"vitaliymaz.vscode-svg-previewer",
 		// Code quality

--- a/about.toml
+++ b/about.toml
@@ -22,8 +22,6 @@ accepted = [
 workarounds = ["ring"]
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
-# Clearly Defined's API would occasionally (every few months) return errors for at least a full day (maybe some weird rate limiting?), but we can just disable to perform local checking (see #1653)
-no-clearly-defined = true
 
 # https://raw.githubusercontent.com/briansmith/webpki/main/LICENSE
 # is the ISC license but test code within the repo is BSD-3-Clause, but is not compiled into the crate when we use it


### PR DESCRIPTION
Some minor fixes to issues I ran into using devcontainer on this project with vscode.
 
- Add `esbenp.prettier-vscode` to the recommended extensions list as it's already used in `.vscode/settings.json`
- Install `wasm32-unknown-unknown` Rust target in devcontainer
- Add cargo-binstall and pin cargo-about version in devcontainer
- Remove `no-clearly-defined = true` from `about.toml`:
  - cargo-about 0.9.1 fails to run if `no-clearly-defined` is present
  - cargo-about 0.8.0 already [removed support](https://github.com/EmbarkStudios/cargo-about/blob/main/CHANGELOG.md#080---2025-09-05) for clearlydefined.io, so the argument is a no-op