### PR TITLE
Make double-clicking a text layer begin editing in shallow select mode, not just deep select mode

### DIFF
--- a/editor/src/messages/tool/tool_messages/select_tool.rs
+++ b/editor/src/messages/tool/tool_messages/select_tool.rs
@@ -2058,6 +2058,7 @@ fn edit_layer_shallowest_manipulation(document: &DocumentMessageHandler, layer: 
 			.parent(document.metadata())
 			.is_some_and(|parent| document.network_interface.selected_nodes().selected_layers_contains(parent, document.metadata()))
 	}) else {
+		edit_layer_deepest_manipulation(layer, &document.network_interface, responses);
 		return;
 	};
 


### PR DESCRIPTION
Closes #4328