### PR TITLE
fix:  blend mode preview resetting to Normal when hovering between dropdown entries

### DIFF
--- a/frontend/src/components/floating-menus/MenuList.svelte
+++ b/frontend/src/components/floating-menus/MenuList.svelte
@@ -250,7 +250,6 @@
 
 	function onEntryPointerLeave(menuListEntry: MenuListEntry) {
 		if (!menuListEntry.children?.length) {
-			dispatch("hoverOutEntry");
 			return;
 		}
 
@@ -261,6 +260,11 @@
 		} else {
 			dispatch("open", false);
 		}
+	}
+
+	function onPointerLeave() {
+		dispatch("hoverOutEntry");
+		return;
 	}
 
 	function includeSeparator(entries: MenuListEntry[][], section: MenuListEntry[], sectionIndex: number, search: string): boolean {
@@ -465,6 +469,7 @@
 		bind:this={scroller}
 		scrollableY={scrollableY && virtualScrollingEntryHeight !== 0}
 		on:scroll={onScroll}
+		on:pointerleave={onPointerLeave}
 		styles={{ "min-width": virtualScrollingEntryHeight ? `${minWidth}px` : `inherit` }}
 	>
 		{#if virtualScrollingEntryHeight}

--- a/frontend/src/components/panels/Layers.svelte
+++ b/frontend/src/components/panels/Layers.svelte
@@ -695,12 +695,13 @@
 		.control-bar {
 			height: 32px;
 			flex: 0 0 auto;
-			margin: 0 4px;
+			padding-right: 15px;
+
 			border-bottom: 1px solid var(--color-2-mildblack);
-			justify-content: space-between;
+			justify-content: space-evenly;
 
 			.widget-span:first-child {
-				flex: 1 1 auto;
+				flex: 1 0.5 auto;
 			}
 
 			&:not(:has(*)) {

--- a/frontend/src/components/panels/Layers.svelte
+++ b/frontend/src/components/panels/Layers.svelte
@@ -695,6 +695,7 @@
 		.control-bar {
 			height: 32px;
 			flex: 0 0 auto;
+			padding-left: 4px;
 			padding-right: 15px;
 
 			border-bottom: 1px solid var(--color-2-mildblack);

--- a/frontend/src/components/widgets/inputs/DropdownInput.svelte
+++ b/frontend/src/components/widgets/inputs/DropdownInput.svelte
@@ -54,6 +54,9 @@
 	$: watchOpen(open);
 
 	function watchOpen(open: boolean) {
+		if (!open && initialSelectedIndex !== undefined) {
+			dispatch("hoverOutEntry", initialSelectedIndex);
+		}
 		initialSelectedIndex = open ? selectedIndex : undefined;
 	}
 

--- a/frontend/src/components/widgets/inputs/DropdownInput.svelte
+++ b/frontend/src/components/widgets/inputs/DropdownInput.svelte
@@ -46,6 +46,7 @@
 	let activeEntry = makeActiveEntry();
 	let activeEntrySkipWatcher = false;
 	let initialSelectedIndex: number | undefined = undefined;
+	let selectionMade = false;
 	let open = false;
 
 	$: watchSelectedIndex(selectedIndex);
@@ -54,10 +55,11 @@
 	$: watchOpen(open);
 
 	function watchOpen(open: boolean) {
-		if (!open && initialSelectedIndex !== undefined) {
+		if (!open && initialSelectedIndex !== undefined && !selectionMade) {
 			dispatch("hoverOutEntry", initialSelectedIndex);
 		}
 		initialSelectedIndex = open ? selectedIndex : undefined;
+		selectionMade = false;
 	}
 
 	// Called only when `selectedIndex` is changed from outside this component
@@ -80,6 +82,7 @@
 			if (initialSelectedIndex !== undefined) dispatch("hoverInEntry", initialSelectedIndex);
 			const index = entries.flat().findIndex((entry) => entry.value === activeEntry.value);
 			if (index !== -1) {
+				selectionMade = true;
 				dispatch("selectedIndex", index);
 			} else {
 				// eslint-disable-next-line no-console

--- a/frontend/src/components/widgets/inputs/DropdownInput.svelte
+++ b/frontend/src/components/widgets/inputs/DropdownInput.svelte
@@ -46,7 +46,7 @@
 	let activeEntry = makeActiveEntry();
 	let activeEntrySkipWatcher = false;
 	let initialSelectedIndex: number | undefined = undefined;
-	let selectionMade = false;
+	let activeEntryOnOpen: string | undefined = undefined;
 	let open = false;
 
 	$: watchSelectedIndex(selectedIndex);
@@ -55,11 +55,18 @@
 	$: watchOpen(open);
 
 	function watchOpen(open: boolean) {
-		if (!open && initialSelectedIndex !== undefined && !selectionMade) {
-			dispatch("hoverOutEntry", initialSelectedIndex);
+		if (open) {
+			initialSelectedIndex = selectedIndex;
+			activeEntryOnOpen = activeEntry.value;
+		} else {
+			// Suppress hoverOutEntry if a new selection was made
+			const selectionMade = activeEntryOnOpen !== undefined && activeEntry.value !== activeEntryOnOpen;
+			if (initialSelectedIndex !== undefined && !selectionMade) {
+				dispatch("hoverOutEntry", initialSelectedIndex);
+			}
+			initialSelectedIndex = undefined;
+			activeEntryOnOpen = undefined;
 		}
-		initialSelectedIndex = open ? selectedIndex : undefined;
-		selectionMade = false;
 	}
 
 	// Called only when `selectedIndex` is changed from outside this component
@@ -82,7 +89,6 @@
 			if (initialSelectedIndex !== undefined) dispatch("hoverInEntry", initialSelectedIndex);
 			const index = entries.flat().findIndex((entry) => entry.value === activeEntry.value);
 			if (index !== -1) {
-				selectionMade = true;
 				dispatch("selectedIndex", index);
 			} else {
 				// eslint-disable-next-line no-console

--- a/frontend/src/components/widgets/inputs/FieldInput.svelte
+++ b/frontend/src/components/widgets/inputs/FieldInput.svelte
@@ -123,7 +123,7 @@
 
 <style lang="scss">
 	.field-input {
-		min-width: 80px;
+		min-width: 70px;
 		height: auto;
 		position: relative;
 		border-radius: 2px;


### PR DESCRIPTION
This PR fixes issue #2863.

## Reason 

Previously, `hoverOutEntry` was fired whenever the cursor left any single `<LayoutRow>`. Because `<Separator />` elements between sections are not entry rows

## Fix

By moving the `pointerleave` listener to the parent `<LayoutCol>`, crossing internal dividers or moving between rows no longer fires `pointerleave` (since `pointerleave` does not bubble and only fires when exiting the container and all of its child elements).


## Before

https://github.com/user-attachments/assets/de4f560d-56d7-407d-bd0c-c11a369a815c

## After

https://github.com/user-attachments/assets/d89e35e5-333c-4a64-ba97-71bc3374701c

