### PR TITLE
Fix Text tool resize locking both max width and max height on a single-edge drag

### DIFF
--- a/editor/src/messages/tool/tool_messages/text_tool.rs
+++ b/editor/src/messages/tool/tool_messages/text_tool.rs
@@ -884,23 +884,29 @@ impl Fsm for TextToolFsmState {
 					// Find the translation necessary from the original position in viewport space
 					let translation_viewport = bounds.original_bound_transform.transform_vector2(translation_bounds_space);
 
-					// TODO: Don't set both max_width and max_height to true at the same time, only do one based on which edge is being dragged (or both if a corner is being dragged)
-					responses.add(NodeGraphMessage::SetInput {
-						input_connector: InputConnector::node(node_id, graphene_std::text::text::HasMaxWidthInput),
-						input: NodeInput::value(TaggedValue::Bool(true), false),
-					});
-					responses.add(NodeGraphMessage::SetInput {
-						input_connector: InputConnector::node(node_id, graphene_std::text::text::MaxWidthInput),
-						input: NodeInput::value(TaggedValue::F64(size_layer.x), false),
-					});
-					responses.add(NodeGraphMessage::SetInput {
-						input_connector: InputConnector::node(node_id, graphene_std::text::text::HasMaxHeightInput),
-						input: NodeInput::value(TaggedValue::Bool(true), false),
-					});
-					responses.add(NodeGraphMessage::SetInput {
-						input_connector: InputConnector::node(node_id, graphene_std::text::text::MaxHeightInput),
-						input: NodeInput::value(TaggedValue::F64(size_layer.y), false),
-					});
+					// Only set the max width/height for the axis (axes) whose edge(s) are actually being dragged, so a single-edge drag doesn't lock the other axis too
+					let (touches_width, touches_height) = (movement.left || movement.right, movement.top || movement.bottom);
+
+					if touches_width {
+						responses.add(NodeGraphMessage::SetInput {
+							input_connector: InputConnector::node(node_id, graphene_std::text::text::HasMaxWidthInput),
+							input: NodeInput::value(TaggedValue::Bool(true), false),
+						});
+						responses.add(NodeGraphMessage::SetInput {
+							input_connector: InputConnector::node(node_id, graphene_std::text::text::MaxWidthInput),
+							input: NodeInput::value(TaggedValue::F64(size_layer.x), false),
+						});
+					}
+					if touches_height {
+						responses.add(NodeGraphMessage::SetInput {
+							input_connector: InputConnector::node(node_id, graphene_std::text::text::HasMaxHeightInput),
+							input: NodeInput::value(TaggedValue::Bool(true), false),
+						});
+						responses.add(NodeGraphMessage::SetInput {
+							input_connector: InputConnector::node(node_id, graphene_std::text::text::MaxHeightInput),
+							input: NodeInput::value(TaggedValue::F64(size_layer.y), false),
+						});
+					}
 					responses.add(GraphOperationMessage::TransformSet {
 						layer: dragging_layer.id,
 						transform: DAffine2::from_translation(translation_viewport) * document.metadata().document_to_viewport * dragging_layer.original_transform,


### PR DESCRIPTION
Fixes #4396

## Problem

While resizing a text box with the Text tool, dragging a **single edge** unconditionally set *both* `max_width` and `max_height` on the Text node.

So dragging just the right edge to set a width constraint also froze the height at whatever it happened to be before the drag. As the text rewrapped to more lines, everything past that frozen height was silently clipped — the user never asked for a height constraint at all.

This was a known gap; the code carried a TODO for exactly this case:

```rust
// TODO: Don't set both max_width and max_height to true at the same time, only do one
// based on which edge is being dragged (or both if a corner is being dragged)
```

## Fix

Gate the two pairs of `SetInput` calls on which edges the drag actually touched, using the `SelectedEdges` state that the resize already tracks:

```rust
let (touches_width, touches_height) = (movement.left || movement.right, movement.top || movement.bottom);
```

- Left/right edge drag → only `has_max_width` + `max_width`
- Top/bottom edge drag → only `has_max_height` + `max_height`
- Corner drag → both, as before

The untouched axis keeps whatever it had (usually unconstrained), so text continues to auto-grow in that direction.

`editor/src/messages/tool/tool_messages/text_tool.rs` — 1 file, resolves the TODO.

## Testing

Built successfully and manually verified in the editor:

- Dragging the right edge of a text box now constrains width only; the box grows downward as text rewraps instead of clipping. ✅
- Dragging the bottom edge constrains height only; width is untouched. ✅
- Dragging a corner still constrains both axes (unchanged behavior). ✅
- Re-dragging the other edge afterwards adds the second constraint as expected. ✅
