### PR TITLE
Make the 'Index Points' node index within each vector element instead of across the whole list

### DIFF
--- a/node-graph/nodes/vector/src/vector_nodes.rs
+++ b/node-graph/nodes/vector/src/vector_nodes.rs
@@ -3251,41 +3251,32 @@ async fn count_points(_: impl Ctx, content: Item<Vector>) -> Item<f64> {
 	Item::new_from_element(count)
 }
 
-/// Retrieves the vec2 position (in local space) of the anchor point at the specified index in a `List` of vector elements.
+/// Retrieves the vec2 position (in local space) of the anchor point at the specified index within a vector element.
 /// If no value exists at that index, the position (0, 0) is returned.
 #[node_macro::node(category("Vector: Measure"), path(graphene_core::vector))]
 async fn index_points(
 	_: impl Ctx,
-	/// The vector element or elements containing the anchor points to be retrieved.
-	content: List<Vector>,
-	/// The index of the points to retrieve, starting from 0 for the first point. Negative indices count backwards from the end, starting from -1 for the last item.
+	/// The vector element containing the anchor points to be retrieved.
+	content: Item<Vector>,
+	/// The index of the points to retrieve, starting from 0 for the first point. Negative indices count backwards from the end, starting from -1 for the last point.
 	index: Item<f64>,
 ) -> Item<DVec2> {
 	let index = index.into_element();
-	let points_count = content.iter_element_values().map(|vector| vector.point_domain.positions().len()).sum::<usize>();
+	let positions = content.element().point_domain.positions();
 
-	if points_count == 0 {
+	let Some(last_index) = positions.len().checked_sub(1) else {
 		return Item::new_from_element(DVec2::ZERO);
-	}
+	};
+
 	// Clamp and allow negative indexing from the end
 	let index = index as isize;
 	let index = if index < 0 {
-		(points_count as isize + index).max(0) as usize
+		(positions.len() as isize + index).max(0) as usize
 	} else {
-		(index as usize).min(points_count - 1)
+		(index as usize).min(last_index)
 	};
 
-	// Find the point at the given index across all vector elements
-	let mut accumulated = 0;
-	for vector in content.iter_element_values() {
-		let row_point_count = vector.point_domain.positions().len();
-		if index - accumulated < row_point_count {
-			return Item::new_from_element(vector.point_domain.positions()[index - accumulated]);
-		}
-		accumulated += row_point_count;
-	}
-
-	Item::new_from_element(DVec2::ZERO)
+	Item::new_from_element(positions[index])
 }
 
 #[node_macro::node(category("Vector: Measure"), path(core_types::vector))]


### PR DESCRIPTION
This has no migration because avoiding repeated migrations would necessitate leaving behind cruft. I'm deeming this rare enough that users can do the migration manually if encountered: inserting a 'Combine Paths' node before 'Index Points'.