### PR TITLE
Fix cargo-about install command

### DIFF
--- a/tools/cargo-run/src/requirements.rs
+++ b/tools/cargo-run/src/requirements.rs
@@ -66,7 +66,7 @@ fn requirements(task: &Task) -> Vec<Requirement> {
 			name: "Cargo About",
 			// NOTICE: keep in sync with the `cargo-about` version pinned in `.github/workflows/build.yml` and `.devcontainer/devcontainer.json`
 			version: Some(">=0.9.2"),
-			install: "cargo install -f cargo-about@0.9.2".into(),
+			install: "cargo install --features=cli -f cargo-about@0.9.2".into(),
 			skip: Some(&|task| matches!(task.target, Target::Cli)),
 			..Default::default()
 		},


### PR DESCRIPTION
Currently the install doesn't do anything:
```
warning: none of the package's binaries are available for install using the selected features
  bin "cargo-about" requires the features: `cli`
Consider enabling some of the needed features by passing, e.g., `--features="cli"`
```

Please consider reviewing @timon-schelling. Thanks.