### PR TITLE
ci: read the !build comment body from env instead of interpolating it

### DIFF
--- a/.github/workflows/comment-!build-commands.yml
+++ b/.github/workflows/comment-!build-commands.yml
@@ -42,8 +42,10 @@ jobs:
     steps:
       - name: 🔎 Parse command, find branch, and set build flags
         id: pr_info
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          COMMENT="${{ github.event.comment.body }}"
+          COMMENT="$COMMENT_BODY"
 
           # Split into space-separated words
           read -ra WORDS <<< "$COMMENT"


### PR DESCRIPTION
Hi, and thanks for Graphite.

In `.github/workflows/comment-!build-commands.yml`, the `!build` comment is read into the shell like this:

```yaml
run: |
  COMMENT="${{ github.event.comment.body }}"

  # Split into space-separated words
  read -ra WORDS <<< "$COMMENT"
```

Actions expands `${{ ... }}` into the script text before bash runs, so the comment body becomes part of the script rather than a string assigned to `COMMENT`. A comment body is completely free text, and `$(...)` and backticks still run inside double quotes — so `!build $(...)` would execute on the runner instead of being parsed as a target argument.

You have already thought about the security of this workflow, and I want to acknowledge that rather than talk past it. The job is gated on:

```yaml
github.event.comment.author_association == 'MEMBER'
```

with a comment explaining exactly why. That is a real control and it means this is not open to the public — it needs an org member. So I am raising this as defence in depth, not as an open door: it matters if a member's account is compromised, and it removes a sharp edge where a member's comment can do something they did not intend.

The change binds the body to an environment variable, which is the fix from GitHub's own hardening guidance:

```yaml
env:
  COMMENT_BODY: ${{ github.event.comment.body }}
run: |
  COMMENT="$COMMENT_BODY"
```

Everything downstream is untouched — `read -ra WORDS <<< "$COMMENT"` and the `!build` / target / profile parsing all behave exactly as they do today. Two lines added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its membership gate myself.
